### PR TITLE
Fix url link to setup after the first WiFi setup

### DIFF
--- a/WebServer.ino
+++ b/WebServer.ino
@@ -138,7 +138,7 @@ void handle_root() {
   // if Wifi setup, launch setup wizard
   if (wifiSetup)
   {
-    WebServer.send(200, "text/html", "<meta HTTP-EQUIV='REFRESH' content='0; url=http://192.168.4.1/setup'>");
+    WebServer.send(200, "text/html", "<meta HTTP-EQUIV='REFRESH' content='0; url=/setup'>");
     return;
   }
 


### PR DESCRIPTION
After the first setup of WiFi, the url is set to http://192.168.4.1/setup, but the ESP takes ip from DHCP server, and url become wrong.
