### PR TITLE
Blynk controler

### DIFF
--- a/Command.ino
+++ b/Command.ino
@@ -27,12 +27,12 @@ void ExecuteCommand(byte source, const char *Line)
     Serial.print(int(loopCounterLast / 30));
     Serial.println(F(")"));
   }
-  
+
   if (strcasecmp_P(Command, PSTR("SerialFloat")) == 0)
   {
     success = true;
-    pinMode(1,INPUT);
-    pinMode(3,INPUT);
+    pinMode(1, INPUT);
+    pinMode(3, INPUT);
     delay(60000);
   }
 
@@ -110,7 +110,7 @@ void ExecuteCommand(byte source, const char *Line)
   if (strcasecmp_P(Command, PSTR("TaskRun")) == 0)
   {
     success = true;
-    SensorSendTask(Par1 -1);
+    SensorSendTask(Par1 - 1);
   }
 
   if (strcasecmp_P(Command, PSTR("TimerSet")) == 0)
@@ -152,7 +152,7 @@ void ExecuteCommand(byte source, const char *Line)
     int index = event.indexOf(',');
     if (index > 0)
     {
-      event = event.substring(index+1);
+      event = event.substring(index + 1);
       SendUDPCommand(Par1, (char*)event.c_str(), event.length());
     }
   }
@@ -165,19 +165,19 @@ void ExecuteCommand(byte source, const char *Line)
     int index = event.indexOf(',');
     if (index > 0)
     {
-      String topic = event.substring(0,index);
-      String value = event.substring(index+1);
-      MQTTclient.publish(topic.c_str(), value.c_str(),Settings.MQTTRetainFlag);
+      String topic = event.substring(0, index);
+      String value = event.substring(index + 1);
+      MQTTclient.publish(topic.c_str(), value.c_str(), Settings.MQTTRetainFlag);
     }
   }
-  
+
   if (strcasecmp_P(Command, PSTR("SendToUDP")) == 0)
   {
     success = true;
     String strLine = Line;
-    String ip = parseString(strLine,2);
-    String port = parseString(strLine,3);
-    int msgpos = getParamStartPos(strLine,4);
+    String ip = parseString(strLine, 2);
+    String port = parseString(strLine, 3);
+    int msgpos = getParamStartPos(strLine, 4);
     String message = strLine.substring(msgpos);
     byte ipaddress[4];
     str2ip((char*)ip.c_str(), ipaddress);
@@ -191,16 +191,16 @@ void ExecuteCommand(byte source, const char *Line)
   {
     success = true;
     String strLine = Line;
-    String host = parseString(strLine,2);
-    String port = parseString(strLine,3);
-    int pathpos = getParamStartPos(strLine,4);
+    String host = parseString(strLine, 2);
+    String port = parseString(strLine, 3);
+    int pathpos = getParamStartPos(strLine, 4);
     String path = strLine.substring(pathpos);
     WiFiClient client;
     if (client.connect(host.c_str(), port.toInt()))
     {
       client.print(String("GET ") + path + " HTTP/1.1\r\n" +
-                 "Host: " + host + "\r\n" +
-                 "Connection: close\r\n\r\n");
+                   "Host: " + host + "\r\n" +
+                   "Connection: close\r\n\r\n");
 
       unsigned long timer = millis() + 200;
       while (!client.available() && millis() < timer)
@@ -250,6 +250,38 @@ void ExecuteCommand(byte source, const char *Line)
   }
 
   // ****************************************
+  // special commands for Blynk
+  // ****************************************
+
+  if (strcasecmp(Command, "BlynkGet") == 0)
+  {
+    String event = Line;
+    event = event.substring(9);
+    int index = event.indexOf(',');
+    if (index > 0)
+    { 
+      int index = event.lastIndexOf(',');
+      String blynkcommand = event.substring(index+1);
+      float value = 0;
+      if (Blynk_get(blynkcommand, &value))
+      {
+        UserVar[(VARS_PER_TASK * (Par1 - 1)) + Par2 - 1] = value;
+      }
+      else
+        status = F("Error getting data");
+    }
+    else
+    {
+      if (!Blynk_get(event))
+      {
+        status = F("Error getting data");
+      }
+    }
+
+  }
+
+
+  // ****************************************
   // configure settings commands
   // ****************************************
   if (strcasecmp_P(Command, PSTR("WifiSSID")) == 0)
@@ -269,19 +301,19 @@ void ExecuteCommand(byte source, const char *Line)
     success = true;
     WifiScan();
   }
-  
+
   if (strcasecmp_P(Command, PSTR("WifiConnect")) == 0)
   {
     success = true;
     WifiConnect(1);
   }
-  
+
   if (strcasecmp_P(Command, PSTR("WifiDisconnect")) == 0)
   {
     success = true;
     WifiDisconnect();
   }
-  
+
   if (strcasecmp_P(Command, PSTR("Reboot")) == 0)
   {
     success = true;
@@ -385,12 +417,12 @@ void ExecuteCommand(byte source, const char *Line)
   }
 
   yield();
-  
+
   if (success)
     status += F("\nOk");
-  else  
+  else
     status += F("\nUnknown command!");
-  SendStatus(source,status);
+  SendStatus(source, status);
   yield();
 }
 

--- a/ESPEasy.ino
+++ b/ESPEasy.ino
@@ -496,6 +496,9 @@ unsigned long flashWrites = 0;
 
 String eventBuffer = "";
 
+// Blynk_get prototype
+boolean Blynk_get(String command,float *data = NULL );
+
 /*********************************************************************************************\
  * SETUP
 \*********************************************************************************************/

--- a/_C011.ino
+++ b/_C011.ino
@@ -1,0 +1,184 @@
+//#######################################################################################################
+//########################### Controller Plugin 011: Blynk  #############################################
+//#######################################################################################################
+
+#define CPLUGIN_011
+#define CPLUGIN_ID_011         1
+#define CPLUGIN_NAME_011       "Blynk HTTP"
+
+
+
+
+boolean CPlugin_011(byte function, struct EventStruct *event, String& string)
+{
+  boolean success = false;
+  
+ 
+
+  switch (function)
+  {
+    case CPLUGIN_PROTOCOL_ADD:
+      {
+        Protocol[++protocolCount].Number = CPLUGIN_ID_011;
+        Protocol[protocolCount].usesMQTT = false;
+        Protocol[protocolCount].usesAccount = false;
+        Protocol[protocolCount].usesPassword = true;
+        Protocol[protocolCount].defaultPort = 8443;
+        break;
+      }
+
+    case CPLUGIN_GET_DEVICENAME:
+      {
+        string = F(CPLUGIN_NAME_011);
+        break;
+      }
+      
+     case CPLUGIN_PROTOCOL_SEND:
+      {
+
+        String postDataStr = "";
+        
+        switch (event->sensorType)
+        {
+          case SENSOR_TYPE_SINGLE:                      // single value sensor, used for Dallas, BH1750, etc
+            postDataStr = F("update/V") ;
+            postDataStr += event->idx;
+            postDataStr += F("?value=");
+            postDataStr += toString(UserVar[event->BaseVarIndex],ExtraTaskSettings.TaskDeviceValueDecimals[0]);
+            Blynk_get(postDataStr );
+            break;
+          case SENSOR_TYPE_TEMP_HUM:                      // dual value
+          case SENSOR_TYPE_TEMP_BARO:
+          case SENSOR_TYPE_DUAL:
+            postDataStr = F("update/V") ;
+            postDataStr += event->idx;
+            postDataStr += F("?value=");
+            postDataStr += toString(UserVar[event->BaseVarIndex],ExtraTaskSettings.TaskDeviceValueDecimals[0]);
+            Blynk_get(postDataStr );
+
+            postDataStr = F("update/V") ;
+            postDataStr += event->idx + 1;
+            postDataStr += F("?value=");
+            postDataStr += toString(UserVar[event->BaseVarIndex + 1],ExtraTaskSettings.TaskDeviceValueDecimals[1]);
+            Blynk_get(postDataStr );
+            break;
+          case SENSOR_TYPE_TEMP_HUM_BARO:
+          case SENSOR_TYPE_TRIPLE:
+            postDataStr = F("update/V") ;
+            postDataStr += event->idx;
+            postDataStr += F("?value=");
+            postDataStr += toString(UserVar[event->BaseVarIndex],ExtraTaskSettings.TaskDeviceValueDecimals[0]);
+            Blynk_get(postDataStr );
+
+            postDataStr = F("update/V") ;
+            postDataStr += event->idx + 1;
+            postDataStr += F("?value=");
+            postDataStr += toString(UserVar[event->BaseVarIndex + 1],ExtraTaskSettings.TaskDeviceValueDecimals[1]);
+            Blynk_get(postDataStr );
+
+            postDataStr = F("update/V") ;
+            postDataStr += event->idx + 2;
+            postDataStr += F("?value=");
+            postDataStr += toString(UserVar[event->BaseVarIndex + 2],ExtraTaskSettings.TaskDeviceValueDecimals[2]);
+            Blynk_get(postDataStr );
+
+            break;
+          case SENSOR_TYPE_SWITCH:
+            break;
+        }
+
+
+
+        break;
+      }
+
+  }
+  return success;
+}
+
+boolean Blynk_get(String command,float *data )
+{
+  boolean success = false;
+  char host[20];
+  char log[80];
+  char command_char[50];
+
+  command.toCharArray(command_char, 50);
+
+  sprintf_P(host, PSTR("%u.%u.%u.%u"), Settings.Controller_IP[0], Settings.Controller_IP[1], Settings.Controller_IP[2], Settings.Controller_IP[3]);
+
+  // Use WiFiClient class to create TCP connections
+  WiFiClient client;
+  if (!client.connect(host, Settings.ControllerPort))
+  {
+    connectionFailures++;
+    return false;
+  }
+  if (connectionFailures)
+    connectionFailures--;
+
+  // We now create a URI for the request
+  char requete[300];
+  sprintf_P(requete, PSTR("GET /%s/%s HTTP/1.1\r\n Host: %s \r\n Connection: close\r\n\r\n"),SecuritySettings.ControllerPassword,command_char , host   );
+  addLog(LOG_LEVEL_DEBUG, requete);
+  client.print(requete);
+  
+  unsigned long timer = millis() + 200;
+  while (!client.available() && millis() < timer)
+    delay(1);
+    
+  // Read all the lines of the reply from server and print them to Serial
+
+  while (client.available()) {
+
+    String line = client.readStringUntil('\n');
+
+    // success ?
+    if (line.substring(0, 15) == "HTTP/1.1 200 OK") {
+      strcpy_P(log, PSTR("HTTP : Success"));
+      success = true;
+    }
+    else if (line.substring(0, 24) == "HTTP/1.1 400 Bad Request") {
+      strcpy_P(log, PSTR("HTTP : Unauthorized"));
+    }
+    else if (line.substring(0, 25) == "HTTP/1.1 401 Unauthorized") {
+      strcpy_P(log, PSTR("HTTP : Unauthorized"));
+    }
+    addLog(LOG_LEVEL_DEBUG, log);
+
+    // data only
+    if (data && line.startsWith("["))
+    {
+      String strValue = line;
+      byte pos = strValue.indexOf('"',2);
+      strValue = strValue.substring(2, pos);
+      strValue.trim();
+      float value = strValue.toFloat();
+      *data = value;
+      success = true;
+
+      char value_char[5] ;
+      strValue.toCharArray(value_char, 5);
+      sprintf_P(log, PSTR("Blynk get - %s => %s"),command_char , value_char   );
+      addLog(LOG_LEVEL_DEBUG, log);
+    }
+
+    
+  }
+  strcpy_P(log, PSTR("HTTP : closing connection"));
+  addLog(LOG_LEVEL_DEBUG, log);
+
+  client.flush();
+  client.stop();
+
+  // important - backgroudtasks - free mem
+  timer = millis() + Settings.MessageDelay;
+  while (millis() < timer)
+              backgroundtasks();
+  
+  return success;
+}
+
+
+
+


### PR DESCRIPTION
Adding a new controler for Blynk.

Presentation on the site http://www.blynk.cc/.
"Blynk is a Platform with iOS and Android apps to control Arduino, Raspberry Pi and the likes over the Internet.
It's a digital dashboard where you can build a graphic interface for your project by simply dragging and dropping widgets."

With this controlling, we can:
- Send the information to Blynk server
- Retrieve information on the server and assign it to a dummy value (as TaskValueSet)

Prerequisite:
- An account on Blynk Cloud or a local server with Blynk server
- The token linked to the account

The controller is based on the HTTP API (http://docs.blynkapi.apiary.io/)
In this version, we can use all APIs GET:
- Get pin value
- Write pin value via GET
- Set Widget Property via GET
- Hardware network status
- Application network status

Example of use in the rules:

On System#Boot do    //When the ESP boots, do
  GPIO,12,0   // relay off
  BlynkGet update/V30?value=7    // set thermostat in app to 7
  BlynkGet update/V32?value=-    //  set temp in app to "-" before the true temp
  TaskValueSet 2,1,7                     //  set dummy thermostat to 7
  timerSet,1,60    //Set Timer 1 for the next event in 60 seconds 
endon


On Rules#Timer=1 do  //When Timer1 expires, do
  BlynkGet 2,1,get/V30                  // get thermostat value and affect to dummy thermostat in ESPEasy
  if [Thermostat#temp_limite] < [DHT#Temperature]
    gpio,12,0                                   // relay off
    BlynkGet update/V31?value=0       // LED in app off
  else
    gpio,12,1                                   // relay on
    BlynkGet update/V31?value=255        // LED in app on
  endif

  timerSet,1,60     //Set Timer 1 for the next event in 60 second
endon