### PR TITLE
Feature tx power

### DIFF
--- a/ESPEasy.ino
+++ b/ESPEasy.ino
@@ -86,6 +86,7 @@
 #define DEFAULT_DNS         "192.168.0.1"       // Enter your DNS
 #define DEFAULT_GW          "192.168.0.1"       // Enter your gateway
 #define DEFAULT_SUBNET      "255.255.255.0"     // Enter your subnet
+#define DEFAULT_TXPOWER     19.5                // default Tx Power
 
 #define DEFAULT_MQTT_TEMPLATE false              // true or false enabled or disabled set mqqt sub and pub
 #define DEFAULT_MQTT_PUB    "sensors/espeasy/%sysname%/%tskname%/%valname%" // Enter your pub
@@ -348,6 +349,7 @@ struct SettingsStruct
   int16_t       TimeZone;
   boolean       MQTTRetainFlag;
   boolean       InitSPI; 
+  float         TxPower;
 } Settings;
 
 struct ExtraTaskSettingsStruct

--- a/Misc.ino
+++ b/Misc.ino
@@ -977,6 +977,8 @@ void ResetFactory(void)
   Settings.deepSleep = false;
   Settings.CustomCSS = false;
   Settings.InitSPI = false;
+  Settings.TxPower = DEFAULT_TXPOWER;
+  
   for (byte x = 0; x < TASKS_MAX; x++)
   {
     Settings.TaskDevicePin1[x] = -1;

--- a/WebServer.ino
+++ b/WebServer.ino
@@ -353,6 +353,7 @@ void handle_config() {
   String password = WebServer.arg("password");
   String ssid = WebServer.arg("ssid");
   String key = WebServer.arg("key");
+  String TxPower = WebServer.arg("txpower");
   String usedns = WebServer.arg("usedns");
   String controllerip = WebServer.arg("controllerip");
   String controllerhostname = WebServer.arg("controllerhostname");
@@ -423,6 +424,7 @@ void handle_config() {
     espdns.toCharArray(tmpString, 26);
     str2ip(tmpString, Settings.DNS);
     Settings.Unit = unit.toInt();
+    Settings.TxPower=TxPower.toFloat();
     SaveSettings();
   }
 
@@ -443,6 +445,9 @@ void handle_config() {
 
   reply += F("'><TR><TD>WPA AP Mode Key:<TD><input type='text' maxlength='63' name='apkey' value='");
   reply += SecuritySettings.WifiAPKey;
+
+  reply += F("'><TR><TD>WiFi Transmit Power:<TD><input type='text' maxlength='4' name='txpower' value='");
+  reply += Settings.TxPower;
 
   reply += F("'><TR><TD>Unit nr:<TD><input type='text' name='unit' value='");
   reply += Settings.Unit;

--- a/Wifi.ino
+++ b/Wifi.ino
@@ -46,6 +46,7 @@ boolean WifiConnect(byte connectAttempts)
     if (hostName[x] == ' ')
       hostName[x] = '-';
   wifi_station_set_hostname(hostName);
+  WiFi.setOutputPower(Settings.TxPower);
   
   if (Settings.IP[0] != 0 && Settings.IP[0] != 255)
   {

--- a/_P035_IRTX.ino
+++ b/_P035_IRTX.ino
@@ -57,7 +57,7 @@ boolean Plugin_035(byte function, struct EventStruct *event, String& string)
       {
         String IrType;
         unsigned long IrCode;
-        unsigned int IrBits;
+        unsigned int IrBits, IrRep, IrWait;
         char command[80];
         command[0] = 0;
         char TmpStr1[80];
@@ -71,19 +71,32 @@ boolean Plugin_035(byte function, struct EventStruct *event, String& string)
         if (GetArgv(command, TmpStr1, 2)) IrType = TmpStr1;
         if (GetArgv(command, TmpStr1, 3)) IrCode = strtoul(TmpStr1, NULL, 16); //(long) TmpStr1
         if (GetArgv(command, TmpStr1, 4)) IrBits = str2int(TmpStr1);
-
+        if (GetArgv(command, TmpStr1, 5)){
+          IrRep  = str2int(TmpStr1);
+          if (GetArgv(command, TmpStr1, 6)) {
+            IrWait = str2int(TmpStr1);
+          }else{
+            IrWait=10;
+          }
+        }else{
+          IrWait = 1;
+          IrRep  = 1;
+        }
         if (tmpString.equalsIgnoreCase("IRSEND") && Plugin_035_irSender != 0)
         {
           success = true;
           if (irReceiver != 0) irReceiver->disableIRIn(); // Stop the receiver
 
-          if (IrType.equalsIgnoreCase("NEC")) Plugin_035_irSender->sendNEC(IrCode, IrBits);
-          if (IrType.equalsIgnoreCase("JVC")) Plugin_035_irSender->sendJVC(IrCode, IrBits, 2);
-          if (IrType.equalsIgnoreCase("RC5")) Plugin_035_irSender->sendRC5(IrCode, IrBits);
-          if (IrType.equalsIgnoreCase("RC6")) Plugin_035_irSender->sendRC6(IrCode, IrBits);
-          if (IrType.equalsIgnoreCase("SAMSUNG")) Plugin_035_irSender->sendSAMSUNG(IrCode, IrBits);
-          if (IrType.equalsIgnoreCase("SONY")) Plugin_035_irSender->sendSony(IrCode, IrBits);
-          if (IrType.equalsIgnoreCase("PANASONIC")) Plugin_035_irSender->sendPanasonic(IrBits, IrCode);
+          for(int l=0;l<=IrRep;l++){
+            if (IrType.equalsIgnoreCase("NEC")) Plugin_035_irSender->sendNEC(IrCode, IrBits);
+            if (IrType.equalsIgnoreCase("JVC")) Plugin_035_irSender->sendJVC(IrCode, IrBits, 2);
+            if (IrType.equalsIgnoreCase("RC5")) Plugin_035_irSender->sendRC5(IrCode, IrBits);
+            if (IrType.equalsIgnoreCase("RC6")) Plugin_035_irSender->sendRC6(IrCode, IrBits);
+            if (IrType.equalsIgnoreCase("SAMSUNG")) Plugin_035_irSender->sendSAMSUNG(IrCode, IrBits);
+            if (IrType.equalsIgnoreCase("SONY")) Plugin_035_irSender->sendSony(IrCode, IrBits);
+            if (IrType.equalsIgnoreCase("PANASONIC")) Plugin_035_irSender->sendPanasonic(IrBits, IrCode);
+            delay(IrWait);
+          }
 
           addLog(LOG_LEVEL_INFO, "IR Code Sent");
           if (printToWeb)


### PR DESCRIPTION
added config option to set the Tx Power in the ESP8266.
This may be helpful when trying to save energy (reducing TxPower significantly reduces the peak current consumption during wifi activity) and, in my case, it was necessary to eliminate false positives from a PIR sensor. I had tried to eliminate the effect by adding caps to the supply lines, but it seems to be an rf issue.

This is my first contribution to espeasy, I think I hit the right places and didn't break anything (hence why I put my new variable at the end of the Settings array).

Changing this setting requires, at this point, a reboot, since I only set the TxPower at WLAN enable.