### PR TITLE
Fix double define

### DIFF
--- a/src/_C001.ino
+++ b/src/_C001.ino
@@ -139,11 +139,12 @@ boolean CPlugin_001(byte function, struct EventStruct *event, String& string)
             case (SENSOR_TYPE_WIND):
               url += F("&svalue=");                   // WindDir in degrees; WindDir as text; Wind speed average ; Wind speed gust; 0
               url += toString(UserVar[event->BaseVarIndex],ExtraTaskSettings.TaskDeviceValueDecimals[0]);
-              char* bearing[] = {";N;",";NNE;",";NE;",";ENE;",";E;",";ESE;",";SE;",";SSE;",";S;",";SSW;",";SW;",";WSW;",";W;",";WNW;",";NW;",";NNW;" };
+              const char* bearing[] = {";N;",";NNE;",";NE;",";ENE;",";E;",";ESE;",";SE;",";SSE;",";S;",";SSW;",";SW;",";WSW;",";W;",";WNW;",";NW;",";NNW;" };
               url += bearing[int(UserVar[event->BaseVarIndex] / 22.5)];
-              url += toString(UserVar[event->BaseVarIndex + 1],ExtraTaskSettings.TaskDeviceValueDecimals[1]);
+              // Domoticz expects the wind speed in (m/s * 10)
+              url += toString((UserVar[event->BaseVarIndex + 1] * 10),ExtraTaskSettings.TaskDeviceValueDecimals[1]);
               url += ";";
-              url += toString(UserVar[event->BaseVarIndex + 2],ExtraTaskSettings.TaskDeviceValueDecimals[2]);
+              url += toString((UserVar[event->BaseVarIndex + 2] * 10),ExtraTaskSettings.TaskDeviceValueDecimals[2]);
               url += ";0";
               break;
           }

--- a/src/_C002.ino
+++ b/src/_C002.ino
@@ -203,11 +203,12 @@ boolean CPlugin_002(byte function, struct EventStruct *event, String& string)
               break;
             case SENSOR_TYPE_WIND:                            // WindDir in degrees; WindDir as text; Wind speed average ; Wind speed gust
               values  = toString(UserVar[event->BaseVarIndex],ExtraTaskSettings.TaskDeviceValueDecimals[0]);
-              char* bearing[] = {";N;",";NNE;",";NE;",";ENE;",";E;",";ESE;",";SE;",";SSE;",";S;",";SSW;",";SW;",";WSW;",";W;",";WNW;",";NW;",";NNW;" };
+              const char* bearing[] = {";N;",";NNE;",";NE;",";ENE;",";E;",";ESE;",";SE;",";SSE;",";S;",";SSW;",";SW;",";WSW;",";W;",";WNW;",";NW;",";NNW;" };
               values += bearing[int(UserVar[event->BaseVarIndex] / 22.5)];
-              values += toString(UserVar[event->BaseVarIndex + 1],ExtraTaskSettings.TaskDeviceValueDecimals[1]);
+              // Domoticz expects the wind speed in (m/s * 10)
+              values += toString((UserVar[event->BaseVarIndex + 1] * 10),ExtraTaskSettings.TaskDeviceValueDecimals[1]);
               values += ";";
-              values += toString(UserVar[event->BaseVarIndex + 2],ExtraTaskSettings.TaskDeviceValueDecimals[2]);
+              values += toString((UserVar[event->BaseVarIndex + 2] * 10),ExtraTaskSettings.TaskDeviceValueDecimals[2]);
               values += ";0;0";
               values.toCharArray(str, 80);
               root["svalue"] =  str;
@@ -247,4 +248,3 @@ boolean CPlugin_002(byte function, struct EventStruct *event, String& string)
   }
   return success;
 }
-

--- a/src/_P020_Ser2Net.ino
+++ b/src/_P020_Ser2Net.ino
@@ -7,7 +7,7 @@
 #define PLUGIN_NAME_020       "Serial Server"
 #define PLUGIN_VALUENAME1_020 "Ser2Net"
 
-#define BUFFER_SIZE 128
+#define P020_BUFFER_SIZE 128
 boolean Plugin_020_init = false;
 byte Plugin_020_SerialProcessing = 0;
 
@@ -179,17 +179,17 @@ boolean Plugin_020(byte function, struct EventStruct *event, String& string)
           if (ser2netClient.connected())
           {
             connectionState = 1;
-            uint8_t net_buf[BUFFER_SIZE];
+            uint8_t net_buf[P020_BUFFER_SIZE];
             int count = ser2netClient.available();
             if (count > 0)
             {
-              if (count > BUFFER_SIZE)
-                count = BUFFER_SIZE;
+              if (count > P020_BUFFER_SIZE)
+                count = P020_BUFFER_SIZE;
               bytes_read = ser2netClient.read(net_buf, count);
               Serial.write(net_buf, bytes_read);
               Serial.flush(); // Waits for the transmission of outgoing serial data to complete
 
-              if (count == BUFFER_SIZE) // if we have a full buffer, drop the last position to stuff with string end marker
+              if (count == P020_BUFFER_SIZE) // if we have a full buffer, drop the last position to stuff with string end marker
               {
                 count--;
                 char log[40];
@@ -197,7 +197,7 @@ boolean Plugin_020(byte function, struct EventStruct *event, String& string)
                 addLog(LOG_LEVEL_ERROR, log);
               }
               net_buf[count] = 0; // before logging as a char array, zero terminate the last position to be safe.
-              char log[BUFFER_SIZE + 40];
+              char log[P020_BUFFER_SIZE + 40];
               sprintf_P(log, PSTR("Ser2N: N>: %s"), (char*)net_buf);
               addLog(LOG_LEVEL_DEBUG, log);
             }
@@ -223,7 +223,7 @@ boolean Plugin_020(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_SERIAL_IN:
       {
-        uint8_t serial_buf[BUFFER_SIZE];
+        uint8_t serial_buf[P020_BUFFER_SIZE];
         int RXWait = Settings.TaskDevicePluginConfig[event->TaskIndex][0];
         if (RXWait == 0)
           RXWait = 1;
@@ -232,7 +232,7 @@ boolean Plugin_020(byte function, struct EventStruct *event, String& string)
         while (timeOut > 0)
         {
           while (Serial.available()) {
-            if (bytes_read < BUFFER_SIZE) {
+            if (bytes_read < P020_BUFFER_SIZE) {
               serial_buf[bytes_read] = Serial.read();
               bytes_read++;
             }
@@ -245,7 +245,7 @@ boolean Plugin_020(byte function, struct EventStruct *event, String& string)
           timeOut--;
         }
 
-        if (bytes_read != BUFFER_SIZE)
+        if (bytes_read != P020_BUFFER_SIZE)
         {
           if (bytes_read > 0) {
             if (Plugin_020_init && ser2netClient.connected())
@@ -265,7 +265,7 @@ boolean Plugin_020(byte function, struct EventStruct *event, String& string)
           addLog(LOG_LEVEL_ERROR, log);
         }
         serial_buf[bytes_read] = 0; // before logging as a char array, zero terminate the last position to be safe.
-        char log[BUFFER_SIZE + 40];
+        char log[P020_BUFFER_SIZE + 40];
         sprintf_P(log, PSTR("Ser2N: S>: %s"), (char*)serial_buf);
         addLog(LOG_LEVEL_DEBUG, log);
 
@@ -330,4 +330,3 @@ boolean Plugin_020(byte function, struct EventStruct *event, String& string)
   }
   return success;
 }
-

--- a/src/_P044_P1WifiGateway.ino
+++ b/src/_P044_P1WifiGateway.ino
@@ -14,7 +14,7 @@
 #define PLUGIN_VALUENAME1_044 "P1WifiGateway"
 
 #define STATUS_LED 12
-#define BUFFER_SIZE 1024
+#define P044_BUFFER_SIZE 1024
 #define NETBUF_SIZE 600
 #define DISABLED 0
 #define WAITING 1
@@ -145,7 +145,7 @@ boolean Plugin_044(byte function, struct EventStruct *event, String& string)
           P1GatewayServer->begin();
 
           if (!Plugin_044_serial_buf)
-            Plugin_044_serial_buf = (char *)malloc(BUFFER_SIZE);
+            Plugin_044_serial_buf = (char *)malloc(P044_BUFFER_SIZE);
 
           if (Settings.TaskDevicePin1[event->TaskIndex] != -1)
           {
@@ -194,17 +194,17 @@ boolean Plugin_044(byte function, struct EventStruct *event, String& string)
           if (P1GatewayClient.connected())
           {
             connectionState = 1;
-            uint8_t net_buf[BUFFER_SIZE];
+            uint8_t net_buf[P044_BUFFER_SIZE];
             int count = P1GatewayClient.available();
             if (count > 0)
             {
-              if (count > BUFFER_SIZE)
-                count = BUFFER_SIZE;
+              if (count > P044_BUFFER_SIZE)
+                count = P044_BUFFER_SIZE;
               bytes_read = P1GatewayClient.read(net_buf, count);
               Serial.write(net_buf, bytes_read);
               Serial.flush(); // Waits for the transmission of outgoing serial data to complete
 
-              if (count == BUFFER_SIZE) // if we have a full buffer, drop the last position to stuff with string end marker
+              if (count == P044_BUFFER_SIZE) // if we have a full buffer, drop the last position to stuff with string end marker
               {
                 count--;
                 char log[40];
@@ -212,7 +212,7 @@ boolean Plugin_044(byte function, struct EventStruct *event, String& string)
                 addLog(LOG_LEVEL_ERROR, log);
               }
               net_buf[count] = 0; // before logging as a char array, zero terminate the last position to be safe.
-              char log[BUFFER_SIZE + 40];
+              char log[P044_BUFFER_SIZE + 40];
               sprintf_P(log, PSTR("P1   : Error: N>: %s"), (char*)net_buf);
               addLog(LOG_LEVEL_DEBUG, log);
             }
@@ -249,7 +249,7 @@ boolean Plugin_044(byte function, struct EventStruct *event, String& string)
             while (timeOut > 0)
             {
               while (Serial.available() && state != DONE) {
-                if (bytes_read < BUFFER_SIZE - 5) {
+                if (bytes_read < P044_BUFFER_SIZE - 5) {
                   char  ch = Serial.read();
                   digitalWrite(STATUS_LED, 1);
                   switch (state) {
@@ -424,7 +424,7 @@ bool checkDatagram(int len) {
   if (serialdebug) {
     Serial.print(F("input length: "));
     Serial.println(len);
-    Serial.print("Start char \ : ");
+    Serial.print("Start char \\ : ");
     Serial.println(startChar);
     Serial.print(F("End char ! : "));
     Serial.println(endChar);
@@ -451,4 +451,3 @@ bool checkDatagram(int len) {
   }
   return validCRCFound;
 }
-

--- a/src/_P046_VentusW266.ino
+++ b/src/_P046_VentusW266.ino
@@ -23,7 +23,7 @@
 
 // The Ventus W266 remote has the following sensor outputs:
 // Humidity, Temperature, Wind direction, Wind avarage, Wind gust, Rainfall, UV and Lightning. That is
-// more than te maximum of 4 values per device for espeasy. The plugins functionality is therefore 
+// more than te maximum of 4 values per device for espeasy. The plugins functionality is therefore
 // devided per sensorgroup. To read all the sensor data you need to run 6 instances of the plugin.
 
 // The plugin can (and should) be used more then one time, however only one plugin instance can be
@@ -52,7 +52,7 @@
 // hh=humidity (bcd) > Humidity is bcd encoded
 // tlth=temperature-low/temphigh (*10) > Temperature is stored as a 16bit integer holding the temperature in Celcius * 10 but low byte first.
 // b=battery (1=low) > This byte is 00 but 01 when the battery of the transmitter runs low
-// wb=bearing (cw0-15) > The windbearing in 16 clockwise steps (0 = north, 4 = east, 8 = south and C = west) 
+// wb=bearing (cw0-15) > The windbearing in 16 clockwise steps (0 = north, 4 = east, 8 = south and C = west)
 // alah=windaverage-low/high (m/s/2) > A 16 bit int holding the wind avarage in m/s * 2, low byte first
 // rlrh=rainfall-low/high (1/4mm) > A 16 bit int holding the wind gust in m/s * 2, low byte first
 // uv=uvindex (*10) > The UV value * 10
@@ -71,14 +71,14 @@
 //        Needs work on a sliding window for the lightning detection.
 //        When porting be beware of the fact that the esp8266 uses 4 bytes as an int when reading the temperature.
 //
-// This plugin is based on the work of the Plugin 199: RF KaKu receiver/sender and Plugin 026: Analog. 
-// CRC calculation is based on the works by Paul Stoffregen from the 1-Wire arduino library. Special 
+// This plugin is based on the work of the Plugin 199: RF KaKu receiver/sender and Plugin 026: Analog.
+// CRC calculation is based on the works by Paul Stoffregen from the 1-Wire arduino library. Special
 // thanks to Greg Cook and the team behind reveng.sourceforge.net.
 
 #ifdef PLUGIN_BUILD_TESTING
 
 #define PLUGIN_046_DEBUG            true                        // Shows recieved frames and crc in log@INFO
- 
+
 #define PLUGIN_046                                              // Mandatory framework constants
 #define PLUGIN_ID_046               046
 #define PLUGIN_NAME_046             "Ventus W266 [TESTING]"
@@ -119,7 +119,7 @@ void Plugin_046_ISR_SCLK() ICACHE_RAM_ATTR;
 boolean Plugin_046(byte function, struct EventStruct *event, String& string)
 {
   boolean success = false;
-  
+
   switch (function)
   {
     case PLUGIN_DEVICE_ADD:
@@ -132,7 +132,7 @@ boolean Plugin_046(byte function, struct EventStruct *event, String& string)
         Device[deviceCount].InverseLogicOption = false;
         Device[deviceCount].FormulaOption = true;
         Device[deviceCount].SendDataOption = true;
-        Device[deviceCount].ValueCount = 3;                     
+        Device[deviceCount].ValueCount = 3;
         break;
       }
 
@@ -147,11 +147,11 @@ boolean Plugin_046(byte function, struct EventStruct *event, String& string)
         options[3] = F("UV");
         options[4] = F("Lightning strikes");
         options[5] = F("Lightning distance");
-        
+
         options[6] = F("Unknown 1, byte 6");
         options[7] = F("Unknown 2, byte 16");
         options[8] = F("Unknown 3, byte 19");
-        
+
         int optionValues[nrchoices];
         for (byte x = 0; x < nrchoices; x++) {
           optionValues[x] = x;
@@ -185,62 +185,62 @@ boolean Plugin_046(byte function, struct EventStruct *event, String& string)
           {
             string += F("<TR><TD><B>Be sure you only have 1 main plugin!</B></TD>");
             string += F("<TR><TD>Value 1: Temperature, 1 decimal<BR>Value 2: Humidity, 0 decimals");
-            string += F("<BR>Value 3: not used</TD>");         
+            string += F("<BR>Value 3: not used</TD>");
             break;
           }
           case (1):
           {
             string += F("<TR><TD>Value 1: Direction, 0 decimals<BR>");
-            string += F("Value 2: Average, 1 decimal<Br>Value 3: Gust, 1 decimal</TD>");                     
+            string += F("Value 2: Average, 1 decimal<Br>Value 3: Gust, 1 decimal</TD>");
             break;
           }
           case (2):
           {
-            string += F("<TR><TD>Value 1: Rain in mm per hour<BR>Value 2: Total rain in mm");                     
-            string += F("<BR>Value 3: not used</TD>");         
+            string += F("<TR><TD>Value 1: Rain in mm per hour<BR>Value 2: Total rain in mm");
+            string += F("<BR>Value 3: not used</TD>");
             break;
           }
           case (3):
           {
-            string += F("<TR><TD>Value 1: UV, 1 decimal");                     
-            string += F("<BR>Values 2, 3</TD>");         
+            string += F("<TR><TD>Value 1: UV, 1 decimal");
+            string += F("<BR>Values 2, 3</TD>");
             break;
           }
           case (4):
           {
             string += F("<TR><TD>Value 1: Strikes this hour, 0 decimals");
-            string += F("<BR>Values 2, 3: not used</TD>");                     
+            string += F("<BR>Values 2, 3: not used</TD>");
             break;
           }
           case (5):
           {
             string += F("<TR><TD>Value 1: Distance in km, 0 decimals");
-            string += F("<BR>Values 2, 3: not used</TD>");                     
+            string += F("<BR>Values 2, 3: not used</TD>");
             break;
           }
           case (6):
           {
             string += F("<TR><TD>Value 1: Batterybyte, 0 decimals");
-            string += F("<BR>Values 2, 3: not used</TD>"); 
+            string += F("<BR>Values 2, 3: not used</TD>");
             break;
           }
           case (7):
           {
             string += F("<TR><TD>Value 1: Last rainbyte, 0 decimals");
-            string += F("<BR>Values 2, 3: not used</TD>");                     
+            string += F("<BR>Values 2, 3: not used</TD>");
             break;
           }
           case (8):
           {
             string += F("<TR><TD>Value 1: Last lightningbyte, 0 decimals");
-            string += F("<BR>Values 2, 3: not used</TD>"); 
+            string += F("<BR>Values 2, 3: not used</TD>");
             break;
           }
         }
 
         success = true;
         break;
-      }    
+      }
 
     case PLUGIN_WEBFORM_SAVE:
       {
@@ -259,7 +259,7 @@ boolean Plugin_046(byte function, struct EventStruct *event, String& string)
         success = true;
         break;
       }
-      
+
     case PLUGIN_GET_DEVICENAME:
       {
         string = F(PLUGIN_NAME_046);
@@ -308,7 +308,7 @@ boolean Plugin_046(byte function, struct EventStruct *event, String& string)
     case PLUGIN_TEN_PER_SECOND:
       {
         if (Settings.TaskDevicePluginConfig[event->TaskIndex][0] == 0) {
-          if (Plugin_046_newData) {                                           
+          if (Plugin_046_newData) {
             uint8_t crc = 0xff;                                             // init = 0xff
             char data; // CRC = MAXIM with modified init: poly 0x31, init 0xff, refin 1; refout 1, xorout 0x00
             // Copy recieved data to buffer and check CRC
@@ -364,8 +364,8 @@ boolean Plugin_046(byte function, struct EventStruct *event, String& string)
         }
         success = true;
         break;
-      }    
-        
+      }
+
     case PLUGIN_READ:
       {
         if (Plugin_046_databuffer[0] == Plugin_046_MagicByte) // buffer[0] should be the MagicByte if valid
@@ -375,7 +375,7 @@ boolean Plugin_046(byte function, struct EventStruct *event, String& string)
           switch (choice)
           {
             case (0):
-            { 
+            {
               int myTemp = int((Plugin_046_databuffer[5] * 256) + Plugin_046_databuffer[4]);
               if (myTemp > 0x8000) { myTemp |= 0xffff0000; }                    // int @ esp8266 = 32 bits!
               float temperature = float(myTemp) / 10.0; // Temperature
@@ -388,10 +388,10 @@ boolean Plugin_046(byte function, struct EventStruct *event, String& string)
             }
             case (1):
             {
-              float average = float((Plugin_046_databuffer[11]) * 256 + Plugin_046_databuffer[10]);    // Wind speed average in 10 * m/s
-              float gust = float((Plugin_046_databuffer[13]) * 256 + Plugin_046_databuffer[12]);       // Wind speed gust in 10 * m/s
-              float bearing = float(Plugin_046_databuffer[9] & 0x0f) * 22.5;                          // Wind bearing (0-359)
-              UserVar[event->BaseVarIndex] = bearing;                                                 // degrees
+              float average = float((Plugin_046_databuffer[11] << 8) + Plugin_046_databuffer[10]) / 10;   // Wind speed average in m/s
+              float gust = float((Plugin_046_databuffer[13] << 8) + Plugin_046_databuffer[12]) / 10;      // Wind speed gust in m/s
+              float bearing = float(Plugin_046_databuffer[9] & 0x0f) * 22.5;                              // Wind bearing (0-359)
+              UserVar[event->BaseVarIndex] = bearing;                                                     // degrees
               UserVar[event->BaseVarIndex + 1] = average;
               UserVar[event->BaseVarIndex + 2] = gust;
               event->sensorType = SENSOR_TYPE_WIND;
@@ -442,7 +442,7 @@ boolean Plugin_046(byte function, struct EventStruct *event, String& string)
               UserVar[event->BaseVarIndex] = float(Plugin_046_strikesph);
               break;
             }
-            case (5): 
+            case (5):
             {
               float distance = float(-1);
               if (Plugin_046_databuffer[18] != 0x3F )
@@ -468,7 +468,7 @@ boolean Plugin_046(byte function, struct EventStruct *event, String& string)
               break;
             }
           }   // switch
-          success = true; 
+          success = true;
         } else {
           success = false;  // No data received yet or incorrect CRC so do not publish any data
         }


### PR DESCRIPTION
Both plugins declared BUFFER_SIZE. Changed both declares by adding a
prefix “PXXX_”.

P1WifiGateway used a backslash which caused a escape character warning
in the compiler, changed this a double backslash.