### PR TITLE
cancel deep sleep loop by pulling the pin GPIO16(D0) to GND

### DIFF
--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -3,6 +3,18 @@ void deepSleep(int delay)
 {
   String log;
 
+  //cancel deep sleep loop by pulling the pin GPIO16(D0) to GND
+  //recommended wiring: 3-pin-header with 1=RST, 2=D0, 3=GND
+  //                    short 1-2 for normal deep sleep / wakeup loop
+  //                    short 2-3 to cancel sleep loop for modifying settings
+  pinMode(16,INPUT_PULLUP);
+  if (!digitalRead(16))
+  {
+    log = F("Deep sleep canceled by GPIO16(D0)=LOW.");
+    addLog(LOG_LEVEL_INFO, log);
+    return;
+  }
+
   //first time deep sleep? offer a way to escape
   if (lastBootCause!=BOOT_CAUSE_DEEP_SLEEP)
   {


### PR DESCRIPTION
On using a smart-phone to change settings a 30 sec limit is a challenge for changing settings. I use a jumper to keep the ESP out of sleep without time restriction.
If GPIO16 is hard-wired to RST this code has no influence.

recommended wiring: 3-pin-header with 1=RST, 2=D0, 3=GND
- short 1-2 for normal deep sleep / wakeup loop
- short 2-3 to cancel sleep loop for modifying settings

