### PR TITLE
Update IRremoteESP8266 library url in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/bblanchon/ArduinoJson.git
 [submodule "lib/IRremoteESP8266"]
 	path = lib/IRremoteESP8266
-	url = https://github.com/sebastienwarin/IRremoteESP8266.git
+	url = https://github.com/markszabo/IRremoteESP8266.git
 [submodule "lib/Adafruit_Motor_Shield_V2"]
 	path = lib/Adafruit_Motor_Shield_V2
 	url = https://github.com/adafruit/Adafruit_Motor_Shield_V2_Library.git


### PR DESCRIPTION
Replace the url to the old un-maintained fork of the IRremoteESP8266 library to its upstream canonical (and maintained) library.

This might explain why we've had some odd non-reproducible reports of our (IRremoteESP8266) library not working as expected.

Ref: #188 