### PR TITLE
update sendSony() call to use repeats.

### DIFF
--- a/src/_P035_IRTX.ino
+++ b/src/_P035_IRTX.ino
@@ -170,7 +170,7 @@ boolean Plugin_035(byte function, struct EventStruct *event, String& string)
             if (IrType.equalsIgnoreCase("RC5")) Plugin_035_irSender->sendRC5(IrCode, IrBits);
             if (IrType.equalsIgnoreCase("RC6")) Plugin_035_irSender->sendRC6(IrCode, IrBits);
             if (IrType.equalsIgnoreCase("SAMSUNG")) Plugin_035_irSender->sendSAMSUNG(IrCode, IrBits);
-            if (IrType.equalsIgnoreCase("SONY")) Plugin_035_irSender->sendSony(IrCode, IrBits);
+            if (IrType.equalsIgnoreCase("SONY")) Plugin_035_irSender->sendSony(IrCode, IrBits, 2);
             if (IrType.equalsIgnoreCase("PANASONIC")) Plugin_035_irSender->sendPanasonic(IrBits, IrCode);
           }
 


### PR DESCRIPTION
The SONY IR protocol calls for the remote code to be sent >= 3 times for it to work. Thus you should probably call this with [repeat=2](https://github.com/markszabo/IRremoteESP8266/blob/master/IRremoteESP8266.h#L167). 
Note however, don't merge this until you've updated easyesp to use the correct IRremoteESP8266 library (#188 #189) which has the repeat feature.