### PR TITLE
Environment naming will better fit in...

### DIFF
--- a/src/_P028_BME280.ino
+++ b/src/_P028_BME280.ino
@@ -4,7 +4,7 @@
 
 #define PLUGIN_028
 #define PLUGIN_ID_028        28
-#define PLUGIN_NAME_028       "Temperature & Humidity & Pressure - BME280"
+#define PLUGIN_NAME_028       "Environment - BME280"
 #define PLUGIN_VALUENAME1_028 "Temperature"
 #define PLUGIN_VALUENAME2_028 "Humidity"
 #define PLUGIN_VALUENAME3_028 "Pressure"


### PR DESCRIPTION
"Environment" naming will better fit in instead of the long "Temperature & Humidity & Pressure", and we will get a few char space more to use and it will fit nicely into the drop-down combo box too, otherwise is way to long!