### PR TITLE
Environment naming will better fit in + HTU21D

### DIFF
--- a/src/_P014_SI7021.ino
+++ b/src/_P014_SI7021.ino
@@ -5,7 +5,7 @@
 
 #define PLUGIN_014
 #define PLUGIN_ID_014        14
-#define PLUGIN_NAME_014       "Temperature & Humidity - SI7021"
+#define PLUGIN_NAME_014       "Environment - SI7021/HTU21D"
 #define PLUGIN_VALUENAME1_014 "Temperature"
 #define PLUGIN_VALUENAME2_014 "Humidity"
 


### PR DESCRIPTION
"Environment" naming will better fit in instead of the long "Temperature & Humidity", and we will get a few char space more to use and it will fit nicely into the drop-down combo box too, otherwise is way to long!