### PR TITLE
Environment naming will better fit in... + naming

### DIFF
--- a/src/_P005_DHT.ino
+++ b/src/_P005_DHT.ino
@@ -4,7 +4,7 @@
 
 #define PLUGIN_005
 #define PLUGIN_ID_005         5
-#define PLUGIN_NAME_005       "Temperature & Humidity - DHT"
+#define PLUGIN_NAME_005       "Environment - DHT11/12/22"
 #define PLUGIN_VALUENAME1_005 "Temperature"
 #define PLUGIN_VALUENAME2_005 "Humidity"
 


### PR DESCRIPTION
"Environment" naming will better fit in instead of the long "Temperature & Humidity", and we will get a few char space more to use and it will fit nicely into the drop-down combo box too, otherwise is way to long, plus added sensor naming like DHT11/12/22!