### PR TITLE
Environment naming will better fit in...

### DIFF
--- a/src/_P006_BMP085.ino
+++ b/src/_P006_BMP085.ino
@@ -4,7 +4,7 @@
 
 #define PLUGIN_006
 #define PLUGIN_ID_006        6
-#define PLUGIN_NAME_006       "Temperature & Pressure - BMP085/180"
+#define PLUGIN_NAME_006       "Environment - BMP085/180"
 #define PLUGIN_VALUENAME1_006 "Temperature"
 #define PLUGIN_VALUENAME2_006 "Pressure"
 


### PR DESCRIPTION
"Environment" naming will better fit in instead of the long "Temperature & Pressure", and we will get a few char space more to use and it will fit nicely into the drop-down combo box too, otherwise is way to long!