### PR TITLE
Environment naming will better fit in...

### DIFF
--- a/src/_P030_BMP280.ino
+++ b/src/_P030_BMP280.ino
@@ -4,7 +4,7 @@
 
 #define PLUGIN_030
 #define PLUGIN_ID_030        30
-#define PLUGIN_NAME_030       "Temperature & Pressure - BMP280"
+#define PLUGIN_NAME_030       "Environment - BMP280"
 #define PLUGIN_VALUENAME1_030 "Temperature"
 #define PLUGIN_VALUENAME2_030 "Pressure"
 


### PR DESCRIPTION
"Environment" naming will better fit in instead of the long "Temperature & Pressure", and we will get a few char space more to use and it will fit nicely into the drop-down combo box too, otherwise is way to long!