### PR TITLE
Environment naming will better fit in...

### DIFF
--- a/src/_P031_SHT1X.ino
+++ b/src/_P031_SHT1X.ino
@@ -4,7 +4,7 @@
 
 #define PLUGIN_031
 #define PLUGIN_ID_031         31
-#define PLUGIN_NAME_031       "Temperature & Humidity - SHT1X"
+#define PLUGIN_NAME_031       "Environment - SHT1X"
 #define PLUGIN_VALUENAME1_031 "Temperature"
 #define PLUGIN_VALUENAME2_031 "Humidity"
 


### PR DESCRIPTION
"Environment" naming will better fit in instead of the long "Temperature & Humidity", and we will get a few char space more to use and it will fit nicely into the drop-down combo box too, otherwise is way to long!