### PR TITLE
Environment naming will better fit in...

### DIFF
--- a/src/_P034_DHT12.ino
+++ b/src/_P034_DHT12.ino
@@ -4,7 +4,7 @@
 
 #define PLUGIN_034
 #define PLUGIN_ID_034         34
-#define PLUGIN_NAME_034       "Temperature & Humidity - DHT12 (I2C)"
+#define PLUGIN_NAME_034       "Environment - DHT12 (I2C)"
 #define PLUGIN_VALUENAME1_034 "Temperature"
 #define PLUGIN_VALUENAME2_034 "Humidity"
 


### PR DESCRIPTION
"Environment" naming will better fit in instead of the long "Temperature & Humidity", and we will get a few char space more to use and it will fit nicely into the drop-down combo box too, otherwise is way to long!