### PR TITLE
Environment naming will better fit in...

### DIFF
--- a/src/_P032_MS5611.ino
+++ b/src/_P032_MS5611.ino
@@ -5,7 +5,7 @@
 
 #define PLUGIN_032
 #define PLUGIN_ID_032        32
-#define PLUGIN_NAME_032       "Temperature & Pressure - MS5611 (GY-63)"
+#define PLUGIN_NAME_032       "Environment - MS5611 (GY-63)"
 #define PLUGIN_VALUENAME1_032 "Temperature"
 #define PLUGIN_VALUENAME2_032 "Pressure"
 


### PR DESCRIPTION
"Environment" naming will better fit in instead of the long "Temperature & Pressure", and we will get a few char space more to use and it will fit nicely into the drop-down combo box too, otherwise is way to long!