### PR TITLE
Little naming correction

### DIFF
--- a/src/_P024_MLX90614.ino
+++ b/src/_P024_MLX90614.ino
@@ -6,7 +6,7 @@
 
 #define PLUGIN_024
 #define PLUGIN_ID_024 24
-#define PLUGIN_NAME_024 "Temperature IR + ambient - MLX90614"
+#define PLUGIN_NAME_024 "Temperature IR & Ambient - MLX90614"
 #define PLUGIN_VALUENAME1_024 "Temperature"
 
 boolean Plugin_024_init = false;


### PR DESCRIPTION
Little naming correction added "&" instead of "+" and changed letter "a" to be Uppercase.