### PR TITLE
Naming correction by Datasheet

### DIFF
--- a/src/_P024_MLX90614.ino
+++ b/src/_P024_MLX90614.ino
@@ -6,7 +6,7 @@
 
 #define PLUGIN_024
 #define PLUGIN_ID_024 24
-#define PLUGIN_NAME_024 "Temperature IR & Ambient - MLX90614"
+#define PLUGIN_NAME_024 "Digital IR Thermometer - MLX90614"
 #define PLUGIN_VALUENAME1_024 "Temperature"
 
 boolean Plugin_024_init = false;


### PR DESCRIPTION
According to manufacturer datasheet, it's nothing to do with "Ambient", they call it "Digital Infrared Thermometer"
https://www.melexis.com/-/media/files/documents/datasheets/mlx90614-datasheet-melexis.pdf