### PR TITLE
Checkbox for inversed Status LED

### DIFF
--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -404,6 +404,7 @@ struct SettingsStruct
   boolean       NotificationEnabled[NOTIFICATION_MAX];
   unsigned int  TaskDeviceID[CONTROLLER_MAX][TASKS_MAX];
   boolean       TaskDeviceSendData[CONTROLLER_MAX][TASKS_MAX];
+  boolean       Pin_status_led_Inversed;
 } Settings;
 
 struct ControllerSettingsStruct

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -346,7 +346,6 @@ boolean timeOut(unsigned long timer)
 /********************************************************************************************\
   Status LED
 \*********************************************************************************************/
-#define STATUS_PWM_LOWACTIVE
 #define STATUS_PWM_NORMALVALUE (PWMRANGE>>2)
 #define STATUS_PWM_NORMALFADE (PWMRANGE>>8)
 #define STATUS_PWM_TRAFFICRISE (PWMRANGE>>1)

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -392,9 +392,8 @@ void statusLED(boolean traffic)
 
     long pwm = nStatusValue * nStatusValue; //simple gamma correction
     pwm >>= 10;
-#ifdef STATUS_PWM_LOWACTIVE
-    pwm = PWMRANGE-pwm;
-#endif
+    if (Settings.Pin_status_led_Inversed)
+      pwm = PWMRANGE-pwm;
 
     analogWrite(Settings.Pin_status_led, pwm);
   }
@@ -942,6 +941,7 @@ void ResetFactory(void)
   Settings.Pin_i2c_sda     = 4;
   Settings.Pin_i2c_scl     = 5;
   Settings.Pin_status_led  = -1;
+  Settings.Pin_status_led_Inversed  = true;
   Settings.Pin_sd_cs       = -1;
   Settings.Protocol[0]        = DEFAULT_PROTOCOL;
   strcpy_P(Settings.Name, PSTR(DEFAULT_NAME));

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -849,6 +849,7 @@ void handle_hardware() {
   String pin_i2c_sda = WebServer.arg(F("psda"));
   String pin_i2c_scl = WebServer.arg(F("pscl"));
   String pin_status_led = WebServer.arg(F("pled"));
+  String pin_status_led_Inversed = WebServer.arg(F("pledi"));
   String pin_sd_cs = WebServer.arg(F("sd"));
 
   String reply = "";
@@ -859,6 +860,7 @@ void handle_hardware() {
     Settings.Pin_i2c_sda     = pin_i2c_sda.toInt();
     Settings.Pin_i2c_scl     = pin_i2c_scl.toInt();
     Settings.Pin_status_led  = pin_status_led.toInt();
+    Settings.Pin_status_led_Inversed  = pin_status_led_Inversed.toInt();
     Settings.Pin_sd_cs  = pin_sd_cs.toInt();
     Settings.PinBootStates[0]  =  WebServer.arg(F("p0")).toInt();
     Settings.PinBootStates[2]  =  WebServer.arg(F("p2")).toInt();
@@ -882,10 +884,20 @@ void handle_hardware() {
   reply += F("<form  method='post'><table><TH>Hardware Settings<TH><TR><TD>");
   reply += F("<TR><TD>Wifi Status Led:<TD>");
   addPinSelect(false, reply, "pled", Settings.Pin_status_led);
+  reply += F("<TR><TD>Wifi Status Led Inversed<TD>");
+  if (Settings.Pin_status_led_Inversed)
+    reply += F("<input type=checkbox id='pledi'  name='pledi' checked>&nbsp;");
+  else
+    reply += F("<input type=checkbox id='pledi' name='pledi'>&nbsp;");
+
+  reply += F("<TR><TD><hr><TD><hr>");
+
   reply += F("<TR><TD>SDA:<TD>");
   addPinSelect(true, reply, "psda", Settings.Pin_i2c_sda);
   reply += F("<TR><TD>SCL:<TD>");
   addPinSelect(true, reply, "pscl", Settings.Pin_i2c_scl);
+
+  reply += F("<TR><TD><hr><TD><hr>");
 
   // SPI Init
   reply += F("<TR><TD>Init SPI:<TD>");
@@ -897,6 +909,8 @@ void handle_hardware() {
 
   reply += F("<TR><TD>SD Card CS Pin:<TD>");
   addPinSelect(false, reply, "sd", Settings.Pin_sd_cs);
+
+  reply += F("<TR><TD><hr><TD><hr>");
 
   reply += F("<TR><TD>GPIO boot states:<TD>");
   reply += F("<TR><TD>Pin mode 0 (D3):<TD>");

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -849,7 +849,6 @@ void handle_hardware() {
   String pin_i2c_sda = WebServer.arg(F("psda"));
   String pin_i2c_scl = WebServer.arg(F("pscl"));
   String pin_status_led = WebServer.arg(F("pled"));
-  String pin_status_led_Inversed = WebServer.arg(F("pledi"));
   String pin_sd_cs = WebServer.arg(F("sd"));
 
   String reply = "";
@@ -857,11 +856,15 @@ void handle_hardware() {
 
   if (pin_i2c_sda.length() != 0)
   {
+    Settings.Pin_status_led  = pin_status_led.toInt();
+    Settings.Pin_status_led_Inversed  = WebServer.arg(F("pledi")) == "on";
+
     Settings.Pin_i2c_sda     = pin_i2c_sda.toInt();
     Settings.Pin_i2c_scl     = pin_i2c_scl.toInt();
-    Settings.Pin_status_led  = pin_status_led.toInt();
-    Settings.Pin_status_led_Inversed  = pin_status_led_Inversed.toInt();
+
+    Settings.InitSPI = WebServer.arg(F("initspi")) == "on";      // SPI Init
     Settings.Pin_sd_cs  = pin_sd_cs.toInt();
+
     Settings.PinBootStates[0]  =  WebServer.arg(F("p0")).toInt();
     Settings.PinBootStates[2]  =  WebServer.arg(F("p2")).toInt();
     Settings.PinBootStates[4]  =  WebServer.arg(F("p4")).toInt();
@@ -874,24 +877,24 @@ void handle_hardware() {
     Settings.PinBootStates[15] =  WebServer.arg(F("p15")).toInt();
     Settings.PinBootStates[16] =  WebServer.arg(F("p16")).toInt();
 
-    Settings.InitSPI = WebServer.arg(F("initspi")) == "on";      // SPI Init
-
     if (!SaveSettings())
       reply += F("<span style=\"color:red\">Error saving to flash!</span>");
-
   }
 
   reply += F("<form  method='post'><table><TH>Hardware Settings<TH><TR><TD>");
-  reply += F("<TR><TD>Wifi Status Led:<TD>");
+  reply += F("<TR><TD><b>Wifi Status LED:</b><TD>");
+  reply += F("<TR><TD>Pin LED:<TD>");
   addPinSelect(false, reply, "pled", Settings.Pin_status_led);
-  reply += F("<TR><TD>Wifi Status Led Inversed<TD>");
+  reply += F("<TR><TD>Inversed LED:<TD>");
   if (Settings.Pin_status_led_Inversed)
     reply += F("<input type=checkbox id='pledi'  name='pledi' checked>&nbsp;");
   else
     reply += F("<input type=checkbox id='pledi' name='pledi'>&nbsp;");
+  reply += F("<TR><TD><TD>(Note: Use &rsquo;GPIO-2 (D4)&rsquo; with &rsquo;Inversed&rsquo; checked for onboard LED)");
 
   reply += F("<TR><TD><hr><TD><hr>");
 
+  reply += F("<TR><TD><b>I2C Interface:</b><TD>");
   reply += F("<TR><TD>SDA:<TD>");
   addPinSelect(true, reply, "psda", Settings.Pin_i2c_sda);
   reply += F("<TR><TD>SCL:<TD>");
@@ -900,6 +903,7 @@ void handle_hardware() {
   reply += F("<TR><TD><hr><TD><hr>");
 
   // SPI Init
+  reply += F("<TR><TD><b>SPI Interface:</b><TD>");
   reply += F("<TR><TD>Init SPI:<TD>");
   if (Settings.InitSPI)
     reply += F("<input type=checkbox id='initspi'  name='initspi' checked>&nbsp;");
@@ -912,7 +916,7 @@ void handle_hardware() {
 
   reply += F("<TR><TD><hr><TD><hr>");
 
-  reply += F("<TR><TD>GPIO boot states:<TD>");
+  reply += F("<TR><TD><b>GPIO boot states:</b><TD>");
   reply += F("<TR><TD>Pin mode 0 (D3):<TD>");
   addPinStateSelect(reply, "p0", Settings.PinBootStates[0]);
   reply += F("<TR><TD>Pin mode 2 (D4):<TD>");
@@ -935,6 +939,8 @@ void handle_hardware() {
   addPinStateSelect(reply, "p15", Settings.PinBootStates[15]);
   reply += F("<TR><TD>Pin mode 16 (D0):<TD>");
   addPinStateSelect(reply, "p16", Settings.PinBootStates[16]);
+
+  reply += F("<TR><TD><hr><TD><hr>");
 
   reply += F("<TR><TD><TD><input class=\"button-link\" type='submit' value='Submit'><TR><TD>");
 


### PR DESCRIPTION
Added checkbox for common cathode (-) status LED

- Setting entry for inversed status LED
- Pimp hardware web site with separators and headlines