### PR TITLE
added union to TaskDevicePin1..3

### DIFF
--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -386,10 +386,15 @@ struct SettingsStruct
   byte          Notification[NOTIFICATION_MAX];
   byte          TaskDeviceNumber[TASKS_MAX];
   unsigned int  OLD_TaskDeviceID[TASKS_MAX];
-  int8_t        TaskDevicePin1[TASKS_MAX];
-  int8_t        TaskDevicePin2[TASKS_MAX];
-  int8_t        TaskDevicePin3[TASKS_MAX];
-  byte          TaskDevicePort[TASKS_MAX];
+  union {
+    struct {
+      int8_t        TaskDevicePin1[TASKS_MAX];
+      int8_t        TaskDevicePin2[TASKS_MAX];
+      int8_t        TaskDevicePin3[TASKS_MAX];
+      byte          TaskDevicePort[TASKS_MAX];
+    };
+    int8_t        TaskDevicePin[4][TASKS_MAX];
+  };
   boolean       TaskDevicePin1PullUp[TASKS_MAX];
   int16_t       TaskDevicePluginConfig[TASKS_MAX][PLUGIN_CONFIGVAR_MAX];
   boolean       TaskDevicePin1Inversed[TASKS_MAX];


### PR DESCRIPTION
use classic usage with single variables:
        if (Settings.TaskDevicePin1[event->TaskIndex] >= 0)
          pinMode(Settings.TaskDevicePin1[event->TaskIndex], OUTPUT);
        if (Settings.TaskDevicePin2[event->TaskIndex] >= 0)
          pinMode(Settings.TaskDevicePin2[event->TaskIndex], OUTPUT);
        if (Settings.TaskDevicePin3[event->TaskIndex] >= 0)
          pinMode(Settings.TaskDevicePin3[event->TaskIndex], OUTPUT);

or use in a more compact way as array:
        for (byte i=0; i<3; i++)
          if (Settings.TaskDevicePin[i][event->TaskIndex] >= 0)
            pinMode(Settings.TaskDevicePin[i][event->TaskIndex], OUTPUT);

or use in combination simultaneously (memory for single vars and array overlaps)

Plugins have not to be changed!