### PR TITLE
Added Par4 and Par5 Variables

### DIFF
--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -465,6 +465,8 @@ struct EventStruct
   int Par1;
   int Par2;
   int Par3;
+  int Par4;
+  int Par5;
   byte OriginTaskIndex;
   String String1;
   String String2;

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -432,10 +432,14 @@ void parseCommandString(struct EventStruct *event, String& string)
   event->Par1 = 0;
   event->Par2 = 0;
   event->Par3 = 0;
+  event->Par4 = 0;
+  event->Par5 = 0;
 
   if (GetArgv(command, TmpStr1, 2)) event->Par1 = str2int(TmpStr1);
   if (GetArgv(command, TmpStr1, 3)) event->Par2 = str2int(TmpStr1);
   if (GetArgv(command, TmpStr1, 4)) event->Par3 = str2int(TmpStr1);
+  if (GetArgv(command, TmpStr1, 5)) event->Par4 = str2int(TmpStr1);
+  if (GetArgv(command, TmpStr1, 6)) event->Par5 = str2int(TmpStr1);
 }
 
 /********************************************************************************************\


### PR DESCRIPTION
I am working on an RGBW lightbulb plugin and 3 variables are not enough
to control it.  Rather than add variables in the plugin (like neopixel
does) i think it is better to add them to EventStruct.  I only needed 4,
but neopixel uses 5