### PR TITLE
TCA9548A i2c  multiplexer Support

### DIFF
--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -363,6 +363,7 @@ struct SettingsStruct
   unsigned long Delay;
   int8_t        Pin_i2c_sda;
   int8_t        Pin_i2c_scl;
+  int8_t        i2c_Multiplexer_adr;
   int8_t        Pin_status_led;
   int8_t        Pin_sd_cs;
   int8_t        PinBootStates[17];
@@ -450,6 +451,7 @@ struct ExtraTaskSettingsStruct
   long    TaskDevicePluginConfigLong[PLUGIN_EXTRACONFIGVAR_MAX];
   byte    TaskDeviceValueDecimals[VARS_PER_TASK];
   int16_t TaskDevicePluginConfig[PLUGIN_EXTRACONFIGVAR_MAX];
+  int8_t    i2c_multiplex_port;
 } ExtraTaskSettings;
 
 struct EventStruct

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -417,6 +417,7 @@ struct SettingsStruct
   unsigned int  TaskDeviceID[CONTROLLER_MAX][TASKS_MAX];
   boolean       TaskDeviceSendData[CONTROLLER_MAX][TASKS_MAX];
   boolean       Pin_status_led_Inversed;
+  int8_t				i2c_multiplex_port[TASKS_MAX];
 } Settings;
 
 struct ControllerSettingsStruct
@@ -451,7 +452,6 @@ struct ExtraTaskSettingsStruct
   long    TaskDevicePluginConfigLong[PLUGIN_EXTRACONFIGVAR_MAX];
   byte    TaskDeviceValueDecimals[VARS_PER_TASK];
   int16_t TaskDevicePluginConfig[PLUGIN_EXTRACONFIGVAR_MAX];
-  int8_t    i2c_multiplex_port;
 } ExtraTaskSettings;
 
 struct EventStruct

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -443,6 +443,7 @@ void taskClear(byte taskIndex, boolean save)
 {
   Settings.TaskDeviceNumber[taskIndex] = 0;
   ExtraTaskSettings.TaskDeviceName[0] = 0;
+  Settings.i2c_multiplex_port[taskIndex] = -1;
   Settings.TaskDeviceDataFeed[taskIndex] = 0;
   Settings.TaskDevicePin1[taskIndex] = -1;
   Settings.TaskDevicePin2[taskIndex] = -1;
@@ -967,6 +968,7 @@ void ResetFactory(void)
     for (byte y = 0; y < CONTROLLER_MAX; y++)
       Settings.TaskDeviceSendData[y][x] = true;
     Settings.TaskDeviceTimer[x] = Settings.Delay;
+    Settings.i2c_multiplex_port[x] = -1;
   }
   Settings.Build = BUILD;
   Settings.UseSerial = true;

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -2600,3 +2600,22 @@ void htmlEscape(String & html)
   html.replace("<",  "&lt;");
   html.replace(">",  "&gt;");
 }
+
+
+// utility method for the TCA9548A multiplexer
+// select the multiplexer port given as parameter
+void i2cMultiplexerSelect(uint8_t i) {
+  if (i > 7) return;
+
+  Wire.beginTransmission(Settings.i2c_Multiplexer_adr);
+  Wire.write(1 << i);
+  Wire.endTransmission();
+}
+
+// utility method for the TCA9548A multiplexer
+// disable all channels on a multiplexer
+void i2cMultiplexerOff() {
+	Wire.beginTransmission(Settings.i2c_Multiplexer_adr);
+	Wire.write(0);  // no channel selected
+	Wire.endTransmission();
+}

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -1113,7 +1113,7 @@ void handle_devices() {
           Settings.TaskDeviceTimer[index - 1] = 0;
       }
 
-			ExtraTaskSettings.i2c_multiplex_port = i2c_multiplex_port.toInt();
+      Settings.i2c_multiplex_port[index - 1] = i2c_multiplex_port.toInt();
 
       taskdevicename.toCharArray(tmpString, 41);
       Settings.TaskDeviceEnabled[index - 1] = (taskdeviceenabled == "on");
@@ -1343,7 +1343,7 @@ void handle_devices() {
 
       if (Device[DeviceIndex].Type == DEVICE_TYPE_I2C)
       {
-      	addLog(LOG_LEVEL_INFO, "multiplex addr: " + String(Settings.i2c_Multiplexer_adr));
+      	addLog(LOG_LEVEL_DEBUG, "multiplex addr: " + String(Settings.i2c_Multiplexer_adr, HEX));
       	if (Settings.i2c_Multiplexer_adr != -1)
       	{
 
@@ -1351,7 +1351,7 @@ void handle_devices() {
       	  String i2c_multiplex_port_options[9];
       	  byte i2c_multiplex_port_optionValues[9];
       	  i2c_multiplex_port_options[0] = F(" ");
-      	  i2c_multiplex_port_optionValues[0] = 255;
+      	  i2c_multiplex_port_optionValues[0] = -1;
       	  for (byte x = 0; x < 8; x++)
       	  {
       	  	i2c_multiplex_port_options[x+1] = String(x);
@@ -1364,7 +1364,7 @@ void handle_devices() {
       	  	reply += F("<option value='");
       	  	reply += i2c_multiplex_port_optionValues[x];
       	  	reply += "'";
-      	    if (ExtraTaskSettings.i2c_multiplex_port == i2c_multiplex_port_optionValues[x])
+      	    if (Settings.i2c_multiplex_port[index - 1] == i2c_multiplex_port_optionValues[x])
       	    	reply += F(" selected");
       	    reply += ">";
       	    reply += i2c_multiplex_port_options[x];

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -841,6 +841,7 @@ void handle_hardware() {
   String pin_i2c_scl = WebServer.arg(F("pscl"));
   String pin_status_led = WebServer.arg(F("pled"));
   String pin_sd_cs = WebServer.arg(F("sd"));
+  String str_i2c_multiplexer_adr = WebServer.arg(F("i2c_multiplex_adr"));
 
   String reply = "";
   addHeader(true, reply);
@@ -852,6 +853,8 @@ void handle_hardware() {
 
     Settings.Pin_i2c_sda     = pin_i2c_sda.toInt();
     Settings.Pin_i2c_scl     = pin_i2c_scl.toInt();
+
+    Settings.i2c_Multiplexer_adr = str_i2c_multiplexer_adr.toInt();
 
     Settings.InitSPI = WebServer.arg(F("initspi")) == "on";      // SPI Init
     Settings.Pin_sd_cs  = pin_sd_cs.toInt();
@@ -890,6 +893,34 @@ void handle_hardware() {
   addPinSelect(true, reply, "psda", Settings.Pin_i2c_sda);
   reply += F("<TR><TD>SCL:<TD>");
   addPinSelect(true, reply, "pscl", Settings.Pin_i2c_scl);
+
+  reply += F("<TR><TD>TCA9548A i2c Multiplexer Address:<TD>");
+  byte choice = Settings.i2c_Multiplexer_adr;
+  String i2c_multiplex_options[9];
+  int i2c_multiplex_optionValues[9];
+  i2c_multiplex_options[0] = F(" ");
+  i2c_multiplex_optionValues[0] = -1;
+  for (byte x = 0; x < 8; x++)
+  {
+  	i2c_multiplex_options[x+1] = String(70+x);
+  	i2c_multiplex_optionValues[x+1] = 0x70 + x;
+  }
+
+  reply += F("<select name='i2c_multiplex_adr'>");
+  for (byte x = 0; x < 9; x++)
+  {
+  	reply += F("<option value='");
+  	reply += i2c_multiplex_optionValues[x];
+  	reply += "'";
+    if (choice == i2c_multiplex_optionValues[x])
+    	reply += F(" selected");
+    reply += ">";
+    reply += i2c_multiplex_options[x];
+    reply += F("</option>");
+  }
+  reply += F("</select>");
+
+
 
   reply += F("<TR><TD><hr><TD><hr>");
 
@@ -991,6 +1022,7 @@ void handle_devices() {
   String taskdevicepin1pullup = WebServer.arg(F("taskdevicepin1pullup"));
   String taskdevicepin1inversed = WebServer.arg(F("taskdevicepin1inversed"));
   String taskdevicename = WebServer.arg(F("taskdevicename"));
+  String i2c_multiplex_port = WebServer.arg(F("i2c_multiplex_port"));
   String taskdeviceport = WebServer.arg(F("taskdeviceport"));
   String taskdeviceformula[VARS_PER_TASK];
   String taskdevicevaluename[VARS_PER_TASK];
@@ -1080,6 +1112,8 @@ void handle_devices() {
         else
           Settings.TaskDeviceTimer[index - 1] = 0;
       }
+
+			ExtraTaskSettings.i2c_multiplex_port = i2c_multiplex_port.toInt();
 
       taskdevicename.toCharArray(tmpString, 41);
       Settings.TaskDeviceEnabled[index - 1] = (taskdeviceenabled == "on");
@@ -1306,6 +1340,42 @@ void handle_devices() {
       reply += F("<TR><TD>Name:<TD><input type='text' maxlength='40' name='taskdevicename' value='");
       reply += ExtraTaskSettings.TaskDeviceName;
       reply += F("'>");
+
+      if (Device[DeviceIndex].Type == DEVICE_TYPE_I2C)
+      {
+      	addLog(LOG_LEVEL_INFO, "multiplex addr: " + String(Settings.i2c_Multiplexer_adr));
+      	if (Settings.i2c_Multiplexer_adr != -1)
+      	{
+
+      	  reply += F("<TR><TD>Multiplexer (TCA9548A) Port:<TD>");
+      	  String i2c_multiplex_port_options[9];
+      	  byte i2c_multiplex_port_optionValues[9];
+      	  i2c_multiplex_port_options[0] = F(" ");
+      	  i2c_multiplex_port_optionValues[0] = 255;
+      	  for (byte x = 0; x < 8; x++)
+      	  {
+      	  	i2c_multiplex_port_options[x+1] = String(x);
+      	  	i2c_multiplex_port_optionValues[x+1] = x;
+      	  }
+
+      	  reply += F("<select name='i2c_multiplex_port'>");
+      	  for (byte x = 0; x < 9; x++)
+      	  {
+      	  	reply += F("<option value='");
+      	  	reply += i2c_multiplex_port_optionValues[x];
+      	  	reply += "'";
+      	    if (ExtraTaskSettings.i2c_multiplex_port == i2c_multiplex_port_optionValues[x])
+      	    	reply += F(" selected");
+      	    reply += ">";
+      	    reply += i2c_multiplex_port_options[x];
+      	    reply += F("</option>");
+      	  }
+      	  reply += F("</select>");
+
+      	}
+
+      }
+
 
       if (Device[DeviceIndex].TimerOption)
       {


### PR DESCRIPTION
added support for the TCA9548A i2c Multiplexer (use multiple i2c devices with the same address), when enable on hardware tab, every i2c device gets an additional option to select the multiplexer port for the device, when not selected no aditional option is displayed.

Every plugin has to implement the functions to enable multiplexer support, see my next pull request to see how... 

i could have done this in the plugin only, but i wanted to implement it in the "core" files, so that other plugins can also use it if they want.