### PR TITLE
Increase DEVICES_MAX for more testing and dev plugins

### DIFF
--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -201,12 +201,16 @@
 #define CMD_REBOOT                         89
 #define CMD_WIFI_DISCONNECT               135
 
-#define DEVICES_MAX                        64
+#ifdef PLUGIN_BUILD_NORMAL
+  #define DEVICES_MAX                      64
+#else
+  #define DEVICES_MAX                      72
+#endif
 #define TASKS_MAX                          12 // max 12!
 #define CONTROLLER_MAX                      3 // max 4!
 #define NOTIFICATION_MAX                    3 // max 4!
 #define VARS_PER_TASK                       4
-#define PLUGIN_MAX                         64
+#define PLUGIN_MAX                DEVICES_MAX
 #define PLUGIN_CONFIGVAR_MAX                8
 #define PLUGIN_CONFIGFLOATVAR_MAX           4
 #define PLUGIN_CONFIGLONGVAR_MAX            4


### PR DESCRIPTION
In dev build are 62 plugins but there is space defined for only 64. Means that only 2 plugins can be copied from playground till crash.

Increased by 8 for testing and dev. Needs 160 byte RAM.
Normal build is left to 64 for more stability.