### PR TITLE
Fixed deep sleep, such that it can be enabled from Rules

### DIFF
--- a/src/Command.ino
+++ b/src/Command.ino
@@ -263,7 +263,7 @@ void ExecuteCommand(byte source, const char *Line)
   {
     success = true;
     if (Par1 > 0)
-      deepSleep(Par1);
+      deepSleepStart(Par1); // call the second part of the function to avoid check and enable one-shot operation
   }
 
   if (strcasecmp_P(Command, PSTR("TaskValueSet")) == 0)

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -51,7 +51,12 @@ void deepSleep(int delay)
     }
   }
 
+  deepSleepStart(delay); // Call deepSleepStart function after these checks
+}
 
+void deepSleepStart(int delay)
+{
+  // separate function that is called from above function or directly from rules, usign deepSleep as a one-shot
   String event = F("System#Sleep");
   rulesProcessing(event);
 
@@ -1004,7 +1009,7 @@ void ResetFactory(void)
   ControllerSettings.Port = DEFAULT_PORT;
   SaveControllerSettings(0, (byte*)&ControllerSettings, sizeof(ControllerSettings));
 #endif
-  
+
   Serial.println("RESET: Succesful, rebooting. (you might need to press the reset button if you've justed flashed the firmware)");
   //NOTE: this is a known ESP8266 bug, not our fault. :)
   delay(1000);


### PR DESCRIPTION
Fixed the logic for deepSleep, such that one can enable it from Rules by calling deepSleep. This is done in a way that general/static deepSleep does not need to be enabled and the user can call it from rules anytime they see fit. Upon wake-up deepSleep is disabled, one must again directly call it from Rules.

Such implementation makes most sense from my use case, where sleep is conditional, for example on voltage levels and other events.