### PR TITLE
Update P053 (PMSx003) to support software serial and minor cleanup

### DIFF
--- a/src/_P053_PMSx003.ino
+++ b/src/_P053_PMSx003.ino
@@ -18,7 +18,6 @@
 #define PLUGIN_VALUENAME3_053 "pm10"
 
 boolean Plugin_053_init = false;
-byte Plugin_PMSx003_UART = 0;
 byte timer = 0;
 boolean values_received = false;
 

--- a/src/_P053_PMSx003.ino
+++ b/src/_P053_PMSx003.ino
@@ -4,7 +4,7 @@
 //
 // http://www.aqmd.gov/docs/default-source/aq-spec/resources-page/plantower-pms5003-manual_v2-3.pdf?sfvrsn=2
 //
-// The PMSx005 are particle sensors. Particles are measured by blowing air though the enclosue and,
+// The PMSx003 are particle sensors. Particles are measured by blowing air though the enclosue and,
 // togther with a laser, count the amount of particles. These sensors have an integrated microcontroller
 // that counts particles and transmits measurement data over the serial connection.
 

--- a/src/_P053_PMSx003.ino
+++ b/src/_P053_PMSx003.ino
@@ -262,16 +262,6 @@ boolean Plugin_053(byte function, struct EventStruct *event, String& string)
       {
         // When new data is available, return true
         success = values_received;
-        if (values_received)
-        {
-          log = F("PMSx003 : pm1.0a=");
-          log += UserVar[event->BaseVarIndex];
-          log += F(", pm2.5a=");
-          log += UserVar[event->BaseVarIndex + 1];
-          log += F(", pm10a=");
-          log += UserVar[event->BaseVarIndex + 2];
-          addLog(LOG_LEVEL_INFO, log);
-        }
         values_received = false;
       }
   }


### PR DESCRIPTION
The module now support both hardware serial and software serial. Depending on the selected pins, either one is selected.

When performance is not an issue, software serial can be used. This mode generates lots of interrupts to the CPU but is in general fully functional.

Hardware serial can be selected when performance is required, for instance processing lots of sensors / rules or with certain timing requirements.

TaskDevicePin1 = RX
TaskDevicePin2 = TX (any number, required by softwareserial lib)
TaskDevicePin3 = Reset (optional)

Both modes are tested working:
- HW serial on IO3,1
- SW serial RX on IO0
- SW serial RX on IO5

