### PR TITLE
Implemented new WiFI AP naming strategy

### DIFF
--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -73,7 +73,7 @@
 // You can always change these during runtime and save to eeprom
 // After loading firmware, issue a 'reset' command to load the defaults.
 
-#define DEFAULT_NAME        "newdevice"         // Enter your device friendly name
+#define DEFAULT_NAME        "ESP_Easy"         // Enter your device friendly name
 #define DEFAULT_SSID        "ssid"              // Enter your network SSID
 #define DEFAULT_KEY         "wpakey"            // Enter your network WPA key
 #define DEFAULT_DELAY       60                  // Enter your Send delay in seconds

--- a/src/Wifi.ino
+++ b/src/Wifi.ino
@@ -6,8 +6,7 @@ void WifiAPconfig()
   // create and store unique AP SSID/PW to prevent ESP from starting AP mode with default SSID and No password!
   char ap_ssid[20];
   ap_ssid[0] = 0;
-  strcpy(ap_ssid, "ESP_");
-  sprintf_P(ap_ssid, PSTR("%s%u"), ap_ssid, Settings.Unit);
+  sprintf_P(ap_ssid, PSTR("%s_%u"), Settings.Name, Settings.Unit);
   // setup ssid for AP Mode when needed
   WiFi.softAP(ap_ssid, SecuritySettings.WifiAPKey);
   // We start in STA mode


### PR DESCRIPTION
Implemented a suggested change to the AP naming #399, such that we achieve the following:

 * replaced the old default device name `newdevice` with `ESP_Easy`
 * defined the AP name to consist of the device name and unit number, such that in default case AP is now `ESP_Easy_0`
 * if user changes the name, then the name used in the AP