### PR TITLE
Fixed multiline define bug on CRLF

### DIFF
--- a/src/__CPlugin.ino
+++ b/src/__CPlugin.ino
@@ -5,6 +5,8 @@
 
 static const char ADDCPLUGIN_ERROR[] PROGMEM = "System: Error - To much C-Plugins";
 
+// Because of compiler-bug (multiline defines gives an error if file ending is CRLF) the define is striped to a single line
+/*
 #define ADDCPLUGIN(NNN) \
   if (x < CPLUGIN_MAX) \
   { \
@@ -13,6 +15,8 @@ static const char ADDCPLUGIN_ERROR[] PROGMEM = "System: Error - To much C-Plugin
   } \
   else \
     addLog(LOG_LEVEL_ERROR, FPSTR(ADDCPLUGIN_ERROR));
+*/
+#define ADDCPLUGIN(NNN) if (x < CPLUGIN_MAX) { CPlugin_id[x] = CPLUGIN_ID_##NNN; CPlugin_ptr[x++] = &CPlugin_##NNN; } else addLog(LOG_LEVEL_ERROR, FPSTR(ADDCPLUGIN_ERROR));
 
 
 void CPluginInit(void)

--- a/src/__NPlugin.ino
+++ b/src/__NPlugin.ino
@@ -5,6 +5,8 @@
 
 static const char ADDNPLUGIN_ERROR[] PROGMEM = "System: Error - To much N-Plugins";
 
+// Because of compiler-bug (multiline defines gives an error if file ending is CRLF) the define is striped to a single line
+/*
 #define ADDNPLUGIN(NNN) \
   if (x < NPLUGIN_MAX) \
   { \
@@ -13,6 +15,8 @@ static const char ADDNPLUGIN_ERROR[] PROGMEM = "System: Error - To much N-Plugin
   } \
   else \
     addLog(LOG_LEVEL_ERROR, FPSTR(ADDNPLUGIN_ERROR));
+*/
+#define ADDNPLUGIN(NNN) if (x < NPLUGIN_MAX) { NPlugin_id[x] = NPLUGIN_ID_##NNN; NPlugin_ptr[x++] = &NPlugin_##NNN; } else addLog(LOG_LEVEL_ERROR, FPSTR(ADDNPLUGIN_ERROR));
 
 
 void NPluginInit(void)

--- a/src/__Plugin.ino
+++ b/src/__Plugin.ino
@@ -5,6 +5,8 @@
 
 static const char ADDPLUGIN_ERROR[] PROGMEM = "System: Error - To much Plugins";
 
+// Because of compiler-bug (multiline defines gives an error if file ending is CRLF) the define is striped to a single line
+/*
 #define ADDPLUGIN(NNN) \
   if (x < PLUGIN_MAX) \
   { \
@@ -13,6 +15,8 @@ static const char ADDPLUGIN_ERROR[] PROGMEM = "System: Error - To much Plugins";
   } \
   else \
     addLog(LOG_LEVEL_ERROR, FPSTR(ADDPLUGIN_ERROR));
+*/
+#define ADDPLUGIN(NNN) if (x < PLUGIN_MAX) { Plugin_id[x] = PLUGIN_ID_##NNN; Plugin_ptr[x++] = &Plugin_##NNN; } else addLog(LOG_LEVEL_ERROR, FPSTR(ADDPLUGIN_ERROR));
 
 
 void PluginInit(void)


### PR DESCRIPTION
Because of compiler-bug (multiline defines gives an error if file ending is CRLF) the define is striped to a single line. The multiline version is left for human reading.

See discussions in #389