### PR TITLE
Added mDNS implementation

### DIFF
--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -281,6 +281,7 @@
 #include <DNSServer.h>
 #include <WiFiUdp.h>
 #include <ESP8266WebServer.h>
+#include <ESP8266mDNS.h>
 #include <Wire.h>
 #include <SPI.h>
 #include <PubSubClient.h>
@@ -321,6 +322,7 @@ bool ArduinoOTAtriggered=false;
 const byte DNS_PORT = 53;
 IPAddress apIP(192, 168, 4, 1);
 DNSServer dnsServer;
+MDNSResponder mdns;
 
 
 // MQTT client

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -495,6 +495,15 @@ void handle_root() {
       reply += F(" dB");
     }
 
+    char mdns_link[80];
+    sprintf_P(mdns_link, PSTR("<TR><TD>mDNS:<TD><a href='http://%s_%u.local'>%s_%u.local</a>"), Settings.Name, Settings.Unit, Settings.Name, Settings.Unit);
+    reply += mdns_link;
+
+    reply += F("<TD><TD><TD>");
+    //reply += placeholder;
+
+
+
     reply += F("<TR><TH>Node List:<TH>Name<TH>Build<TH>Type<TH>IP<TH>Age<TR><TD><TD>");
     for (byte x = 0; x < UNIT_MAX; x++)
     {

--- a/src/Wifi.ino
+++ b/src/Wifi.ino
@@ -96,6 +96,21 @@ boolean WifiConnect(byte connectAttempts)
       WiFi.config(ip, gw, subnet);
     }
 
+    //mdns setup
+    char mdns_name[20];
+    mdns_name[0] = 0;
+    sprintf_P(mdns_name, PSTR("%s_%u"), Settings.Name, Settings.Unit);
+
+    String log = F("SYS  : ");
+    if (MDNS.begin(mdns_name, WiFi.localIP())) {
+      log += F("mDNS started");
+
+    }
+    else{
+      log += F("mDNS failed");
+    }
+    addLog(LOG_LEVEL_INFO, log);
+
     return(true);
   }
 


### PR DESCRIPTION
Added mDNS for easier connectivity to devices without knowing the IP address. It is implemented in the following way:

 * generate when WiFi connected the mDNS name from device name and number, default is then `ESP-Easy_0.local`
 * display on the default screen to the user

Please review if the implementation is clean enough.