### PR TITLE
Renamed command to be unique.

### DIFF
--- a/src/_P052_SenseAir.ino
+++ b/src/_P052_SenseAir.ino
@@ -71,7 +71,7 @@ boolean Plugin_052(byte function, struct EventStruct *event, String& string)
       			String param1 = parseString(tmpString, 2);
 
 
-            if (cmd.equalsIgnoreCase(F("relaystatus")))
+            if (cmd.equalsIgnoreCase(F("senseair_setrelay")))
             {
               if (param1.toInt() == 0 || param1.toInt() == 1 || param1.toInt() == -1) {
                 Plugin_052_setRelayStatus(param1.toInt());


### PR DESCRIPTION
I have now renamed the command "relaystatus" to be unique "senseair_setrelay" as @mvdbro pointed out in a comment.

@Grovkillen can you update Wiki accordingly?