### PR TITLE
Added Value Logger on SD Card

### DIFF
--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -10,6 +10,9 @@ boolean sendData(struct EventStruct *event)
   if (Settings.GlobalSync && Settings.TaskDeviceGlobalSync[event->TaskIndex])
     SendUDPTaskData(0, event->TaskIndex, event->TaskIndex);
 
+  if (Settings.UseValueLogger && Settings.InitSPI && Settings.Pin_sd_cs >= 0)
+    SendValueLogger(event->TaskIndex);
+
 //  if (!Settings.TaskDeviceSendData[event->TaskIndex])
 //    return false;
 

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -426,6 +426,7 @@ struct SettingsStruct
   boolean       TaskDeviceSendData[CONTROLLER_MAX][TASKS_MAX];
   boolean       Pin_status_led_Inversed;
   boolean       deepSleepOnFail;
+  boolean       UseValueLogger;
   //its safe to extend this struct, up to 65535 bytes, default values in config are 0
 } Settings;
 

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -2474,6 +2474,45 @@ void createRuleEvents(byte TaskIndex)
   }
 }
 
+
+void SendValueLogger(byte TaskIndex)
+{
+  String logger;
+
+  LoadTaskSettings(TaskIndex);
+  byte BaseVarIndex = TaskIndex * VARS_PER_TASK;
+  byte DeviceIndex = getDeviceIndex(Settings.TaskDeviceNumber[TaskIndex]);
+  byte sensorType = Device[DeviceIndex].VType;
+  for (byte varNr = 0; varNr < Device[DeviceIndex].ValueCount; varNr++)
+  {
+    logger += getDateString('-');
+    logger += F(" ");
+    logger += getTimeString(':');
+    logger += F(",");
+    logger += Settings.Unit;
+    logger += F(",");
+    logger += ExtraTaskSettings.TaskDeviceName;
+    logger += F(",");
+    logger += ExtraTaskSettings.TaskDeviceValueNames[varNr];
+    logger += F(",");
+
+    if (sensorType == SENSOR_TYPE_LONG)
+      logger += (unsigned long)UserVar[BaseVarIndex] + ((unsigned long)UserVar[BaseVarIndex + 1] << 16);
+    else
+      logger += String(UserVar[BaseVarIndex + varNr], ExtraTaskSettings.TaskDeviceValueDecimals[varNr]);
+    logger += F("\r\n");
+  }
+
+  addLog(LOG_LEVEL_DEBUG, logger);
+
+  String filename = F("VALUES.CSV");
+  File logFile = SD.open(filename, FILE_WRITE);
+  if (logFile)
+    logFile.print(logger);
+  logFile.close();
+}
+
+
 void checkRAM( const __FlashStringHelper* flashString)
 {
   uint16_t freeRAM = FreeMem();

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -1142,6 +1142,7 @@ void handle_hardware() {
   addFormSubHeader(reply, F("SPI Interface"));
 
   addFormCheckBox(reply, F("Init SPI"), F("initspi"), Settings.InitSPI);
+  addFormNote(reply, F("CLK=GPIO-14 (D5), MISO=GPIO-12 (D6), MOSI=GPIO-13 (D7)"));
   addFormNote(reply, F("Chip Select (CS) config must be done in the plugin"));
   addFormPinSelect(reply, F("SD Card CS Pin"), "sd", Settings.Pin_sd_cs);
 
@@ -2961,6 +2962,7 @@ void handle_advanced() {
     Settings.SerialLogLevel = serialloglevel.toInt();
     Settings.WebLogLevel = webloglevel.toInt();
     Settings.SDLogLevel = sdloglevel.toInt();
+    Settings.UseValueLogger = isFormItemChecked(F("valuelogger"));
     Settings.BaudRate = baudrate.toInt();
     Settings.UseNTP = (usentp == "on");
     Settings.DST = (dst == "on");
@@ -3008,6 +3010,8 @@ void handle_advanced() {
   addFormNumericBox(reply, F("Serial log Level"), F("serialloglevel"), Settings.SerialLogLevel, 0, 4);
   addFormNumericBox(reply, F("Web log Level"), F("webloglevel"), Settings.WebLogLevel, 0, 4);
   addFormNumericBox(reply, F("SD Card log Level"), F("sdloglevel"), Settings.SDLogLevel, 0, 4);
+
+  addFormCheckBox(reply, F("SD Card Value Logger"), F("valuelogger"), Settings.UseValueLogger);
 
 
   addFormSubHeader(reply, F("Serial Settings"));


### PR DESCRIPTION
This optional feature writes an Excel-confom CSV to the SD card for all device values

Workflow:
* Add a SD card to the ESP (SPI...)
* In hardware-tab check "Init SPI" and set the "SD Card CS Pin"
* In tools-tab enter advanced page and enter NTP settings (for correct time stamp)
* In tools-tab enter advanced page check "SD Card Value Logger"
* In device-tab add your sensors with corresponding delay times

A file named "VALUES.CSV" is written on the SD card. It can be imported by any spread sheet program (e.g. Excel)
The file can also be downloaded in tools-tab -> "SD card" -> "VALUES.CSV"