### PR TITLE
Plugin65 MP3 - volume updated in device menu - issue #424

### DIFF
--- a/src/_P065_DRF0299_MP3.ino
+++ b/src/_P065_DRF0299_MP3.ino
@@ -141,6 +141,7 @@ boolean Plugin_065(byte function, struct EventStruct *event, String& string)
 
           int8_t vol = param.toInt();
           if (vol == 0) vol = 30;
+          CONFIG(0) = vol;
           Plugin_065_SetVol(vol);
           log += vol;
 


### PR DESCRIPTION
Note: As all commands the internal struct is set but not automatically saved to SPIFFS