### PR TITLE
Descriptive GPIO-Names

### DIFF
--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -181,6 +181,8 @@
 #define PLUGIN_TIMER_IN                    19
 #define PLUGIN_FIFTY_PER_SECOND            20
 #define PLUGIN_REMOTE_CONFIG               21
+#define PLUGIN_GET_DEVICEGPIONAMES         22
+#define PLUGIN_EXIT                        23
 
 #define CPLUGIN_PROTOCOL_ADD                1
 #define CPLUGIN_PROTOCOL_TEMPLATE           2
@@ -495,6 +497,7 @@ struct EventStruct
   byte OriginTaskIndex;
   String String1;
   String String2;
+  String String3;
   byte *Data;
 };
 

--- a/src/_P055_Chiming.ino
+++ b/src/_P055_Chiming.ino
@@ -119,6 +119,14 @@ boolean Plugin_055(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case PLUGIN_GET_DEVICEGPIONAMES:
+      {
+        event->String1 = F("GPIO &rarr; Driver#1");
+        event->String2 = F("GPIO &rarr; Driver#2");
+        event->String3 = F("GPIO &rarr; Driver#4");
+        break;
+      }
+
     case PLUGIN_WEBFORM_LOAD:
       {
         //default values
@@ -127,7 +135,7 @@ boolean Plugin_055(byte function, struct EventStruct *event, String& string)
         if (Settings.TaskDevicePluginConfig[event->TaskIndex][1] <= 0)   //Plugin_055_millisPauseTime
           Settings.TaskDevicePluginConfig[event->TaskIndex][1] = 400;
 
-        addFormPinSelect(string, F("4th GPIO"), F("TDP4"), (int)(Settings.TaskDevicePin[3][event->TaskIndex]));
+        addFormPinSelect(string, F("GPIO &rarr; Driver#8"), F("TDP4"), (int)(Settings.TaskDevicePin[3][event->TaskIndex]));
 
 
         addFormSubHeader(string, F("Timing"));

--- a/src/_P059_Encoder.ino
+++ b/src/_P059_Encoder.ino
@@ -70,6 +70,14 @@ boolean Plugin_059(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case PLUGIN_GET_DEVICEGPIONAMES:
+      {
+        event->String1 = F("GPIO &larr; A");
+        event->String2 = F("GPIO &larr; B");
+        event->String3 = F("GPIO &#8672; I (optional)");
+        break;
+      }
+
     case PLUGIN_WEBFORM_LOAD:
       {
         // default values

--- a/src/_P063_TTP229_KeyPad.ino
+++ b/src/_P063_TTP229_KeyPad.ino
@@ -103,6 +103,13 @@ boolean Plugin_063(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case PLUGIN_GET_DEVICEGPIONAMES:
+      {
+        event->String1 = F("GPIO &rarr; SCL");
+        event->String2 = F("GPIO &#8644; SDO");
+        break;
+      }
+
     case PLUGIN_WEBFORM_LOAD:
       {
         addFormCheckBox(string, F("ScanCode"), F("scancode"), CONFIG(1));

--- a/src/_P065_DRF0299_MP3.ino
+++ b/src/_P065_DRF0299_MP3.ino
@@ -74,6 +74,12 @@ boolean Plugin_065(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+      case PLUGIN_GET_DEVICEGPIONAMES:
+        {
+          event->String1 = F("GPIO &rarr; RX");
+          break;
+        }
+
     case PLUGIN_WEBFORM_LOAD:
       {
           addFormNumericBox(string, F("Volume"), F("volume"), CONFIG(0), 1, 30);

--- a/src/_P067_HX711_Load_Cell.ino
+++ b/src/_P067_HX711_Load_Cell.ino
@@ -112,6 +112,13 @@ boolean Plugin_067(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case PLUGIN_GET_DEVICEGPIONAMES:
+      {
+        event->String1 = F("GPIO &rarr; SCL");
+        event->String2 = F("GPIO &larr; DOUT");
+        break;
+      }
+
     case PLUGIN_WEBFORM_LOAD:
       {
         addFormSubHeader(string, F("Measurement"));

--- a/src/__Plugin.ino
+++ b/src/__Plugin.ino
@@ -1152,11 +1152,13 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
 
     // Call to specific plugin that is used for current task
     case PLUGIN_INIT:
+    case PLUGIN_EXIT:
     case PLUGIN_WEBFORM_LOAD:
     case PLUGIN_WEBFORM_SAVE:
     case PLUGIN_WEBFORM_SHOW_VALUES:
     case PLUGIN_WEBFORM_SHOW_CONFIG:
     case PLUGIN_GET_DEVICEVALUENAMES:
+    case PLUGIN_GET_DEVICEGPIONAMES:
     case PLUGIN_READ:
     case PLUGIN_REMOTE_CONFIG:
       for (x = 0; x < PLUGIN_MAX; x++)


### PR DESCRIPTION
Changes:

* Added PLUGIN_GET_DEVICEGPIONAMES to retreive GPIO-names from plugins (issue #447)
* Changed Webserver to ask for GPIO-names (backward compatibility for old plugins) (issue #447)
* Added GPIO-names to plugins
  - Chiming
  - Encoder
  - TTP229_KeyPad
  - DRF0299_MP3
  - HX711_Load_Cell
  - (more will follow)
* Changed GPIO-names in hardware-page for uniformity

And because it was on the way:
* Deselected GPIOs with name "- None -" (Issue #445)
* Added PLUGIN_EXIT and prepared to unload members and memory from deselected device plugins (Issue #354)
* Warning symbol for GPIO-9