### PR TITLE
Implemented web activity timer

### DIFF
--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -598,6 +598,7 @@ unsigned long timer20ms;
 unsigned long timer1s;
 unsigned long timerwd;
 unsigned long lastSend;
+unsigned long lastWeb;
 unsigned int NC_Count = 0;
 unsigned int C_Count = 0;
 byte cmd_within_mainloop = 0;

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -66,6 +66,9 @@ void sendWebPage(const String& tmplName, String& pageContent)
 
   pageTemplate = F("");
   pageContent = F("");
+
+  //web activity timer
+  lastWeb = millis();
 }
 
 

--- a/src/_P026_Sysinfo.ino
+++ b/src/_P026_Sysinfo.ino
@@ -40,7 +40,7 @@ boolean Plugin_026(byte function, struct EventStruct *event, String& string)
     case PLUGIN_WEBFORM_LOAD:
       {
         byte choice = Settings.TaskDevicePluginConfig[event->TaskIndex][0];
-        String options[9];
+        String options[10];
         options[0] = F("Uptime");
         options[1] = F("Free RAM");
         options[2] = F("Wifi RSSI");
@@ -50,7 +50,8 @@ boolean Plugin_026(byte function, struct EventStruct *event, String& string)
         options[6] = F("IP 2.Octet");
         options[7] = F("IP 3.Octet");
         options[8] = F("IP 4.Octet");
-        addFormSelector(string, F("Indicator"), F("plugin_026"), 9, options, NULL, choice);
+        options[9] = F("Web activity");
+        addFormSelector(string, F("Indicator"), F("plugin_026"), 10, options, NULL, choice);
 
         success = true;
         break;
@@ -115,6 +116,11 @@ boolean Plugin_026(byte function, struct EventStruct *event, String& string)
           case 8:
           {
             value = WiFi.localIP()[3];
+            break;
+          }
+          case 9:
+          {
+            value = (millis()-lastWeb)/1000; // respond in seconds
             break;
           }
         }


### PR DESCRIPTION
Moving towards a solution for implementing proper connected user detection 
#457 , this web activity timer is implemented to enable one to check seconds elapsed since last webserver action and monitor it as a system parameter.

Using this in conjunction with Rules, one can decide to go to sleep or postpone it given this variable state.

