### PR TITLE
publish LWT with "Controller Publish" setting

### DIFF
--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -109,9 +109,10 @@ void MQTTConnect()
   clientid += Settings.Unit;
   String subscribeTo = "";
 
-  String LWTTopic = ControllerSettings.Subscribe;
-  LWTTopic.replace(F("/#"), F("/status"));
-  LWTTopic.replace(F("%sysname%"), Settings.Name);
+  String LWTTopic = ControllerSettings.Publish;
+  LWTTopic.remove(LWTTopic.lastIndexOf(F("%sysname%")));
+  LWTTopic += Settings.Name;
+  LWTTopic += F("/status");
 
   for (byte x = 1; x < 3; x++)
   {


### PR DESCRIPTION


After configuring "openhab mqtt" controller with:

  * Controller Subscribe: cmnd/home/ground_floor/kitchen/%sysname%/#
  * Controller Publish: stat/home/ground_floor/kitchen/%sysname%/%tskname%/%valname%
  
Here is what I see on my debug mqtt session:

```
received PUBLISH (d0, q0, r0, m0, 'cmnd/home/ground_floor/kitchen/backlight/status', ... (9 bytes))
Connected
```

What I would expected with those settings is topic like 

> stat/home/ground_floor/kitchen/%sysname%/status
