### PR TITLE
MQTT client id

### DIFF
--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -105,7 +105,7 @@ void MQTTConnect()
   MQTTclient.setCallback(callback);
 
   // MQTT needs a unique clientname to subscribe to broker
-  String clientid = "ESPClient";
+  String clientid = Settings.Name;
   clientid += Settings.Unit;
   String subscribeTo = "";
 


### PR DESCRIPTION

MQTT client id need to be unique. Just use device name, instead of fixed one. Does it means that "Unit Number" can be dropped?