### PR TITLE
Dallas Plugin enhanced : no more "delay()"

### DIFF
--- a/src/_P004_Dallas.ino
+++ b/src/_P004_Dallas.ino
@@ -269,7 +269,7 @@ int Plugin_004_DS_getResolution(uint8_t ROM[8])
 
     if (Plugin_004_DS_crc8(ScratchPad, 8) != ScratchPad[8])
     {
-        return false;
+        return 0;
     }
     else
     {


### PR DESCRIPTION
- Proposition to split DS_readTemp() in 2: DS_convertTemp() and DS_readonlyTemp().
DS_convertTemp() is first called after DS_setResolution().
Then DS_convertTemp() is called after temp has been read.
Pooling delay is always > 1 second, thus DS_convertTemp() is always called at least 1 second before DS_readonlyTemp().
The only downside is that you read the temperature of previous query (value set by Timer/TDT option).
DS_readTemp() has been kept for compatibility.
- Some minor typos