### PR TITLE
retain MQTT LWT messages

### DIFF
--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -119,9 +119,9 @@ void MQTTConnect()
     boolean MQTTresult = false;
 
     if ((SecuritySettings.ControllerUser[0] != 0) && (SecuritySettings.ControllerPassword[0] != 0))
-      MQTTresult = MQTTclient.connect(clientid.c_str(), SecuritySettings.ControllerUser[0], SecuritySettings.ControllerPassword[0], LWTTopic.c_str(), 0, 0, "Connection Lost");
+      MQTTresult = MQTTclient.connect(clientid.c_str(), SecuritySettings.ControllerUser[0], SecuritySettings.ControllerPassword[0], LWTTopic.c_str(), 0, 1, "Connection Lost");
     else
-      MQTTresult = MQTTclient.connect(clientid.c_str(), LWTTopic.c_str(), 0, 0, "Connection Lost");
+      MQTTresult = MQTTclient.connect(clientid.c_str(), LWTTopic.c_str(), 0, 1, "Connection Lost");
 
     if (MQTTresult)
     {
@@ -134,7 +134,7 @@ void MQTTConnect()
       log += subscribeTo;
       addLog(LOG_LEVEL_INFO, log);
 
-      MQTTclient.publish(LWTTopic.c_str(), "Connected");
+      MQTTclient.publish(LWTTopic.c_str(), "Connected", 1);
 
       statusLED(true);
       break; // end loop if succesfull


### PR DESCRIPTION
Retaining will messages allows monitoring agent to receive full info about clients state.
Without retaining, the monitoring agent will only be informed about events (connect/connection lost) happening during agent's connection to broker. Any reconnect would cause monitoring agent to lose state.