### PR TITLE
[HT16K33_LED] Brightness control

### DIFF
--- a/src/_P057_HT16K33_LED.ino
+++ b/src/_P057_HT16K33_LED.ino
@@ -10,6 +10,7 @@
 // (2) MX,<param>,<param>,<param>, ...    with hexadecimal values
 // (3) MNUM,<param>,<param>,<param>, ...    with decimal values for 7-segment displays
 // (4) MPRINT,<text>    with decimal values for 7-segment displays
+// (5) MBR,<0-15>    set display brightness, between 0 and 15
 
 // List of M* params:
 // (a) <value>
@@ -169,7 +170,12 @@ boolean Plugin_057(byte function, struct EventStruct *event, String& string)
           Plugin_057_M->TransmitRowBuffer();
           success = true;
         }
-
+        else if (command == F("mbr")) {
+          int paramPos = getParamStartPos(string, 2);
+          uint8_t brightness = string.substring(paramPos).toInt();
+          Plugin_057_M->SetBrightness(brightness);
+          success = true;
+        }
         else if (command == F("m") || command == F("mx") || command == F("mnum"))
         {
           String param;


### PR DESCRIPTION
Add command for controlling the LED display's brightness. Uses the function already available in the HT16K33 library.