### PR TITLE
[>49.7 days uptime overflow] Use separate function to compute time differences

### DIFF
--- a/src/Command.ino
+++ b/src/Command.ino
@@ -4,9 +4,8 @@ char* ramtest;
 //We make sure we're not reading more than maxSize bytes and we're not busy for longer than timeout mS.
 bool safeReadStringUntil(Stream &input, String &str, char terminator, unsigned int maxSize=1024, unsigned int timeout=1000)
 {
-    unsigned long startMillis;
     int c;
-    startMillis = millis();
+    const unsigned long timer = millis() + timeout;
     str="";
 
     do {
@@ -32,7 +31,7 @@ bool safeReadStringUntil(Stream &input, String &str, char terminator, unsigned i
             }
         }
         yield();
-    } while(millis() - startMillis < timeout);
+    } while(!timeOutReached(timer));
 
     addLog(LOG_LEVEL_ERROR, F("Timeout while reading input data!"));
     return(false);
@@ -67,7 +66,7 @@ void ExecuteCommand(byte source, const char *Line)
     success = true;
     unsigned long timer = millis() + Par1;
     Serial.println("start");
-    while (millis() < timer)
+    while (!timeOutReached(timer))
       backgroundtasks();
     Serial.println("end");
   }
@@ -396,7 +395,7 @@ void ExecuteCommand(byte source, const char *Line)
                    "Connection: close\r\n\r\n");
 
       unsigned long timer = millis() + 200;
-      while (!client.available() && millis() < timer)
+      while (!client.available() && !timeOutReached(timer))
         delay(1);
 
       while (client.available()) {

--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -18,8 +18,8 @@ void sendData(struct EventStruct *event)
 
   if (Settings.MessageDelay != 0)
   {
-    uint16_t dif = millis() - lastSend;
-    if (dif < Settings.MessageDelay)
+    const long dif = timePassedSince(lastSend);
+    if (dif > 0 && dif < static_cast<long>(Settings.MessageDelay))
     {
       uint16_t delayms = Settings.MessageDelay - dif;
       //this is logged nowhere else, so might as well disable it here also:
@@ -27,7 +27,7 @@ void sendData(struct EventStruct *event)
       delayBackground(delayms);
 
       // unsigned long timer = millis() + delayms;
-      // while (millis() < timer)
+      // while (!timeOutReached(timer))
       //   backgroundtasks();
     }
   }

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -882,16 +882,16 @@ void loop()
   else
   {
 
-    if (millis() > timer20ms)
+    if (timeOutReached(timer20ms))
       run50TimesPerSecond();
 
-    if (millis() > timer100ms)
+    if (timeOutReached(timer100ms))
       run10TimesPerSecond();
 
-    if (millis() > timerwd)
+    if (timeOutReached(timerwd))
       runEach30Seconds();
 
-    if (millis() > timer1s)
+    if (timeOutReached(timer1s))
       runOncePerSecond();
   }
   backgroundtasks();
@@ -1007,7 +1007,7 @@ void runOncePerSecond()
     Serial.println(timer);
   }
 
-  if (timerAPoff != 0 && millis() > timerAPoff)
+  if (timerAPoff != 0 && timeOutReached(timerAPoff))
   {
     timerAPoff = 0;
     WifiAPMode(false);
@@ -1061,7 +1061,7 @@ void checkSensors()
   {
     if (
         (Settings.TaskDeviceTimer[x] != 0) &&
-        (isDeepSleep || (millis() > timerSensor[x]))
+        (isDeepSleep || timeOutReached(timerSensor[x]))
     )
     {
       timerSensor[x] = millis() + Settings.TaskDeviceTimer[x] * 1000;
@@ -1198,7 +1198,7 @@ void checkSystemTimers()
   for (byte x = 0; x < SYSTEM_TIMER_MAX; x++)
     if (systemTimers[x].timer != 0)
     {
-      if (timeOut(systemTimers[x].timer))
+      if (timeOutReached(systemTimers[x].timer))
       {
         struct EventStruct TempEvent;
         TempEvent.Par1 = systemTimers[x].Par1;
@@ -1213,7 +1213,7 @@ void checkSystemTimers()
 
   for (byte x = 0; x < SYSTEM_CMD_TIMER_MAX; x++)
     if (systemCMDTimers[x].timer != 0)
-      if (timeOut(systemCMDTimers[x].timer))
+      if (timeOutReached(systemCMDTimers[x].timer))
       {
         struct EventStruct TempEvent;
         parseCommandString(&TempEvent, systemCMDTimers[x].action);

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -353,22 +353,57 @@ String getPinStateJSON(boolean search, byte plugin, byte index, String& log, uin
 
 /********************************************************************************************\
   Unsigned long Timer timeOut check
-  \*********************************************************************************************/
+\*********************************************************************************************/
 
-boolean timeOut(unsigned long timer)
+// Return the time difference as a signed value, taking into account the timers may overflow.
+// Returned timediff is between -24.9 days and +24.9 days.
+// Returned value is positive when "next" is after "prev"
+long timeDiff(unsigned long prev, unsigned long next)
+{
+  long signed_diff = 0;
+  // To cast a value to a signed long, the difference may not exceed half the ULONG_MAX
+  const unsigned long half_max_unsigned_long = 2147483647u;
+  if (next >= prev) {
+    const unsigned long diff = next - prev;
+    if (diff < half_max_unsigned_long) {
+      // Normal situation, just return the difference.
+      // Difference is a positive value.
+      signed_diff = static_cast<long>(diff);
+    } else {
+      // prev has overflow, return a negative difference value
+      signed_diff = static_cast<long>((ULONG_MAX - next) + prev + 1u);
+      signed_diff = -1 * signed_diff;
+    }
+  } else {
+    // next < prev
+    const unsigned long diff = prev - next;
+    if (diff < half_max_unsigned_long) {
+      // Normal situation, return a negative difference value
+      signed_diff = static_cast<long>(diff);
+      signed_diff = -1 * signed_diff;
+    } else {
+      // next has overflow, return a positive difference value
+      signed_diff = static_cast<long>((ULONG_MAX - prev) + next + 1u);
+    }
+  }
+  return signed_diff;
+}
+
+// Compute the numbe of milliSeconds passed since timestamp given.
+// N.B. value can be negative if the timestamp has not yet been reached.
+long timePassedSince(unsigned long timestamp) {
+  return timeDiff(timestamp, millis());
+}
+
+// Check if a certain timeout has been reached.
+boolean timeOutReached(unsigned long timer)
 {
   // This routine solves the 49 day bug without the need for separate start time and duration
   //   that would need two 32 bit variables if duration is not static
   // It limits the maximum delay to 24.9 days.
-
-  unsigned long now = millis();
-  //XXX: fix me, something fishy going on here, this << operator is in the wrong place or parenthesis are wrong
-  if (((now >= timer) && ((now - timer) < 1u << 31))  || ((timer >= now) && (timer - now > 1u << 31)))
-    return true;
-
-  return false;
+  const long passed = timePassedSince(timer);
+  return passed >= 0;
 }
-
 
 /********************************************************************************************\
   Status LED
@@ -399,7 +434,7 @@ void statusLED(boolean traffic)
 
     if (WiFi.status() == WL_CONNECTED)
     {
-      long int delta=millis()-gnLastUpdate;
+      long int delta = timePassedSince(gnLastUpdate);
       if (delta>0 || delta<0 )
       {
         nStatusValue -= STATUS_PWM_NORMALFADE; //ramp down slowly
@@ -441,7 +476,7 @@ void statusLED(boolean traffic)
 void delayBackground(unsigned long delay)
 {
   unsigned long timer = millis() + delay;
-  while (millis() < timer)
+  while (!timeOutReached(timer))
     backgroundtasks();
 }
 
@@ -1986,12 +2021,12 @@ void setTime(unsigned long t) {
 
 unsigned long now() {
   // calculate number of seconds passed since last call to now()
-  while (millis() - prevMillis >= 1000) {
-    // millis() and prevMillis are both unsigned ints thus the subtraction will always be the absolute value of the difference
-    sysTime++;
-    prevMillis += 1000;
-  }
+  const long msec_passed = timePassedSince(prevMillis);
+  const long seconds_passed = msec_passed / 1000;
+  sysTime += seconds_passed;
+  prevMillis += seconds_passed * 1000;
   if (nextSyncTime <= sysTime) {
+    // nextSyncTime & sysTime are in seconds
     unsigned long  t = getNtpTime();
     if (t != 0) {
       if (Settings.DST)
@@ -2116,7 +2151,7 @@ unsigned long getNtpTime()
     udp.endPacket();
 
     uint32_t beginWait = millis();
-    while (millis() - beginWait < 1000) {
+    while (!timeOutReached(beginWait + 1000)) {
       int size = udp.parsePacket();
       if (size >= NTP_PACKET_SIZE) {
         udp.read(packetBuffer, NTP_PACKET_SIZE);  // read packet into the buffer
@@ -2127,7 +2162,7 @@ unsigned long getNtpTime()
         secsSince1900 |= (unsigned long)packetBuffer[42] << 8;
         secsSince1900 |= (unsigned long)packetBuffer[43];
         log = F("NTP  : NTP replied: ");
-        log += millis() - beginWait;
+        log += timePassedSince(beginWait);
         log += F(" mSec");
         addLog(LOG_LEVEL_DEBUG_MORE, log);
         return secsSince1900 - 2208988800UL + Settings.TimeZone * SECS_PER_MIN;
@@ -2162,7 +2197,7 @@ void rulesProcessing(String& event)
   }
 
   log = F("EVENT: Processing time:");
-  log += millis() - timer;
+  log += timePassedSince(timer);
   log += F(" milliSeconds");
   addLog(LOG_LEVEL_DEBUG, log);
 
@@ -2523,7 +2558,7 @@ void rulesTimers()
   {
     if (RulesTimer[x] != 0L) // timer active?
     {
-      if (RulesTimer[x] <= millis()) // timer finished?
+      if (timeOutReached(RulesTimer[x])) // timer finished?
       {
         RulesTimer[x] = 0L; // turn off this timer
         String event = F("Rules#Timer=");

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -362,10 +362,10 @@ long timeDiff(unsigned long prev, unsigned long next)
 {
   long signed_diff = 0;
   // To cast a value to a signed long, the difference may not exceed half the ULONG_MAX
-  const unsigned long half_max_unsigned_long = 2147483647u;
+  const unsigned long half_max_unsigned_long = 2147483647u; // = 2^31 -1
   if (next >= prev) {
     const unsigned long diff = next - prev;
-    if (diff < half_max_unsigned_long) {
+    if (diff <= half_max_unsigned_long) {
       // Normal situation, just return the difference.
       // Difference is a positive value.
       signed_diff = static_cast<long>(diff);
@@ -377,7 +377,7 @@ long timeDiff(unsigned long prev, unsigned long next)
   } else {
     // next < prev
     const unsigned long diff = prev - next;
-    if (diff < half_max_unsigned_long) {
+    if (diff <= half_max_unsigned_long) {
       // Normal situation, return a negative difference value
       signed_diff = static_cast<long>(diff);
       signed_diff = -1 * signed_diff;
@@ -389,7 +389,7 @@ long timeDiff(unsigned long prev, unsigned long next)
   return signed_diff;
 }
 
-// Compute the numbe of milliSeconds passed since timestamp given.
+// Compute the number of milliSeconds passed since timestamp given.
 // N.B. value can be negative if the timestamp has not yet been reached.
 long timePassedSince(unsigned long timestamp) {
   return timeDiff(timestamp, millis());
@@ -398,9 +398,6 @@ long timePassedSince(unsigned long timestamp) {
 // Check if a certain timeout has been reached.
 boolean timeOutReached(unsigned long timer)
 {
-  // This routine solves the 49 day bug without the need for separate start time and duration
-  //   that would need two 32 bit variables if duration is not static
-  // It limits the maximum delay to 24.9 days.
   const long passed = timePassedSince(timer);
   return passed >= 0;
 }

--- a/src/Networking.ino
+++ b/src/Networking.ino
@@ -699,10 +699,10 @@ void SSDP_update() {
     }
   }
 
-  if (_pending && (millis() - _process_time) > _delay) {
+  if (_pending && timeOutReached(_process_time + _delay)) {
     _pending = false; _delay = 0;
     SSDP_send(NONE);
-  } else if (_notify_time == 0 || (millis() - _notify_time) > (SSDP_INTERVAL * 1000L)) {
+  } else if (_notify_time == 0 || timeOutReached(_notify_time + (SSDP_INTERVAL * 1000L))) {
     _notify_time = millis();
     SSDP_send(NOTIFY);
   }

--- a/src/_C001.ino
+++ b/src/_C001.ino
@@ -178,7 +178,7 @@ boolean CPlugin_001(byte function, struct EventStruct *event, String& string)
           client.print(request);
 
           unsigned long timer = millis() + 200;
-          while (!client.available() && millis() < timer)
+          while (!client.available() && !timeOutReached(timer)) 
             yield();
 
           // Read all the lines of the reply from server and log them

--- a/src/_C003.ino
+++ b/src/_C003.ino
@@ -67,11 +67,11 @@ boolean CPlugin_003(byte function, struct EventStruct *event, String& string)
         client.print(" \n");
 
         unsigned long timer = millis() + 200;
-        while (!client.available() && millis() < timer)
+        while (!client.available() && !timeOutReached(timer))
           delay(1);
 
         timer = millis() + 1000;
-        while (client.available() && millis() < timer && !success)
+        while (client.available() && !timeOutReached(timer) && !success)
         {
 
           //   String line = client.readStringUntil('\n');

--- a/src/_C004.ino
+++ b/src/_C004.ino
@@ -86,7 +86,7 @@ boolean CPlugin_004(byte function, struct EventStruct *event, String& string)
         client.print(postStr);
 
         unsigned long timer = millis() + 200;
-        while (!client.available() && millis() < timer)
+        while (!client.available() && !timeOutReached(timer))
           delay(1);
 
         // Read all the lines of the reply from server and print them to Serial

--- a/src/_C007.ino
+++ b/src/_C007.ino
@@ -124,7 +124,7 @@ boolean CPlugin_007(byte function, struct EventStruct *event, String& string)
         client.print(postDataStr);
 
         unsigned long timer = millis() + 200;
-        while (!client.available() && millis() < timer)
+        while (!client.available() && !timeOutReached(timer))
           delay(1);
 
         // Read all the lines of the reply from server and print them to Serial

--- a/src/_C008.ino
+++ b/src/_C008.ino
@@ -51,7 +51,7 @@ boolean CPlugin_008(byte function, struct EventStruct *event, String& string)
           {
             delayBackground(Settings.MessageDelay);
             // unsigned long timer = millis() + Settings.MessageDelay;
-            // while (millis() < timer)
+            // while (!timeOutReached(timer))
             //   backgroundtasks();
           }
         }
@@ -132,7 +132,7 @@ boolean HTTPSend(struct EventStruct *event, byte varIndex, float value, unsigned
                F("Connection: close\r\n\r\n"));
 
   unsigned long timer = millis() + 200;
-  while (!client.available() && millis() < timer)
+  while (!client.available() && !timeOutReached(timer))
     yield();
 
   // Read all the lines of the reply from server and print them to Serial

--- a/src/_C009.ino
+++ b/src/_C009.ino
@@ -176,7 +176,7 @@ void FHEMHTTPsend(String & url, String & buffer, byte index)
               + buffer);
 
   unsigned long timer = millis() + 200;
-  while (!client.available() && millis() < timer)
+  while (!client.available() && !timeOutReached(timer))
     yield();
 
   // Read all the lines of the reply from server and print them to Serial

--- a/src/_C010.ino
+++ b/src/_C010.ino
@@ -50,7 +50,7 @@ boolean CPlugin_010(byte function, struct EventStruct *event, String& string)
           {
             delayBackground(Settings.MessageDelay);
             // unsigned long timer = millis() + Settings.MessageDelay;
-            // while (millis() < timer)
+            // while (!timeOutReached(timer))
             //   backgroundtasks();
           }
         }

--- a/src/_C011.ino
+++ b/src/_C011.ino
@@ -193,7 +193,7 @@ boolean HTTPSend011(struct EventStruct *event)
   addLog(LOG_LEVEL_DEBUG_MORE, payload);
 
   unsigned long timer = millis() + 200;
-  while (!client.available() && millis() < timer)
+  while (!client.available() && !timeOutReached(timer))
     yield();
 
   // Read all the lines of the reply from server and print them to Serial

--- a/src/_N001_Email.ino
+++ b/src/_N001_Email.ino
@@ -122,9 +122,9 @@ boolean NPlugin_001_MTA(WiFiClient client, String aStr, String aWaitForPattern)
   yield();
 
   // Wait For Response
-  unsigned long ts = millis();
+  unsigned long timer = millis() + NPLUGIN_001_TIMEOUT;
   while (true) {
-    if ( ts + NPLUGIN_001_TIMEOUT < millis() ) {
+    if (timeOutReached(timer)) {
       myStatus = false;
       break;
     }

--- a/src/_P003_Pulse.ino
+++ b/src/_P003_Pulse.ino
@@ -180,7 +180,7 @@ boolean Plugin_003(byte function, struct EventStruct *event, String& string)
 \*********************************************************************************************/
 void Plugin_003_pulsecheck(byte Index)
 {
-  unsigned long PulseTime=millis() - Plugin_003_pulseTimePrevious[Index];
+  const unsigned long PulseTime=timePassedSince(Plugin_003_pulseTimePrevious[Index]);
   if(PulseTime > (unsigned long)Settings.TaskDevicePluginConfig[Index][0]) // check with debounce time for this task
     {
       Plugin_003_pulseCounter[Index]++;

--- a/src/_P042_Candle.ino
+++ b/src/_P042_Candle.ino
@@ -300,7 +300,7 @@ boolean Plugin_042(byte function, struct EventStruct *event, String& string)
           case 2: // Random Updates for Simple Candle, Advanced Candle, Fire Simulation
           case 3:
             {
-              if (millis() > Candle_Update) {
+              if (timeOutReached(Candle_Update)) {
                 if (Candle_type == 2) {
                   type_Simple_Candle();
                 }
@@ -314,7 +314,7 @@ boolean Plugin_042(byte function, struct EventStruct *event, String& string)
 
           case 4:   // Update for Police
             {
-              if (millis() > Candle_Update) {
+              if (timeOutReached(Candle_Update)) {
                 type_Police();
                 Candle_Update = millis() + 150;
               }
@@ -323,7 +323,7 @@ boolean Plugin_042(byte function, struct EventStruct *event, String& string)
 
           case 5:   // Update for Blink
             {
-              if (millis() > Candle_Update) {
+              if (timeOutReached(Candle_Update)) {
                 type_BlinkStrobe();
                 Candle_Update = millis() + 100;
               }
@@ -337,7 +337,7 @@ boolean Plugin_042(byte function, struct EventStruct *event, String& string)
             }
           case 7:   // Update for ColorFader
             {
-              if (millis() > Candle_Update) {
+              if (timeOutReached(Candle_Update)) {
                 type_ColorFader();
                 Candle_Update = millis() + 2000;
               }

--- a/src/_P045_MPU6050.ino
+++ b/src/_P045_MPU6050.ino
@@ -239,7 +239,7 @@ boolean Plugin_045(byte function, struct EventStruct *event, String& string)
         addLog(LOG_LEVEL_INFO,log);
 */
         // Run this bit every 5 seconds per deviceaddress (not per instance)
-        if ((_P045_time[dev] + 5000) < millis())
+        if (timeOutReached(_P045_time[dev] + 5000))
         {
           _P045_time[dev] = millis();
 

--- a/src/_P049_MHZ19.ino
+++ b/src/_P049_MHZ19.ino
@@ -9,11 +9,9 @@
   DevicePin2 - is TX for ESP
 */
 
-#ifdef PLUGIN_BUILD_TESTING
-
 #define PLUGIN_049
 #define PLUGIN_ID_049         49
-#define PLUGIN_NAME_049       "Gases - CO2 MH-Z19 [TESTING]"
+#define PLUGIN_NAME_049       "Gases - CO2 MH-Z19"
 #define PLUGIN_VALUENAME1_049 "PPM"
 #define PLUGIN_VALUENAME2_049 "Temperature" // Temperature in C
 #define PLUGIN_VALUENAME3_049 "U" // Undocumented, minimum measurement per time period?
@@ -205,9 +203,9 @@ boolean Plugin_049(byte function, struct EventStruct *event, String& string)
           // get response
           memset(mhzResp, 0, sizeof(mhzResp));
 
-          long start = millis();
+          long timer = millis() + PLUGIN_READ_TIMEOUT;
           int counter = 0;
-          while (((millis() - start) < PLUGIN_READ_TIMEOUT) && (counter < 9)) {
+          while (!timeOutReached(timer) && (counter < 9)) {
             if (Plugin_049_SoftSerial->available() > 0) {
               mhzResp[counter++] = Plugin_049_SoftSerial->read();
             } else {
@@ -358,5 +356,3 @@ boolean Plugin_049(byte function, struct EventStruct *event, String& string)
   }
   return success;
 }
-
-#endif

--- a/src/_P055_Chiming.ino
+++ b/src/_P055_Chiming.ino
@@ -290,7 +290,7 @@ boolean Plugin_055(byte function, struct EventStruct *event, String& string)
 
         if (Plugin_055_Data->millisStateEnd > 0)   // just striking?
         {
-          if (Plugin_055_Data->millisStateEnd <= millisAct)   // end reached?
+          if (timeDiff(millisAct, Plugin_055_Data->millisStateEnd) <= 0)   // end reached?
           {
             for (byte i=0; i<4; i++)
             {


### PR DESCRIPTION
As discussed in #594
The timeOut() function had already a remark that it was behaving fishy.

It is now split into a timeDiff function and two convenience functions:
- timeOutReached
- timePassedSince

The timeDiff function may be a bit more elaborate than strictly needed, but it is very important to do it right and the original notation was very hard to read and understand.

Almost all locations in the code where millis() was used to compute a time difference or check for timeouts now use these functions.
Potentially all of these locations could cause issues when the timer wraps.

Please let several people have a look at the code to see no mistakes have been made at places where these time functions are used.