### PR TITLE
[Domoticz HTTP] Compatibility fix for BMP280

### DIFF
--- a/src/_C001.ino
+++ b/src/_C001.ino
@@ -95,12 +95,12 @@ boolean CPlugin_001(byte function, struct EventStruct *event, String& string)
               url += F(";");
               url += humStat(UserVar[event->BaseVarIndex + 1]);
               break;
-            case SENSOR_TYPE_TEMP_BARO:                      // temp + hum + hum_stat + bar + bar_fore, used for BMP085
+            case SENSOR_TYPE_TEMP_BARO:                      // temp + bar used for BMP085 and BMP280
               url += F("&svalue=");
               url += formatUserVar(event, 0);
-              url += F(";0;0;");
+              url += F(";");
               url += formatUserVar(event, 1);
-              url += F(";0");
+              url += F(";0;0;");
               break;
             case SENSOR_TYPE_TRIPLE:
               url += F("&svalue=");


### PR DESCRIPTION
For Temp+Baro(SENSOR_TYPE_TEMP_BARO) sensors ESPEasy sends to Domoticz:
`GET /json.htm?type=command&param=udevice&idx=12&svalue=21.72;0;0;971.79;0 HTTP/1.1`

This is correct (according to [Domoticz Wiki](http://www.domoticz.com/wiki/Domoticz_API/JSON_URL%27s#Temperature.2Fbarometer)):
`GET /json.htm?type=command&param=udevice&idx=12&svalue=21.58;972.04;0;0; HTTP/1.1`