### PR TITLE
[Security] Add IP-based filtering to web interface and http-commands.

### DIFF
--- a/src/Command.ino
+++ b/src/Command.ino
@@ -180,6 +180,21 @@ void ExecuteCommand(byte source, const char *Line)
     delay(60000);
   }
 
+  if (strcasecmp_P(Command, PSTR("accessinfo")) == 0)
+  {
+    success = true;
+    Serial.print(F("Allowed IP range : "));
+    Serial.println(describeAllowedIPrange());
+  }
+
+  if (strcasecmp_P(Command, PSTR("clearaccessblock")) == 0)
+  {
+    success = true;
+    clearAccessBlock();
+    Serial.print(F("Allowed IP range : "));
+    Serial.println(describeAllowedIPrange());
+  }
+
   if (strcasecmp_P(Command, PSTR("meminfo")) == 0)
   {
     success = true;

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -90,6 +90,9 @@
 #define DEFAULT_DNS         "192.168.0.1"       // Enter your DNS
 #define DEFAULT_GW          "192.168.0.1"       // Enter your gateway
 #define DEFAULT_SUBNET      "255.255.255.0"     // Enter your subnet
+#define DEFAULT_IPRANGE_LOW  "0.0.0.0"          // Allowed IP range to access webserver
+#define DEFAULT_IPRANGE_HIGH "255.255.255.255"  // Allowed IP range to access webserver
+#define DEFAULT_IP_BLOCK_LEVEL 1                // 0: ALL_ALLOWED  1: LOCAL_SUBNET_ALLOWED  2: ONLY_IP_RANGE_ALLOWED
 
 #define DEFAULT_CONTROLLER   false              // true or false enabled or disabled, set 1st controller defaults
 // using a default template, you also need to set a DEFAULT PROTOCOL to a suitable MQTT protocol !
@@ -357,7 +360,7 @@
   #include <WiFi.h>
   #include <ESP32WebServer.h>
   #include "SPIFFS.h"
-  ESP32WebServer WebServer(80); 
+  ESP32WebServer WebServer(80);
   #ifdef FEATURE_MDNS
     #include <ESPmDNS.h>
   #endif
@@ -412,6 +415,9 @@ struct SecurityStruct
   char          ControllerUser[CONTROLLER_MAX][26];
   char          ControllerPassword[CONTROLLER_MAX][64];
   char          Password[26];
+  byte          AllowedIPrangeLow[4]; // TD-er: Use these
+  byte          AllowedIPrangeHigh[4];
+  byte          IPblockLevel;
   //its safe to extend this struct, up to 4096 bytes, default values in config are 0
 } SecuritySettings;
 
@@ -807,7 +813,7 @@ void setup()
 
   fileSystemCheck();
   LoadSettings();
-        
+
   if (strcasecmp(SecuritySettings.WifiSSID, "ssid") == 0)
     wifiSetup = true;
 

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -1759,10 +1759,8 @@ String parseTemplate(String &tmpString, byte lineSize)
   newString.replace(F("%vcc%"), String(vcc));
 #endif
 
-  IPAddress ip = WiFi.localIP();
-  char strIP[20];
-  formatIP(ip, strIP);
-  newString.replace(F("%ip%"), strIP);
+  const IPAddress ip = WiFi.localIP();
+  newString.replace(F("%ip%"), formatIP(ip));
   newString.replace(F("%ip1%"), String(ip[0]));
   newString.replace(F("%ip2%"), String(ip[1]));
   newString.replace(F("%ip3%"), String(ip[2]));
@@ -2244,10 +2242,8 @@ unsigned long getNtpTime()
     else
       WiFi.hostByName(ntpServerName, timeServerIP);
 
-    char host[20];
-    formatIP(timeServerIP, host);
     log = F("NTP  : NTP send to ");
-    log += host;
+    log += formatIP(timeServerIP);
     addLog(LOG_LEVEL_DEBUG_MORE, log);
 
     while (udp.parsePacket() > 0) ; // discard any previously received packets

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -1060,6 +1060,11 @@ void ResetFactory(void)
   strcpy_P(SecuritySettings.WifiKey, PSTR(DEFAULT_KEY));
   strcpy_P(SecuritySettings.WifiAPKey, PSTR(DEFAULT_AP_KEY));
   SecuritySettings.Password[0] = 0;
+  // TD-er Reset access control
+  str2ip((char*)DEFAULT_IPRANGE_LOW, SecuritySettings.AllowedIPrangeLow);
+  str2ip((char*)DEFAULT_IPRANGE_HIGH, SecuritySettings.AllowedIPrangeHigh);
+  SecuritySettings.IPblockLevel = DEFAULT_IP_BLOCK_LEVEL;
+
   Settings.Delay           = DEFAULT_DELAY;
   Settings.Pin_i2c_sda     = 4;
   Settings.Pin_i2c_scl     = 5;

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -1636,6 +1636,23 @@ boolean matchClockEvent(unsigned long clockEvent, unsigned long clockSet)
   Parse string template
   \*********************************************************************************************/
 
+// Call this by first declaring a char array of size 20, like:
+//  char strIP[20];
+//  formatIP(ip, strIP);
+void formatIP(const IPAddress& ip, char (&strIP)[20]) {
+  sprintf_P(strIP, PSTR("%u.%u.%u.%u"), ip[0], ip[1], ip[2], ip[3]);
+}
+
+String formatIP(const IPAddress& ip) {
+  char strIP[20];
+  formatIP(ip, strIP);
+  return String(strIP);
+}
+
+void formatMAC(const uint8_t* mac, char (&strMAC)[20]) {
+  sprintf_P(strMAC, PSTR("%02X:%02X:%02X:%02X:%02X:%02X"), mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+}
+
 String parseTemplate(String &tmpString, byte lineSize)
 {
   String newString = "";
@@ -1744,7 +1761,7 @@ String parseTemplate(String &tmpString, byte lineSize)
 
   IPAddress ip = WiFi.localIP();
   char strIP[20];
-  sprintf_P(strIP, PSTR("%u.%u.%u.%u"), ip[0], ip[1], ip[2], ip[3]);
+  formatIP(ip, strIP);
   newString.replace(F("%ip%"), strIP);
   newString.replace(F("%ip1%"), String(ip[0]));
   newString.replace(F("%ip2%"), String(ip[1]));
@@ -2228,7 +2245,7 @@ unsigned long getNtpTime()
       WiFi.hostByName(ntpServerName, timeServerIP);
 
     char host[20];
-    sprintf_P(host, PSTR("%u.%u.%u.%u"), timeServerIP[0], timeServerIP[1], timeServerIP[2], timeServerIP[3]);
+    formatIP(timeServerIP, host);
     log = F("NTP  : NTP send to ");
     log += host;
     addLog(LOG_LEVEL_DEBUG_MORE, log);

--- a/src/Networking.ino
+++ b/src/Networking.ino
@@ -414,10 +414,8 @@ void sendSysInfoUDP(byte repeats)
   \*********************************************************************************************/
 void SSDP_schema(WiFiClient &client) {
 
-  IPAddress ip = WiFi.localIP();
-  char str[20];
-  formatIP(ip, str);
-  uint32_t chipId = ESP.getChipId();
+  const IPAddress ip = WiFi.localIP();
+  const uint32_t chipId = ESP.getChipId();
   char uuid[64];
   sprintf_P(uuid, PSTR("38323636-4558-4dda-9188-cda0e6%02x%02x%02x"),
             (uint16_t) ((chipId >> 16) & 0xff),
@@ -437,7 +435,7 @@ void SSDP_schema(WiFiClient &client) {
                          "<minor>0</minor>"
                          "</specVersion>"
                          "<URLBase>http://");
-  ssdp_schema += str;
+  ssdp_schema += formatIP(ip);
   ssdp_schema += F(":80/</URLBase>"
                    "<device>"
                    "<deviceType>urn:schemas-upnp-org:device:BinaryLight:1</deviceType>"

--- a/src/Networking.ino
+++ b/src/Networking.ino
@@ -65,7 +65,7 @@ void checkUDP()
     return;
 
   runningUPDCheck = true;
-    
+
   // UDP events
   int packetSize = portUDP.parsePacket();
   if (packetSize)
@@ -138,9 +138,9 @@ void checkUDP()
             }
 
             char macaddress[20];
-            sprintf_P(macaddress, PSTR("%02x:%02x:%02x:%02x:%02x:%02x"), mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
-            char ipaddress[16];
-            sprintf_P(ipaddress, PSTR("%u.%u.%u.%u"), ip[0], ip[1], ip[2], ip[3]);
+            formatMAC(mac, macaddress);
+            char ipaddress[20];
+            formatIP(ip, ipaddress);
             char log[80];
             sprintf_P(log, PSTR("UDP  : %s,%s,%u"), macaddress, ipaddress, unit);
             addLog(LOG_LEVEL_DEBUG_MORE, log);
@@ -416,7 +416,7 @@ void SSDP_schema(WiFiClient &client) {
 
   IPAddress ip = WiFi.localIP();
   char str[20];
-  sprintf_P(str, PSTR("%u.%u.%u.%u"), ip[0], ip[1], ip[2], ip[3]);
+  formatIP(ip, str);
   uint32_t chipId = ESP.getChipId();
   char uuid[64];
   sprintf_P(uuid, PSTR("38323636-4558-4dda-9188-cda0e6%02x%02x%02x"),

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -516,10 +516,8 @@ void handle_root() {
     reply += lowestRAMfunction;
     reply += F(")");
 
-    char str[20];
-    formatIP(ip, str);
     reply += F("<TR><TD>IP:<TD>");
-    reply += str;
+    reply += formatIP(ip);
 
     reply += F("<TD><TD>Wifi RSSI:<TD>");
     if (WiFi.status() == WL_CONNECTED)
@@ -3792,7 +3790,7 @@ void handle_setup() {
   if (WiFi.status() == WL_CONNECTED)
   {
     addHtmlError(reply, SaveSettings());
-    IPAddress ip = WiFi.localIP();
+    const IPAddress ip = WiFi.localIP();
     char host[20];
     formatIP(ip, host);
     reply += F("<BR>ESP is connected and using IP Address: <BR><h1>");
@@ -4161,18 +4159,15 @@ void handle_sysinfo() {
   }
 
   {
-    char str[20];
-    formatIP(WiFi.localIP(), str);
     reply += F("<TR><TD>IP<TD>");
-    reply += str;
+    reply += formatIP(WiFi.localIP());
 
-    formatIP(WiFi.gatewayIP(), str);
     reply += F("<TR><TD>GW<TD>");
-    reply += str;
+    reply += formatIP(WiFi.gatewayIP());
 
-    formatIP(WebServer.client().remoteIP(), str);
     reply += F("<TR><TD>Client IP<TD>");
-    reply += str;
+    WiFiClient client(WebServer.client());
+    reply += formatIP(client.remoteIP());
   }
 
   reply += F("<TR><TD>STA MAC<TD>");

--- a/src/Wifi.ino
+++ b/src/Wifi.ino
@@ -97,10 +97,8 @@ boolean WifiConnect(byte connectAttempts)
   //use static ip?
   if (Settings.IP[0] != 0 && Settings.IP[0] != 255)
   {
-    char str[20];
-    sprintf_P(str, PSTR("%u.%u.%u.%u"), Settings.IP[0], Settings.IP[1], Settings.IP[2], Settings.IP[3]);
     log = F("IP   : Static IP :");
-    log += str;
+    log += formatIP(Settings.IP);
     addLog(LOG_LEVEL_INFO, log);
     IPAddress ip = Settings.IP;
     IPAddress gw = Settings.Gateway;
@@ -197,9 +195,7 @@ boolean WifiConnectSSID(char WifiSSID[], char WifiKey[], byte connectAttempts)
     {
       log = F("WIFI : Connected! IP: ");
       IPAddress ip = WiFi.localIP();
-      char str[20];
-      sprintf_P(str, PSTR("%u.%u.%u.%u"), ip[0], ip[1], ip[2], ip[3]);
-      log += str;
+      log += formatIP(ip);
       log += F(" (");
       log += WifiGetHostname();
       log += F(")");

--- a/src/Wifi.ino
+++ b/src/Wifi.ino
@@ -97,13 +97,13 @@ boolean WifiConnect(byte connectAttempts)
   //use static ip?
   if (Settings.IP[0] != 0 && Settings.IP[0] != 255)
   {
+    const IPAddress ip = Settings.IP;
     log = F("IP   : Static IP :");
-    log += formatIP(Settings.IP);
+    log += ip;
     addLog(LOG_LEVEL_INFO, log);
-    IPAddress ip = Settings.IP;
-    IPAddress gw = Settings.Gateway;
-    IPAddress subnet = Settings.Subnet;
-    IPAddress dns = Settings.DNS;
+    const IPAddress gw = Settings.Gateway;
+    const IPAddress subnet = Settings.Subnet;
+    const IPAddress dns = Settings.DNS;
     WiFi.config(ip, gw, subnet, dns);
   }
 
@@ -194,8 +194,7 @@ boolean WifiConnectSSID(char WifiSSID[], char WifiKey[], byte connectAttempts)
     if (WiFi.status() == WL_CONNECTED)
     {
       log = F("WIFI : Connected! IP: ");
-      IPAddress ip = WiFi.localIP();
-      log += formatIP(ip);
+      log += WiFi.localIP();
       log += F(" (");
       log += WifiGetHostname();
       log += F(")");

--- a/src/Wifi.ino
+++ b/src/Wifi.ino
@@ -194,7 +194,7 @@ boolean WifiConnectSSID(char WifiSSID[], char WifiKey[], byte connectAttempts)
     if (WiFi.status() == WL_CONNECTED)
     {
       log = F("WIFI : Connected! IP: ");
-      log += WiFi.localIP();
+      log += formatIP(WiFi.localIP());
       log += F(" (");
       log += WifiGetHostname();
       log += F(")");
@@ -300,4 +300,30 @@ void WifiCheck()
       WifiAPMode(false);
     }
   }
+}
+
+//********************************************************************************
+// Return subnet range of WiFi.
+//********************************************************************************
+bool getSubnetRange(IPAddress& low, IPAddress& high)
+{
+  if (WifiIsAP()) {
+    // WiFi is active as accesspoint, do not check.
+    return false;
+  }
+  if (WiFi.status() != WL_CONNECTED) {
+    return false;
+  }
+  const IPAddress ip = WiFi.localIP();
+  const IPAddress subnet = WiFi.subnetMask();
+  low = ip;
+  high = ip;
+  // Compute subnet range.
+  for (byte i=0; i < 4; ++i) {
+    if (subnet[i] != 255) {
+      low[i] = low[i] & subnet[i];
+      high[i] = high[i] | ~subnet[i];
+    }
+  }
+  return true;
 }


### PR DESCRIPTION
As discussed in #647:
In the Config tab, a "Client IP filtering" section is added.
This allows for 3 levels of IP filtering:
* "Allow All" - does not imply any filtering based on IP address of the client.
* "Allow Local Subnet" - Allow only clients from within the local subnet, based on IP and subnetmask of the ESP.
* "Allow IP range" - Allow only clients within a range of IP-addresses.

Settings like these are very likely to lock out the rightful owner, so there are also two commands added, which can be sent via the serial connection.
* accessinfo
* clearaccessblock

The first one just displays the current active IP filtering.
The "clearaccessblock" command will temporarily disable the access filtering. This allows the user to login and reset the access filtering. Clearing the lock will not write to flash, thus cleared state will remain until reboot.

"Allow Local Subnet" is set as factory default.
Only when first loading a new firmware with this feature and existing configuration, the "All Allowed" is active (the old default)