### PR TITLE
[PubSubClient] Bug in handling domainname

### DIFF
--- a/lib/pubsubclient/src/PubSubClient.cpp
+++ b/lib/pubsubclient/src/PubSubClient.cpp
@@ -117,8 +117,8 @@ boolean PubSubClient::connect(const char *id, const char *user, const char *pass
     if (!connected()) {
         int result = 0;
 
-        if (domain != NULL) {
-            result = _client->connect(this->domain, this->port);
+        if (domain.length() != 0) {
+            result = _client->connect(this->domain.c_str(), this->port);
         } else {
             result = _client->connect(this->ip, this->port);
         }
@@ -560,7 +560,7 @@ PubSubClient& PubSubClient::setServer(uint8_t * ip, uint16_t port) {
 PubSubClient& PubSubClient::setServer(IPAddress ip, uint16_t port) {
     this->ip = ip;
     this->port = port;
-    this->domain = NULL;
+    this->domain = "";
     return *this;
 }
 

--- a/lib/pubsubclient/src/PubSubClient.h
+++ b/lib/pubsubclient/src/PubSubClient.h
@@ -95,7 +95,7 @@ private:
    boolean write(uint8_t header, uint8_t* buf, uint16_t length);
    uint16_t writeString(const char* string, uint8_t* buf, uint16_t pos);
    IPAddress ip;
-   const char* domain;
+   String domain;
    uint16_t port;
    Stream* stream;
    int _state;
@@ -114,6 +114,7 @@ public:
    PubSubClient(const char*, uint16_t, Client& client, Stream&);
    PubSubClient(const char*, uint16_t, MQTT_CALLBACK_SIGNATURE,Client& client);
    PubSubClient(const char*, uint16_t, MQTT_CALLBACK_SIGNATURE,Client& client, Stream&);
+   virtual ~PubSubClient() {}
 
    PubSubClient& setServer(IPAddress ip, uint16_t port);
    PubSubClient& setServer(uint8_t * ip, uint16_t port);


### PR DESCRIPTION
As discussed in pull request #629 and the new issue #658 and also on https://github.com/knolleary/pubsubclient/issues/375
In short, the PubSubClient does not store the domainname used to connect to, but only a pointer to the string.
However, PubSubClient should not expect this pointer to remain valid, since it is outside its scope. So PubSubClient should keep the domainname stored in its own variables.

This fixes the problem where the MQTT broker is no longer reachable after a while when using DNS instead of IP.