### PR TITLE
[SDS011] Allow the sensor to sleep to extend sensor lifetime

### DIFF
--- a/lib/SerialDevices/jkSDS011.cpp
+++ b/lib/SerialDevices/jkSDS011.cpp
@@ -35,8 +35,86 @@ CjkSDS011::CjkSDS011(int16_t pinRX, int16_t pinTX) : _serial(pinRX, pinTX)
   _pm10_avr = 0;
   _avr = 0;
   _data.SetPacketLength(10);
+  _command.SetPacketLength(19);
+  _working_period = -1;
+  _sleepmode_active = false;
 
   _serial.begin(9600);
+}
+
+void CjkSDS011::SendCommand(byte byte1, byte byte2, byte byte3) {
+  _command[0] = 0xAA; // Head
+  _command[1] = 0xB4; // Command ID
+  _command[2] = byte1; // Data Byte 1
+  _command[3] = byte2; // Data Byte 2
+  _command[4] = byte3; // Data Byte 3
+  _command[5] = 0; // Data Byte 4
+  _command[6] = 0; // Data Byte 5
+  _command[7] = 0; // Data Byte 6
+  _command[8] = 0; // Data Byte 7
+  _command[9] = 0; // Data Byte 8
+  _command[10] = 0; // Data Byte 9
+  _command[11] = 0; // Data Byte 10
+  _command[12] = 0; // Data Byte 11
+  _command[13] = 0; // Data Byte 12
+  _command[14] = 0; // Data Byte 13
+  _command[15] = 0xFF; // Device ID byte 1, FF: All sensor response
+  _command[16] = 0xFF; // Device ID byte 2, FF: All sensor response
+
+  byte checksum = 0;
+  for (byte i=2; i< 17; ++i) {
+    checksum += _command[i];
+  }
+  _command[17] = checksum; // Checksum
+  _command[18] = 0xAB; // Tail
+
+  for (int i = 0; i < 19; ++i) {
+    _serial.write(_command[i]);
+  }
+}
+
+void CjkSDS011::SetSleepMode(bool enabled) {
+  byte databyte3 = enabled ? 0 : 1;
+  SendCommand(6, 1, databyte3);
+}
+
+void CjkSDS011::SetWorkingPeriod(int minutes) {
+  // Data byte 1: 8
+  // Data byte 2: 0: query the current mode
+  //              1: set mode
+  // Data byte 3: 0：continuous(default)
+  //              1-30minute：work 30 seconds and sleep n*60-30 seconds
+  if (minutes < 0 || minutes > 30) return;
+  // Working period is stored in the flash of the sensor. Only write to change.
+  if (minutes != GetWorkingPeriod())
+    SendCommand(8, 1, minutes);
+}
+
+int CjkSDS011::GetWorkingPeriod() {
+  // Data byte 1: 8
+  // Data byte 2: 0: query the current mode
+  //              1: set mode
+  // Data byte 3: 0：continuous(default)
+  //              1-30minute：work 30 seconds and sleep n*60-30 seconds
+  SendCommand(8, 0, 0);
+  Process();
+  return _working_period;
+}
+
+void CjkSDS011::ParseCommandReply() {
+  switch(_data[2]) {
+    case 6: // Enable/Disable sleep mode.
+      if (_data[3] == 0)
+        _sleepmode_active = _data[4];
+      break;
+    case 8: // Set/Get working period
+      if (_data[3] == 0)
+        _working_period = _data[4];
+      break;
+    default:
+      // Not implemented.
+      break;
+  }
 }
 
 void CjkSDS011::Process()
@@ -45,33 +123,37 @@ void CjkSDS011::Process()
   {
   	_data.AddData(_serial.read());
 
-    if (_data[0] == 0xAA && _data[9] == 0xAB && (_data[1] == 0xC0 || _data[1] == 0xCF))   // correct packet frame?
+    if (_data[0] == 0xAA && _data[9] == 0xAB)   // correct packet frame?
     {
       byte checksum = 0;
       for (byte i=2; i<= 7; i++)
-      checksum += _data[i];
+        checksum += _data[i];
       if (checksum != _data[8])
         continue;
 
-      if (_data[1] == 0xC0)   // SDS011 or SDS018?
-      {
-        _pm2_5 = (float)((_data[3] << 8) | _data[2]) * 0.1;
-        _pm10_ = (float)((_data[5] << 8) | _data[4]) * 0.1;
-        _available = true;
+      switch(_data[1]) {
+        case 0xC0:     // SDS011 or SDS018?
+          _pm2_5 = (float)((_data[3] << 8) | _data[2]) * 0.1;
+          _pm10_ = (float)((_data[5] << 8) | _data[4]) * 0.1;
+          _available = true;
+          break;
+        case 0xCF:    // SDS198?
+          _pm2_5 = (float)((_data[5] << 8) | _data[4]);
+          _pm10_ = (float)((_data[3] << 8) | _data[2]);
+          _available = true;
+          break;
+        case 0xC5:   // Reply on command ID 0xB4
+          ParseCommandReply();
+          break;
+        default:
+          break;
       }
-      else if (_data[1] == 0xCF)   // SDS198?
-      {
-        _pm2_5 = (float)((_data[5] << 8) | _data[4]);
-        _pm10_ = (float)((_data[3] << 8) | _data[2]);
-        _available = true;
+      if (_available) {
+        _pm2_5avr += _pm2_5;
+        _pm10_avr += _pm10_;
+        _avr++;
+        return;
       }
-      else
-        continue;
-
-      _pm2_5avr += _pm2_5;
-      _pm10_avr += _pm10_;
-      _avr++;
-      return;
     }
   }
 }

--- a/lib/SerialDevices/jkSDS011.cpp
+++ b/lib/SerialDevices/jkSDS011.cpp
@@ -90,7 +90,8 @@ void CjkSDS011::SetWorkingPeriod(int minutes) {
   //              1-30minute：work 30 seconds and sleep n*60-30 seconds
   if (minutes < 0 || minutes > 30) return;
   // Working period is stored in the flash of the sensor. Only write to change.
-  if (minutes != GetWorkingPeriod())
+  const int currentWorkingPeriod = GetWorkingPeriod();
+  if (minutes != currentWorkingPeriod)
     SendCommand(8, 1, minutes);
 }
 
@@ -156,6 +157,7 @@ void CjkSDS011::Process()
         _pm2_5avr += _pm2_5;
         _pm10_avr += _pm10_;
         _avr++;
+        _data.Clear();
         return;
       }
     }

--- a/lib/SerialDevices/jkSDS011.h
+++ b/lib/SerialDevices/jkSDS011.h
@@ -27,13 +27,15 @@
 #define _jkSDS011_H_
 
 #include "Arduino.h"
-#include "SensorSerial.h"
+//#include "SensorSerial.h"
 #include "SensorSerialBuffer.h"
+#include "ESPeasySoftwareSerial.h"
 
 class CjkSDS011
 {
 public:
   CjkSDS011(int16_t pinRX, int16_t pinTX);
+  virtual ~CjkSDS011();
 
   void Process();
 
@@ -42,7 +44,8 @@ public:
   float GetPM2_5() { return _pm2_5; };
   float GetPM10_() { return _pm10_; };
 
-  void ReadAverage(float &pm25, float &pm10);
+  // Return true when there are valid samples.
+  boolean ReadAverage(float &pm25, float &pm10);
 
   void SetSleepMode(bool enabled);
 
@@ -59,7 +62,8 @@ private:
   void SendCommand(byte byte1, byte byte2, byte byte3);
   void ParseCommandReply();
 
-  SensorSerial _serial;
+//  SensorSerial _serial;
+  ESPeasySoftwareSerial *_serial;
   CSensorSerialBuffer _data;
   CSensorSerialBuffer _command;
   float _pm2_5;

--- a/lib/SerialDevices/jkSDS011.h
+++ b/lib/SerialDevices/jkSDS011.h
@@ -44,9 +44,24 @@ public:
 
   void ReadAverage(float &pm25, float &pm10);
 
+  void SetSleepMode(bool enabled);
+
+  // Set interval to get new data, 0 .. 30 minutes.
+  // Minutes = 0 => continous mode.
+  // The setting is still effective after power off(factory default is continuous measurement)
+  void SetWorkingPeriod(int minutes);
+
+  // Get the working period in minutes (0 = continuous reading)
+  // Negative return value indicates error during communication.
+  int GetWorkingPeriod();
+
 private:
+  void SendCommand(byte byte1, byte byte2, byte byte3);
+  void ParseCommandReply();
+
   SensorSerial _serial;
   CSensorSerialBuffer _data;
+  CSensorSerialBuffer _command;
   float _pm2_5;
   float _pm10_;
   float _pm2_5avr;
@@ -54,6 +69,8 @@ private:
   uint16_t _avr;
   boolean _available;
   boolean _sws;
+  int _working_period;
+  boolean _sleepmode_active;
 };
 
 #endif

--- a/src/_P056_SDS011-Dust.ino
+++ b/src/_P056_SDS011-Dust.ino
@@ -33,7 +33,7 @@ boolean Plugin_056(byte function, struct EventStruct *event, String& string)
     case PLUGIN_DEVICE_ADD:
       {
         Device[++deviceCount].Number = PLUGIN_ID_056;
-        Device[deviceCount].Type = DEVICE_TYPE_SINGLE;
+        Device[deviceCount].Type = DEVICE_TYPE_DUAL;
         Device[deviceCount].VType = SENSOR_TYPE_DUAL;
         Device[deviceCount].Ports = 0;
         Device[deviceCount].PullUpOption = false;
@@ -59,11 +59,34 @@ boolean Plugin_056(byte function, struct EventStruct *event, String& string)
         strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[1], PSTR(PLUGIN_VALUENAME2_056));
         break;
       }
-
+    case PLUGIN_WEBFORM_LOAD:
+      {
+        if (Plugin_056_hasTxPin(event)) {
+          addFormNumericBox(string, F("Sleep time"), F("plugin_056_sleeptime"),
+                            Settings.TaskDevicePluginConfig[event->TaskIndex][0],
+                            0, 30);
+          addUnit(string, F("Minutes"));
+          addFormNote(string, F("0 = continous, 1..30 = Work 30 seconds and sleep n*60-30 seconds"));
+        }
+        break;
+      }
+      case PLUGIN_WEBFORM_SAVE:
+        {
+          if (Plugin_056_hasTxPin(event)) {
+            // Communications to device should work.
+            const int newsleeptime = getFormItemInt(F("plugin_056_sleeptime"));
+            if (Settings.TaskDevicePluginConfig[event->TaskIndex][0] != newsleeptime) {
+              Settings.TaskDevicePluginConfig[event->TaskIndex][0] = getFormItemInt(F("plugin_056_sleeptime"));
+              Plugin_056_setWorkingPeriod(newsleeptime);
+            }
+          }
+          success = true;
+          break;
+        }
     case PLUGIN_GET_DEVICEGPIONAMES:
       {
         event->String1 = F("GPIO &larr; TX");
-        //event->String2 = F("GPIO &#8674; RX (optional)");
+        event->String2 = F("GPIO &#8674; RX (optional)");
         break;
       }
 
@@ -71,8 +94,14 @@ boolean Plugin_056(byte function, struct EventStruct *event, String& string)
       {
         if (Plugin_056_SDS)
           delete Plugin_056_SDS;
-        Plugin_056_SDS = new CjkSDS011(Settings.TaskDevicePin1[event->TaskIndex], -1);
-        addLog(LOG_LEVEL_INFO, F("SDS  : Init OK "));
+        const int16_t serial_rx = Settings.TaskDevicePin1[event->TaskIndex];
+        const int16_t serial_tx = Settings.TaskDevicePin2[event->TaskIndex];
+        Plugin_056_SDS = new CjkSDS011(serial_rx, serial_tx);
+        String log = F("SDS  : Init OK  ESP GPIO-pin RX:");
+        log += serial_rx;
+        log += F(" TX:");
+        log += serial_tx;
+        addLog(LOG_LEVEL_INFO, log);
 
         success = true;
         break;
@@ -132,6 +161,43 @@ boolean Plugin_056(byte function, struct EventStruct *event, String& string)
   }
 
   return success;
+}
+
+boolean Plugin_056_hasTxPin(struct EventStruct *event) {
+  const int16_t serial_tx = Settings.TaskDevicePin2[event->TaskIndex];
+  return serial_tx >= 0;
+}
+
+String Plugin_056_ErrorToString(int error) {
+  String log;
+  if (error < 0) {
+    log =  F("comm error: ");
+    log += error;
+  }
+  return log;
+}
+
+String Plugin_056_WorkingPeriodToString(int workingPeriod) {
+  if (workingPeriod < 0) {
+    return Plugin_056_ErrorToString(workingPeriod);
+  }
+  String log;
+  if (workingPeriod > 0) {
+    log += workingPeriod;
+    log += F(" minutes");
+  } else {
+    log += F(" continuous");
+  }
+  return log;
+}
+
+void Plugin_056_setWorkingPeriod(int minutes) {
+  if (!Plugin_056_SDS)
+    return;
+  Plugin_056_SDS->SetWorkingPeriod(minutes);
+  String log = F("SDS  : Working Period set to: ");
+  log += Plugin_056_WorkingPeriodToString(minutes);
+  addLog(LOG_LEVEL_INFO, log);
 }
 
 #endif   //PLUGIN_BUILD_TESTING

--- a/src/_P056_SDS011-Dust.ino
+++ b/src/_P056_SDS011-Dust.ino
@@ -42,7 +42,7 @@ boolean Plugin_056(byte function, struct EventStruct *event, String& string)
         Device[deviceCount].ValueCount = 2;
         Device[deviceCount].SendDataOption = true;
         Device[deviceCount].TimerOption = true;
-        Device[deviceCount].TimerOptional = true;
+        Device[deviceCount].TimerOptional = false;
         Device[deviceCount].GlobalSyncOption = true;
         break;
       }
@@ -95,16 +95,18 @@ boolean Plugin_056(byte function, struct EventStruct *event, String& string)
 
         if (Plugin_056_SDS->available())
         {
+          const float pm2_5 = Plugin_056_SDS->GetPM2_5();
+          const float pm10 = Plugin_056_SDS->GetPM10_();
           String log = F("SDS  : act ");
-          log += Plugin_056_SDS->GetPM2_5();
+          log += pm2_5;
           log += F(" ");
-          log += Plugin_056_SDS->GetPM10_();
+          log += pm10;
           addLog(LOG_LEVEL_DEBUG, log);
 
           if (Settings.TaskDeviceTimer[event->TaskIndex] == 0)
           {
-            UserVar[event->BaseVarIndex + 0] = Plugin_056_SDS->GetPM2_5();
-            UserVar[event->BaseVarIndex + 1] = Plugin_056_SDS->GetPM10_();
+            UserVar[event->BaseVarIndex + 0] = pm2_5;
+            UserVar[event->BaseVarIndex + 1] = pm10;
             event->sensorType = SENSOR_TYPE_DUAL;
             sendData(event);
           }
@@ -120,11 +122,11 @@ boolean Plugin_056(byte function, struct EventStruct *event, String& string)
           break;
 
         float pm25, pm10;
-        Plugin_056_SDS->ReadAverage(pm25, pm10);
-
-        UserVar[event->BaseVarIndex + 0] = pm25;
-        UserVar[event->BaseVarIndex + 1] = pm10;
-        success = true;
+        if (Plugin_056_SDS->ReadAverage(pm25, pm10)) {
+          UserVar[event->BaseVarIndex + 0] = pm25;
+          UserVar[event->BaseVarIndex + 1] = pm10;
+          success = true;
+        }
         break;
       }
   }


### PR DESCRIPTION
As discussed in issue #499 

The internal laser of the SDS011 only will last for about 1 year when ran continuously.
When the RX of the sensor is connected, it can be set to sleep for N minutes between measurements. This will extend the lifetime of the sensor and reduce power consumption.
This sleep time is stored inside the flash of the sensor, so it can be set once and then the RX on the sensor could be disconnected again to be used for other purposes.

This pull request is now set on top of the Mega branch, but perhaps it could also be set to the v2.0 branch?
I've also changed the polling of the sensor and it now uses SoftSerial (see #631 when thinking about merging in v2.0 branch). This will lessen the CPU load of the ESP quite a lot, which will result in more stable operations.