### PR TITLE
Bugfix/v2.0 crash switch

### DIFF
--- a/lib/pubsubclient/src/PubSubClient.cpp
+++ b/lib/pubsubclient/src/PubSubClient.cpp
@@ -244,7 +244,7 @@ uint16_t PubSubClient::readPacket(uint8_t* lengthLength) {
         buffer[len++] = digit;
         length += (digit & 127) * multiplier;
         multiplier *= 128;
-    } while ((digit & 128) != 0);
+    } while ((digit & 128) != 0 && len < (MQTT_MAX_PACKET_SIZE -2));
     *lengthLength = len-1;
 
     if (isPublish) {
@@ -525,7 +525,7 @@ uint16_t PubSubClient::writeString(const char* string, uint8_t* buf, uint16_t po
     const char* idp = string;
     uint16_t i = 0;
     pos += 2;
-    while (*idp) {
+    while (*idp && pos < (MQTT_MAX_PACKET_SIZE - 2)) {
         buf[pos++] = *idp++;
         i++;
     }

--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -16,6 +16,7 @@ void sendData(struct EventStruct *event)
 //  if (!Settings.TaskDeviceSendData[event->TaskIndex])
 //    return false;
 
+  delay(1); // Make sure the yield() is called even when flooded with messages.
   if (Settings.MessageDelay != 0)
   {
     const long dif = timePassedSince(lastSend);
@@ -24,7 +25,11 @@ void sendData(struct EventStruct *event)
       uint16_t delayms = Settings.MessageDelay - dif;
       //this is logged nowhere else, so might as well disable it here also:
       // addLog(LOG_LEVEL_DEBUG_MORE, String(F("CTRL : Message delay (ms): "))+delayms);
-      delayBackground(delayms);
+
+      // Something really fishy is going on with the delayBackground function,
+      // which will result in crashes.
+      // Disabled for now and delay(1) added outside this if-scope.
+//      delayBackground(delayms);
 
       // unsigned long timer = millis() + delayms;
       // while (!timeOutReached(timer))

--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -17,6 +17,7 @@ void sendData(struct EventStruct *event)
 //    return false;
 
   delay(1); // Make sure the yield() is called even when flooded with messages.
+  /*
   if (Settings.MessageDelay != 0)
   {
     const long dif = timePassedSince(lastSend);
@@ -36,6 +37,7 @@ void sendData(struct EventStruct *event)
       //   backgroundtasks();
     }
   }
+  */
 
   LoadTaskSettings(event->TaskIndex); // could have changed during background tasks.
 

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -411,7 +411,7 @@ struct SettingsStruct
           TaskDevicePluginConfigFloat[task][cv] = 0.0;
         }
         for (byte cv = 0; cv < PLUGIN_CONFIGLONGVAR_MAX; ++cv) {
-          TaskDevicePluginConfigLong[task][PLUGIN_CONFIGLONGVAR_MAX] = 0;
+          TaskDevicePluginConfigLong[task][cv] = 0;
         }
         OLD_TaskDeviceSendData[task] = false;
         TaskDeviceGlobalSync[task] = false;

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -380,6 +380,47 @@ struct SecurityStruct
 
 struct SettingsStruct
 {
+  SettingsStruct() :
+    PID(0), Version(0), Build(0), IP_Octet(0), Unit(0), Delay(0),
+    Pin_i2c_sda(-1), Pin_i2c_scl(-1), Pin_status_led(-1), Pin_sd_cs(-1),
+    UDPPort(0), SyslogLevel(0), SerialLogLevel(0), WebLogLevel(0), SDLogLevel(0),
+    BaudRate(0), MessageDelay(0), deepSleep(0),
+    CustomCSS(false), DST(false), WDI2CAddress(0),
+    UseRules(false), UseSerial(false), UseSSDP(false), UseNTP(false),
+    WireClockStretchLimit(0), GlobalSync(false), ConnectionFailuresThreshold(0),
+    TimeZone(0), MQTTRetainFlag(false), InitSPI(false),
+    Pin_status_led_Inversed(false), deepSleepOnFail(false), UseValueLogger(false)
+    {
+      for (byte i = 0; i < CONTROLLER_MAX; ++i) {
+        Protocol[i] = 0;
+        ControllerEnabled[i] = false;
+        for (byte task = 0; task < TASKS_MAX; ++task) {
+          TaskDeviceID[i][task] = 0;
+          TaskDeviceSendData[i][task] = false;
+        }
+      }
+      for (byte task = 0; task < TASKS_MAX; ++task) {
+        TaskDeviceNumber[task] = 0;
+        OLD_TaskDeviceID[task] = 0;
+        TaskDevicePin1PullUp[task] = false;
+        for (byte cv = 0; cv < PLUGIN_CONFIGVAR_MAX; ++cv) {
+          TaskDevicePluginConfig[task][cv] = 0;
+        }
+        TaskDevicePin1Inversed[task] = false;
+        for (byte cv = 0; cv < PLUGIN_CONFIGFLOATVAR_MAX; ++cv) {
+          TaskDevicePluginConfigFloat[task][cv] = 0.0;
+        }
+        for (byte cv = 0; cv < PLUGIN_CONFIGLONGVAR_MAX; ++cv) {
+          TaskDevicePluginConfigLong[task][PLUGIN_CONFIGLONGVAR_MAX] = 0;
+        }
+        OLD_TaskDeviceSendData[task] = false;
+        TaskDeviceGlobalSync[task] = false;
+        TaskDeviceDataFeed[task] = 0;
+        TaskDeviceTimer[task] = 0;
+        TaskDeviceEnabled[task] = false;
+      }
+    }
+
   unsigned long PID;
   int           Version;
   int16_t       Build;
@@ -456,6 +497,7 @@ struct SettingsStruct
 
 struct ControllerSettingsStruct
 {
+  ControllerSettingsStruct() : UseDNS(false), Port(0) {}
   boolean       UseDNS;
   byte          IP[4];
   unsigned int  Port;
@@ -519,6 +561,21 @@ struct NotificationSettingsStruct
 
 struct ExtraTaskSettingsStruct
 {
+  ExtraTaskSettingsStruct() : TaskIndex(0) {
+    TaskDeviceName[0] = 0;
+    for (byte i = 0; i < VARS_PER_TASK; ++i) {
+      for (byte j = 0; j < 41; ++j) {
+        TaskDeviceFormula[i][j] = 0;
+        TaskDeviceValueNames[i][j] = 0;
+        TaskDeviceValueDecimals[i] = 0;
+      }
+    }
+    for (byte i = 0; i < PLUGIN_EXTRACONFIGVAR_MAX; ++i) {
+      TaskDevicePluginConfigLong[i] = 0;
+      TaskDevicePluginConfig[i] = 0;
+    }
+  }
+
   byte    TaskIndex;
   char    TaskDeviceName[41];
   char    TaskDeviceFormula[VARS_PER_TASK][41];
@@ -530,6 +587,10 @@ struct ExtraTaskSettingsStruct
 
 struct EventStruct
 {
+  EventStruct() :
+    Source(0), TaskIndex(0), ControllerIndex(0), ProtocolIndex(0), NotificationIndex(0),
+    BaseVarIndex(0), idx(0), sensorType(0), Par1(0), Par2(0), Par3(0), Par4(0), Par5(0),
+    OriginTaskIndex(0), Data(NULL) {}
   byte Source;
   byte TaskIndex; // index position in TaskSettings array, 0-11
   byte ControllerIndex; // index position in Settings.Controller, 0-3
@@ -554,6 +615,7 @@ struct EventStruct
 
 struct LogStruct
 {
+  LogStruct() : timeStamp(0), Message(NULL) {}
   unsigned long timeStamp;
   char* Message;
 } Logging[10];
@@ -561,6 +623,11 @@ int logcount = -1;
 
 struct DeviceStruct
 {
+  DeviceStruct() :
+    Number(0), Type(0), VType(0), Ports(0),
+    PullUpOption(false), InverseLogicOption(false), FormulaOption(false),
+    ValueCount(0), Custom(false), SendDataOption(false), GlobalSyncOption(false),
+    TimerOption(false), TimerOptional(false), DecimalsOnly(false) {}
   byte Number;
   byte Type;
   byte VType;
@@ -579,6 +646,9 @@ struct DeviceStruct
 
 struct ProtocolStruct
 {
+  ProtocolStruct() :
+    Number(0), usesMQTT(false), usesAccount(false), usesPassword(false),
+    defaultPort(0), usesTemplate(false), usesID(false) {}
   byte Number;
   boolean usesMQTT;
   boolean usesAccount;
@@ -590,6 +660,8 @@ struct ProtocolStruct
 
 struct NotificationStruct
 {
+  NotificationStruct() :
+    Number(0), usesMessaging(false), usesGPIO(0) {}
   byte Number;
   boolean usesMessaging;
   byte usesGPIO;
@@ -597,6 +669,11 @@ struct NotificationStruct
 
 struct NodeStruct
 {
+  NodeStruct() :
+    age(0), build(0), nodeName(NULL), nodeType(0)
+    {
+      for (byte i = 0; i < 4; ++i) ip[i] = 0;
+    }
   byte ip[4];
   byte age;
   uint16_t build;
@@ -606,6 +683,9 @@ struct NodeStruct
 
 struct systemTimerStruct
 {
+  systemTimerStruct() :
+    timer(0), plugin(0), Par1(0), Par2(0), Par3(0) {}
+
   unsigned long timer;
   byte plugin;
   byte Par1;
@@ -615,6 +695,7 @@ struct systemTimerStruct
 
 struct systemCMDTimerStruct
 {
+  systemCMDTimerStruct() : timer(0) {}
   unsigned long timer;
   String action;
 } systemCMDTimers[SYSTEM_CMD_TIMER_MAX];


### PR DESCRIPTION
When pressing the switch very frequently, the ESP device would crash.
Either due to something really fishy in delaying the background tasks (which isn't fixed yet), or the watchdog performing a panic reset of the ESP module.

Is related to #679,  #676 and #674 and might be a fix for all of them.
  