### PR TITLE
[CPPcheck] v2.0 ControllerSettingsStruct some variables not initialized

### DIFF
--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -497,7 +497,11 @@ struct SettingsStruct
 
 struct ControllerSettingsStruct
 {
-  ControllerSettingsStruct() : UseDNS(false), Port(0) {}
+  ControllerSettingsStruct() : UseDNS(false), Port(0) {
+    memset(HostName, 0, sizeof(HostName));
+    memset(Publish, 0, sizeof(Publish));
+    memset(Subscribe, 0, sizeof(Subscribe));
+  }
   boolean       UseDNS;
   byte          IP[4];
   unsigned int  Port;


### PR DESCRIPTION
Fixing these cppcheck errors:
```
cppcheck --enable=warning src/*.ino -q --force -I src --include=src/ESPEasy.ino --error-exitcode=1
[src/ESPEasy.ino:500]: (warning) Member variable 'ControllerSettingsStruct::HostName' is not initialized in the constructor.
[src/ESPEasy.ino:500]: (warning) Member variable 'ControllerSettingsStruct::Publish' is not initialized in the constructor.
[src/ESPEasy.ino:500]: (warning) Member variable 'ControllerSettingsStruct::Subscribe' is not initialized in the constructor.
```