### PR TITLE
[v2.0 #470] Do not send invalid values to a controller

### DIFF
--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -39,11 +39,19 @@ void sendData(struct EventStruct *event)
   {
     event->ControllerIndex = x;
     event->idx = Settings.TaskDeviceID[x][event->TaskIndex];
-
-    if (Settings.TaskDeviceSendData[event->ControllerIndex][event->TaskIndex] && Settings.ControllerEnabled[event->ControllerIndex] && Settings.Protocol[event->ControllerIndex])
+    if (Settings.TaskDeviceSendData[event->ControllerIndex][event->TaskIndex] &&
+        Settings.ControllerEnabled[event->ControllerIndex] && Settings.Protocol[event->ControllerIndex])
     {
       event->ProtocolIndex = getProtocolIndex(Settings.Protocol[event->ControllerIndex]);
-      CPlugin_ptr[event->ProtocolIndex](CPLUGIN_PROTOCOL_SEND, event, dummyString);
+      if (validUserVar(event)) {
+        CPlugin_ptr[event->ProtocolIndex](CPLUGIN_PROTOCOL_SEND, event, dummyString);
+      } else {
+        String log = F("Invalid value detected for controller ");
+        String controllerName;
+        CPlugin_ptr[event->ProtocolIndex](CPLUGIN_GET_DEVICENAME, event, controllerName);
+        log += controllerName;
+        addLog(LOG_LEVEL_DEBUG, log);
+      }
     }
   }
 
@@ -51,6 +59,17 @@ void sendData(struct EventStruct *event)
   lastSend = millis();
 }
 
+boolean validUserVar(struct EventStruct *event) {
+  for (int i = 0; i < VARS_PER_TASK; ++i) {
+    const float f(UserVar[event->BaseVarIndex + i]);
+    if (f == NAN)      return false; //("NaN");
+    if (f == INFINITY) return false; //("INFINITY");
+    if (-f == INFINITY)return false; //("-INFINITY");
+    if (isnan(f))      return false; //("isnan");
+    if (isinf(f))      return false; //("isinf");
+  }
+  return true;
+}
 
 /*********************************************************************************************\
  * Handle incoming MQTT messages


### PR DESCRIPTION
Prevent sending of invalid values (NaN, inf) to any controller.
Simple test is to output any plugin value with formula set to "%value%/0" and try to send it to any controller.
Is a fix for #470 and #693