### PR TITLE
[issue 728] Proper reconnect for MQTT controllers

### DIFF
--- a/src/Command.ino
+++ b/src/Command.ino
@@ -350,15 +350,19 @@ void ExecuteCommand(byte source, const char *Line)
   }
   if (strcasecmp_P(Command, PSTR("Publish")) == 0 && WiFi.status() == WL_CONNECTED)
   {
-    success = true;
-    String event = Line;
-    event = event.substring(8);
-    int index = event.indexOf(',');
-    if (index > 0)
-    {
-      String topic = event.substring(0, index);
-      String value = event.substring(index + 1);
-      MQTTclient.publish(topic.c_str(), value.c_str(), Settings.MQTTRetainFlag);
+    // ToDo TD-er: Not sure about this function, but at least it sends to an existing MQTTclient
+    int enabledMqttController = firstEnabledMQTTController();
+    if (enabledMqttController >= 0) {
+      success = true;
+      String event = Line;
+      event = event.substring(8);
+      int index = event.indexOf(',');
+      if (index > 0)
+      {
+        String topic = event.substring(0, index);
+        String value = event.substring(index + 1);
+        MQTTpublish(enabledMqttController, topic.c_str(), value.c_str(), Settings.MQTTRetainFlag);
+      }
     }
   }
 

--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -80,8 +80,12 @@ void callback(char* c_topic, byte* b_payload, unsigned int length) {
   char c_payload[384];
 
   statusLED(true);
-
-  if (length>sizeof(c_payload)-1)
+  int enabledMqttController = firstEnabledMQTTController();
+  if (enabledMqttController < 0) {
+    addLog(LOG_LEVEL_ERROR, F("MQTT : No enabled MQTT controller"));
+    return;
+  }
+  if ((length + 1) > sizeof(c_payload))
   {
     addLog(LOG_LEVEL_ERROR, F("MQTT : Ignored too big message"));
     return;
@@ -108,7 +112,7 @@ void callback(char* c_topic, byte* b_payload, unsigned int length) {
   struct EventStruct TempEvent;
   TempEvent.String1 = c_topic;
   TempEvent.String2 = c_payload;
-  byte ProtocolIndex = getProtocolIndex(Settings.Protocol[0]);
+  byte ProtocolIndex = getProtocolIndex(Settings.Protocol[enabledMqttController]);
   CPlugin_ptr[ProtocolIndex](CPLUGIN_PROTOCOL_RECV, &TempEvent, dummyString);
 }
 
@@ -116,11 +120,11 @@ void callback(char* c_topic, byte* b_payload, unsigned int length) {
 /*********************************************************************************************\
  * Connect to MQTT message broker
 \*********************************************************************************************/
-void MQTTConnect()
+void MQTTConnect(int controller_idx)
 {
   if (WiFi.status() != WL_CONNECTED) return;
   ControllerSettingsStruct ControllerSettings;
-  LoadControllerSettings(0, (byte*)&ControllerSettings, sizeof(ControllerSettings)); // todo index is now fixed to 0
+  LoadControllerSettings(controller_idx, (byte*)&ControllerSettings, sizeof(ControllerSettings));
 
   if (ControllerSettings.UseDNS) {
     MQTTclient.setServer(ControllerSettings.getHost().c_str(), ControllerSettings.Port);
@@ -143,8 +147,8 @@ void MQTTConnect()
     String log = "";
     boolean MQTTresult = false;
 
-    if ((SecuritySettings.ControllerUser[0] != 0) && (SecuritySettings.ControllerPassword[0] != 0))
-      MQTTresult = MQTTclient.connect(clientid.c_str(), SecuritySettings.ControllerUser[0], SecuritySettings.ControllerPassword[0], LWTTopic.c_str(), 0, 0, "Connection Lost");
+    if ((SecuritySettings.ControllerUser[controller_idx] != 0) && (SecuritySettings.ControllerPassword[controller_idx] != 0))
+      MQTTresult = MQTTclient.connect(clientid.c_str(), SecuritySettings.ControllerUser[controller_idx], SecuritySettings.ControllerPassword[controller_idx], LWTTopic.c_str(), 0, 0, "Connection Lost");
     else
       MQTTresult = MQTTclient.connect(clientid.c_str(), LWTTopic.c_str(), 0, 0, "Connection Lost");
 
@@ -178,9 +182,9 @@ void MQTTConnect()
 /*********************************************************************************************\
  * Check connection MQTT message broker
 \*********************************************************************************************/
-void MQTTCheck()
+void MQTTCheck(int controller_idx)
 {
-  byte ProtocolIndex = getProtocolIndex(Settings.Protocol[0]);
+  byte ProtocolIndex = getProtocolIndex(Settings.Protocol[controller_idx]);
   if (Protocol[ProtocolIndex].usesMQTT)
   {
     if (!MQTTclient.connected() || WiFi.status() != WL_CONNECTED)
@@ -190,7 +194,7 @@ void MQTTCheck()
       MQTTclient.disconnect();
       if (WiFi.status() == WL_CONNECTED) {
         delay(1000);
-        MQTTConnect();
+        MQTTConnect(controller_idx);
       }
     }
     else if (connectionFailures)
@@ -220,6 +224,14 @@ void SendStatus(byte source, String status)
   }
 }
 
+boolean MQTTpublish(int controller_idx, const char* topic, const char* payload, boolean retained)
+{
+  if (MQTTclient.publish(topic, payload, retained))
+    return true;
+  addLog(LOG_LEVEL_DEBUG, F("MQTT : publish failed"));
+  MQTTConnect(controller_idx);
+  return false;
+}
 
 /*********************************************************************************************\
  * Send status info back to channel where request came from
@@ -227,10 +239,12 @@ void SendStatus(byte source, String status)
 void MQTTStatus(String& status)
 {
   ControllerSettingsStruct ControllerSettings;
-  LoadControllerSettings(0, (byte*)&ControllerSettings, sizeof(ControllerSettings)); // todo index is now fixed to 0
-
-  String pubname = ControllerSettings.Subscribe;
-  pubname.replace(F("/#"), F("/status"));
-  pubname.replace(F("%sysname%"), Settings.Name);
-  MQTTclient.publish(pubname.c_str(), status.c_str(),Settings.MQTTRetainFlag);
+  int enabledMqttController = firstEnabledMQTTController();
+  if (enabledMqttController >= 0) {
+    LoadControllerSettings(enabledMqttController, (byte*)&ControllerSettings, sizeof(ControllerSettings));
+    String pubname = ControllerSettings.Subscribe;
+    pubname.replace(F("/#"), F("/status"));
+    pubname.replace(F("%sysname%"), Settings.Name);
+    MQTTpublish(enabledMqttController, pubname.c_str(), status.c_str(),Settings.MQTTRetainFlag);
+  }
 }

--- a/src/_C002.ino
+++ b/src/_C002.ino
@@ -254,11 +254,8 @@ boolean CPlugin_002(byte function, struct EventStruct *event, String& string)
           pubname.replace(F("%tskname%"), ExtraTaskSettings.TaskDeviceName);
           pubname.replace(F("%id%"), String(event->idx));
 
-          if (!MQTTclient.publish(pubname.c_str(), json.c_str(), Settings.MQTTRetainFlag))
+          if (!MQTTpublish(event->ControllerIndex, pubname.c_str(), json.c_str(), Settings.MQTTRetainFlag))
           {
-            log = F("MQTT : publish failed");
-            addLog(LOG_LEVEL_DEBUG, log);
-            MQTTConnect();
             connectionFailures++;
           }
           else if (connectionFailures)

--- a/src/_C005.ino
+++ b/src/_C005.ino
@@ -111,7 +111,7 @@ boolean CPlugin_005(byte function, struct EventStruct *event, String& string)
             value = (unsigned long)UserVar[event->BaseVarIndex] + ((unsigned long)UserVar[event->BaseVarIndex + 1] << 16);
           else
             value = toString(UserVar[event->BaseVarIndex + x], ExtraTaskSettings.TaskDeviceValueDecimals[x]);
-          MQTTclient.publish(tmppubname.c_str(), value.c_str(), Settings.MQTTRetainFlag);
+          MQTTpublish(event->ControllerIndex, tmppubname.c_str(), value.c_str(), Settings.MQTTRetainFlag);
           String log = F("MQTT : ");
           log += tmppubname;
           log += " ";

--- a/src/_C006.ino
+++ b/src/_C006.ino
@@ -104,7 +104,7 @@ boolean CPlugin_006(byte function, struct EventStruct *event, String& string)
             value = (unsigned long)UserVar[event->BaseVarIndex] + ((unsigned long)UserVar[event->BaseVarIndex + 1] << 16);
           else
             value = toString(UserVar[event->BaseVarIndex + x], ExtraTaskSettings.TaskDeviceValueDecimals[x]);
-          MQTTclient.publish(tmppubname.c_str(), value.c_str(), Settings.MQTTRetainFlag);
+          MQTTpublish(event->ControllerIndex, tmppubname.c_str(), value.c_str(), Settings.MQTTRetainFlag);
         }
         break;
       }

--- a/src/_P037_MQTTImport.ino
+++ b/src/_P037_MQTTImport.ino
@@ -324,21 +324,23 @@ void mqttcallback_037(char* c_topic, byte* b_payload, unsigned int length)
 // It would be nice to understand this....
 
 boolean MQTTConnect_037(String clientid)
-
 {
-  ControllerSettingsStruct ControllerSettings;
-  LoadControllerSettings(0, (byte*)&ControllerSettings, sizeof(ControllerSettings)); // todo index is now fixed to 0
-
   boolean result = false;
-
+  // @ToDo TD-er: Plugin allows for more than one MQTT controller, but we're now using only the first enabled one.
+  int enabledMqttController = firstEnabledMQTTController();
+  if (enabledMqttController < 0) {
+    // No enabled MQTT controller
+    return false;
+  }
   // Do nothing if already connected
-
-  if (MQTTclient_037->connected())return true;
+  if (MQTTclient_037->connected()) return true;
 
   // define stuff for the client - this could also be done in the intial declaration of MQTTclient_037
   if (WiFi.status() != WL_CONNECTED) {
     return false; // Not connected, so no use in wasting time to connect to a host.
   }
+  ControllerSettingsStruct ControllerSettings;
+  LoadControllerSettings(enabledMqttController, (byte*)&ControllerSettings, sizeof(ControllerSettings));
   if (ControllerSettings.UseDNS) {
     MQTTclient_037->setServer(ControllerSettings.getHost().c_str(), ControllerSettings.Port);
   } else {
@@ -352,8 +354,8 @@ boolean MQTTConnect_037(String clientid)
   {
     String log = "";
 
-    if ((SecuritySettings.ControllerUser[0][0] != 0) && (SecuritySettings.ControllerPassword[0][0] != 0)) //
-      result = MQTTclient_037->connect(clientid.c_str(), SecuritySettings.ControllerUser[0], SecuritySettings.ControllerPassword[0]); // todo
+    if ((SecuritySettings.ControllerUser[enabledMqttController][0] != 0) && (SecuritySettings.ControllerPassword[enabledMqttController][0] != 0))
+      result = MQTTclient_037->connect(clientid.c_str(), SecuritySettings.ControllerUser[enabledMqttController], SecuritySettings.ControllerPassword[enabledMqttController]);
     else
       result = MQTTclient_037->connect(clientid.c_str());
 


### PR DESCRIPTION
See #728
Also looked into the very strange configuration settings lookup for MQTT settings. The way it was, the settings for the first MQTT controller were used even when the actual MQTT controller was inactive or using different settings.

Now the controller selected in the the plugin is being used and when no plugin setting is available (and also for P037 MQTT import) the first active MQTT controller will be used.