### PR TITLE
Central function for system variable replacement

### DIFF
--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -1421,6 +1421,7 @@ void parseSystemVariables(String& s, boolean useURLencode)
 
   sprintf_P(valueString, PSTR("%02d"), year()%100);
   repl(F("%sysyears%"),valueString, s, useURLencode);
+  repl(F("%lcltime%"), getDateTimeString('-',':',' '), s, useURLencode);
 
   repl(F("%tskname%"), ExtraTaskSettings.TaskDeviceName, s, useURLencode);
   repl(F("%uptime%"), String(wdcounter / 2), s, useURLencode);

--- a/src/TimeESPeasy.ino
+++ b/src/TimeESPeasy.ino
@@ -126,7 +126,6 @@ byte day()
 	return tm.Day;
 }
 
-
 byte hour()
 {
   return tm.Hour;
@@ -203,10 +202,8 @@ unsigned long getNtpTime()
     else
       WiFi.hostByName(ntpServerName, timeServerIP);
 
-    char host[20];
-    sprintf_P(host, PSTR("%u.%u.%u.%u"), timeServerIP[0], timeServerIP[1], timeServerIP[2], timeServerIP[3]);
     log = F("NTP  : NTP send to ");
-    log += host;
+    log += timeServerIP.toString();
     addLog(LOG_LEVEL_DEBUG_MORE, log);
 
     while (udp.parsePacket() > 0) ; // discard any previously received packets
@@ -413,7 +410,6 @@ String getDateTimeString(const timeStruct& ts, char dateDelimiter, char timeDeli
 String getDateTimeString(char dateDelimiter, char timeDelimiter,  char dateTimeDelimiter) {
   return getDateTimeString(tm, dateDelimiter, timeDelimiter, dateTimeDelimiter);
 }
-
 
 /********************************************************************************************\
   Convert a string like "Sun,12:30" into a 32 bit integer

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -2914,6 +2914,8 @@ void handle_json()
     reply += BUILD;
     reply += F(",\n\"Unit\": ");
     reply += Settings.Unit;
+    reply += F(",\n\"Local time\": ");
+    reply += getDateTimeString('-',':',' ');
     reply += F(",\n\"Uptime\": ");
     reply += wdcounter / 2;
     reply += F(",\n\"Free RAM\": ");

--- a/src/_C002.ino
+++ b/src/_C002.ino
@@ -274,10 +274,8 @@ boolean CPlugin_002(byte function, struct EventStruct *event, String& string)
           addLog(LOG_LEVEL_DEBUG, log);
 
           String pubname = ControllerSettings.Publish;
-          pubname.replace(F("%sysname%"), Settings.Name);
-          pubname.replace(F("%tskname%"), ExtraTaskSettings.TaskDeviceName);
-          pubname.replace(F("%id%"), String(event->idx));
-
+          parseSystemVariables(pubname, false);
+          parseEventVariables(pubname, event, false);
           if (!MQTTpublish(event->ControllerIndex, pubname.c_str(), json.c_str(), Settings.MQTTRetainFlag))
           {
             connectionFailures++;

--- a/src/_C005.ino
+++ b/src/_C005.ino
@@ -96,9 +96,8 @@ boolean CPlugin_005(byte function, struct EventStruct *event, String& string)
           PluginCall(PLUGIN_GET_DEVICEVALUENAMES, event, dummyString);
 
         String pubname = ControllerSettings.Publish;
-        pubname.replace(F("%sysname%"), Settings.Name);
-        pubname.replace(F("%tskname%"), ExtraTaskSettings.TaskDeviceName);
-        pubname.replace(F("%id%"), String(event->idx));
+        parseSystemVariables(pubname, false);
+        parseEventVariables(pubname, event, false);
 
         String value = "";
         // byte DeviceIndex = getDeviceIndex(Settings.TaskDeviceNumber[event->TaskIndex]);

--- a/src/_C006.ino
+++ b/src/_C006.ino
@@ -89,9 +89,8 @@ boolean CPlugin_006(byte function, struct EventStruct *event, String& string)
           PluginCall(PLUGIN_GET_DEVICEVALUENAMES, event, dummyString);
 
         String pubname = ControllerSettings.Publish;
-        pubname.replace(F("%sysname%"), Settings.Name);
-        pubname.replace(F("%tskname%"), ExtraTaskSettings.TaskDeviceName);
-        pubname.replace(F("%id%"), String(event->idx));
+        parseSystemVariables(pubname, false);
+        parseEventVariables(pubname, event, false);
 
         String value = "";
         // byte DeviceIndex = getDeviceIndex(Settings.TaskDeviceNumber[event->TaskIndex]);

--- a/src/_C008.ino
+++ b/src/_C008.ino
@@ -105,10 +105,9 @@ boolean HTTPSend(struct EventStruct *event, byte varIndex, float value, unsigned
 
   String url = "/";
   url += ControllerSettings.Publish;
-  //TODO: move this to a generic replacement function?
-  url.replace(F("%sysname%"), URLEncode(Settings.Name));
-  url.replace(F("%tskname%"), URLEncode(ExtraTaskSettings.TaskDeviceName));
-  url.replace(F("%id%"), String(event->idx));
+  parseSystemVariables(url, true);
+  parseEventVariables(url, event, true);
+
   url.replace(F("%valname%"), URLEncode(ExtraTaskSettings.TaskDeviceValueNames[varIndex]));
   if (longValue)
     url.replace(F("%value%"), String(longValue));

--- a/src/_C010.ino
+++ b/src/_C010.ino
@@ -80,6 +80,8 @@ void C010_Send(struct EventStruct *event, byte varIndex, float value, unsigned l
 
   String msg = "";
   msg += ControllerSettings.Publish;
+  parseSystemVariables(msg, false);
+  parseEventVariables(msg, event, false);
   msg.replace(F("%sysname%"), Settings.Name);
   msg.replace(F("%tskname%"), ExtraTaskSettings.TaskDeviceName);
   msg.replace(F("%id%"), String(event->idx));

--- a/src/_C011.ino
+++ b/src/_C011.ino
@@ -306,39 +306,9 @@ void ReplaceTokenByValue(String& s, struct EventStruct *event)
 	addLog(LOG_LEVEL_DEBUG_MORE, s);
 
   //NOTE: cant we just call parseTemplate() for all the standard stuff??
+  parseSystemVariables(s, true);
+  parseEventVariables(s, event, true);
 
-  s.replace(F("%systime%"), getTimeString(':'));
-
-	#if FEATURE_ADC_VCC
-		s.replace(F("%vcc%"), String(vcc));
-	#endif
-
-  // IPAddress ip = WiFi.localIP();
-  // char strIP[20];
-  // sprintf_P(strIP, PSTR("%u.%u.%u.%u"), ip[0], ip[1], ip[2], ip[3]);
-  s.replace(F("%ip%"),WiFi.localIP().toString());
-
-  s.replace(F("%sysload%"), String(100 - (100 * loopCounterLast / loopCounterMax)));
-  s.replace(F("%uptime%"), String(wdcounter / 2));
-
-  s.replace(F("%CR%"), F("\r"));
-  s.replace(F("%LF%"), F("\n"));
-  s.replace(F("%sysname%"), URLEncode(Settings.Name));
-  s.replace(F("%tskname%"), URLEncode(ExtraTaskSettings.TaskDeviceName));
-  s.replace(F("%id%"), String(event->idx));
-  s.replace(F("%vname1%"), URLEncode(ExtraTaskSettings.TaskDeviceValueNames[0]));
-  s.replace(F("%vname2%"), URLEncode(ExtraTaskSettings.TaskDeviceValueNames[1]));
-  s.replace(F("%vname3%"), URLEncode(ExtraTaskSettings.TaskDeviceValueNames[2]));
-  s.replace(F("%vname4%"), URLEncode(ExtraTaskSettings.TaskDeviceValueNames[3]));
-
-  if (event->sensorType == SENSOR_TYPE_LONG)
-    s.replace(F("%val1%"), String((unsigned long)UserVar[event->BaseVarIndex] + ((unsigned long)UserVar[event->BaseVarIndex + 1] << 16)));
-  else {
-    s.replace(F("%val1%"), toString(UserVar[event->BaseVarIndex + 0], ExtraTaskSettings.TaskDeviceValueDecimals[0]));
-    s.replace(F("%val2%"), toString(UserVar[event->BaseVarIndex + 1], ExtraTaskSettings.TaskDeviceValueDecimals[1]));
-    s.replace(F("%val3%"), toString(UserVar[event->BaseVarIndex + 2], ExtraTaskSettings.TaskDeviceValueDecimals[2]));
-    s.replace(F("%val4%"), toString(UserVar[event->BaseVarIndex + 3], ExtraTaskSettings.TaskDeviceValueDecimals[3]));
-  }
 	addLog(LOG_LEVEL_DEBUG_MORE, F("HTTP after replacements: "));
 	addLog(LOG_LEVEL_DEBUG_MORE, s);
 }


### PR DESCRIPTION
Related to:
- #698 => Not complete
- #709 => fixed
- #751 => fixed

Redesign of PR #485 (in mega branch)

One note: no sensor values can be used in controllers. Is this what we want, or should we call parseTemplate everywhere parseSystemVariables is being used?
Also not all controllers apparently allow system variables. Is this also correct?