### PR TITLE
[issue #759] Disable Senseair ABC due to firmware issues

### DIFF
--- a/src/_P052_SenseAir.ino
+++ b/src/_P052_SenseAir.ino
@@ -79,6 +79,9 @@ boolean Plugin_052(byte function, struct EventStruct *event, String& string)
               success = true;
             }
 
+            /*
+            // ABC functionality disabled for now, due to a bug in the firmware.
+            // See https://github.com/letscontrolit/ESPEasy/issues/759
             if (cmd.equalsIgnoreCase(F("senseair_setABCperiod")))
             {
               if (param1.toInt() >= 0) {
@@ -87,6 +90,7 @@ boolean Plugin_052(byte function, struct EventStruct *event, String& string)
               }
               success = true;
             }
+            */
 
             break;
           }
@@ -94,13 +98,17 @@ boolean Plugin_052(byte function, struct EventStruct *event, String& string)
     case PLUGIN_WEBFORM_LOAD:
       {
           byte choiceSensor = Settings.TaskDevicePluginConfig[event->TaskIndex][0];
-          byte choiceABCperiod = Settings.TaskDevicePluginConfig[event->TaskIndex][1];
-          
+
           String optionsSensor[7] = { F("Error Status"), F("Carbon Dioxide"), F("Temperature"), F("Humidity"), F("Relay Status"), F("Temperature Adjustment"), F("ABC period") };
           addFormSelector(string, F("Sensor"), F("plugin_052_sensor"), 7, optionsSensor, NULL, choiceSensor);
-          
+
+          /*
+          // ABC functionality disabled for now, due to a bug in the firmware.
+          // See https://github.com/letscontrolit/ESPEasy/issues/759
+          byte choiceABCperiod = Settings.TaskDevicePluginConfig[event->TaskIndex][1];
           String optionsABCperiod[9] = { F("disable"), F("1 h"), F("12 h"), F("1 day"), F("2 days"), F("4 days"), F("7 days"), F("14 days"), F("30 days") };
           addFormSelector(string, F("ABC period"), F("plugin_052_ABC_period"), 9, optionsABCperiod, NULL, choiceABCperiod);
+          */
 
           success = true;
           break;
@@ -109,11 +117,15 @@ boolean Plugin_052(byte function, struct EventStruct *event, String& string)
     case PLUGIN_WEBFORM_SAVE:
       {
         Settings.TaskDevicePluginConfig[event->TaskIndex][0] = getFormItemInt(F("plugin_052_sensor"));
-        Settings.TaskDevicePluginConfig[event->TaskIndex][1] = getFormItemInt(F("plugin_052_ABC_period"));          
-        
+        /*
+        // ABC functionality disabled for now, due to a bug in the firmware.
+        // See https://github.com/letscontrolit/ESPEasy/issues/759
+        Settings.TaskDevicePluginConfig[event->TaskIndex][1] = getFormItemInt(F("plugin_052_ABC_period"));
+        */
+
         success = true;
         break;
-      }      
+      }
 
     case PLUGIN_INIT:
       {
@@ -121,11 +133,15 @@ boolean Plugin_052(byte function, struct EventStruct *event, String& string)
         Plugin_052_SoftSerial = new SoftwareSerial(Settings.TaskDevicePin1[event->TaskIndex],
                                                    Settings.TaskDevicePin2[event->TaskIndex]);
 
+        /*
+        // ABC functionality disabled for now, due to a bug in the firmware.
+        // See https://github.com/letscontrolit/ESPEasy/issues/759
         const int periodInHours[9] = {0, 1, 12, (24*1), (24*2), (24*4), (24*7), (24*14), (24*30) };
         byte choiceABCperiod = Settings.TaskDevicePluginConfig[event->TaskIndex][1];
-        
+
         Plugin_052_setABCperiod(periodInHours[choiceABCperiod]);
-        
+        */
+
         success = true;
         break;
       }
@@ -345,13 +361,16 @@ int Plugin_052_readABCperiod(void)
 {
   int period = 0;
   byte frame[8] = {0};
-  
+
   Plugin_052_buildFrame(0xFE, 0x03, 0x001F, 0x0001, frame);
   period = Plugin_052_sendCommand(frame);
-  
+
   return period;
 }
 
+/*
+// ABC functionality disabled for now, due to a bug in the firmware.
+// See https://github.com/letscontrolit/ESPEasy/issues/759
 void Plugin_052_setABCperiod(int period)
 {
   byte frame[8] = {0};
@@ -359,6 +378,7 @@ void Plugin_052_setABCperiod(int period)
   Plugin_052_buildFrame(0xFE, 0x06, 0x001F, period, frame);
   Plugin_052_sendCommand(frame);
 }
+*/
 
 // Compute the MODBUS RTU CRC
 unsigned int Plugin_052_ModRTU_CRC(byte buf[], int len, byte checkSum[2])


### PR DESCRIPTION
See #759

Just commented the Set ABC functionality. People may compile it for themselves, but be aware of possible consequences.