### PR TITLE
[Mega] Allow compile with 2.4.0 core library

### DIFF
--- a/lib/IRremoteESP8266/IRKelvinator.cpp
+++ b/lib/IRremoteESP8266/IRKelvinator.cpp
@@ -93,8 +93,8 @@ bool ICACHE_FLASH_ATTR IRKelvinatorAC::getPower() {
 
 // Set the temp. in deg C
 void ICACHE_FLASH_ATTR IRKelvinatorAC::setTemp(uint8_t temp) {
-    temp = max(KELVINATOR_MIN_TEMP, temp);
-    temp = min(KELVINATOR_MAX_TEMP, temp);
+    temp = max(static_cast<uint8_t>(KELVINATOR_MIN_TEMP), temp);
+    temp = min(static_cast<uint8_t>(KELVINATOR_MAX_TEMP), temp);
     remote_state[1] = (remote_state[1] & 0xF0U) | (temp - KELVINATOR_MIN_TEMP);
     remote_state[9] = remote_state[1];  // Duplicate to the 2nd command chunk.
 }
@@ -106,12 +106,12 @@ uint8_t ICACHE_FLASH_ATTR IRKelvinatorAC::getTemp() {
 
 // Set the speed of the fan, 0-5, 0 is auto, 1-5 is the speed
 void ICACHE_FLASH_ATTR IRKelvinatorAC::setFan(uint8_t fan) {
-  fan = min(KELVINATOR_FAN_MAX, fan);  // Bounds check
+  fan = min(static_cast<uint8_t>(KELVINATOR_FAN_MAX), fan);  // Bounds check
 
   // Only change things if we need to.
   if (fan != getFan()) {
     // Set the basic fan values.
-    uint8_t fan_basic = min(KELVINATOR_BASIC_FAN_MAX, fan);
+    uint8_t fan_basic = min(static_cast<uint8_t>(KELVINATOR_BASIC_FAN_MAX), fan);
     remote_state[0] = (remote_state[0] & KELVINATOR_BASIC_FAN_MASK) |
         (fan_basic << KELVINATOR_FAN_OFFSET);
     remote_state[8] = remote_state[0];  // Duplicate to the 2nd command chunk.

--- a/lib/IRremoteESP8266/IRMitsubishiAC.cpp
+++ b/lib/IRremoteESP8266/IRMitsubishiAC.cpp
@@ -77,8 +77,8 @@ bool ICACHE_FLASH_ATTR IRMitsubishiAC::getPower() {
 
 // Set the temp. in deg C
 void ICACHE_FLASH_ATTR IRMitsubishiAC::setTemp(uint8_t temp) {
-    temp = max(MITSUBISHI_AC_MIN_TEMP, temp);
-    temp = min(MITSUBISHI_AC_MAX_TEMP, temp);
+    temp = max(static_cast<uint8_t>(MITSUBISHI_AC_MIN_TEMP), temp);
+    temp = min(static_cast<uint8_t>(MITSUBISHI_AC_MAX_TEMP), temp);
     remote_state[7] = temp - MITSUBISHI_AC_MIN_TEMP;
 }
 
@@ -136,7 +136,7 @@ void ICACHE_FLASH_ATTR IRMitsubishiAC::setMode(uint8_t mode) {
 
 // Set the requested vane operation mode of the a/c unit.
 void ICACHE_FLASH_ATTR IRMitsubishiAC::setVane(uint8_t mode) {
-  mode = max(mode, B111);  // bounds check
+  mode = max(mode, static_cast<uint8_t>(B111));  // bounds check
   mode |= B1000;
   mode <<= 3;
   remote_state[9] |= mode;

--- a/lib/IRremoteESP8266/IRremoteESP8266.cpp
+++ b/lib/IRremoteESP8266/IRremoteESP8266.cpp
@@ -155,7 +155,7 @@ void ICACHE_FLASH_ATTR IRsend::sendNEC (unsigned long data, int nbits,
   // Footer
   mark(NEC_BIT_MARK);
   // Gap to next command.
-  space(max(0, NEC_MIN_COMMAND_LENGTH - usecs.elapsed()));
+  space(max(0ul, NEC_MIN_COMMAND_LENGTH - usecs.elapsed()));
 
   // Optional command repeat sequence.
   for (unsigned int i = 0; i < repeat; i++) {
@@ -164,7 +164,7 @@ void ICACHE_FLASH_ATTR IRsend::sendNEC (unsigned long data, int nbits,
     space(NEC_RPT_SPACE);
     mark(NEC_BIT_MARK);
     // Gap till next command.
-    space(max(0, NEC_MIN_COMMAND_LENGTH - usecs.elapsed()));
+    space(max(0ul, NEC_MIN_COMMAND_LENGTH - usecs.elapsed()));
   }
 }
 
@@ -236,7 +236,7 @@ void ICACHE_FLASH_ATTR IRsend::sendSony(unsigned long data, int nbits,
     // Footer
     // The Sony protocol requires us to wait 45ms from start of a code to the
     // start of the next one. A 10ms minimum gap is also required.
-    space(max(10000, 45000 - usecs.elapsed()));
+    space(max(10000u, 45000 - usecs.elapsed()));
   }
   // A space() is always performed last, so no need to turn off the LED.
 }
@@ -367,7 +367,7 @@ void ICACHE_FLASH_ATTR IRsend::sendRCMM(uint32_t data, uint8_t nbits) {
   mark(RCMM_BIT_MARK);
   // Protocol requires us to wait at least RCMM_RPT_LENGTH usecs from the start
   // or RCMM_MIN_GAP usecs.
-  space(max(RCMM_RPT_LENGTH - usecs.elapsed(), RCMM_MIN_GAP));
+  space(max(RCMM_RPT_LENGTH - usecs.elapsed(), static_cast<uint32_t>(RCMM_MIN_GAP)));
 }
 
 void ICACHE_FLASH_ATTR IRsend::sendPanasonic(unsigned int address,
@@ -415,7 +415,7 @@ void ICACHE_FLASH_ATTR IRsend::sendJVC(unsigned long data, int nbits,
     // Footer
     mark(JVC_BIT_MARK);
     // Wait till the end of the repeat time window before we send another code.
-    space(max(0, JVC_RPT_LENGTH - usecs.elapsed()));
+    space(max(0u, JVC_RPT_LENGTH - usecs.elapsed()));
     usecs.reset();
   }
   // No need to turn off the LED as we will always end with a space().
@@ -647,7 +647,7 @@ void ICACHE_FLASH_ATTR IRsend::sendSherwood(unsigned long data, int nbits,
                                             unsigned int repeat) {
   // Sherwood remote codes appear to be NEC codes with a manditory repeat code.
   // i.e. repeat should be >= 1.
-  sendNEC(data, nbits, max(1, repeat));
+  sendNEC(data, nbits, max(1u, repeat));
 }
 
 void ICACHE_FLASH_ATTR IRsend::sendMitsubishiAC(unsigned char data[]) {
@@ -911,7 +911,7 @@ bool ICACHE_FLASH_ATTR IRrecv::decode(decode_results *results,
 //   Nr. of ticks.
 uint32_t IRrecv::ticksLow(uint32_t usecs, uint8_t tolerance) {
   // max() used to ensure the result can't drop below 0 before the cast.
-  return((uint32_t) max(usecs * (1.0 - tolerance/100.)/USECPERTICK, 0));
+  return((uint32_t) max(usecs * (1.0 - tolerance/100.)/USECPERTICK, 0.0));
 }
 
 // Calculate the upper bound of the nr. of ticks.


### PR DESCRIPTION
Last few days, lots of issues reported by users who installed the 2.4.0 core libraries.
e.g. #769 and #763  
This fixes #725 and thus makes #688 less urgent.
It appeared the default PlatformIO Espressif 8266 1.6.0 libs now include the 2.4.0 core libraries.
Now I have to find a way to get my own environment back to the 2.3.0 core libs and see how I can get PlatformIO Espressif 8266 library back to version 1.5.0

One of the main issues is the change in implementation for min() and max().