### PR TITLE
Fixes  DateTimeString in /json page (#800)

### DIFF
--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -2985,7 +2985,9 @@ void handle_json()
     reply += F(",\n\"Unit\": ");
     reply += Settings.Unit;
     reply += F(",\n\"Local time\": ");
+    reply += F("\"");
     reply += getDateTimeString('-',':',' ');
+    reply += F("\"");
     reply += F(",\n\"Uptime\": ");
     reply += wdcounter / 2;
     reply += F(",\n\"Free RAM\": ");


### PR DESCRIPTION
The DateTimeString was NOT quoted, as it should be in a compliant JSON format.
Now fixed ;-)
