### PR TITLE
[issue #739] Reconnect MQTT when Unit Name has changed.

### DIFF
--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -355,6 +355,7 @@ MDNSResponder mdns;
 // MQTT client
 WiFiClient mqtt;
 PubSubClient MQTTclient(mqtt);
+bool MQTTclient_should_reconnect = true;
 
 // WebServer
 ESP8266WebServer WebServer(80);

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -704,6 +704,10 @@ void handle_config() {
 
   if (ssid[0] != 0)
   {
+    if (strcmp(Settings.Name, name.c_str()) != 0) {
+      addLog(LOG_LEVEL_INFO, F("Unit Name changed."));
+      MQTTclient_should_reconnect = true;
+    }
     strncpy(Settings.Name, name.c_str(), sizeof(Settings.Name));
     //strncpy(SecuritySettings.Password, password.c_str(), sizeof(SecuritySettings.Password));
     copyFormPassword(F("password"), SecuritySettings.Password, sizeof(SecuritySettings.Password));
@@ -3144,7 +3148,7 @@ void handle_advanced() {
   addFormLogLevelSelect(reply, F("Serial log Level"),  F("serialloglevel"), Settings.SerialLogLevel);
   addFormLogLevelSelect(reply, F("Web log Level"),     F("webloglevel"),    Settings.WebLogLevel);
   addFormLogLevelSelect(reply, F("SD Card log Level"), F("sdloglevel"),     Settings.SDLogLevel);
-  
+
   addFormCheckBox(reply, F("SD Card Value Logger"), F("valuelogger"), Settings.UseValueLogger);
 
 

--- a/src/_P037_MQTTImport.ino
+++ b/src/_P037_MQTTImport.ino
@@ -130,9 +130,13 @@ boolean Plugin_037(byte function, struct EventStruct *event, String& string)
       {
         //  Here we check that the MQTT client is alive.
 
-        if (!MQTTclient_037->connected()) {
+        if (!MQTTclient_037->connected() || MQTTclient_should_reconnect) {
+          if (MQTTclient_should_reconnect) {
+            addLog(LOG_LEVEL_ERROR, F("IMPT : MQTT 037 Intentional reconnect"));
+          } else {
+            addLog(LOG_LEVEL_ERROR, F("IMPT : MQTT 037 Connection lost"));
+          }
 
-          addLog(LOG_LEVEL_ERROR, F("IMPT : MQTT 037 Connection lost"));
 
           MQTTclient_037->disconnect();
           delay(1000);


### PR DESCRIPTION
See #739
When %sysname% has changed, force a reconnect of the MQTT client.

Also made the client ID guaranteed unique by using the MAC address.