### PR TITLE
Fixes Syslog format to be RFC3164 compliant

### DIFF
--- a/src/Networking.ino
+++ b/src/Networking.ino
@@ -14,7 +14,14 @@ void syslog(const char *message)
     portUDP.beginPacket(broadcastIP, 514);
     char str[256];
     str[0] = 0;
-    snprintf_P(str, sizeof(str), PSTR("<7>ESP Unit: %u : %s"), Settings.Unit, message);
+	// An RFC3164 compliant message must be formated like :  "<PRIO>[TimeStamp ]Hostname TaskName: Message"	
+
+	// Using Settings.Name as the Hostname (Hostname must NOT content space)
+    snprintf_P(str, sizeof(str), PSTR("<7>%s EspEasy: %s"), Settings.Name, message);
+
+	// Using Setting.Unit to build a Hostname
+    //snprintf_P(str, sizeof(str), PSTR("<7>EspEasy_%u ESP: %s"), Settings.Unit, message);
+
     portUDP.write(str);
     portUDP.endPacket();
   }


### PR DESCRIPTION
The Current syslog format was not RFC3164 compliant, because there was two much fields (space separated).  [More info](https://sematext.com/blog/what-is-syslog-daemons-message-formats-and-protocols/)

The consequence was that if you gather logs from differents EspEasy devices in a single remote log server (ie Rsyslog), Rsylog was seeing "ESP" as the hostname, and thus was NOT able to distingue between different devices.

My PR fixes that, and BTW use the Settings.Name as the HostName (instead of the Unit Number)

_Successfully Tested on Rsyslog 8.4.2_