### PR TITLE
Custom define file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .piolibdeps
 
 lib/readme.txt
+src/Custom.h

--- a/src/Custom-sample.h
+++ b/src/Custom-sample.h
@@ -1,0 +1,42 @@
+/*
+	To modify the stock configuration without changing the EspEasy.ino file :
+
+	1) rename this file to "Custom.h" (It is ignored by Git)
+	2) define your own settings below 
+    3) define USE_CUSTOM_H as a build flags. ie : export PLATFORMIO_BUILD_FLAGS="'-DUSE_CUSTOM_H'" 	
+*/
+
+
+
+// make the compiler show a warning to confirm that this file is inlcuded
+#warning "**** Using Settings from Custom.h File ***"
+
+/*
+
+#######################################################################################################
+Your Own Default Settings
+#######################################################################################################
+
+	You can basically ovveride ALL macro defined in ESPEasy.ino.
+	Don't forget to first #undef each existing #define that you add below.
+	Here are some examples:
+*/
+
+
+#undef	DEFAULT_NAME
+#define DEFAULT_NAME		"MyEspEasyDevice"			// Enter your device friendly name
+
+#undef	DEFAULT_SSID
+#define DEFAULT_SSID		"MyHomeSSID"			   // Enter your network SSID
+
+#undef	DEFAULT_KEY
+#define DEFAULT_KEY			"MySuperSecretPassword"		// Enter your network WPA key
+
+#undef	DEFAULT_AP_KEY
+#define DEFAULT_AP_KEY		"MyOwnConfigPassword"		// Enter network WPA key for AP (config) mode
+
+#ifdef BUILD_GIT
+#undef BUILD_GIT
+#endif
+
+#define BUILD_GIT "MyBuildNum"

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -297,6 +297,17 @@
 #define DAT_OFFSET_CUSTOM_CONTROLLER    32768  // each custom controller config = 1k, 4 max.
 
 
+/*
+	To modify the stock configuration without changing this repo file :
+    - define USE_CUSTOM_H as a build flags. ie : export PLATFORMIO_BUILD_FLAGS="'-DUSE_CUSTOM_H'" 
+	- add a "Custom.h" file in this folder.
+	
+*/
+#ifdef USE_CUSTOM_H
+#include "Custom.h"
+#endif
+
+
 #include "lwip/tcp_impl.h"
 #include <ESP8266WiFi.h>
 #include <DNSServer.h>


### PR DESCRIPTION
Allows  to use a custom file  (non git tracked), to add own custom defines. Really more convenient when having/testing multiples devices.