### PR TITLE
Add compile time

### DIFF
--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -414,6 +414,15 @@ PubSubClient MQTTclient(mqtt);
 // udp protocol stuff (syslog, global sync, node info list, ntp time)
 WiFiUDP portUDP;
 
+struct CRCStruct{
+  char compileTimeMD5[16+32+1]= "MD5_MD5_MD5_MD5_BoundariesOfTheSegmentsGoHere...";
+  char compileTime[16]= __TIME__;
+  char compileDate[16]= __DATE__;
+  uint8_t runTimeMD5[16]={0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+  bool checkPassed (void){ return memcmp(compileTimeMD5,runTimeMD5,16)==0 ; }
+  uint32_t numberOfCRCBytes=0;
+}CRCValues; 
+ 
 struct SecurityStruct
 {
   SecurityStruct() {
@@ -920,7 +929,6 @@ String eventBuffer = "";
 
 uint32_t lowestRAM = 0;
 String lowestRAMfunction = "";
-uint8_t thisBinaryMd5[16]={0};
 
 bool shouldReboot=false;
 

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -4452,9 +4452,19 @@ void handle_sysinfo() {
     reply += F(" [Development]");
   #endif
 
-  reply += F("<TR><TD>Md5<TD>");
-  for (byte i = 0; i<16; i++)   reply += String(thisBinaryMd5[i],HEX);
-
+  reply += F("<TR><TD>Build Md5<TD>");
+  for (byte i = 0; i<16; i++)   reply += String(CRCValues.compileTimeMD5[i],HEX);
+ 
+  reply += F("<TR><TD>Md5 check<TD>");
+  if (! CRCValues.checkPassed()) 
+    reply +="<font color = 'red'>fail !</font>";
+  else reply +="passed.";
+  
+  reply += F("<TR><TD>Build time<TD>");
+  reply += String(CRCValues.compileDate);
+  reply += " ";
+  reply += String(CRCValues.compileTime);
+ 
   reply += F("<TR><TD colspan=2><H3>ESP board</H3></TD></TR>");
 
   reply += F("<TR><TD>ESP Chip ID<TD>");


### PR DESCRIPTION
and introduced a struct which holds md5 data.  The linker puts the md5 now in segment 3 but that doesn't matter as this segment is not included in the check.
Add compile date and time in sysinfo