### PR TITLE
Webserver min memory

### DIFF
--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -6,11 +6,11 @@
 #include <md5.h>
 #if defined(ESP8266)
  
-    struct tcp_pcb;
-    extern struct tcp_pcb* tcp_tw_pcbs;
-    extern "C" void tcp_abort (struct tcp_pcb* pcb);
+struct tcp_pcb;
+extern struct tcp_pcb* tcp_tw_pcbs;
+extern void tcp_abort (struct tcp_pcb* pcb);
  
- void tcpCleanup()  // see https://github.com/esp8266/Arduino/commit/b15102ad28c5f509aa59632ca63663ad8c9e186a
+void tcpCleanup()   
 {
      while(tcp_tw_pcbs!=NULL)
     {

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -8,7 +8,7 @@
  
 struct tcp_pcb;
 extern struct tcp_pcb* tcp_tw_pcbs;
-extern void tcp_abort (struct tcp_pcb* pcb);
+extern "C" void tcp_abort (struct tcp_pcb* pcb);
  
 void tcpCleanup()   
 {

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -5,17 +5,18 @@
 // and https://github.com/letscontrolit/ESPEasy/issues/253
 #include <md5.h>
 #if defined(ESP8266)
-void tcpCleanup()
+ 
+    struct tcp_pcb;
+    extern struct tcp_pcb* tcp_tw_pcbs;
+    extern "C" void tcp_abort (struct tcp_pcb* pcb);
+ 
+ void tcpCleanup()  // see https://github.com/esp8266/Arduino/commit/b15102ad28c5f509aa59632ca63663ad8c9e186a
 {
-  #if LWIP_VERSION_MAJOR == 2
-    // is it still needed ?
-  #else
-    while(tcp_tw_pcbs!=NULL)
+     while(tcp_tw_pcbs!=NULL)
     {
       tcp_abort(tcp_tw_pcbs);
     }
-  #endif
-}
+ }
 #endif
 
 bool isDeepSleepEnabled()

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -300,7 +300,7 @@ void sendWebPageChunkedBegin(String& log)
 
 void sendWebPageChunkedData(String& log, String& data)
 {
-  while (ESP.getFreeHeap() < 8000) backgroundtasks(); 
+  while (ESP.getFreeHeap() < 7000) backgroundtasks(); 
   checkRAM(F("sendWebPageChunkedData"));
   if (data.length() > 0)
   {

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -300,7 +300,10 @@ void sendWebPageChunkedBegin(String& log)
 
 void sendWebPageChunkedData(String& log, String& data)
 {
-  while (ESP.getFreeHeap() < 7000) backgroundtasks(); 
+  long timeout= millis();  
+  while ((ESP.getFreeHeap() < 7000) && ((millis()-timeout < 100)) ) {
+    backgroundtasks(); 
+  }
   checkRAM(F("sendWebPageChunkedData"));
   if (data.length() > 0)
   {

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -300,6 +300,7 @@ void sendWebPageChunkedBegin(String& log)
 
 void sendWebPageChunkedData(String& log, String& data)
 {
+  while (ESP.getFreeHeap() < 8000) backgroundtasks(); 
   checkRAM(F("sendWebPageChunkedData"));
   if (data.length() > 0)
   {

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -300,8 +300,8 @@ void sendWebPageChunkedBegin(String& log)
 
 void sendWebPageChunkedData(String& log, String& data)
 {
-  long timeout= millis();  
-  while ((ESP.getFreeHeap() < 7000) && ((millis()-timeout < 100)) ) {
+  uint32_t beginWait = millis();
+  while ((ESP.getFreeHeap() < 7000) &&  !timeOutReached(beginWait + 1000)) {
     backgroundtasks(); 
   }
   checkRAM(F("sendWebPageChunkedData"));

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -4669,4 +4669,4 @@ String getValueSymbol(byte index)
   ret += 10112 + index;
   ret += F(";");
   return ret;
-} 
+}

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -4669,4 +4669,4 @@ String getValueSymbol(byte index)
   ret += 10112 + index;
   ret += F(";");
   return ret;
-}
+} 

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -300,10 +300,12 @@ void sendWebPageChunkedBegin(String& log)
 
 void sendWebPageChunkedData(String& log, String& data)
 {
+  /*
   uint32_t beginWait = millis();
   while ((ESP.getFreeHeap() < 7000) &&  !timeOutReached(beginWait + 1000)) {
     backgroundtasks(); 
   }
+  */
   checkRAM(F("sendWebPageChunkedData"));
   if (data.length() > 0)
   {
@@ -320,8 +322,13 @@ void sendWebPageChunkedData(String& log, String& data)
       WebServer.sendContent(data);
       WebServer.sendContent("\r\n");
     #else  // ESP8266 2.4.0rc2 and higher and the ESP32 webserver supports chunked http transfer
+      uint32_t beginWait = millis();
+      uint32_t freeBeforeSend= ESP.getFreeHeap();
       WebServer.sendContent(data);
-    #endif
+      while ((ESP.getFreeHeap() < freeBeforeSend) &&  !timeOutReached(beginWait + 1000)) {
+         delay(1);
+        }
+     #endif
     data = F("");   //free RAM
   }
 }

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -290,7 +290,7 @@ void sendWebPageChunkedBegin(String& log)
 {
   statusLED(true);
   WebServer.setContentLength(CONTENT_LENGTH_UNKNOWN);
-  // WebServer.sendHeader("Content-Type","text/html",true);
+  WebServer.sendHeader("Content-Type","text/html",true);
   WebServer.sendHeader("Cache-Control","no-cache");
   #if defined(ESP8266) && defined(ARDUINO_ESP8266_RELEASE_2_3_0)
   WebServer.sendHeader("Transfer-Encoding","chunked");


### PR DESCRIPTION
Using 2.4.0 / lwip2 web interface becomes unresponsive now and then. Most likely reason is that free
memory went as low as 3k. Added a wait loop to wait for it to return ...
Fixes the issue as far as I can see.

EDIT: 
current PR keeps the free memory (no devices defined) always above 12k.  
The unresponsiveness is an issue of the 2.4.0 core and my Wifi repeater.