### PR TITLE
Added HIGH-Z state options for GPIO command

### DIFF
--- a/src/_P001_Switch.ino
+++ b/src/_P001_Switch.ino
@@ -203,9 +203,14 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
           success = true;
           if (event->Par1 >= 0 && event->Par1 <= PIN_D_MAX)
           {
-            pinMode(event->Par1, OUTPUT);
-            digitalWrite(event->Par1, event->Par2);
-            setPinState(PLUGIN_ID_001, event->Par1, PIN_MODE_OUTPUT, event->Par2);
+            if (event->Par2 == 2) {
+              pinMode(event->Par1, INPUT);
+              setPinState(PLUGIN_ID_001, event->Par1, PIN_MODE_INPUT, 0);
+            } else {
+              pinMode(event->Par1, OUTPUT);
+              digitalWrite(event->Par1, event->Par2);
+              setPinState(PLUGIN_ID_001, event->Par1, PIN_MODE_OUTPUT, event->Par2);
+            }
             log = String(F("SW   : GPIO ")) + String(event->Par1) + String(F(" Set to ")) + String(event->Par2);
             addLog(LOG_LEVEL_INFO, log);
             SendStatus(event->Source, getPinStateJSON(SEARCH_PIN_STATE, PLUGIN_ID_001, event->Par1, log, 0));


### PR DESCRIPTION
Add command like 'GPIO,12,2' for set pin to HIGH-Z (INPUT) state.
It useful for low-level relay.