### PR TITLE
Added support for Pioneer IR signals

### DIFF
--- a/lib/IRremoteESP8266/IRremoteESP8266.cpp
+++ b/lib/IRremoteESP8266/IRremoteESP8266.cpp
@@ -168,6 +168,51 @@ void ICACHE_FLASH_ATTR IRsend::sendNEC (unsigned long data, int nbits,
   }
 }
 
+void ICACHE_FLASH_ATTR IRsend::sendPioneer (unsigned long data, int nbits,
+                                            unsigned int repeat, unsigned long secondData) {
+  // Details about timings can be found at:
+  //   http://www.sbprojects.com/knowledge/ir/nec.php
+  // More about the pioneer format:
+  //   http://www.adrian-kingston.com/IRFormatPioneer.htm
+
+  // Set IR carrier frequency
+  enableIROut(40);
+  IRtimer usecs = IRtimer();
+
+  for (unsigned int i = 0; i <= repeat; i++) {
+    usecs.reset();
+    // Header
+    mark(PIONEER_HDR_MARK);
+    space(PIONEER_HDR_SPACE);
+
+    sendData(PIONEER_BIT_MARK, PIONEER_ONE_SPACE, PIONEER_BIT_MARK, PIONEER_ZERO_SPACE,
+             data, nbits, true);
+
+    // Footer
+    mark(PIONEER_BIT_MARK);
+    space(PIONEER_ONE_SPACE);
+    // Gap till next command.
+    space(max(0ul, PIONEER_MIN_COMMAND_LENGTH - usecs.elapsed()));
+    
+    // Some Pioneer signals have two 32 bit commands
+    if (secondData) {
+      usecs.reset();
+      // Header
+      mark(PIONEER_HDR_MARK);
+      space(PIONEER_HDR_SPACE);
+
+      sendData(PIONEER_BIT_MARK, PIONEER_ONE_SPACE, PIONEER_BIT_MARK, PIONEER_ZERO_SPACE,
+               secondData, nbits, true);
+
+      // Footer
+      mark(PIONEER_BIT_MARK);
+      space(PIONEER_ONE_SPACE);
+      // Gap till next command.
+      space(max(0ul, PIONEER_MIN_COMMAND_LENGTH - usecs.elapsed()));
+    }
+  }
+}
+
 void ICACHE_FLASH_ATTR IRsend::sendLG (unsigned long data, int nbits,
                                        unsigned int repeat) {
   // Args:

--- a/lib/IRremoteESP8266/IRremoteESP8266.h
+++ b/lib/IRremoteESP8266/IRremoteESP8266.h
@@ -53,6 +53,7 @@ enum decode_type_t {
   RC5,
   RC6,
   NEC,
+  PIONEER,
   SONY,
   PANASONIC,
   JVC,
@@ -92,6 +93,7 @@ public:
 #define REPEAT 0xffffffff
 
 #define SEND_PROTOCOL_NEC      case NEC: sendNEC(data, nbits); break;
+#define SEND_PROTOCOL_PIONEER  case PIONEER: sendPioneer(data, nbits, 1, 0ul); break;
 #define SEND_PROTOCOL_SONY     case SONY: sendSony(data, nbits); break;
 #define SEND_PROTOCOL_RC5      case RC5: sendRC5(data, nbits); break;
 #define SEND_PROTOCOL_RC6      case RC6: sendRC6(data, nbits); break;
@@ -162,6 +164,7 @@ public:
   void send(int type, unsigned long data, int nbits) {
     switch (type) {
         SEND_PROTOCOL_NEC
+        SEND_PROTOCOL_PIONEER
         SEND_PROTOCOL_SONY
         SEND_PROTOCOL_RC5
         SEND_PROTOCOL_RC6
@@ -179,6 +182,7 @@ public:
   void sendCOOLIX(unsigned long data, int nbits);
   void sendWhynter(unsigned long data, int nbits);
   void sendNEC(unsigned long data, int nbits=32, unsigned int repeat=0);
+  void sendPioneer(unsigned long data, int nbits=32, unsigned int repeat=0, unsigned long secondData=0ul);
   void sendLG(unsigned long data, int nbits=28, unsigned int repeat=0);
   // sendSony() should typically be called with repeat=2 as Sony devices
   // expect the code to be sent at least 3 times. (code + 2 repeats = 3 codes)

--- a/lib/IRremoteESP8266/IRremoteInt.h
+++ b/lib/IRremoteESP8266/IRremoteInt.h
@@ -60,6 +60,14 @@
 #define NEC_RPT_SPACE	2250
 #define NEC_MIN_COMMAND_LENGTH 108000UL
 
+#define PIONEER_HDR_MARK	8000
+#define PIONEER_HDR_SPACE	4000
+#define PIONEER_BIT_MARK	500
+#define PIONEER_ONE_SPACE	1500
+#define PIONEER_ZERO_SPACE	500
+#define PIONEER_RPT_SPACE	2250
+#define PIONEER_MIN_COMMAND_LENGTH 90000UL
+
 // Timings based on http://www.sbprojects.com/knowledge/ir/sirc.php
 #define SONY_HDR_MARK	2400
 #define SONY_HDR_SPACE	600

--- a/src/_P035_IRTX.ino
+++ b/src/_P035_IRTX.ino
@@ -195,9 +195,14 @@ boolean Plugin_035(byte function, struct EventStruct *event, String& string)
             //sprintf_P(log, PSTR("IR Params2: RAW Code:%s"), IrRaw.c_str());
             //addLog(LOG_LEVEL_INFO, log);
           } else {
+            unsigned int IrRepeat=0;
+            unsigned long IrSecondCode=0UL;
+
             if (GetArgv(command, TmpStr1, 2)) IrType = TmpStr1;
             if (GetArgv(command, TmpStr1, 3)) IrCode = strtoul(TmpStr1, NULL, 16); //(long) TmpStr1
             if (GetArgv(command, TmpStr1, 4)) IrBits = str2int(TmpStr1);
+            if (GetArgv(command, TmpStr1, 5)) IrRepeat = str2int(TmpStr1);
+            if (GetArgv(command, TmpStr1, 6)) IrSecondCode = strtoul(TmpStr1, NULL, 16);
 
             if (IrType.equalsIgnoreCase("NEC")) Plugin_035_irSender->sendNEC(IrCode, IrBits);
             if (IrType.equalsIgnoreCase("JVC")) Plugin_035_irSender->sendJVC(IrCode, IrBits, 2);
@@ -206,6 +211,7 @@ boolean Plugin_035(byte function, struct EventStruct *event, String& string)
             if (IrType.equalsIgnoreCase("SAMSUNG")) Plugin_035_irSender->sendSAMSUNG(IrCode, IrBits);
             if (IrType.equalsIgnoreCase("SONY")) Plugin_035_irSender->sendSony(IrCode, IrBits);
             if (IrType.equalsIgnoreCase("PANASONIC")) Plugin_035_irSender->sendPanasonic(IrBits, IrCode);
+            if (IrType.equalsIgnoreCase("PIONEER")) Plugin_035_irSender->sendPioneer(IrCode, IrBits, IrRepeat, IrSecondCode);
           }
 
           addLog(LOG_LEVEL_INFO, F("IRTX :IR Code Sent"));


### PR DESCRIPTION
Hi,

I created some changes to support the IR signals of a Pioneer receiver I own (VSX-500k, most likely this will also work for other pioneer receivers)
The Pioneer IR protocol looks a lot like the NEC protocol, with some slight differences:
- The carrier frequency is 40kHz
- Timing/length of the signals is different
- Repeat signals are not just `FFFFFFFF`, but the commands repeated
- For one signal, there can be multiple 32bit commands, which is also important to keep while repeating.

Although the code looks a lot like the NEC stuff, I decided to keep it separated, so it is more clear to be specific for this pioneer stuff. 

Since this is my first contribution, let me know if anything is not following the rules of contribution here. I compiled on my own platform.io instance, but might have missed something I don't know about. (I have the code running on a Wemos D1)