### PR TITLE
[issue #825] Change labels and password form for Thingspeak controller

### DIFF
--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -245,6 +245,15 @@
 #define CPLUGIN_GET_DEVICENAME              5
 #define CPLUGIN_WEBFORM_SAVE                6
 #define CPLUGIN_WEBFORM_LOAD                7
+#define CPLUGIN_GET_PROTOCOL_DISPLAY_NAME   8
+
+#define CONTROLLER_HOSTNAME                 1
+#define CONTROLLER_IP                       2
+#define CONTROLLER_PORT                     3
+#define CONTROLLER_USER                     4
+#define CONTROLLER_PASS                     5
+#define CONTROLLER_SUBSCRIBE                6
+#define CONTROLLER_PUBLISH                  7
 
 #define NPLUGIN_PROTOCOL_ADD                1
 #define NPLUGIN_GET_DEVICENAME              2
@@ -1135,6 +1144,11 @@ int firstEnabledMQTTController() {
   return -1;
 }
 
+bool getControllerProtocolDisplayName(byte ProtocolIndex, byte parameterIdx, String& protoDisplayName) {
+  EventStruct tmpEvent;
+  tmpEvent.idx=parameterIdx;
+  return CPlugin_ptr[ProtocolIndex](CPLUGIN_GET_PROTOCOL_DISPLAY_NAME, &tmpEvent, protoDisplayName);
+}
 
 /*********************************************************************************************\
  * MAIN LOOP

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -968,22 +968,39 @@ void handle_controllers() {
       byte ProtocolIndex = getProtocolIndex(Settings.Protocol[controllerindex]);
       if (Protocol[ProtocolIndex].usesAccount)
       {
-        addFormTextBox(reply, F("Controller User"), F("controlleruser"), SecuritySettings.ControllerUser[controllerindex], sizeof(SecuritySettings.ControllerUser[0])-1);
+        String protoDisplayName;
+        if (!getControllerProtocolDisplayName(ProtocolIndex, CONTROLLER_USER, protoDisplayName)) {
+          protoDisplayName = F("Controller User");
+        }
+        addFormTextBox(reply, protoDisplayName, F("controlleruser"), SecuritySettings.ControllerUser[controllerindex], sizeof(SecuritySettings.ControllerUser[0])-1);
       }
-
       if (Protocol[ProtocolIndex].usesPassword)
       {
-        addFormPasswordBox(reply, F("Controller Password"), F("controllerpassword"), SecuritySettings.ControllerPassword[controllerindex], sizeof(SecuritySettings.ControllerPassword[0])-1);
+        String protoDisplayName;
+        if (getControllerProtocolDisplayName(ProtocolIndex, CONTROLLER_PASS, protoDisplayName)) {
+          // It is not a regular password, thus use normal text field.
+          addFormTextBox(reply, protoDisplayName, F("controllerpassword"), SecuritySettings.ControllerPassword[controllerindex], sizeof(SecuritySettings.ControllerPassword[0])-1);
+        } else {
+          addFormPasswordBox(reply, F("Controller Password"), F("controllerpassword"), SecuritySettings.ControllerPassword[controllerindex], sizeof(SecuritySettings.ControllerPassword[0])-1);
+        }
       }
 
       if (Protocol[ProtocolIndex].usesTemplate || Protocol[ProtocolIndex].usesMQTT)
       {
-        addFormTextBox(reply, F("Controller Subscribe"), F("controllersubscribe"), ControllerSettings.Subscribe, sizeof(ControllerSettings.Subscribe)-1);
+        String protoDisplayName;
+        if (!getControllerProtocolDisplayName(ProtocolIndex, CONTROLLER_SUBSCRIBE, protoDisplayName)) {
+          protoDisplayName = F("Controller Subscribe");
+        }
+        addFormTextBox(reply, protoDisplayName, F("controllersubscribe"), ControllerSettings.Subscribe, sizeof(ControllerSettings.Subscribe)-1);
       }
 
       if (Protocol[ProtocolIndex].usesTemplate || Protocol[ProtocolIndex].usesMQTT)
       {
-        addFormTextBox(reply, F("Controller Publish"), F("controllerpublish"), ControllerSettings.Publish, sizeof(ControllerSettings.Publish)-1);
+        String protoDisplayName;
+        if (!getControllerProtocolDisplayName(ProtocolIndex, CONTROLLER_PUBLISH, protoDisplayName)) {
+          protoDisplayName = F("Controller Publish");
+        }
+        addFormTextBox(reply, protoDisplayName, F("controllerpublish"), ControllerSettings.Publish, sizeof(ControllerSettings.Publish)-1);
       }
 
       addFormCheckBox(reply, F("Enabled"), F("controllerenabled"), Settings.ControllerEnabled[controllerindex]);

--- a/src/_C004.ino
+++ b/src/_C004.ino
@@ -16,7 +16,7 @@ boolean CPlugin_004(byte function, struct EventStruct *event, String& string)
       {
         Protocol[++protocolCount].Number = CPLUGIN_ID_004;
         Protocol[protocolCount].usesMQTT = false;
-        Protocol[protocolCount].usesAccount = false;
+        Protocol[protocolCount].usesAccount = true;
         Protocol[protocolCount].usesPassword = true;
         Protocol[protocolCount].defaultPort = 80;
         Protocol[protocolCount].usesID = true;
@@ -27,6 +27,22 @@ boolean CPlugin_004(byte function, struct EventStruct *event, String& string)
       {
         string = F(CPLUGIN_NAME_004);
         break;
+      }
+
+    case CPLUGIN_GET_PROTOCOL_DISPLAY_NAME:
+      {
+        success = true;
+        switch (event->idx) {
+          case CONTROLLER_USER:
+            string = F("ThingHTTP Name");
+            break;
+          case CONTROLLER_PASS:
+            string = F("API Key");
+            break;
+          default:
+            success = false;
+            break;
+        }
       }
 
     case CPLUGIN_PROTOCOL_SEND:


### PR DESCRIPTION
See #825

Added option for controllers to change their display string on some controller fields in the web interface.
When password field label is non-default it also implies to use a visible textfield instead of a password field.