### PR TITLE
[MQTT] Allow for background tests while waiting for wifi

### DIFF
--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -423,7 +423,7 @@ ESP8266WebServer WebServer(80);
 // udp protocol stuff (syslog, global sync, node info list, ntp time)
 WiFiUDP portUDP;
 
-
+bool WiFiConnected(uint32_t timeout_ms);
 
 extern "C" {
 #include "spi_flash.h"
@@ -605,7 +605,7 @@ struct ControllerSettingsStruct
   }
 
   boolean connectToHost(WiFiClient &client) {
-    if (WiFi.status() != WL_CONNECTED) {
+    if (!WiFiConnected(100)) {
       return false; // Not connected, so no use in wasting time to connect to a host.
     }
     if (UseDNS) {
@@ -615,7 +615,7 @@ struct ControllerSettingsStruct
   }
 
   int beginPacket(WiFiUDP &client) {
-    if (WiFi.status() != WL_CONNECTED) {
+    if (!WiFiConnected(100)) {
       return 0; // Not connected, so no use in wasting time to connect to a host.
     }
     if (UseDNS) {

--- a/src/Networking.ino
+++ b/src/Networking.ino
@@ -14,7 +14,7 @@ void syslog(const char *message)
     portUDP.beginPacket(broadcastIP, 514);
     char str[256];
     str[0] = 0;
-	// An RFC3164 compliant message must be formated like :  "<PRIO>[TimeStamp ]Hostname TaskName: Message"	
+	// An RFC3164 compliant message must be formated like :  "<PRIO>[TimeStamp ]Hostname TaskName: Message"
 
 	// Using Settings.Name as the Hostname (Hostname must NOT content space)
     snprintf_P(str, sizeof(str), PSTR("<7>%s EspEasy: %s"), Settings.Name, message);
@@ -226,7 +226,7 @@ void checkUDP()
   \*********************************************************************************************/
 void SendUDPTaskInfo(byte destUnit, byte sourceTaskIndex, byte destTaskIndex)
 {
-  if (WiFi.status() != WL_CONNECTED) {
+  if (!WiFiConnected(100)) {
     return;
   }
   struct infoStruct infoReply;
@@ -261,7 +261,7 @@ void SendUDPTaskInfo(byte destUnit, byte sourceTaskIndex, byte destTaskIndex)
   \*********************************************************************************************/
 void SendUDPTaskData(byte destUnit, byte sourceTaskIndex, byte destTaskIndex)
 {
-  if (WiFi.status() != WL_CONNECTED) {
+  if (!WiFiConnected(100)) {
     return;
   }
   struct dataStruct dataReply;
@@ -293,7 +293,7 @@ void SendUDPTaskData(byte destUnit, byte sourceTaskIndex, byte destTaskIndex)
   \*********************************************************************************************/
 void SendUDPCommand(byte destUnit, char* data, byte dataLength)
 {
-  if (WiFi.status() != WL_CONNECTED) {
+  if (!WiFiConnected(100)) {
     return;
   }
   byte firstUnit = 1;
@@ -317,7 +317,7 @@ void SendUDPCommand(byte destUnit, char* data, byte dataLength)
   \*********************************************************************************************/
 void sendUDP(byte unit, byte* data, byte size)
 {
-  if (WiFi.status() != WL_CONNECTED) {
+  if (!WiFiConnected(100)) {
     return;
   }
   if (unit != 255)
@@ -363,7 +363,7 @@ void refreshNodeList()
 void sendSysInfoUDP(byte repeats)
 {
   char log[80];
-  if (Settings.UDPPort == 0 || WiFi.status() != WL_CONNECTED)
+  if (Settings.UDPPort == 0 || !WiFiConnected(100))
     return;
 
   // TODO: make a nice struct of it and clean up
@@ -423,7 +423,7 @@ void sendSysInfoUDP(byte repeats)
   Respond to HTTP XML requests for SSDP information
   \*********************************************************************************************/
 void SSDP_schema(WiFiClient &client) {
-  if (WiFi.status() != WL_CONNECTED) {
+  if (!WiFiConnected(100)) {
     return;
   }
 
@@ -737,5 +737,21 @@ void SSDP_update() {
     while (_server->next())
       _server->flush();
   }
+}
 
+// Check WiFi connection. Maximum timeout 2000 msec.
+bool WiFiConnected(uint32_t timeout_ms) {
+  uint32_t timer = millis() + (timeout_ms > 2000 ? 2000 : timeout_ms);
+  uint32_t min_delay = timeout_ms / 10;
+  if (min_delay < 10) {
+    yield(); // Allow at least once time for backgroundtasks
+    min_delay = 10;
+  }
+  while (WiFi.status() != WL_CONNECTED) {
+    if (timeOutReached(timer)) {
+      return false;
+    }
+    delay(min_delay); // Allow the backgroundtasks to continue procesing.
+  }
+  return true;
 }

--- a/src/TimeESPeasy.ino
+++ b/src/TimeESPeasy.ino
@@ -180,7 +180,7 @@ void checkTime()
 
 unsigned long getNtpTime()
 {
-  if (WiFi.status() != WL_CONNECTED || !Settings.UseNTP) {
+  if (!Settings.UseNTP || !WiFiConnected(100)) {
     return 0;
   }
   WiFiUDP udp;

--- a/src/Wifi.ino
+++ b/src/Wifi.ino
@@ -174,10 +174,10 @@ boolean WifiConnectSSID(char WifiSSID[], char WifiKey[], byte connectAttempts)
     //wait until it connects
     for (byte x = 0; x < 200; x++)
     {
-      if (WiFi.status() != WL_CONNECTED)
+      if (!WiFiConnected(50))
       {
         statusLED(false);
-        delay(50);
+        // No delay needed, since the WiFi check has a delay
       }
       else
         break;

--- a/src/_C001.ino
+++ b/src/_C001.ino
@@ -33,7 +33,7 @@ boolean CPlugin_001(byte function, struct EventStruct *event, String& string)
       {
         if (event->idx != 0)
         {
-          if (WiFi.status() != WL_CONNECTED) {
+          if (!WiFiConnected(100)) {
             success = false;
             break;
           }

--- a/src/_C002.ino
+++ b/src/_C002.ino
@@ -135,7 +135,7 @@ boolean CPlugin_002(byte function, struct EventStruct *event, String& string)
       {
         if (event->idx != 0)
         {
-          if (WiFi.status() != WL_CONNECTED) {
+          if (!WiFiConnected(100)) {
             success = false;
             break;
           }

--- a/src/_C005.ino
+++ b/src/_C005.ino
@@ -88,7 +88,7 @@ boolean CPlugin_005(byte function, struct EventStruct *event, String& string)
 
     case CPLUGIN_PROTOCOL_SEND:
       {
-        if (WiFi.status() != WL_CONNECTED) {
+        if (!WiFiConnected(100)) {
           success = false;
           break;
         }

--- a/src/_C006.ino
+++ b/src/_C006.ino
@@ -76,7 +76,7 @@ boolean CPlugin_006(byte function, struct EventStruct *event, String& string)
 
     case CPLUGIN_PROTOCOL_SEND:
       {
-        if (WiFi.status() != WL_CONNECTED) {
+        if (!WiFiConnected(100)) {
           success = false;
           break;
         }

--- a/src/_C007.ino
+++ b/src/_C007.ino
@@ -31,7 +31,7 @@ boolean CPlugin_007(byte function, struct EventStruct *event, String& string)
 
     case CPLUGIN_PROTOCOL_SEND:
       {
-        if (WiFi.status() != WL_CONNECTED) {
+        if (!WiFiConnected(100)) {
           success = false;
           break;
         }

--- a/src/_C008.ino
+++ b/src/_C008.ino
@@ -68,7 +68,7 @@ boolean CPlugin_008(byte function, struct EventStruct *event, String& string)
 //********************************************************************************
 boolean HTTPSend(struct EventStruct *event, byte varIndex, float value, unsigned long longValue)
 {
-  if (WiFi.status() != WL_CONNECTED) {
+  if (!WiFiConnected(100)) {
     return false;
   }
   ControllerSettingsStruct ControllerSettings;

--- a/src/_C009.ino
+++ b/src/_C009.ino
@@ -56,7 +56,7 @@ boolean CPlugin_009(byte function, struct EventStruct *event, String& string)
 
     case CPLUGIN_PROTOCOL_SEND:
       {
-        if (WiFi.status() != WL_CONNECTED) {
+        if (!WiFiConnected(100)) {
           success = false;
           break;
         }

--- a/src/_C011.ino
+++ b/src/_C011.ino
@@ -120,7 +120,7 @@ boolean CPlugin_011(byte function, struct EventStruct *event, String& string)
 //********************************************************************************
 boolean HTTPSend011(struct EventStruct *event)
 {
-  if (WiFi.status() != WL_CONNECTED) {
+  if (!WiFiConnected(100)) {
     return false;
   }
   ControllerSettingsStruct ControllerSettings;

--- a/src/_P037_MQTTImport.ino
+++ b/src/_P037_MQTTImport.ino
@@ -340,7 +340,7 @@ boolean MQTTConnect_037(String clientid)
   if (MQTTclient_037->connected()) return true;
 
   // define stuff for the client - this could also be done in the intial declaration of MQTTclient_037
-  if (WiFi.status() != WL_CONNECTED) {
+  if (!WiFiConnected(1000)) {
     return false; // Not connected, so no use in wasting time to connect to a host.
   }
   ControllerSettingsStruct ControllerSettings;


### PR DESCRIPTION
Recent changes in 'early exit' when not connected, triggered lots of retry events.
Added some function to allow to wait for WiFi and in the meantime do some background tasks.