### PR TITLE
[issue #847 ] OpenHAB MQTT rewrite topic parser

### DIFF
--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -1206,7 +1206,7 @@ boolean isNumerical(const String& tBuf, bool mustBeInteger) {
   int firstDec = 0;
   if(tBuf.charAt(0) == '+' || tBuf.charAt(0) == '-')
     firstDec = 1;
-  for(int x=firstDec; x < tBuf.length(); ++x) {
+  for(unsigned int x=firstDec; x < tBuf.length(); ++x) {
     if(tBuf.charAt(x) == '.') {
       if (mustBeInteger) return false;
       // Only one decimal point allowed

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -1189,6 +1189,36 @@ float ul2float(unsigned long ul)
   return f;
 }
 
+/********************************************************************************************\
+  Check if string is valid float
+  \*********************************************************************************************/
+
+boolean isFloat(const String& tBuf) {
+  return isNumerical(tBuf, false);
+}
+
+boolean isInt(const String& tBuf) {
+  return isNumerical(tBuf, true);
+}
+
+boolean isNumerical(const String& tBuf, bool mustBeInteger) {
+  boolean decPt = false;
+  int firstDec = 0;
+  if(tBuf.charAt(0) == '+' || tBuf.charAt(0) == '-')
+    firstDec = 1;
+  for(int x=firstDec; x < tBuf.length(); ++x) {
+    if(tBuf.charAt(x) == '.') {
+      if (mustBeInteger) return false;
+      // Only one decimal point allowed
+      if(decPt) return false;
+      else decPt = true;
+    }
+    else if(tBuf.charAt(x) < '0' || tBuf.charAt(x) > '9') return false;
+  }
+  return true;
+}
+
+
 
 /********************************************************************************************\
   Init critical variables for logging (important during initial factory reset stuff )
@@ -1915,7 +1945,7 @@ String rulesProcessingFile(String fileName, String& event)
   fs::File f = SPIFFS.open(fileName, "r+");
   SPIFFS_CHECK(f, fileName.c_str());
 
-  static byte nestingLevel;
+  static byte nestingLevel = 0;
   int data = 0;
   String log = "";
 

--- a/src/_C005.ino
+++ b/src/_C005.ino
@@ -44,44 +44,38 @@ boolean CPlugin_005(byte function, struct EventStruct *event, String& string)
           // Controller is not enabled.
           break;
         } else {
-          // Split topic into array
-          String tmpTopic = event->String1.substring(1);
-          String topicSplit[10];
-          int SlashIndex = tmpTopic.indexOf('/');
-          byte count = 0;
-          while (SlashIndex > 0 && (count < (10 - 1)))
-          {
-            topicSplit[count] = tmpTopic.substring(0, SlashIndex);
-            tmpTopic = tmpTopic.substring(SlashIndex + 1);
-            SlashIndex = tmpTopic.indexOf('/');
-            count++;
-          }
-          topicSplit[count] = tmpTopic;
-
-          String cmd = "";
+          String cmd;
           struct EventStruct TempEvent;
-
-          if (topicSplit[count] == F("cmd"))
-          {
+          bool validTopic = false;
+          const int lastindex = event->String1.lastIndexOf('/');
+          const String lastPartTopic = event->String1.substring(lastindex + 1);
+          if (lastPartTopic == F("cmd")) {
             cmd = event->String2;
             parseCommandString(&TempEvent, cmd);
             TempEvent.Source = VALUE_SOURCE_MQTT;
+            validTopic = true;
+          } else {
+            if (lastindex > 0) {
+              // Topic has at least one separator
+              if (isFloat(event->String2) && isInt(lastPartTopic)) {
+                int prevLastindex = event->String1.lastIndexOf('/', lastindex - 1);
+                cmd = event->String1.substring(prevLastindex + 1, lastindex - 1);
+                TempEvent.Par1 = lastPartTopic.toInt();
+                TempEvent.Par2 = event->String2.toFloat();
+                TempEvent.Par3 = 0;
+                validTopic = true;
+              }
+            }
           }
-          else
-          {
-            cmd = topicSplit[count - 1];
-            TempEvent.Par1 = topicSplit[count].toInt();
-            TempEvent.Par2 = event->String2.toFloat();
-            TempEvent.Par3 = 0;
-          }
-          // in case of event, store to buffer and return...
-          String command = parseString(cmd, 1);
-          if (command == F("event"))
+          if (validTopic) {
+            // in case of event, store to buffer and return...
+            String command = parseString(cmd, 1);
+            if (command == F("event")) {
             eventBuffer = cmd.substring(6);
-          else if
-            (PluginCall(PLUGIN_WRITE, &TempEvent, cmd));
-          else
-            remoteConfig(&TempEvent, cmd);
+            } else if (!PluginCall(PLUGIN_WRITE, &TempEvent, cmd)) {
+              remoteConfig(&TempEvent, cmd);
+            }
+          }
         }
         break;
       }


### PR DESCRIPTION
When OpenHAB MQTT controller was selected, the web interface becomes unresponsive when the controller tab was selected.
Also the ESP almost freezes when MQTT messages were sent.

This is an attempt to make them work faster.
Also a lot of string manipulation, copies and resizes are now no longer needed and the received values are checked to be valid int or float before used.