### PR TITLE
[MQTT] LWT "Connected" message doesn't have the retained flag

### DIFF
--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -166,7 +166,7 @@ bool MQTTConnect(int controller_idx)
   log += subscribeTo;
   addLog(LOG_LEVEL_INFO, log);
 
-  if (MQTTclient.publish(LWTTopic.c_str(), "Connected")) {
+  if (MQTTclient.publish(LWTTopic.c_str(), "Connected", 1)) {
     statusLED(true);
     return true; // end loop if succesfull
   }


### PR DESCRIPTION
See comments of [Superpiffer](https://github.com/letscontrolit/ESPEasy/commit/a93a078c0b8ae4090c22717eacc8bc8ba92ad780#commitcomment-27718045)