### PR TITLE
 - extend conditions with AND/OR, now it is possible to simplify rules

### DIFF
--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -2228,7 +2228,6 @@ boolean conditionMatchExtended(String& check) {
 		if (condAnd > 0 || condOr > 0) { // we got AND/OR
 			if (condAnd > 0	&& ((condOr < 0 && condOr < condAnd) || (condOr > 0 && condOr > condAnd))) { //AND is first
 				check = check.substring(condAnd + 5);
-				Serial.println(check);
 				rightcond = conditionMatch(check);
 				leftcond = (leftcond && rightcond);
 			} else { //OR is first

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -2243,7 +2243,7 @@ String rulesProcessingFile(String fileName, String& event)
           {
             conditional = true;
             String check = lcAction.substring(split + 3);
-            condition = conditionMatch(check);
+            condition = conditionMatchExtended(check);
             ifBranche = true;
             isCommand = false;
           }
@@ -2419,6 +2419,33 @@ boolean ruleMatch(String& event, String& rule)
 /********************************************************************************************\
   Check expression
   \*********************************************************************************************/
+
+boolean conditionMatchExtended(String& check) {
+	int condAnd = -1;
+	int condOr = -1;
+	boolean rightcond = false;
+	boolean leftcond = conditionMatch(check); // initial check
+
+	do {
+		condAnd = check.indexOf(F(" and "));
+		condOr  = check.indexOf(F(" or "));
+
+		if (condAnd > 0 || condOr > 0) { // we got AND/OR
+			if (condAnd > 0	&& ((condOr < 0 && condOr < condAnd) || (condOr > 0 && condOr > condAnd))) { //AND is first
+				check = check.substring(condAnd + 5);
+				Serial.println(check);
+				rightcond = conditionMatch(check);
+				leftcond = (leftcond && rightcond);
+			} else { //OR is first
+				check = check.substring(condOr + 4);
+				rightcond = conditionMatch(check);
+				leftcond = (leftcond || rightcond);
+			}
+		}
+	} while (condAnd > 0 || condOr > 0);
+	return leftcond;
+}
+
 boolean conditionMatch(String& check)
 {
   boolean match = false;

--- a/src/_P019_PCF8574.ino
+++ b/src/_P019_PCF8574.ino
@@ -112,9 +112,17 @@ boolean Plugin_019(byte function, struct EventStruct *event, String& string)
         if (command == F("pcfgpio"))
         {
           success = true;
-          Plugin_019_Write(event->Par1, event->Par2);
-          setPinState(PLUGIN_ID_019, event->Par1, PIN_MODE_OUTPUT, event->Par2);
-          log = String(F("PCF  : GPIO ")) + String(event->Par1) + String(F(" Set to ")) + String(event->Par2);
+          if (event->Par2 == 2) { //INPUT
+        	  // PCF8574 specific: only can read 0/low state, so we must send 1
+        	  setPinState(PLUGIN_ID_019, event->Par1, PIN_MODE_INPUT, 1);
+        	  Plugin_019_Write(event->Par1,1);
+        	  log = String(F("PCF  : GPIO ")) + String(event->Par1) + String(F(" Set to 1"));
+          }
+          else { // OUTPUT
+        	  setPinState(PLUGIN_ID_019, event->Par1, PIN_MODE_OUTPUT, event->Par2);
+        	  Plugin_019_Write(event->Par1, event->Par2);
+        	  log = String(F("PCF  : GPIO ")) + String(event->Par1) + String(F(" Set to ")) + String(event->Par2);
+          }
           addLog(LOG_LEVEL_INFO, log);
           SendStatus(event->Source, getPinStateJSON(SEARCH_PIN_STATE, PLUGIN_ID_019, event->Par1, log, 0));
         }
@@ -200,28 +208,33 @@ int Plugin_019_Read(byte Par1)
 //********************************************************************************
 boolean Plugin_019_Write(byte Par1, byte Par2)
 {
-  boolean success = false;
-  byte portvalue = 0;
   byte unit = (Par1 - 1) / 8;
   byte port = Par1 - (unit * 8);
   uint8_t address = 0x20 + unit;
   if (unit > 7) address += 0x10;
 
-  // get the current pin status
-  Wire.requestFrom(address, (uint8_t)0x1);
-  if (Wire.available())
-  {
-    portvalue = Wire.read();
-    if (Par2 == 1)
-      portvalue |= (1 << (port - 1));
-    else
-      portvalue &= ~(1 << (port - 1));
-
-    // write back new data
-    Wire.beginTransmission(address);
-    Wire.write(portvalue);
-    Wire.endTransmission();
-    success = true;
+  //generate bitmask
+  int i = 0;
+  byte portmask = 0;
+  byte mode = 0;
+  uint16_t value = 0;
+  unit *= 8; // calculate first pin
+  unit += 1;
+  for(i =0;i<8;i++){
+	  mode =0;
+	  if(!getPinState(PLUGIN_ID_019, unit, &mode, &value) || mode == PIN_MODE_INPUT || (mode == PIN_MODE_OUTPUT && value == 1))
+		  portmask |= (1 << i);
+	  unit++;
   }
-  return(success);
+
+  if (Par2 == 1)
+    portmask |= (1 << (port - 1));
+  else
+    portmask &= ~(1 << (port - 1));
+
+  Wire.beginTransmission(address);
+  Wire.write(portmask);
+  Wire.endTransmission();
+
+  return true;
 }


### PR DESCRIPTION
related to #909 
@Grovkillen @TD-er what do You think about it, can we push this to v2.0?
Condition is resolved from left to right.

test rules:
```
on test do
  if [test#a]=0 or [test#b]=0 or [test#c]=0
    event ok
  else
    event nok
  endif
endon

on test2 do
  if [test#a]=1 and [test#b]=1 and [test#c]=1
    event ok
  else
    event nok
  endif
endon

on test3 do
  if [test#a]=1 and [test#b]=1 or [test#c]=0
    event ok
  else
    event nok
  endif
endon

on test4 do
  if [test#a]=0
    event ok
  else
    event nok
  endif
endon
```