### PR TITLE
[timeouts] Improve response when hosts are not reachable

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -22,11 +22,13 @@
 
 [common]
 build_flags = -D BUILD_GIT='"${env.TRAVIS_TAG}"'
+lib_deps = ESP8266Ping
 
 
 #normal version with stable plugins, 1024k version
 [env:normal_ESP8266_1024]
 platform = espressif8266@1.5.0
+lib_deps = ${common.lib_deps}
 framework = arduino
 board = esp12e
 upload_speed=460800
@@ -35,6 +37,7 @@ build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld
 
 [env:normal_ESP8266_1024_DOUT]
 platform = espressif8266@1.5.0
+lib_deps = ${common.lib_deps}
 board_flash_mode = dout
 framework = arduino
 board = esp12e
@@ -45,6 +48,7 @@ build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld
 #normal version with stable plugins, 4096k version
 [env:normal_ESP8266_4096]
 platform = espressif8266@1.5.0
+lib_deps = ${common.lib_deps}
 framework = arduino
 board = esp12e
 upload_speed=460800
@@ -54,6 +58,7 @@ build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.4m1m.ld
 #normal version with stable plugins, 4096k version for esp8285
 [env:normal_ESP8285_1024]
 platform = espressif8266@1.5.0
+lib_deps = ${common.lib_deps}
 framework = arduino
 board = esp8285
 upload_speed=460800
@@ -64,6 +69,7 @@ build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -DESP8285
 #version with additional plugins (and dependend code) that are in test-stadium 1024k
 [env:test_ESP8266_1024]
 platform = espressif8266@1.5.0
+lib_deps = ${common.lib_deps}
 framework = arduino
 board = esp12e
 upload_speed=460800
@@ -72,6 +78,7 @@ build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_BUILD
 #version with additional plugins (and dependend code) that are in test-stadium 4096k
 [env:test_ESP8266_4096]
 platform = espressif8266@1.5.0
+lib_deps = ${common.lib_deps}
 framework = arduino
 board = esp12e
 upload_speed=460800
@@ -79,6 +86,7 @@ build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.4m1m.ld -D PLUGIN_BUILD_
 
 [env:test_ESP8266_4096_VCC]
 platform = espressif8266@1.5.0
+lib_deps = ${common.lib_deps}
 framework = arduino
 board = esp12e
 upload_speed=460800
@@ -87,6 +95,7 @@ build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.4m1m.ld -D PLUGIN_BUILD_
 #version with additional plugins (and dependend code) that are in test-stadium 4096k for esp8285
 [env:test_ESP8285_1024]
 platform = espressif8266@1.5.0
+lib_deps = ${common.lib_deps}
 framework = arduino
 board = esp8285
 upload_speed=460800
@@ -96,6 +105,7 @@ build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_BUILD
 #version with additional plugins (and dependend code) that is in development (probably broken or incomplete) 1024k
 [env:dev_ESP8266_1024]
 platform = espressif8266@1.5.0
+lib_deps = ${common.lib_deps}
 framework = arduino
 board = esp12e
 upload_speed=460800
@@ -104,6 +114,7 @@ build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_BUILD
 #version with additional plugins (and dependend code) that is in development (probably broken or incomplete) 4096k
 [env:dev_ESP8266_4096]
 platform = espressif8266@1.5.0
+lib_deps = ${common.lib_deps}
 framework = arduino
 board = esp12e
 upload_speed=460800
@@ -112,6 +123,7 @@ build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.4m1m.ld -D PLUGIN_BUILD_
 #version with additional plugins (and dependend code) that is in development (probably broken or incomplete) 4096k for esp8285
 [env:dev_ESP8285_1024]
 platform = espressif8266@1.5.0
+lib_deps = ${common.lib_deps}
 framework = arduino
 board = esp8285
 upload_speed=460800
@@ -122,6 +134,7 @@ build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_BUILD
 #special patched version for PUYA flash chips, see https://github.com/letscontrolit/ESPEasy/issues/650
 [env:dev_ESP8266PUYA_1024]
 platform = espressif8266@1.5.0
+lib_deps = ${common.lib_deps}
 framework = arduino
 board = esp12e
 upload_speed=460800
@@ -130,6 +143,7 @@ build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_BUILD
 #special patched version for PUYA flash chips, see https://github.com/letscontrolit/ESPEasy/issues/650
 [env:dev_ESP8266PUYA_1024_VCC]
 platform = espressif8266@1.5.0
+lib_deps = ${common.lib_deps}
 framework = arduino
 board = esp12e
 upload_speed=460800

--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -118,11 +118,12 @@ void callback(char* c_topic, byte* b_payload, unsigned int length) {
 \*********************************************************************************************/
 bool MQTTConnect(int controller_idx)
 {
-  if (!WiFiConnected(100)) return false;
-  if (MQTTclient.connected())
-    MQTTclient.disconnect();
   ControllerSettingsStruct ControllerSettings;
   LoadControllerSettings(controller_idx, (byte*)&ControllerSettings, sizeof(ControllerSettings));
+  if (!ControllerSettings.checkHostReachable(true))
+    return false;
+  if (MQTTclient.connected())
+    MQTTclient.disconnect();
   if (ControllerSettings.UseDNS) {
     MQTTclient.setServer(ControllerSettings.getHost().c_str(), ControllerSettings.Port);
   } else {
@@ -226,7 +227,6 @@ boolean MQTTpublish(int controller_idx, const char* topic, const char* payload, 
   if (MQTTclient.publish(topic, payload, retained))
     return true;
   addLog(LOG_LEVEL_DEBUG, F("MQTT : publish failed"));
-  MQTTConnect(controller_idx);
   return false;
 }
 

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -367,6 +367,7 @@
 #include "ESPEasyTimeTypes.h"
 #include "lwip/tcp_impl.h"
 #include <ESP8266WiFi.h>
+#include <ESP8266Ping.h>
 #include <DNSServer.h>
 #include <WiFiUdp.h>
 #include <ESP8266WebServer.h>
@@ -429,7 +430,10 @@ ESP8266WebServer WebServer(80);
 // udp protocol stuff (syslog, global sync, node info list, ntp time)
 WiFiUDP portUDP;
 
+// Forward declarations.
 bool WiFiConnected(uint32_t timeout_ms);
+bool hostReachable(const IPAddress& ip);
+bool hostReachable(const String& hostname);
 
 extern "C" {
 #include "spi_flash.h"
@@ -610,24 +614,55 @@ struct ControllerSettingsStruct
     return getIP().toString();
   }
 
-  boolean connectToHost(WiFiClient &client) {
-    if (!WiFiConnected(100)) {
+  void setHostname(const String& controllerhostname) {
+    strncpy(HostName, controllerhostname.c_str(), sizeof(HostName));
+    updateIPcache();
+  }
+
+  boolean checkHostReachable(bool quick) {
+    if (!WiFiConnected(10)) {
       return false; // Not connected, so no use in wasting time to connect to a host.
     }
+    if (quick) return true;
     if (UseDNS) {
-      return client.connect(HostName, Port);
+      if (!updateIPcache()) {
+        return false;
+      }
     }
-    return client.connect(getIP(), Port);
+    return hostReachable(getIP());
+  }
+
+  boolean connectToHost(WiFiClient &client) {
+    if (!checkHostReachable(true)) {
+      return false; // Host not reachable
+    }
+    byte retry = 2;
+    bool connected = false;
+    while (retry > 0 && !connected) {
+      --retry;
+      connected = client.connect(getIP(), Port);
+      if (connected) return true;
+      if (!checkHostReachable(false))
+        return false;
+    }
+    return false;
   }
 
   int beginPacket(WiFiUDP &client) {
-    if (!WiFiConnected(100)) {
-      return 0; // Not connected, so no use in wasting time to connect to a host.
+    if (!checkHostReachable(true)) {
+      return 0; // Host not reachable
     }
-    if (UseDNS) {
-      return client.beginPacket(HostName, Port);
+    byte retry = 2;
+    int connected = 0;
+    while (retry > 0 && !connected) {
+      --retry;
+      connected = client.beginPacket(getIP(), Port);
+      if (connected != 0) return connected;
+      if (!checkHostReachable(false))
+        return false;
+      delay(10);
     }
-    return client.beginPacket(getIP(), Port);
+    return false;
   }
 
   String getHostPortString() const {
@@ -636,6 +671,22 @@ struct ControllerSettingsStruct
     result += Port;
     return result;
   }
+
+private:
+  bool updateIPcache() {
+    if (!UseDNS) {
+      return true;
+    }
+    IPAddress tmpIP;
+    if (WiFi.hostByName(HostName, tmpIP)) {
+      for (byte x = 0; x < 4; x++) {
+        IP[x] = tmpIP[x];
+      }
+      return true;
+    }
+    return false;
+  }
+
 };
 
 struct NotificationSettingsStruct
@@ -909,6 +960,7 @@ unsigned long timer20ms;
 unsigned long timer1s;
 unsigned long timerwd;
 unsigned long timermqtt;
+unsigned long timermqtt_interval;
 unsigned long lastSend;
 unsigned int NC_Count = 0;
 unsigned int C_Count = 0;
@@ -1108,6 +1160,7 @@ void setup()
   timer1s = 0; // timer for periodic actions once per/sec
   timerwd = 0; // timer for watchdog once per 30 sec
   timermqtt = 0; // Timer for the MQTT keep alive loop.
+  timermqtt_interval = 250; // Interval for checking MQTT
 
   PluginInit();
   CPluginInit();
@@ -1215,14 +1268,17 @@ void loop()
 
     if (timeOutReached(timermqtt)) {
       // MQTT_KEEPALIVE = 15 seconds.
-      timermqtt = millis() + 250;
+      timermqtt = millis() + timermqtt_interval;
       //dont do this in backgroundtasks(), otherwise causes crashes. (https://github.com/letscontrolit/ESPEasy/issues/683)
       int enabledMqttController = firstEnabledMQTTController();
       if (enabledMqttController >= 0) {
         if (!MQTTclient.loop()) {
           if (!MQTTCheck(enabledMqttController)) {
             // Check failed, no need to retry it immediately.
-            timermqtt = millis() + 500;
+            if (timermqtt_interval < 2000)
+              timermqtt_interval += 250;
+          } else {
+            timermqtt_interval = 250;
           }
         }
       }

--- a/src/Networking.ino
+++ b/src/Networking.ino
@@ -739,10 +739,10 @@ void SSDP_update() {
   }
 }
 
-// Check WiFi connection. Maximum timeout 2000 msec.
+// Check WiFi connection. Maximum timeout 500 msec.
 bool WiFiConnected(uint32_t timeout_ms) {
-  uint32_t timer = millis() + (timeout_ms > 2000 ? 2000 : timeout_ms);
-  uint32_t min_delay = timeout_ms / 10;
+  uint32_t timer = millis() + (timeout_ms > 500 ? 500 : timeout_ms);
+  uint32_t min_delay = timeout_ms / 20;
   if (min_delay < 10) {
     yield(); // Allow at least once time for backgroundtasks
     min_delay = 10;
@@ -754,4 +754,28 @@ bool WiFiConnected(uint32_t timeout_ms) {
     delay(min_delay); // Allow the backgroundtasks to continue procesing.
   }
   return true;
+}
+
+bool hostReachable(const IPAddress& ip) {
+  // Only do 1 ping at a time to return early
+  byte retry = 3;
+  while (retry > 0) {
+    if (Ping.ping(ip, 1)) return true;
+    delay(50);
+    --retry;
+  }
+  String log = F("Host unreachable: ");
+  log += ip;
+  addLog(LOG_LEVEL_ERROR, log);
+  return false;
+}
+
+bool hostReachable(const String& hostname) {
+  IPAddress remote_addr;
+  if (WiFi.hostByName(hostname.c_str(), remote_addr))
+    return hostReachable(remote_addr);
+  String log = F("Hostname cannot be resolved: ");
+  log += hostname;
+  addLog(LOG_LEVEL_ERROR, log);
+  return false;
 }

--- a/src/TimeESPeasy.ino
+++ b/src/TimeESPeasy.ino
@@ -89,7 +89,8 @@ unsigned long now() {
       setTime(t);
       applyTimeZone(t);
     } else {
-      nextSyncTime = sysTime + syncInterval;
+      // Unable to sync, retry again in a minute
+      nextSyncTime = sysTime + 60;
     }
   }
   uint32_t localSystime = toLocal(sysTime);
@@ -183,65 +184,62 @@ unsigned long getNtpTime()
   if (!Settings.UseNTP || !WiFiConnected(100)) {
     return 0;
   }
+  IPAddress timeServerIP;
+  const char* ntpServerName = "pool.ntp.org";
+  // Have to do a lookup eacht time, since the NTP pool always returns another IP
+  if (Settings.NTPHost[0] != 0)
+    WiFi.hostByName(Settings.NTPHost, timeServerIP);
+  else
+    WiFi.hostByName(ntpServerName, timeServerIP);
+
+  if (!hostReachable(timeServerIP))
+    return 0;
+
   WiFiUDP udp;
   udp.begin(123);
-  for (byte x = 1; x < 4; x++)
-  {
-    String log = F("NTP  : NTP sync request:");
-    log += x;
-    addLog(LOG_LEVEL_DEBUG_MORE, log);
 
-    const int NTP_PACKET_SIZE = 48; // NTP time is in the first 48 bytes of message
-    byte packetBuffer[NTP_PACKET_SIZE]; //buffer to hold incoming & outgoing packets
+  const int NTP_PACKET_SIZE = 48; // NTP time is in the first 48 bytes of message
+  byte packetBuffer[NTP_PACKET_SIZE]; //buffer to hold incoming & outgoing packets
 
-    IPAddress timeServerIP;
-    const char* ntpServerName = "pool.ntp.org";
+  String log = F("NTP  : NTP send to ");
+  log += timeServerIP.toString();
+  addLog(LOG_LEVEL_DEBUG_MORE, log);
 
-    if (Settings.NTPHost[0] != 0)
-      WiFi.hostByName(Settings.NTPHost, timeServerIP);
-    else
-      WiFi.hostByName(ntpServerName, timeServerIP);
+  while (udp.parsePacket() > 0) ; // discard any previously received packets
 
-    log = F("NTP  : NTP send to ");
-    log += timeServerIP.toString();
-    addLog(LOG_LEVEL_DEBUG_MORE, log);
+  memset(packetBuffer, 0, NTP_PACKET_SIZE);
+  packetBuffer[0] = 0b11100011;   // LI, Version, Mode
+  packetBuffer[1] = 0;     // Stratum, or type of clock
+  packetBuffer[2] = 6;     // Polling Interval
+  packetBuffer[3] = 0xEC;  // Peer Clock Precision
+  packetBuffer[12]  = 49;
+  packetBuffer[13]  = 0x4E;
+  packetBuffer[14]  = 49;
+  packetBuffer[15]  = 52;
+  udp.beginPacket(timeServerIP, 123); //NTP requests are to port 123
+  udp.write(packetBuffer, NTP_PACKET_SIZE);
+  udp.endPacket();
 
-    while (udp.parsePacket() > 0) ; // discard any previously received packets
-
-    memset(packetBuffer, 0, NTP_PACKET_SIZE);
-    packetBuffer[0] = 0b11100011;   // LI, Version, Mode
-    packetBuffer[1] = 0;     // Stratum, or type of clock
-    packetBuffer[2] = 6;     // Polling Interval
-    packetBuffer[3] = 0xEC;  // Peer Clock Precision
-    packetBuffer[12]  = 49;
-    packetBuffer[13]  = 0x4E;
-    packetBuffer[14]  = 49;
-    packetBuffer[15]  = 52;
-    udp.beginPacket(timeServerIP, 123); //NTP requests are to port 123
-    udp.write(packetBuffer, NTP_PACKET_SIZE);
-    udp.endPacket();
-
-    uint32_t beginWait = millis();
-    while (!timeOutReached(beginWait + 1000)) {
-      int size = udp.parsePacket();
-      if (size >= NTP_PACKET_SIZE) {
-        udp.read(packetBuffer, NTP_PACKET_SIZE);  // read packet into the buffer
-        unsigned long secsSince1900;
-        // convert four bytes starting at location 40 to a long integer
-        secsSince1900 =  (unsigned long)packetBuffer[40] << 24;
-        secsSince1900 |= (unsigned long)packetBuffer[41] << 16;
-        secsSince1900 |= (unsigned long)packetBuffer[42] << 8;
-        secsSince1900 |= (unsigned long)packetBuffer[43];
-        log = F("NTP  : NTP replied: ");
-        log += timePassedSince(beginWait);
-        log += F(" mSec");
-        addLog(LOG_LEVEL_DEBUG_MORE, log);
-        return secsSince1900 - 2208988800UL;
-      }
+  uint32_t beginWait = millis();
+  while (!timeOutReached(beginWait + 1000)) {
+    int size = udp.parsePacket();
+    if (size >= NTP_PACKET_SIZE) {
+      udp.read(packetBuffer, NTP_PACKET_SIZE);  // read packet into the buffer
+      unsigned long secsSince1900;
+      // convert four bytes starting at location 40 to a long integer
+      secsSince1900 =  (unsigned long)packetBuffer[40] << 24;
+      secsSince1900 |= (unsigned long)packetBuffer[41] << 16;
+      secsSince1900 |= (unsigned long)packetBuffer[42] << 8;
+      secsSince1900 |= (unsigned long)packetBuffer[43];
+      log = F("NTP  : NTP replied: ");
+      log += timePassedSince(beginWait);
+      log += F(" mSec");
+      addLog(LOG_LEVEL_DEBUG_MORE, log);
+      return secsSince1900 - 2208988800UL;
     }
-    log = F("NTP  : No reply");
-    addLog(LOG_LEVEL_DEBUG_MORE, log);
   }
+  log = F("NTP  : No reply");
+  addLog(LOG_LEVEL_DEBUG_MORE, log);
   return 0;
 }
 

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -854,11 +854,7 @@ void handle_controllers() {
         ControllerSettings.UseDNS = usedns.toInt();
         if (ControllerSettings.UseDNS)
         {
-          strncpy(ControllerSettings.HostName, controllerhostname.c_str(), sizeof(ControllerSettings.HostName));
-          IPAddress IP;
-          WiFi.hostByName(ControllerSettings.HostName, IP);
-          for (byte x = 0; x < 4; x++)
-            ControllerSettings.IP[x] = IP[x];
+          ControllerSettings.setHostname(controllerhostname);
         }
         //no protocol selected
         else

--- a/src/_C002.ino
+++ b/src/_C002.ino
@@ -135,14 +135,12 @@ boolean CPlugin_002(byte function, struct EventStruct *event, String& string)
       {
         if (event->idx != 0)
         {
-          if (!WiFiConnected(100)) {
+          ControllerSettingsStruct ControllerSettings;
+          LoadControllerSettings(event->ControllerIndex, (byte*)&ControllerSettings, sizeof(ControllerSettings));
+          if (!ControllerSettings.checkHostReachable(true)) {
             success = false;
             break;
           }
-
-          ControllerSettingsStruct ControllerSettings;
-          LoadControllerSettings(event->ControllerIndex, (byte*)&ControllerSettings, sizeof(ControllerSettings));
-
           StaticJsonBuffer<200> jsonBuffer;
 
           JsonObject& root = jsonBuffer.createObject();
@@ -151,7 +149,7 @@ boolean CPlugin_002(byte function, struct EventStruct *event, String& string)
           #if FEATURE_ADC_VCC
             root[F("Battery")] = mapVccToDomoticz();
           #endif
-          
+
           switch (event->sensorType)
           {
             case SENSOR_TYPE_SWITCH:


### PR DESCRIPTION
See #922 and #847

Problem with DNS resolve is that it is quite slow when resulting in a failure and it tends to keep the ESP occupied and make it unresponsive.

Changed the way it is connecting to a controller.
Checks to see if a host is online is now primarily done using IP. Controllers use DNS when needed (e.g. for HTTP)
The IP-address is being cached when using DNS and this is being refreshed as soon as a connection fails using the IP.

N.B. some routers may implement a non-standard DNS resolver which always resolves to a standard address when DNS name cannot be resolved. This will not be fixed and will always remain an issue.