### PR TITLE
Feature TxPower

### DIFF
--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -135,7 +135,7 @@
 #define LOG_TO_SDCARD         4
 #define DEFAULT_SYSLOG_IP			""				// Syslog IP Address
 #define DEFAULT_SYSLOG_LEVEL		0				// Syslog Log Level
-#define DEFAULT_SERIAL_LOG_LEVEL	LOG_LEVEL_INFO	// Serial Log Level
+#define DEFAULT_SERIAL_LOG_LEVEL	LOG_LEVEL_DEBUG_DEV	// Serial Log Level
 #define DEFAULT_WEB_LOG_LEVEL		LOG_LEVEL_INFO	// Web Log Level
 #define DEFAULT_SD_LOG_LEVEL		0				// SD Card Log Level
 #define DEFAULT_USE_SD_LOG			false			// (true|false) Enable Logging to the SD card
@@ -476,7 +476,7 @@ struct SettingsStruct
     WireClockStretchLimit(0), GlobalSync(false), ConnectionFailuresThreshold(0),
     TimeZone(0), MQTTRetainFlag(false), InitSPI(false),
     Pin_status_led_Inversed(false), deepSleepOnFail(false), UseValueLogger(false),
-    DST_Start(0), DST_End(0)
+    DST_Start(0), DST_End(0), TxPower(20)
     {
       for (byte i = 0; i < CONTROLLER_MAX; ++i) {
         Protocol[i] = 0;
@@ -579,6 +579,7 @@ struct SettingsStruct
   boolean       UseValueLogger;
   uint16_t      DST_Start;
   uint16_t      DST_End;
+  float         TxPower;
   //its safe to extend this struct, up to several bytes, default values in config are 0
   //look in misc.ino how config.dat is used because also other stuff is stored in it at different offsets.
   //TODO: document config.dat somewhere here

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -135,7 +135,7 @@
 #define LOG_TO_SDCARD         4
 #define DEFAULT_SYSLOG_IP			""				// Syslog IP Address
 #define DEFAULT_SYSLOG_LEVEL		0				// Syslog Log Level
-#define DEFAULT_SERIAL_LOG_LEVEL	LOG_LEVEL_DEBUG_DEV	// Serial Log Level
+#define DEFAULT_SERIAL_LOG_LEVEL	LOG_LEVEL_INFO	// Serial Log Level
 #define DEFAULT_WEB_LOG_LEVEL		LOG_LEVEL_INFO	// Web Log Level
 #define DEFAULT_SD_LOG_LEVEL		0				// SD Card Log Level
 #define DEFAULT_USE_SD_LOG			false			// (true|false) Enable Logging to the SD card

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -748,6 +748,7 @@ void handle_config() {
   addFormPasswordBox(reply, F("WPA Key"), F("key"), SecuritySettings.WifiKey, 63);
   addFormTextBox(reply, F("Fallback SSID"), F("ssid2"), SecuritySettings.WifiSSID2, 31);
   addFormPasswordBox(reply, F("Fallback WPA Key"), F("key2"), SecuritySettings.WifiKey2, 63);
+  addFormNumericBox(reply, F("Tx Power (0-20.5dB)"), F("TxPower"),Settings.TxPower,0,20);
   addFormSeparator(reply);
   addFormPasswordBox(reply, F("WPA AP Mode Key"), F("apkey"), SecuritySettings.WifiAPKey, 63);
 

--- a/src/Wifi.ino
+++ b/src/Wifi.ino
@@ -79,15 +79,19 @@ void WifiAPMode(boolean state)
 //********************************************************************************
 boolean WifiConnect(byte connectAttempts)
 {
+  char str[20];
   String log = "";
   char hostname[40];
   strncpy(hostname, WifiGetHostname().c_str(), sizeof(hostname));
   wifi_station_set_hostname(hostname);
-
+  sprintf_P(str, PSTR("%u"), (uint8_t)Settings.TxPower);
+  log = F("WIFI : TxPower :");
+  log += str;
+  addLog(LOG_LEVEL_INFO, log);
+  WiFi.setOutputPower(Settings.TxPower);
   //use static ip?
   if (Settings.IP[0] != 0 && Settings.IP[0] != 255)
   {
-    char str[20];
     sprintf_P(str, PSTR("%u.%u.%u.%u"), Settings.IP[0], Settings.IP[1], Settings.IP[2], Settings.IP[3]);
     log = F("IP   : Static IP :");
     log += str;


### PR DESCRIPTION
added an option to configure the ESP8266's WiFi OutputPower (setOutputPower() )
this may be helpful to reduce peak current useage, but in my case, it was mostly necessary to get my PIR sensors working.
It seems that, at close quarters, they are sensitive to the 2.4GHz bursts the WiFi module will put out.