### PR TITLE
[BuildError] StreamingBuffer code cleanup + fix order member initialize

### DIFF
--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -13,7 +13,7 @@ void sendHeaderBlocking(bool json);
 
 class StreamingBuffer{
 private:
-  bool lowMemorySkip; 
+  bool lowMemorySkip;
 public:
   uint32_t initialRam;
   uint32_t beforeTXRam;
@@ -22,29 +22,22 @@ public:
   uint32_t maxCoreUsage;
   uint32_t maxServerUsage;
   unsigned int BufferSize;
-  String buf;
   unsigned int sentBytes;
+  String buf;
 
-  StreamingBuffer(void) :
+  StreamingBuffer(void) : lowMemorySkip(false),
     initialRam(0), beforeTXRam(0), duringTXRam(0), finalRam(0), maxCoreUsage(0),
-    maxServerUsage(0), BufferSize(400), sentBytes(0),lowMemorySkip(false)
+    maxServerUsage(0), BufferSize(400), sentBytes(0)
     {
       buf.reserve(BufferSize+100);
       buf = "";
     }
-  StreamingBuffer(String &a) :
-    initialRam(0), beforeTXRam(0), duringTXRam(0), finalRam(0), maxCoreUsage(0),
-    maxServerUsage(0), BufferSize(400), sentBytes(0) {
-      buf.reserve(BufferSize+100);
-      buf = a;
-    }
-  StreamingBuffer operator= (String& a)                 {    this->buf= a;                  checkFull();  return *this;  }
-  StreamingBuffer operator= (const String& a)           { this->buf+= a;                     checkFull();   return *this; }
-  StreamingBuffer operator+= (long unsigned int  a)     { this->buf+=String(a);  checkFull(); return *this;   }
+  StreamingBuffer operator= (String& a)                 { this->buf=a;           checkFull();  return *this;  }
+  StreamingBuffer operator= (const String& a)           { this->buf=a;           checkFull();  return *this;  }
+  StreamingBuffer operator+= (long unsigned int  a)     { this->buf+=String(a);  checkFull();  return *this;  }
   StreamingBuffer operator+= (float a)                  { this->buf+=String(a);  checkFull();  return *this;  }
   StreamingBuffer operator+= (int a)                    { this->buf+=String(a);  checkFull();  return *this;  }
   StreamingBuffer operator+= (uint32_t a)               { this->buf+=String(a);  checkFull();  return *this;  }
-  StreamingBuffer operator+= (const StreamingBuffer& a) { this->buf+=a.buf;      checkFull(); return *this;   }
   StreamingBuffer operator+= (const String& a)          {
     if (lowMemorySkip) return *this;
     if ((      (this->buf.length() + a.length()) >BufferSize)&&(this->buf.length()>100 ))
@@ -53,11 +46,9 @@ public:
       checkFull();
       return *this;
     }
-  StreamingBuffer operator+ (const StreamingBuffer& a)  { this->buf = this->buf+a.buf;      checkFull(); return *this;  }
-  StreamingBuffer operator+ (const String& a)           { this->buf = this->buf+a;          checkFull(); return *this;  }
 
   void checkFull(void){
-    if (lowMemorySkip) this->buf=""; 
+    if (lowMemorySkip) this->buf="";
     if (this->buf.length()>BufferSize) {
     trackTotalMem();
     sendContentBlocking(this->buf);
@@ -70,12 +61,12 @@ public:
     initialRam=  ESP.getFreeHeap();
     sentBytes=0;
     buf ="";
-    if (beforeTXRam<3000 ){ 
-       lowMemorySkip=true; 
+    if (beforeTXRam<3000 ){
+       lowMemorySkip=true;
        WebServer.send(200,"text/plain","Low memory. Cannot display webpage :-(");
-       tcpCleanup();   
+       tcpCleanup();
        return;
-       } 
+       }
      else
    sendHeaderBlocking(json);
   }
@@ -100,7 +91,7 @@ void trackCoreMem()
         sendContentBlocking(buf);
         WebServer.sendHeader( "Content-Length", "0");
         WebServer.send ( 200, "text/plain", "");
-    
+
         finalRam= ESP.getFreeHeap();
         String log = String("Ram usage: Webserver only: ")+ maxServerUsage +" including Core: "+ maxCoreUsage;
         addLog(LOG_LEVEL_DEBUG, log);


### PR DESCRIPTION
The order in which the members are defined should also be the order in which they will be initialized.

Also applied #958