### PR TITLE
[issue #968] Use template parser for OLED commands

### DIFF
--- a/src/_P023_OLED.ino
+++ b/src/_P023_OLED.ino
@@ -189,7 +189,8 @@ boolean Plugin_023(byte function, struct EventStruct *event, String& string)
           success = true;
           argIndex = string.lastIndexOf(',');
           tmpString = string.substring(argIndex + 1);
-          Plugin_023_sendStrXY(tmpString.c_str(), event->Par1 - 1, event->Par2 - 1);
+          String newString = P023_parseTemplate(tmpString, 16);
+          Plugin_023_sendStrXY(newString.c_str(), event->Par1 - 1, event->Par2 - 1);
         }
         if (tmpString.equalsIgnoreCase(F("OLEDCMD")))
         {


### PR DESCRIPTION
N.B. Now even task values can be used in commands, next to special characters.