### PR TITLE
Bugfix/mqtt proper case

### DIFF
--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -14,12 +14,12 @@ extern "C" void tcp_abort (struct tcp_pcb* pcb);
 
 void tcpCleanup()
 {
-    
+
      while(tcp_tw_pcbs!=NULL)
     {
       tcp_abort(tcp_tw_pcbs);
     }
-   
+
  }
 #endif
 
@@ -1540,7 +1540,7 @@ int RPNCalculate(char* token)
   if (token[0] == 0)
     return 0; // geen moeite doen voor een lege string
 
-  if (is_operator(token[0]))
+  if (is_operator(token[0]) && token[1] == 0)
   {
     float second = pop();
     float first = pop();
@@ -1611,7 +1611,7 @@ int Calculate(const char *input, float* result)
 {
   const char *strpos = input, *strend = input + strlen(input);
   char token[25];
-  char c, *TokenPos = token;
+  char c, oc, *TokenPos = token;
   char stack[32];       // operator stack
   unsigned int sl = 0;  // stack length
   char     sc;          // used for record stack element
@@ -1619,15 +1619,16 @@ int Calculate(const char *input, float* result)
 
   //*sp=0; // bug, it stops calculating after 50 times
   sp = globalstack - 1;
-
+  oc=c=0;
   while (strpos < strend)
   {
     // read one token from the input stream
+    oc = c;
     c = *strpos;
     if (c != ' ')
     {
       // If the token is a number (identifier), then add it to the token queue.
-      if ((c >= '0' && c <= '9') || c == '.')
+      if ((c >= '0' && c <= '9') || c == '.' || (c == '-' && is_operator(oc)))
       {
         *TokenPos = c;
         ++TokenPos;
@@ -1881,7 +1882,7 @@ String rulesProcessingFile(String fileName, String& event)
           {
             conditional = true;
             String check = lcAction.substring(split + 3);
-            condition = conditionMatch(check);
+            condition = conditionMatchExtended(check);
             ifBranche = true;
             isCommand = false;
           }
@@ -1966,14 +1967,14 @@ boolean ruleMatch(String& event, String& rule)
         tmpEvent = event.substring(0,rule.length());
         tmpRule = rule;
       }
-      
+
     pos = rule.indexOf('*');
     if (pos != -1) // a * sign in rule, so use a'wildcard' match on message
       {
         tmpEvent = event.substring(0,pos-1);
         tmpRule = rule.substring(0,pos-1);
       }
-     
+
     if (tmpEvent.equalsIgnoreCase(tmpRule))
       return true;
     else

--- a/src/TimeESPeasy.ino
+++ b/src/TimeESPeasy.ino
@@ -421,7 +421,7 @@ String getDateTimeString(char dateDelimiter, char timeDelimiter,  char dateTimeD
 /********************************************************************************************\
   Convert a string like "Sun,12:30" into a 32 bit integer
   \*********************************************************************************************/
-unsigned long string2TimeLong(String &str)
+unsigned long string2TimeLong(const String &str)
 {
   // format 0000WWWWAAAABBBBCCCCDDDD
   // WWWW=weekday, AAAA=hours tens digit, BBBB=hours, CCCC=minutes tens digit DDDD=minutes
@@ -430,8 +430,12 @@ unsigned long string2TimeLong(String &str)
   char TmpStr1[10];
   int w, x, y;
   unsigned long a;
-  str.toLowerCase();
-  str.toCharArray(command, 20);
+  {
+    // Within a scope so the tmpString is only used for copy.
+    String tmpString(str);
+    tmpString.toLowerCase();
+    tmpString.toCharArray(command, 20);    
+  }
   unsigned long lngTime = 0;
 
   if (GetArgv(command, TmpStr1, 1))

--- a/src/_P054_DMX512.ino
+++ b/src/_P054_DMX512.ino
@@ -31,7 +31,7 @@
 // DMX,5=123,8=44"   Set channel 5 to value 123, channel 8 to 44
 // DMX,OFF"   Pitch Black
 
-// Transeiver:
+// Transceiver:
 // SN75176 or MAX485 or LT1785 or ...
 // Pin 5: GND
 // Pin 2, 3, 5: +5V
@@ -134,8 +134,9 @@ boolean Plugin_054(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_WRITE:
       {
-        string.toLowerCase();
-        String command = parseString(string, 1);
+        String lowerString=string;
+        lowerString.toLowerCase();
+        String command = parseString(lowerString, 1);
 
         if (command == F("dmx"))
         {
@@ -146,11 +147,11 @@ boolean Plugin_054(byte function, struct EventStruct *event, String& string)
           int16_t channel = 1;
           int16_t value = 0;
 
-          string.replace("  ", " ");
-          string.replace(" =", "=");
-          string.replace("= ", "=");
+          lowerString.replace("  ", " ");
+          lowerString.replace(" =", "=");
+          lowerString.replace("= ", "=");
 
-          param = parseString(string, paramIdx++);
+          param = parseString(lowerString, paramIdx++);
           if (param.length())
           {
             while (param.length())
@@ -211,7 +212,7 @@ boolean Plugin_054(byte function, struct EventStruct *event, String& string)
                 channel++;
               }
 
-              param = parseString(string, paramIdx++);
+              param = parseString(lowerString, paramIdx++);
             }
           }
           else

--- a/src/_P057_HT16K33_LED.ino
+++ b/src/_P057_HT16K33_LED.ino
@@ -150,13 +150,14 @@ boolean Plugin_057(byte function, struct EventStruct *event, String& string)
         if (!Plugin_057_M)
           return false;
 
-        string.toLowerCase();
-        String command = parseString(string, 1);
+        String lowerString=string;
+        lowerString.toLowerCase();
+        String command = parseString(lowerString, 1);
 
         if (command == F("mprint"))
         {
-          int paramPos = getParamStartPos(string, 2);
-          String text = string.substring(paramPos);
+          int paramPos = getParamStartPos(lowerString, 2);
+          String text = lowerString.substring(paramPos);
           byte seg = 0;
 
           Plugin_057_M->ClearRowBuffer();
@@ -171,8 +172,8 @@ boolean Plugin_057(byte function, struct EventStruct *event, String& string)
           success = true;
         }
         else if (command == F("mbr")) {
-          int paramPos = getParamStartPos(string, 2);
-          uint8_t brightness = string.substring(paramPos).toInt();
+          int paramPos = getParamStartPos(lowerString, 2);
+          uint8_t brightness = lowerString.substring(paramPos).toInt();
           Plugin_057_M->SetBrightness(brightness);
           success = true;
         }
@@ -185,11 +186,11 @@ boolean Plugin_057(byte function, struct EventStruct *event, String& string)
           uint8_t seg = 0;
           uint16_t value = 0;
 
-          string.replace("  ", " ");
-          string.replace(" =", "=");
-          string.replace("= ", "=");
+          lowerString.replace("  ", " ");
+          lowerString.replace(" =", "=");
+          lowerString.replace("= ", "=");
 
-          param = parseString(string, paramIdx++);
+          param = parseString(lowerString, paramIdx++);
           if (param.length())
           {
             while (param.length())
@@ -259,7 +260,7 @@ boolean Plugin_057(byte function, struct EventStruct *event, String& string)
                 seg++;
               }
 
-              param = parseString(string, paramIdx++);
+              param = parseString(lowerString, paramIdx++);
             }
           }
           else

--- a/src/_P065_DRF0299_MP3.ino
+++ b/src/_P065_DRF0299_MP3.ino
@@ -5,20 +5,20 @@
 // ESPEasy Plugin to controls a MP3-player-module DFPlayer-Mini SKU:DFR0299
 // written by Jochen Krapf (jk@nerd2nerd.org)
 
-// Important! The module WTV020-SD look similar to the module DFPlayer-Mini but is NOT pin and command compatible!
+// Important! The module WTV020-SD look similar to the module DFPlayer-Mini but is NOT pin nor command compatible!
 
 // Commands:
-// play,<track>        Plays the n-th track 1...3000 on SD-card in root folder. The track number is the physical ordenr - not the order displayed in file explorer!
+// play,<track>        Plays the n-th track 1...3000 on SD-card in root folder. The track number is the physical order - not the order displayed in file explorer!
 // stop                Stops actual playing sound
 // vol,<volume>        Set volume level 1...30
 // eq,<type>           Set the equalizer type 0=Normal, 1=Pop, 2=Rock, 3=Jazz, 4=classic, 5=Base
 
 // Circuit wiring
 // 1st-GPIO -> ESP TX to module RX [Pin2]
-// 5V to module VCC [Pin1] (can be more than 100mA) Note: Use a capacitor to denoise VCC
+// 5 V to module VCC [Pin1] (can be more than 100 mA) Note: Use a blocking capacitor to stabilise VCC
 // GND to module GND [Pin7+Pin10]
 // Speaker to module SPK_1 and SPK_2 [Pin6,Pin8] (not to GND!) Note: If speaker has to low impedance, use a resistor (like 33 Ohm) in line to speaker
-// (optional) module BUSY [Pin16] to LED driver (3.3V on idle, 0V on playing)
+// (optional) module BUSY [Pin16] to LED driver (3.3 V on idle, 0 V on playing)
 // All other pins unconnected
 
 // Note: Notification sounds with Creative Commons Attribution license: https://notificationsounds.com/
@@ -121,9 +121,10 @@ boolean Plugin_065(byte function, struct EventStruct *event, String& string)
         if (!Plugin_065_SoftSerial)
           break;
 
-        string.toLowerCase();
-        String command = parseString(string, 1);
-        String param = parseString(string, 2);
+        String lowerString=string;
+        lowerString.toLowerCase();
+        String command = parseString(lowerString, 1);
+        String param = parseString(lowerString, 2);
 
         if (command == F("play"))
         {

--- a/src/_P067_HX711_Load_Cell.ino
+++ b/src/_P067_HX711_Load_Cell.ino
@@ -266,8 +266,9 @@ boolean Plugin_067(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_WRITE:
       {
-        string.toLowerCase();
-        String command = parseString(string, 1);
+        String lowerString=string;
+        lowerString.toLowerCase();
+        String command = parseString(lowerString, 1);
 
         if (command == F("tare"))
         {

--- a/src/_P070_NeoPixel_Clock.ino
+++ b/src/_P070_NeoPixel_Clock.ino
@@ -144,11 +144,12 @@ boolean Plugin_070(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_WRITE:
       {
-        string.toLowerCase();
-        String command = parseString(string, 1);
-        String param1 = parseString(string, 2);
-        String param2 = parseString(string, 3);
-        String param3 = parseString(string, 4);
+        String lowerString=string;
+        lowerString.toLowerCase();
+        String command = parseString(lowerString, 1);
+        String param1 = parseString(lowerString, 2);
+        String param2 = parseString(lowerString, 3);
+        String param3 = parseString(lowerString, 4);
 
         if (command == F("clock")) {
           if (param1 != "") {


### PR DESCRIPTION
[Issue #827] MQTT not using proper case for %sysname% variable. 

Merge from Mega to v2.0:
Add AND/OR to rules & prevent unwanted case changes in strings (#994)