### PR TITLE
Fixes P073 plugin for latest TM1637 based 7 segments displays modules

### DIFF
--- a/src/_P073_7DGT.ino
+++ b/src/_P073_7DGT.ino
@@ -47,6 +47,7 @@ byte    p073_dotpos;
 
 #define TM1637_POWER_ON   0b10001000
 #define TM1637_POWER_OFF  0b10000000
+#define TM1637_BIT_DELAY  50
 
 // each char table is specific for each display and maps all numbers/symbols needed:
 //   - pos 0-9  - Numbers from 0 to 9
@@ -409,22 +410,26 @@ void p073_FillBufferWithDash()  // in case of error show all dashes
 #define DIO_HIGH()  pinMode(dio_pin, INPUT)
 #define DIO_LOW()   pinMode(dio_pin, OUTPUT)
 
+void tm1637_bitDelay(){
+	delayMicroseconds(TM1637_BIT_DELAY);
+}
+
 void tm1637_i2cStart (uint8_t clk_pin, uint8_t dio_pin)
 {
   CLK_HIGH();
   DIO_HIGH();
-  delayMicroseconds(2);
+  tm1637_bitDelay();
   DIO_LOW();
 }
 
 void tm1637_i2cStop (uint8_t clk_pin, uint8_t dio_pin)
 {
   CLK_LOW();
-  delayMicroseconds(2);
+  tm1637_bitDelay();
   DIO_LOW();
-  delayMicroseconds(2);
+  tm1637_bitDelay();
   CLK_HIGH();
-  delayMicroseconds(2);
+  tm1637_bitDelay();
   DIO_HIGH();
 }
 
@@ -432,10 +437,10 @@ void tm1637_i2cAck (uint8_t clk_pin, uint8_t dio_pin)
 {
   CLK_LOW();
   DIO_HIGH();
-  delayMicroseconds(5);
+  tm1637_bitDelay();
   while(digitalRead(dio_pin));
   CLK_HIGH();
-  delayMicroseconds(2);
+  tm1637_bitDelay();
   CLK_LOW();
 }
 
@@ -446,10 +451,10 @@ void tm1637_i2cWrite (uint8_t clk_pin, uint8_t dio_pin, uint8_t bytetoprint)
   {
     CLK_LOW();
     (bytetoprint & B00000001)? DIO_HIGH() : DIO_LOW();
-    delayMicroseconds(3);
+    tm1637_bitDelay();
     bytetoprint = bytetoprint >> 1;
     CLK_HIGH();
-    delayMicroseconds(3);
+    tm1637_bitDelay();
   }
 }
 


### PR DESCRIPTION
This PR fixes (at leaset here) the no display issue on recent TM1637 based displays, as discussed here:
https://www.letscontrolit.com/forum/viewtopic.php?f=5&t=3512&start=110

I had the same probleme (no display at all) and also so crash, hang or being unable to activate the plugin).

I then make a litte change on tdelays, inspired by the @3zuli comment and PR by @Kazoo here:
https://github.com/avishorp/TM1637/issues/18

Bingo ! all issue fixed !

- I've made all the test on a RobotDyn 4seg  display, with a NodeMcu v2.
- timing of 50 seems fine
- timing between 20, 25, or  30 lead to crash, even to corruption (had to wipe before re-upload)
- timing of 100 (as in original  issue) seems to work fine too

As I have no old diplays, and as my understanding of this hardware timing issue is too much limited, I have no idea if this would STILL work on older displayz. I bet yes, but some users should first confirm that. 
If not, somebody with both display, should either find a timing which works well for both, or add a selector to the plugin GUI to switch between new and old displays.

HTH



