### PR TITLE
_P072_HDC1080 add success and break statement 

### DIFF
--- a/src/_P072_HDC1080.ino
+++ b/src/_P072_HDC1080.ino
@@ -90,6 +90,9 @@ boolean Plugin_072(byte function, struct EventStruct *event, String& string)
         log = F("HDC1080: Humidity: ");
         log += UserVar[event->BaseVarIndex + 1];
         addLog(LOG_LEVEL_INFO, log);
+        success = true;
+        break;
+
       }
   }
   return success;


### PR DESCRIPTION
it seems that without the break statement and success set to true, the values aren ot sent back to the controller(s).