### PR TITLE
[issue #892 ] Only use sensor type when really needed

### DIFF
--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -148,43 +148,6 @@ String flashGuard()
 //use this in function that can return an error string. it automaticly returns with an error string if there where too many flash writes.
 #define FLASH_GUARD() { String flashErr=flashGuard(); if (flashErr.length()) return(flashErr); }
 
-/*********************************************************************************************\
-   Get value count from sensor type
-  \*********************************************************************************************/
-
-byte getValueCountFromSensorType(byte sensorType)
-{
-  byte valueCount = 0;
-
-  switch (sensorType)
-  {
-    case SENSOR_TYPE_SINGLE:                      // single value sensor, used for Dallas, BH1750, etc
-    case SENSOR_TYPE_SWITCH:
-    case SENSOR_TYPE_DIMMER:
-      valueCount = 1;
-      break;
-    case SENSOR_TYPE_LONG:                      // single LONG value, stored in two floats (rfid tags)
-      valueCount = 1;
-      break;
-    case SENSOR_TYPE_TEMP_HUM:
-    case SENSOR_TYPE_TEMP_BARO:
-    case SENSOR_TYPE_DUAL:
-      valueCount = 2;
-      break;
-    case SENSOR_TYPE_TEMP_HUM_BARO:
-    case SENSOR_TYPE_TRIPLE:
-    case SENSOR_TYPE_WIND:
-      valueCount = 3;
-      break;
-    case SENSOR_TYPE_QUAD:
-      valueCount = 4;
-      break;
-  }
-  return valueCount;
-}
-
-
-
 
 /*********************************************************************************************\
    set pin mode & state (info table)
@@ -2527,31 +2490,3 @@ void ArduinoOTAInit()
 }
 
 #endif
-
-String getBearing(int degrees)
-{
-  const __FlashStringHelper* bearing[] = {
-    F("N"),
-    F("NNE"),
-    F("NE"),
-    F("ENE"),
-    F("E"),
-    F("ESE"),
-    F("SE"),
-    F("SSE"),
-    F("S"),
-    F("SSW"),
-    F("SW"),
-    F("WSW"),
-    F("W"),
-    F("WNW"),
-    F("NW"),
-    F("NNW")
-  };
-  int bearing_idx=int(degrees/22.5);
-  if (bearing_idx<0 || bearing_idx>=(int) (sizeof(bearing)/sizeof(bearing[0])))
-    return("");
-  else
-    return(bearing[bearing_idx]);
-
-}

--- a/src/_C007.ino
+++ b/src/_C007.ino
@@ -35,6 +35,12 @@ boolean CPlugin_007(byte function, struct EventStruct *event, String& string)
           success = false;
           break;
         }
+        const byte valueCount = getValueCountFromSensorType(event->sensorType);
+        if (valueCount == 0 || valueCount > 3) {
+          addLog(LOG_LEVEL_ERROR, F("emoncms : Unknown sensortype or too many sensor values"));
+          break;
+        }
+
         ControllerSettingsStruct ControllerSettings;
         LoadControllerSettings(event->ControllerIndex, (byte*)&ControllerSettings, sizeof(ControllerSettings));
 
@@ -59,46 +65,14 @@ boolean CPlugin_007(byte function, struct EventStruct *event, String& string)
         postDataStr += Settings.Unit;
         postDataStr += F("&json=");
 
-        switch (event->sensorType)
-        {
-          case SENSOR_TYPE_SINGLE:                      // single value sensor, used for Dallas, BH1750, etc
-          case SENSOR_TYPE_SWITCH:                      // report switch state
-            postDataStr += F("{field");
-            postDataStr += event->idx;
-            postDataStr += ":";
-            postDataStr += formatUserVar(event, 0);
-            postDataStr += "}";
-            break;
-          case SENSOR_TYPE_TEMP_HUM:                      // dual value
-          case SENSOR_TYPE_TEMP_BARO:
-          case SENSOR_TYPE_DUAL:
-            postDataStr += F("{field");
-            postDataStr += event->idx;
-            postDataStr += ":";
-            postDataStr += formatUserVar(event, 0);
-            postDataStr += F(",field");
-            postDataStr += event->idx + 1;
-            postDataStr += ":";
-            postDataStr += formatUserVar(event, 1);
-            postDataStr += "}";
-            break;
-          case SENSOR_TYPE_TEMP_HUM_BARO:
-          case SENSOR_TYPE_TRIPLE:
-            postDataStr += F("{field");
-            postDataStr += event->idx;
-            postDataStr += ":";
-            postDataStr += formatUserVar(event, 0);
-            postDataStr += F(",field");
-            postDataStr += event->idx + 1;
-            postDataStr += ":";
-            postDataStr += formatUserVar(event, 1);
-            postDataStr += F(",field");
-            postDataStr += event->idx + 2;
-            postDataStr += ":";
-            postDataStr += formatUserVar(event, 2);
-            postDataStr += "}";
-            break;
+        for (byte i = 0; i < valueCount; ++i) {
+          postDataStr += (i == 0) ? F("{") : F(",");
+          postDataStr += F("field");
+          postDataStr += event->idx + i;
+          postDataStr += ":";
+          postDataStr += formatUserVar(event, i);
         }
+        postDataStr += "}";
         postDataStr += F("&apikey=");
         postDataStr += SecuritySettings.ControllerPassword[event->ControllerIndex]; // "0UDNN17RW6XAS2E5" // api key
 

--- a/src/_C011.ino
+++ b/src/_C011.ino
@@ -270,37 +270,8 @@ void ReplaceTokenByValue(String& s, struct EventStruct *event)
 //	%1%%vname1%,Standort=%tskname% Wert=%val1%%/1%%2%%LF%%vname2%,Standort=%tskname% Wert=%val2%%/2%%3%%LF%%vname3%,Standort=%tskname% Wert=%val3%%/3%%4%%LF%%vname4%,Standort=%tskname% Wert=%val4%%/4%
 	addLog(LOG_LEVEL_DEBUG_MORE, F("HTTP before parsing: "));
 	addLog(LOG_LEVEL_DEBUG_MORE, s);
-
-	switch (event->sensorType)
-	{
-		case SENSOR_TYPE_SINGLE:
-		case SENSOR_TYPE_SWITCH:
-		case SENSOR_TYPE_DIMMER:
-		case SENSOR_TYPE_WIND:
-		case SENSOR_TYPE_LONG:
-		{
-			DeleteNotNeededValues(s,1);
-			break;
-		}
-		case SENSOR_TYPE_DUAL:
-		case SENSOR_TYPE_TEMP_HUM:
-		case SENSOR_TYPE_TEMP_BARO:
-		{
-			DeleteNotNeededValues(s,2);
-			break;
-		}
-		case SENSOR_TYPE_TRIPLE:
-		case SENSOR_TYPE_TEMP_HUM_BARO:
-		{
-			DeleteNotNeededValues(s,3);
-			break;
-		}
-		case SENSOR_TYPE_QUAD:
-		{
-			DeleteNotNeededValues(s,4);
-			break;
-		}
-	}
+  const byte valueCount = getValueCountFromSensorType(event->sensorType);
+  DeleteNotNeededValues(s,valueCount);
 
 	addLog(LOG_LEVEL_DEBUG_MORE, F("HTTP after parsing: "));
 	addLog(LOG_LEVEL_DEBUG_MORE, s);

--- a/src/_C012.ino
+++ b/src/_C012.ino
@@ -39,29 +39,8 @@ boolean CPlugin_012(byte function, struct EventStruct *event, String& string)
         }
 
         String postDataStr = F("");
-
-        switch (event->sensorType)
-        {
-          case SENSOR_TYPE_SINGLE:                      // single value sensor, used for Dallas, BH1750, etc
-            success = CPlugin_012_send(event, 1);
-            break;
-          case SENSOR_TYPE_TEMP_HUM:                      // dual value
-          case SENSOR_TYPE_TEMP_BARO:
-          case SENSOR_TYPE_DUAL:
-            success = CPlugin_012_send(event, 2);
-            break;
-          case SENSOR_TYPE_TEMP_HUM_BARO:
-          case SENSOR_TYPE_TRIPLE:
-            success = CPlugin_012_send(event, 3);
-            break;
-          case SENSOR_TYPE_QUAD:
-            success = CPlugin_012_send(event, 4);
-            break;
-
-          case SENSOR_TYPE_SWITCH:
-            success = CPlugin_012_send(event, 1);
-            break;
-        }
+        const byte valueCount = getValueCountFromSensorType(event->sensorType);
+        success = CPlugin_012_send(event, valueCount);
         break;
       }
   }

--- a/src/_CPlugin_SensorTypeHelper.ino
+++ b/src/_CPlugin_SensorTypeHelper.ino
@@ -1,0 +1,59 @@
+/*********************************************************************************************\
+   Get value count from sensor type
+  \*********************************************************************************************/
+
+byte getValueCountFromSensorType(byte sensorType)
+{
+  switch (sensorType)
+  {
+    case SENSOR_TYPE_SINGLE:                      // single value sensor, used for Dallas, BH1750, etc
+    case SENSOR_TYPE_SWITCH:
+    case SENSOR_TYPE_DIMMER:
+      return 1;
+    case SENSOR_TYPE_LONG:                      // single LONG value, stored in two floats (rfid tags)
+      return 1;
+    case SENSOR_TYPE_TEMP_HUM:
+    case SENSOR_TYPE_TEMP_BARO:
+    case SENSOR_TYPE_DUAL:
+      return 2;
+    case SENSOR_TYPE_TEMP_HUM_BARO:
+    case SENSOR_TYPE_TRIPLE:
+    case SENSOR_TYPE_WIND:
+      return 3;
+    case SENSOR_TYPE_QUAD:
+      return 4;
+  }
+  addLog(LOG_LEVEL_ERROR, F("getValueCountFromSensorType: Unknown sensortype"));
+  return 0;
+}
+
+/*********************************************************************************************\
+   Convert bearing in degree to bearing string
+  \*********************************************************************************************/
+
+String getBearing(int degrees)
+{
+  const __FlashStringHelper* bearing[] = {
+    F("N"),
+    F("NNE"),
+    F("NE"),
+    F("ENE"),
+    F("E"),
+    F("ESE"),
+    F("SE"),
+    F("SSE"),
+    F("S"),
+    F("SSW"),
+    F("SW"),
+    F("WSW"),
+    F("W"),
+    F("WNW"),
+    F("NW"),
+    F("NNW")
+  };
+  int bearing_idx=int(degrees/22.5);
+  if (bearing_idx<0 || bearing_idx>=(int) (sizeof(bearing)/sizeof(bearing[0])))
+    return("");
+  else
+    return(bearing[bearing_idx]);
+}


### PR DESCRIPTION
Only the Domoticz controllers need the sensor type. The rest just needs the number of sensor values.