### PR TITLE
Ignores OS specific hidden files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,18 @@
+## OS Specific Hidden Files ####
+
+# MacOSX Finder *****
+.DS_Store
+
+# Fuse FileSystem ***
+.fuse_hidden*
+
+
+## PlatformIO ##################
 .pioenvs
 .clang_complete
 .gcc-flags.json
 .piolibdeps
 
+## Project #####################
 lib/readme.txt
 src/Custom.h


### PR DESCRIPTION
Useful for
-  MacOSX users 
- people like me that mount their dev projects from a remote server via sshfs (fuse FS)

Obviously, this does not hurt anything

