### PR TITLE
[Rule Events] Add a number of events to handle in rules and awake timer

### DIFF
--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -169,6 +169,11 @@ bool MQTTConnect(int controller_idx)
   addLog(LOG_LEVEL_INFO, log);
 
   if (MQTTclient.publish(LWTTopic.c_str(), "Connected", 1)) {
+    if (Settings.UseRules)
+    {
+      String event = F("MQTT#Connected");
+      rulesProcessing(event);
+    }
     statusLED(true);
     return true; // end loop if succesfull
   }

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -1071,6 +1071,7 @@ byte cmd_within_mainloop = 0;
 unsigned long connectionFailures;
 unsigned long wdcounter = 0;
 unsigned long timerAPoff = 0;
+unsigned long timerAwakeFromDeepSleep = 0;
 
 #if FEATURE_ADC_VCC
 float vcc = -1.0;
@@ -1270,11 +1271,16 @@ void setup()
   timerwd = 0; // timer for watchdog once per 30 sec
   timermqtt = 0; // Timer for the MQTT keep alive loop.
   timermqtt_interval = 250; // Interval for checking MQTT
+  timerAwakeFromDeepSleep = millis();
 
   PluginInit();
   CPluginInit();
   NPluginInit();
-
+  if (Settings.UseRules)
+  {
+    String event = F("System#Initialized");
+    rulesProcessing(event);
+  }
   WebServerInit();
 
   #ifdef FEATURE_ARDUINO_OTA

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -27,6 +27,8 @@ bool isDeepSleepEnabled()
 {
   if (!Settings.deepSleep)
     return false;
+  if (!timeOutReached(timerAwakeFromDeepSleep + 1000 * Settings.deepSleep))
+    return false;
 
   //cancel deep sleep loop by pulling the pin GPIO16(D0) to GND
   //recommended wiring: 3-pin-header with 1=RST, 2=D0, 3=GND
@@ -1553,7 +1555,7 @@ String parseTemplate(String &tmpString, byte lineSize)
           valueFormat = valueName.substring(hashtagIndex + 1);
           valueName = valueName.substring(0, hashtagIndex);
         }
-        
+
         if (deviceName.equalsIgnoreCase("Plugin"))
         {
           String tmpString = tmpStringMid.substring(7);

--- a/src/TimeESPeasy.ino
+++ b/src/TimeESPeasy.ino
@@ -74,6 +74,13 @@ void setTime(unsigned long t) {
   sysTime = (uint32_t)t;
   nextSyncTime = (uint32_t)t + syncInterval;
   prevMillis = millis();  // restart counting from now (thanks to Korman for this fix)
+  if (Settings.UseRules)
+  {
+    static bool firstUpdate = true;
+    String event = firstUpdate ? F("Time#Initialized") : F("Time#Set");
+    firstUpdate = false;
+    rulesProcessing(event);
+  }
 }
 
 unsigned long now() {
@@ -434,7 +441,7 @@ unsigned long string2TimeLong(const String &str)
     // Within a scope so the tmpString is only used for copy.
     String tmpString(str);
     tmpString.toLowerCase();
-    tmpString.toCharArray(command, 20);    
+    tmpString.toCharArray(command, 20);
   }
   unsigned long lngTime = 0;
 

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -1014,7 +1014,7 @@ void handle_config() {
     }
 
     Settings.Delay = sensordelay.toInt();
-    Settings.deepSleep = (deepsleep == "on");
+    Settings.deepSleep = deepsleep.toInt();
     Settings.deepSleepOnFail = (deepsleeponfail == "on");
     str2ip(espip, Settings.IP);
     str2ip(espgateway, Settings.Gateway);
@@ -1070,7 +1070,9 @@ void handle_config() {
 
   addFormSubHeader(TXBuffer.buf,  F("Sleep Mode"));
 
-  addFormCheckBox(TXBuffer.buf,  F("Sleep enabled"), F("deepsleep"), Settings.deepSleep);
+  addFormNumericBox(TXBuffer.buf,  F("Sleep awake time"), F("deepsleep"), Settings.deepSleep, 0, 255);
+  addUnit(TXBuffer.buf,  F("sec"));
+  addFormNote(TXBuffer.buf,  F("0 = Sleep Disabled, else time awake from sleep"));
 
   addHelpButton(TXBuffer.buf,  F("SleepMode"));
   addFormNumericBox(TXBuffer.buf,  F("Sleep Delay"), F("delay"), Settings.Delay, 0, 4294);   //limited by hardware to ~1.2h
@@ -3393,6 +3395,11 @@ void handle_login() {
     else
     {
       TXBuffer += F("Invalid password!");
+      if (Settings.UseRules)
+      {
+        String event = F("Login#Failed");
+        rulesProcessing(event);
+      }
     }
   }
 

--- a/src/Wifi.ino
+++ b/src/Wifi.ino
@@ -138,7 +138,11 @@ boolean WifiConnect(byte connectAttempts)
       }
       addLog(LOG_LEVEL_INFO, log);
     #endif
-
+    if (Settings.UseRules)
+    {
+      String event = F("WiFi#Connected");
+      rulesProcessing(event);
+    }
     return(true);
   }
 


### PR DESCRIPTION
Changed the sleep checkbox to allow a number of seconds awake from deep sleep.

Also added the following events:

- `MQTT#Connected`
- `WiFi#Connected`
- `System#Initialized`   Before connecting to WiFi
- `Time#Set`    Time set by an update from NTP.
- `Time#Initialized`  Time set for the first time since boot.
- `Login#Failed`

See #951