### PR TITLE
Cleaning Platform.ini & preparing for Plugins Sets

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -51,6 +51,16 @@ board = esp8285
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -DESP8285
 
+# NORMAL: 2048k version -------------------------
+[env:normal_WROOM02_2048]
+platform = espressif8266@1.5.0
+lib_deps = ${common.lib_deps}
+board_flash_mode = dout
+framework = arduino
+board = esp_wroom_02
+upload_speed=460800
+build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.2m.ld
+
 # NORMAL: 4096k version -------------------------
 [env:normal_ESP8266_4096]
 platform = espressif8266@1.5.0
@@ -85,6 +95,16 @@ framework = arduino
 board = esp8285
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_BUILD_TESTING -DESP8285
+
+# TEST: 2048k version -------------------------
+[env:test_WROOM02_2048]
+platform = espressif8266@1.5.0
+lib_deps = ${common.lib_deps}
+board_flash_mode = dout
+framework = arduino
+board = esp_wroom_02
+upload_speed=460800
+build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.2m.ld -D PLUGIN_BUILD_TESTING
 
 # TEST: 4096k version -------------------------
 [env:test_ESP8266_4096]
@@ -129,6 +149,16 @@ framework = arduino
 board = esp8285
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_BUILD_TESTING -D PLUGIN_BUILD_DEV -DESP8285
+
+# DEV: 2048k version -------------------------
+[env:dev_WROOM02_2048]
+platform = espressif8266@1.5.0
+lib_deps = ${common.lib_deps}
+board_flash_mode = dout
+framework = arduino
+board = esp_wroom_02
+upload_speed=460800
+build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.2m.ld -D PLUGIN_BUILD_TESTING -D PLUGIN_BUILD_DEV
 
 # DEV : 4096k version -------------------------
 [env:dev_ESP8266_4096]

--- a/platformio.ini
+++ b/platformio.ini
@@ -51,15 +51,6 @@ board = esp12e
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld
 
-# NORMAL: 4096k version -------------------------
-[env:normal_ESP8266_4096]
-platform = espressif8266@1.5.0
-lib_deps = ${common.lib_deps}
-framework = arduino
-board = esp12e
-upload_speed=460800
-build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.4m1m.ld
-
 # NORMAL: 1024k for esp8285 ----------------------
 [env:normal_ESP8285_1024]
 platform = espressif8266@1.5.0
@@ -69,6 +60,15 @@ framework = arduino
 board = esp8285
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -DESP8285
+
+# NORMAL: 4096k version -------------------------
+[env:normal_ESP8266_4096]
+platform = espressif8266@1.5.0
+lib_deps = ${common.lib_deps}
+framework = arduino
+board = esp12e
+upload_speed=460800
+build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.4m1m.ld
 
 
 
@@ -85,6 +85,16 @@ framework = arduino
 board = esp12e
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_BUILD_TESTING
+
+# TEST: 1024k for esp8285 ----------------------
+[env:test_ESP8285_1024]
+platform = espressif8266@1.5.0
+lib_deps = ${common.lib_deps}
+board_flash_mode = dout
+framework = arduino
+board = esp8285
+upload_speed=460800
+build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_BUILD_TESTING -DESP8285
 
 # TEST: 4096k version -------------------------
 [env:test_ESP8266_4096]
@@ -104,16 +114,6 @@ board = esp12e
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.4m1m.ld -D PLUGIN_BUILD_TESTING -D FEATURE_ADC_VCC=true
 
-# TEST: 1024k for esp8285 ----------------------
-[env:test_ESP8285_1024]
-platform = espressif8266@1.5.0
-lib_deps = ${common.lib_deps}
-board_flash_mode = dout
-framework = arduino
-board = esp8285
-upload_speed=460800
-build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_BUILD_TESTING -DESP8285
-
 
 
 ### DEV ##################################################################################
@@ -130,15 +130,6 @@ board = esp12e
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_BUILD_TESTING -D PLUGIN_BUILD_DEV
 
-# DEV : 4096k version -------------------------
-[env:dev_ESP8266_4096]
-platform = espressif8266@1.5.0
-lib_deps = ${common.lib_deps}
-framework = arduino
-board = esp12e
-upload_speed=460800
-build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.4m1m.ld -D PLUGIN_BUILD_TESTING -D PLUGIN_BUILD_DEV
-
 # DEV: 1024k for esp8285 ----------------------
 [env:dev_ESP8285_1024]
 platform = espressif8266@1.5.0
@@ -148,6 +139,15 @@ framework = arduino
 board = esp8285
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_BUILD_TESTING -D PLUGIN_BUILD_DEV -DESP8285
+
+# DEV : 4096k version -------------------------
+[env:dev_ESP8266_4096]
+platform = espressif8266@1.5.0
+lib_deps = ${common.lib_deps}
+framework = arduino
+board = esp12e
+upload_speed=460800
+build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.4m1m.ld -D PLUGIN_BUILD_TESTING -D PLUGIN_BUILD_DEV
 
 
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -31,7 +31,7 @@ lib_deps = ""
 # normal version with stable plugins                                                     #
 ##########################################################################################
 
-# NORMAL: 1024k version -------------------------
+# NORMAL: 1024k version --------------------------
 [env:normal_ESP8266_1024]
 platform = espressif8266@1.5.0
 lib_deps = ${common.lib_deps}
@@ -51,7 +51,7 @@ board = esp8285
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -DESP8285
 
-# NORMAL: 2048k version -------------------------
+# NORMAL: 2048k version --------------------------
 [env:normal_WROOM02_2048]
 platform = espressif8266@1.5.0
 lib_deps = ${common.lib_deps}
@@ -61,7 +61,7 @@ board = esp_wroom_02
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.2m.ld
 
-# NORMAL: 4096k version -------------------------
+# NORMAL: 4096k version --------------------------
 [env:normal_ESP8266_4096]
 platform = espressif8266@1.5.0
 lib_deps = ${common.lib_deps}
@@ -76,7 +76,7 @@ build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.4m1m.ld
 # additional plugins (and dependend code) that are in test-stadium                       #
 ##########################################################################################
 
-# TEST: 1024k version -------------------------
+# TEST: 1024k version ----------------------------
 [env:test_ESP8266_1024]
 platform = espressif8266@1.5.0
 lib_deps = ${common.lib_deps}
@@ -86,7 +86,7 @@ board = esp12e
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_BUILD_TESTING
 
-# TEST: 1024k for esp8285 ----------------------
+# TEST: 1024k for esp8285 ------------------------
 [env:test_ESP8285_1024]
 platform = espressif8266@1.5.0
 lib_deps = ${common.lib_deps}
@@ -96,7 +96,7 @@ board = esp8285
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_BUILD_TESTING -DESP8285
 
-# TEST: 2048k version -------------------------
+# TEST: 2048k version ----------------------------
 [env:test_WROOM02_2048]
 platform = espressif8266@1.5.0
 lib_deps = ${common.lib_deps}
@@ -106,7 +106,7 @@ board = esp_wroom_02
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.2m.ld -D PLUGIN_BUILD_TESTING
 
-# TEST: 4096k version -------------------------
+# TEST: 4096k version ----------------------------
 [env:test_ESP8266_4096]
 platform = espressif8266@1.5.0
 lib_deps = ${common.lib_deps}
@@ -115,7 +115,7 @@ board = esp12e
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.4m1m.ld -D PLUGIN_BUILD_TESTING
 
-# TEST: 4096k version + FEATURE_ADC_VCC -------
+# TEST: 4096k version + FEATURE_ADC_VCC ----------
 [env:test_ESP8266_4096_VCC]
 platform = espressif8266@1.5.0
 lib_deps = ${common.lib_deps}
@@ -130,7 +130,7 @@ build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.4m1m.ld -D PLUGIN_BUILD_
 # additional plugins (and dependend code) that is in development (probably broken or incomplete) 
 ##########################################################################################
 
-# DEV : 1024k version -------------------------
+# DEV : 1024k version ----------------------------
 [env:dev_ESP8266_1024]
 platform = espressif8266@1.5.0
 lib_deps = ${common.lib_deps}
@@ -140,7 +140,7 @@ board = esp12e
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_BUILD_TESTING -D PLUGIN_BUILD_DEV
 
-# DEV: 1024k for esp8285 ----------------------
+# DEV: 1024k for esp8285 -------------------------
 [env:dev_ESP8285_1024]
 platform = espressif8266@1.5.0
 lib_deps = ${common.lib_deps}
@@ -150,7 +150,7 @@ board = esp8285
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_BUILD_TESTING -D PLUGIN_BUILD_DEV -DESP8285
 
-# DEV: 2048k version -------------------------
+# DEV: 2048k version -----------------------------
 [env:dev_WROOM02_2048]
 platform = espressif8266@1.5.0
 lib_deps = ${common.lib_deps}
@@ -160,7 +160,7 @@ board = esp_wroom_02
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.2m.ld -D PLUGIN_BUILD_TESTING -D PLUGIN_BUILD_DEV
 
-# DEV : 4096k version -------------------------
+# DEV : 4096k version ----------------------------
 [env:dev_ESP8266_4096]
 platform = espressif8266@1.5.0
 lib_deps = ${common.lib_deps}
@@ -172,10 +172,10 @@ build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.4m1m.ld -D PLUGIN_BUILD_
 
 
 ### DEV + PUYA ###########################################################################
-# special patched version for PUYA flash chips, see issue #650 at Github 
+# special patched version for PUYA flash chips, see issue #650 at Github                 #
 ##########################################################################################
 
-# DEV+PUYA : 1024k version -------------------------
+# DEV+PUYA : 1024k version -----------------------
 [env:dev_ESP8266PUYA_1024]
 platform = espressif8266@1.5.0
 lib_deps = ${common.lib_deps}
@@ -185,7 +185,7 @@ board = esp12e
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_BUILD_TESTING -D PLUGIN_BUILD_DEV -D FLASH_QUIRK_WRITE_0_TO_1
 
-# DEV+PUYA : 1024k version + FEATURE_ADC_VCC -------
+# DEV+PUYA : 1024k version + FEATURE_ADC_VCC -----
 [env:dev_ESP8266PUYA_1024_VCC]
 platform = espressif8266@1.5.0
 lib_deps = ${common.lib_deps}
@@ -197,10 +197,185 @@ build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_BUILD
 
 
 
-### DEVICE SPECIFIC VERSIONS #############################################################
-# version specially designed to fit, and contents only needed plugind for each hardware
+
+### HARDWARE SPECIFIC VERSIONS ###########################################################
+# versions specially designed to fit, and contents only needed plugins for each hardware #
 ##########################################################################################
 
+# ITHEAD Products ################################
 
-### TODO
+# ITHEAD / SONOFF BASIC version ------------------
+[env:hard_SONOFF_BASIC]
+upload_speed     = 460800
+framework        = arduino
+platform         = espressif8266@1.5.0
+lib_deps         = ${common.lib_deps}
+board_flash_mode = dout
+board            = esp01_1m
+build_flags      = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_SET_SONOFF_BASIC
 
+# ITHEAD / SONOFF TH10 version -------------------
+[env:hard_SONOFF_TH10]
+upload_speed     = 460800
+framework        = arduino
+platform         = espressif8266@1.5.0
+lib_deps         = ${common.lib_deps}
+board_flash_mode = dout
+board            = esp01_1m
+build_flags      = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_SET_SONOFF_TH10
+
+# ITHEAD / SONOFF TH16 version -------------------
+[env:hard_SONOFF_TH16]
+upload_speed     = 460800
+framework        = arduino
+platform         = espressif8266@1.5.0
+lib_deps         = ${common.lib_deps}
+board_flash_mode = dout
+board            = esp01_1m
+build_flags      = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_SET_SONOFF_TH16
+
+# ITHEAD / SONOFF POW version --------------------
+[env:hard_SONOFF_POW]
+upload_speed     = 460800
+framework        = arduino
+platform         = espressif8266@1.5.0
+lib_deps         = ${common.lib_deps}
+board_flash_mode = dout
+board            = esp01_1m
+build_flags      = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_SET_SONOFF_POW
+
+# ITHEAD / SONOFF S20 version --------------------
+[env:hard_SONOFF_S20]
+upload_speed     = 460800
+framework        = arduino
+platform         = espressif8266@1.5.0
+lib_deps         = ${common.lib_deps}
+board_flash_mode = dout
+board            = esp01_1m
+build_flags      = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_SET_SONOFF_S20
+
+# ITHEAD / SONOFF 4CH version --------------------
+[env:hard_SONOFF_4CH]
+upload_speed     = 460800
+framework        = arduino
+platform         = espressif8266@1.5.0
+lib_deps         = ${common.lib_deps}
+board_flash_mode = dout
+board            = esp01_1m
+build_flags      = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_SET_SONOFF_4CH
+
+# ITHEAD / SONOFF TOUCH version ------------------
+[env:hard_SONOFF_TOUCH]
+upload_speed     = 460800
+framework        = arduino
+platform         = espressif8266@1.5.0
+lib_deps         = ${common.lib_deps}
+board_flash_mode = dout
+board            = esp01_1m
+build_flags      = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_SET_SONOFF_TOUCH
+
+
+
+# LED Strips #####################################
+
+# Huacanxing / H801 ------------------------------
+[env:hard_HUACANXING_H801]
+upload_speed     = 460800
+framework        = arduino
+platform         = espressif8266@1.5.0
+lib_deps         = ${common.lib_deps}
+board_flash_mode = dout
+board            = esp01_1m
+build_flags      = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_SET_H801
+
+# MagicHome / Led Controller ---------------------
+[env:hard_MAGICHOME]
+upload_speed = 460800
+upload_speed     = 460800
+framework        = arduino
+platform         = espressif8266@1.5.0
+lib_deps         = ${common.lib_deps}
+board_flash_mode = dout
+board            = esp01_1m
+build_flags      = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_SET_MAGICHOME
+
+# MagicHome / Led Controller with IR -------------
+[env:hard_MAGICHOME_IR]
+upload_speed     = 460800
+framework        = arduino
+platform         = espressif8266@1.5.0
+lib_deps         = ${common.lib_deps}
+board_flash_mode = dout
+board            = esp01_1m
+build_flags      = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_SET_MAGICHOME_IR
+
+
+
+
+### EASY VERSIONS ########################################################################
+# versions specially designed to be small and cover a specific usage                     #
+##########################################################################################
+
+# Easy Temperature Sensor ------------------------
+[env:easy_TEMP]
+upload_speed     = 460800
+framework        = arduino
+platform         = espressif8266@1.5.0
+lib_deps         = ${common.lib_deps}
+board_flash_mode = dout
+board            = esp01_1m
+build_flags      = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_SET_EASY_TEMP
+
+
+# Easy Carbon Sensor -----------------------------
+[env:easy_CARBON]
+upload_speed     = 460800
+framework        = arduino
+platform         = espressif8266@1.5.0
+lib_deps         = ${common.lib_deps}
+board_flash_mode = dout
+board            = esp01_1m
+build_flags      = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_SET_EASY_CARBON
+
+## Easy Nextion ----------------------------------
+##PLUGIN_SET_EASY_NEXTION
+
+# Easy OLED Display v1 ---------------------------
+[env:easy_OLED_V1]
+upload_speed     = 460800
+framework        = arduino
+platform         = espressif8266@1.5.0
+lib_deps         = ${common.lib_deps}
+board_flash_mode = dout
+board            = esp01_1m
+build_flags      = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_SET_EASY_OLED1
+
+# Easy OLED Display v2 ---------------------------
+[env:easy_OLED_V2]
+upload_speed     = 460800
+framework        = arduino
+platform         = espressif8266@1.5.0
+lib_deps         = ${common.lib_deps}
+board_flash_mode = dout
+board            = esp01_1m
+build_flags      = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_SET_EASY_OLED2
+
+# Easy Relay Switch ------------------------------
+[env:easy_OLED_V2]
+upload_speed     = 460800
+framework        = arduino
+platform         = espressif8266@1.5.0
+lib_deps         = ${common.lib_deps}
+board_flash_mode = dout
+board            = esp01_1m
+build_flags      = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_SET_EASY_RELAY
+
+# Easy  Generic (1M) device ----------------------
+[env:easy_GENERIC_1M]
+upload_speed     = 460800
+framework        = arduino
+platform         = espressif8266@1.5.0
+lib_deps         = ${common.lib_deps}
+board_flash_mode = dout
+board            = esp01_1m
+build_flags      = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_SET_GENERIC_1M

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,12 +20,18 @@
 #                    -Wstrict-overflow=5 -Wundef -Wno-unused -Wno-variadic-macros -Wno-parentheses -fdiagnostics-show-option
 # thanks @chouffe103
 
+##########################################################################################
+
 [common]
 build_flags = -D BUILD_GIT='"${env.TRAVIS_TAG}"'
 lib_deps = ""
 
 
-#normal version with stable plugins, 1024k version
+### NORMAL (STABLE) ######################################################################
+# normal version with stable plugins                                                     #
+##########################################################################################
+
+# NORMAL: 1024k version -------------------------
 [env:normal_ESP8266_1024]
 platform = espressif8266@1.5.0
 lib_deps = ${common.lib_deps}
@@ -34,8 +40,8 @@ framework = arduino
 board = esp12e
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld
-# upload_port = /dev/ttyUSB0
 
+# NORMAL: 1024k version DOUT -------------------------
 [env:normal_ESP8266_1024_DOUT]
 platform = espressif8266@1.5.0
 lib_deps = ${common.lib_deps}
@@ -44,9 +50,8 @@ framework = arduino
 board = esp12e
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld
-# upload_port = /dev/ttyUSB0
 
-#normal version with stable plugins, 4096k version
+# NORMAL: 4096k version -------------------------
 [env:normal_ESP8266_4096]
 platform = espressif8266@1.5.0
 lib_deps = ${common.lib_deps}
@@ -54,9 +59,8 @@ framework = arduino
 board = esp12e
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.4m1m.ld
-# upload_port = /dev/ttyUSB0
 
-#normal version with stable plugins, 4096k version for esp8285
+# NORMAL: 1024k for esp8285 ----------------------
 [env:normal_ESP8285_1024]
 platform = espressif8266@1.5.0
 lib_deps = ${common.lib_deps}
@@ -65,10 +69,14 @@ framework = arduino
 board = esp8285
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -DESP8285
-# upload_port = /dev/ttyUSB0
 
 
-#version with additional plugins (and dependend code) that are in test-stadium 1024k
+
+### TESTING ##############################################################################
+# additional plugins (and dependend code) that are in test-stadium                       #
+##########################################################################################
+
+# TEST: 1024k version -------------------------
 [env:test_ESP8266_1024]
 platform = espressif8266@1.5.0
 lib_deps = ${common.lib_deps}
@@ -78,7 +86,7 @@ board = esp12e
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_BUILD_TESTING
 
-#version with additional plugins (and dependend code) that are in test-stadium 4096k
+# TEST: 4096k version -------------------------
 [env:test_ESP8266_4096]
 platform = espressif8266@1.5.0
 lib_deps = ${common.lib_deps}
@@ -87,6 +95,7 @@ board = esp12e
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.4m1m.ld -D PLUGIN_BUILD_TESTING
 
+# TEST: 4096k version + FEATURE_ADC_VCC -------
 [env:test_ESP8266_4096_VCC]
 platform = espressif8266@1.5.0
 lib_deps = ${common.lib_deps}
@@ -95,7 +104,7 @@ board = esp12e
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.4m1m.ld -D PLUGIN_BUILD_TESTING -D FEATURE_ADC_VCC=true
 
-#version with additional plugins (and dependend code) that are in test-stadium 4096k for esp8285
+# TEST: 1024k for esp8285 ----------------------
 [env:test_ESP8285_1024]
 platform = espressif8266@1.5.0
 lib_deps = ${common.lib_deps}
@@ -106,7 +115,12 @@ upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_BUILD_TESTING -DESP8285
 
 
-#version with additional plugins (and dependend code) that is in development (probably broken or incomplete) 1024k
+
+### DEV ##################################################################################
+# additional plugins (and dependend code) that is in development (probably broken or incomplete) 
+##########################################################################################
+
+# DEV : 1024k version -------------------------
 [env:dev_ESP8266_1024]
 platform = espressif8266@1.5.0
 lib_deps = ${common.lib_deps}
@@ -116,7 +130,7 @@ board = esp12e
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_BUILD_TESTING -D PLUGIN_BUILD_DEV
 
-#version with additional plugins (and dependend code) that is in development (probably broken or incomplete) 4096k
+# DEV : 4096k version -------------------------
 [env:dev_ESP8266_4096]
 platform = espressif8266@1.5.0
 lib_deps = ${common.lib_deps}
@@ -125,7 +139,7 @@ board = esp12e
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.4m1m.ld -D PLUGIN_BUILD_TESTING -D PLUGIN_BUILD_DEV
 
-#version with additional plugins (and dependend code) that is in development (probably broken or incomplete) 4096k for esp8285
+# DEV: 1024k for esp8285 ----------------------
 [env:dev_ESP8285_1024]
 platform = espressif8266@1.5.0
 lib_deps = ${common.lib_deps}
@@ -137,7 +151,11 @@ build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_BUILD
 
 
 
-#special patched version for PUYA flash chips, see https://github.com/letscontrolit/ESPEasy/issues/650
+### DEV + PUYA ###########################################################################
+# special patched version for PUYA flash chips, see issue #650 at Github 
+##########################################################################################
+
+# DEV+PUYA : 1024k version -------------------------
 [env:dev_ESP8266PUYA_1024]
 platform = espressif8266@1.5.0
 lib_deps = ${common.lib_deps}
@@ -147,7 +165,7 @@ board = esp12e
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_BUILD_TESTING -D PLUGIN_BUILD_DEV -D FLASH_QUIRK_WRITE_0_TO_1
 
-#special patched version for PUYA flash chips, see https://github.com/letscontrolit/ESPEasy/issues/650
+# DEV+PUYA : 1024k version + FEATURE_ADC_VCC -------
 [env:dev_ESP8266PUYA_1024_VCC]
 platform = espressif8266@1.5.0
 lib_deps = ${common.lib_deps}
@@ -156,3 +174,13 @@ framework = arduino
 board = esp12e
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld -D PLUGIN_BUILD_TESTING -D PLUGIN_BUILD_DEV -D FLASH_QUIRK_WRITE_0_TO_1 -D FEATURE_ADC_VCC=true
+
+
+
+### DEVICE SPECIFIC VERSIONS #############################################################
+# version specially designed to fit, and contents only needed plugind for each hardware
+##########################################################################################
+
+
+### TODO
+

--- a/platformio.ini
+++ b/platformio.ini
@@ -41,16 +41,6 @@ board = esp12e
 upload_speed=460800
 build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld
 
-# NORMAL: 1024k version DOUT -------------------------
-[env:normal_ESP8266_1024_DOUT]
-platform = espressif8266@1.5.0
-lib_deps = ${common.lib_deps}
-board_flash_mode = dout
-framework = arduino
-board = esp12e
-upload_speed=460800
-build_flags = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld
-
 # NORMAL: 1024k for esp8285 ----------------------
 [env:normal_ESP8285_1024]
 platform = espressif8266@1.5.0


### PR DESCRIPTION
This PR 
- cleanup the Platform.ini comments
- suppress the no longer needed DOUT version
- add support for WROOM-02 boards
- adds  Device specifics build, as seen in #1019, and pushed in #1025 + #1034 

_BTW the current layout of the  WROOM-02 boards is 1M flash + 1M SPIFFS... If there a way to change it to a larger flash size, with a lower SPIFFS partitions? Has it to be asked on arduino-esp8266 Git, or is this an hardware limitation?_
