### PR TITLE
[AM/PM] Am/Pm notation doesn't have '0' hours

### DIFF
--- a/src/TimeESPeasy.ino
+++ b/src/TimeESPeasy.ino
@@ -394,8 +394,10 @@ String getTimeString(const timeStruct& ts, char delimiter, bool am_pm)
 {
   char TimeString[20]; //19 digits plus the null char
   if (am_pm) {
+    uint8_t hour(ts.Hour % 12);
+    if (hour == 0) { hour = 12; }
     sprintf_P(TimeString, PSTR("%02d%c%02d%c%02d%cm"),
-     ts.Hour %12, delimiter, ts.Minute, delimiter, ts.Second,
+     hour, delimiter, ts.Minute, delimiter, ts.Second,
      ts.Hour < 12 ? 'a' : 'p');
   } else {
     sprintf_P(TimeString, PSTR("%02d%c%02d%c%02d"),


### PR DESCRIPTION
11.59 a.m. => 12.00 p.m.
12.59 p.m. => 1.00 p.m.
11.59 p.m. => 12.00 a.m.