### PR TITLE
[issue #1057] AM PM display issue

### DIFF
--- a/src/ESPEasyTimeTypes.h
+++ b/src/ESPEasyTimeTypes.h
@@ -59,3 +59,5 @@ struct TimeChangeRule {
 void applyTimeZone(uint32_t curTime = 0);
 void setTimeZone(const TimeChangeRule& dstStart, const TimeChangeRule& stdStart, uint32_t curTime = 0);
 uint32_t calcTimeChangeForRule(const TimeChangeRule& r, int yr);
+String getTimeString(char delimiter, bool show_seconds=true);
+String getTimeString_ampm(char delimiter, bool show_seconds=true);

--- a/src/StringConverter.ino
+++ b/src/StringConverter.ino
@@ -288,6 +288,8 @@ void parseSystemVariables(String& s, boolean useURLencode)
 
   if (s.indexOf(F("%sys")) != -1) {
     SMART_REPL(F("%sysload%"), String(100 - (100 * loopCounterLast / loopCounterMax)))
+    SMART_REPL(F("%systm_hm%"), getTimeString(':', false))
+    SMART_REPL(F("%systm_hm_am%"), getTimeString_ampm(':', false))
     SMART_REPL(F("%systime%"), getTimeString(':'))
     SMART_REPL(F("%systime_am%"), getTimeString_ampm(':'))
     repl(F("%sysname%"), Settings.Name, s, useURLencode);

--- a/src/TimeESPeasy.ino
+++ b/src/TimeESPeasy.ino
@@ -390,30 +390,40 @@ String getDateString()
 
 // returns the current Time separated by the given delimiter
 // time format example with ':' delimiter: 23:59:59 (HH:MM:SS)
-String getTimeString(const timeStruct& ts, char delimiter, bool am_pm)
+String getTimeString(const timeStruct& ts, char delimiter, bool am_pm, bool show_seconds)
 {
   char TimeString[20]; //19 digits plus the null char
   if (am_pm) {
     uint8_t hour(ts.Hour % 12);
     if (hour == 0) { hour = 12; }
-    sprintf_P(TimeString, PSTR("%02d%c%02d%c%02d%cm"),
-     hour, delimiter, ts.Minute, delimiter, ts.Second,
-     ts.Hour < 12 ? 'a' : 'p');
+    const char a_or_p = ts.Hour < 12 ? 'A' : 'P';
+    if (show_seconds) {
+      sprintf_P(TimeString, PSTR("%d%c%02d%c%02d %cM"),
+        hour, delimiter, ts.Minute, delimiter, ts.Second, a_or_p);
+    } else {
+      sprintf_P(TimeString, PSTR("%d%c%02d %cM"),
+        hour, delimiter, ts.Minute, a_or_p);
+    }
   } else {
-    sprintf_P(TimeString, PSTR("%02d%c%02d%c%02d"),
-     ts.Hour, delimiter, ts.Minute, delimiter, ts.Second);
+    if (show_seconds) {
+      sprintf_P(TimeString, PSTR("%02d%c%02d%c%02d"),
+        ts.Hour, delimiter, ts.Minute, delimiter, ts.Second);
+    } else {
+      sprintf_P(TimeString, PSTR("%d%c%02d"),
+        ts.Hour, delimiter, ts.Minute);
+    }
   }
   return TimeString;
 }
 
-String getTimeString(char delimiter)
+String getTimeString(char delimiter, bool show_seconds /*=true*/)
 {
-  return getTimeString(tm, delimiter, false);
+  return getTimeString(tm, delimiter, false, show_seconds);
 }
 
-String getTimeString_ampm(char delimiter)
+String getTimeString_ampm(char delimiter, bool show_seconds /*=true*/)
 {
-  return getTimeString(tm, delimiter, true);
+  return getTimeString(tm, delimiter, true, show_seconds);
 }
 
 // returns the current Time without delimiter
@@ -436,7 +446,7 @@ String getDateTimeString(const timeStruct& ts, char dateDelimiter, char timeDeli
 	String ret = getDateString(ts, dateDelimiter);
 	if (dateTimeDelimiter != '\0')
 		ret += dateTimeDelimiter;
-	ret += getTimeString(ts, timeDelimiter, am_pm);
+	ret += getTimeString(ts, timeDelimiter, am_pm, true);
 	return ret;
 }
 


### PR DESCRIPTION
- X:XX PM (for hours 1...9)
- X:XX AM (for hours 1...9)
- XX:XX PM (for hours 10...12)
- XX:XX AM (for hours 10...12)

Added for H:MM (without seconds) notations:
- `%systm_hm%`
- `%systm_hm_am%`