### PR TITLE
[issue #951] Changed System#Initialized  => System#Wake

### DIFF
--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -219,7 +219,7 @@ void setup()
   NPluginInit();
   if (Settings.UseRules)
   {
-    String event = F("System#Initialized");
+    String event = F("System#Wake");
     rulesProcessing(event);
   }
 


### PR DESCRIPTION
Changed System#Initialized  => System#Wake
New event name makes more sense and Initialized may be used later to indicate all needed connections, etc. are ready.