### PR TITLE
[Relaxed WiFi] Perform WiFi initialization in steps

### DIFF
--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -1045,6 +1045,13 @@ byte lastBootCause = BOOT_CAUSE_MANUAL_REBOOT;
 
 boolean wifiSetup = false;
 boolean wifiSetupConnect = false;
+uint8_t lastBSSID[6] = {0};
+boolean wifiConnected = false;
+unsigned long wifi_connect_timer = 0;
+unsigned int reconnect_attempt = 0;
+uint8_t lastWiFiSettings = 0;
+
+
 
 unsigned long start = 0;
 unsigned long elapsed = 0;

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -1048,7 +1048,7 @@ boolean wifiSetupConnect = false;
 uint8_t lastBSSID[6] = {0};
 boolean wifiConnected = false;
 unsigned long wifi_connect_timer = 0;
-unsigned int reconnect_attempt = 0;
+unsigned int wifi_connect_attempt = 0;
 uint8_t lastWiFiSettings = 0;
 
 

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -239,8 +239,7 @@ void setup()
     }
   }
   else
-    // 3 connect attempts
-    WifiConnect(3);
+    WiFiConnectRelaxed();
 
   #ifdef FEATURE_REPORTING
   ReportStatus();
@@ -454,8 +453,8 @@ void runOncePerSecond()
     }
     cmd_within_mainloop = 0;
   }
+  WifiCheck();
 
-  checkWifiJustConnected();
   // clock events
   if (Settings.UseNTP)
     checkTime();
@@ -535,8 +534,6 @@ void runEach30Seconds()
   loopCounter = 0;
   if (loopCounterLast > loopCounterMax)
     loopCounterMax = loopCounterLast;
-
-  WifiCheck();
 
   #ifdef FEATURE_REPORTING
   ReportStatus();

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -455,6 +455,7 @@ void runOncePerSecond()
     cmd_within_mainloop = 0;
   }
 
+  checkWifiJustConnected();
   // clock events
   if (Settings.UseNTP)
     checkTime();

--- a/src/ESPEasyTimeTypes.h
+++ b/src/ESPEasyTimeTypes.h
@@ -1,4 +1,8 @@
+#ifndef ESPEASY_TIMETYPES_H_
+#define ESPEASY_TIMETYPES_H_
+
 #include <stdint.h>
+#include <String.h>
 
 struct  timeStruct {
   timeStruct() : Second(0), Minute(0), Hour(0), Wday(0), Day(0), Month(0), Year(0) {}
@@ -61,3 +65,6 @@ void setTimeZone(const TimeChangeRule& dstStart, const TimeChangeRule& stdStart,
 uint32_t calcTimeChangeForRule(const TimeChangeRule& r, int yr);
 String getTimeString(char delimiter, bool show_seconds=true);
 String getTimeString_ampm(char delimiter, bool show_seconds=true);
+
+
+#endif /* ESPEASY_TIMETYPES_H_ */

--- a/src/ESPEasyTimeTypes.h
+++ b/src/ESPEasyTimeTypes.h
@@ -2,7 +2,6 @@
 #define ESPEASY_TIMETYPES_H_
 
 #include <stdint.h>
-#include <String.h>
 
 struct  timeStruct {
   timeStruct() : Second(0), Minute(0), Hour(0), Wday(0), Day(0), Month(0), Year(0) {}

--- a/src/Networking.ino
+++ b/src/Networking.ino
@@ -596,6 +596,11 @@ bool WiFiConnected(uint32_t timeout_ms) {
     yield(); // Allow at least once time for backgroundtasks
     min_delay = 10;
   }
+  if (!wifiConnected) {
+    // Apparently something needs network, perform check to see if it is ready now.
+    if (tryConnectWiFi())
+      checkWifiJustConnected();
+  }
   while (WiFi.status() != WL_CONNECTED) {
     if (timeOutReached(timer)) {
       return false;
@@ -633,4 +638,3 @@ bool hostReachable(const String& hostname) {
   addLog(LOG_LEVEL_ERROR, log);
   return false;
 }
-


### PR DESCRIPTION
Doing WiFi initialization in multiple steps, will reduce boot time a lot.
For deepsleep the Setup is waiting for wifi initialization to complete, but for normal use the wifi connection is initiated during setup and checked on regular intervals to see if it is available.
The same for WiFi reconnect, which will hopefully not affect the performance of the ESP module during reconnects.

Also added a check + event when connected to another accesspoint with different BSSID (MAC address of accesspoint). Also the last used BSSID is used to reconnect to try to connect to the same device over and over, which may be useful with WiFi repeaters.
