### PR TITLE
[issue #1097] WiFi connect with deepsleep enabled trigger watchdog reset

### DIFF
--- a/src/Wifi.ino
+++ b/src/Wifi.ino
@@ -270,6 +270,7 @@ boolean WifiConnectAndWait(byte connectAttempts)
       do {
         if (checkWifiJustConnected())
           return true;
+        delay(50);
       } while (!wifiConnectTimeoutReached());
     }
     // log = F("WIFI : Disconnecting!");
@@ -292,7 +293,7 @@ bool checkWifiJustConnected() {
   if (wifiConnected) return true;
   if (WiFi.status() != WL_CONNECTED) {
     statusLED(false);
-    // No delay needed, since the WiFi check has a delay
+    delay(1);
     return false;
   }
   wifiConnected = true;


### PR DESCRIPTION
Did not allow for enough time to do background tasks while waiting for wifi connect with DeepSleep enabled.