### PR TITLE
[issue #1131] Add %unixtime%

### DIFF
--- a/src/StringConverter.ino
+++ b/src/StringConverter.ino
@@ -311,6 +311,7 @@ void parseSystemVariables(String& s, boolean useURLencode)
   SMART_REPL(F("%lcltime%"), getDateTimeString('-',':',' '))
   SMART_REPL(F("%lcltime_am%"), getDateTimeString_ampm('-',':',' '))
   SMART_REPL(F("%uptime%"), String(wdcounter / 2))
+  SMART_REPL(F("%unixtime%"), String(getUnixTime()))
 
   repl(F("%tskname%"), ExtraTaskSettings.TaskDeviceName, s, useURLencode);
   if (s.indexOf("%vname") != -1) {

--- a/src/TimeESPeasy.ino
+++ b/src/TimeESPeasy.ino
@@ -72,6 +72,7 @@ void breakTime(unsigned long timeInput, struct timeStruct &tm) {
 
 void setTime(unsigned long t) {
   sysTime = (uint32_t)t;
+  applyTimeZone(t);
   nextSyncTime = (uint32_t)t + syncInterval;
   prevMillis = millis();  // restart counting from now (thanks to Korman for this fix)
   if (Settings.UseRules)
@@ -81,6 +82,10 @@ void setTime(unsigned long t) {
     firstUpdate = false;
     rulesProcessing(event);
   }
+}
+
+uint32_t getUnixTime() {
+  return sysTime;
 }
 
 unsigned long now() {
@@ -94,7 +99,6 @@ unsigned long now() {
     unsigned long  t = getNtpTime();
     if (t != 0) {
       setTime(t);
-      applyTimeZone(t);
     } else {
       // Unable to sync, retry again in a minute
       nextSyncTime = sysTime + 60;


### PR DESCRIPTION
Show the current time as [Unix time](https://en.wikipedia.org/wiki/Unix_time) (numbers of seconds that have elapsed since midnight 1970-01-01, UTC)