### PR TITLE
[P1 Wifi Gateway] Support for ESMR 5.0

### DIFF
--- a/src/_P044_P1WifiGateway.ino
+++ b/src/_P044_P1WifiGateway.ino
@@ -123,7 +123,7 @@ boolean Plugin_044(byte function, struct EventStruct *event, String& string)
           #endif
           #if defined(ESP32)
             Serial.begin(ExtraTaskSettings.TaskDevicePluginConfigLong[1], serialconfig);
-          #endif            
+          #endif
           if (P1GatewayServer) P1GatewayServer->close();
           P1GatewayServer = new WiFiServer(ExtraTaskSettings.TaskDevicePluginConfigLong[0]);
           P1GatewayServer->begin();
@@ -347,7 +347,7 @@ void blinkLED() {
        checks whether the incoming character is a valid one for a P1 datagram. Returns false if not, which signals corrupt datagram
 */
 bool validP1char(char ch) {
-  if ((ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch == '.') || (ch == '!') || (ch == 92) || (ch == 13) || (ch == '\n') || (ch == '(') || (ch == ')') || (ch == '-') || (ch == '*') || (ch == ':') )
+  if ((ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch == '.') || (ch == '!') || (ch == ' ') || (ch == 92) || (ch == 13) || (ch == '\n') || (ch == '(') || (ch == ')') || (ch == '-') || (ch == '*') || (ch == ':') )
   {
     return true;
   } else {


### PR DESCRIPTION
In the latest standard for P1 Meters (ESMR 5.0), the identification can also contain spaces. Previously, the P1 Wifi Gateway considered the space character to be illegal. This PR adds the space character to the list of valid characters.

Example of identification:
```
/Ene5\XS210 ESMR 5.0
```