### PR TITLE
[wifi] Event based connect/reconnect

### DIFF
--- a/src/Command.ino
+++ b/src/Command.ino
@@ -373,7 +373,7 @@ void ExecuteCommand(byte source, const char *Line)
       SendUDPCommand(Par1, (char*)event.c_str(), event.length());
     }
   }
-  if (strcasecmp_P(Command, PSTR("Publish")) == 0 && WiFi.status() == WL_CONNECTED)
+  if (strcasecmp_P(Command, PSTR("Publish")) == 0 && wifiStatus == ESPEASY_WIFI_SERVICES_INITIALIZED)
   {
     // ToDo TD-er: Not sure about this function, but at least it sends to an existing MQTTclient
     int enabledMqttController = firstEnabledMQTTController();
@@ -391,7 +391,7 @@ void ExecuteCommand(byte source, const char *Line)
     }
   }
 
-  if (strcasecmp_P(Command, PSTR("SendToUDP")) == 0 && WiFi.status() == WL_CONNECTED)
+  if (strcasecmp_P(Command, PSTR("SendToUDP")) == 0 && wifiStatus == ESPEASY_WIFI_SERVICES_INITIALIZED)
   {
     success = true;
     String strLine = Line;
@@ -412,7 +412,7 @@ void ExecuteCommand(byte source, const char *Line)
     }
   }
 
-  if (strcasecmp_P(Command, PSTR("SendToHTTP")) == 0 && WiFi.status() == WL_CONNECTED)
+  if (strcasecmp_P(Command, PSTR("SendToHTTP")) == 0 && wifiStatus == ESPEASY_WIFI_SERVICES_INITIALIZED)
   {
     success = true;
     String strLine = Line;
@@ -520,7 +520,7 @@ void ExecuteCommand(byte source, const char *Line)
   if (strcasecmp_P(Command, PSTR("WifiConnect")) == 0)
   {
     success = true;
-    WifiConnect(1);
+    WiFiConnectRelaxed();
   }
 
   if (strcasecmp_P(Command, PSTR("WifiDisconnect")) == 0)

--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -183,10 +183,12 @@ bool MQTTConnect(int controller_idx)
 \*********************************************************************************************/
 bool MQTTCheck(int controller_idx)
 {
+  if (!WiFiConnected(10))
+    return false;
   byte ProtocolIndex = getProtocolIndex(Settings.Protocol[controller_idx]);
   if (Protocol[ProtocolIndex].usesMQTT)
   {
-    if (MQTTclient_should_reconnect || !WiFiConnected(10) || !MQTTclient.connected())
+    if (MQTTclient_should_reconnect || !MQTTclient.connected())
     {
       if (MQTTclient_should_reconnect) {
         addLog(LOG_LEVEL_ERROR, F("MQTT : Intentional reconnect"));

--- a/src/Convert.ino
+++ b/src/Convert.ino
@@ -84,6 +84,14 @@ String minutesToDayHour(int minutes) {
   return TimeString;
 }
 
+String minutesToHourMinute(int minutes) {
+  int hours = (minutes % 1440) / 60;
+  int mins = (minutes % 1440) % 60;
+  char TimeString[20];
+  sprintf_P(TimeString, PSTR("%d%c%02d%c"), hours, 'h', mins, 'm');
+  return TimeString;
+}
+
 String minutesToDayHourMinute(int minutes) {
   int days = minutes / 1440;
   int hours = (minutes % 1440) / 60;
@@ -104,7 +112,33 @@ String secondsToDayHourMinuteSecond(int seconds) {
   return TimeString;
 }
 
-
+String format_msec_duration(long duration) {
+  String result;
+  if (duration < 0) {
+    result = "-";
+    duration = -1 * duration;
+  }
+  if (duration < 10000) {
+    result += duration;
+    result += F(" ms");
+    return result;
+  }
+  duration /= 1000;
+  if (duration < 3600) {
+    int sec = duration % 60;
+    int minutes = duration / 60;
+    if (minutes > 0) {
+      result += minutes;
+      result += F(" m ");
+    }
+    result += sec;
+    result += F(" s");
+    return result;
+  }
+  duration /= 60;
+  if (duration < 1440) return minutesToHourMinute(duration);
+  return minutesToDayHourMinute(duration);
+}
 
 
 /********************************************************************************************\

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -434,6 +434,14 @@ using namespace fs;
 ADC_MODE(ADC_VCC);
 #endif
 
+#define ESPEASY_WIFI_DISCONNECTED            0
+#define ESPEASY_WIFI_CONNECTED               1
+#define ESPEASY_WIFI_GOT_IP                  2
+#define ESPEASY_WIFI_SERVICES_INITIALIZED    3
+
+WiFiEventHandler stationConnectedHandler;
+WiFiEventHandler stationDisconnectedHandler;
+WiFiEventHandler stationGotIpHandler;
 
 // Setup DNS, only used if the ESP has no valid WiFi config
 const byte DNS_PORT = 53;
@@ -1045,14 +1053,28 @@ String dummyString = "";
 
 byte lastBootCause = BOOT_CAUSE_MANUAL_REBOOT;
 
+// WiFi related data
 boolean wifiSetup = false;
 boolean wifiSetupConnect = false;
 uint8_t lastBSSID[6] = {0};
-boolean wifiConnected = false;
-unsigned long wifi_connect_timer = 0;
+uint8_t wifiStatus = ESPEASY_WIFI_DISCONNECTED;
+unsigned long last_wifi_connect_attempt_moment = 0;
 unsigned int wifi_connect_attempt = 0;
 uint8_t lastWiFiSettings = 0;
+String last_ssid;
+bool bssid_changed = false;
+uint8 last_channel = 0;
+WiFiDisconnectReason lastDisconnectReason = WIFI_DISCONNECT_REASON_UNSPECIFIED;
+unsigned long lastConnectMoment = 0;
+unsigned long lastDisconnectMoment = 0;
+unsigned long lastGetIPmoment = 0;
+unsigned long lastConnectedDuration = 0;
+bool intent_to_reboot = false;
 
+// Semaphore like booleans for processing data gathered from WiFi events.
+bool processedConnect = true;
+bool processedDisconnect = true;
+bool processedGetIP = true;
 
 
 unsigned long start = 0;

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -317,7 +317,7 @@ void statusLED(boolean traffic)
   else
   {
 
-    if (WiFi.status() == WL_CONNECTED)
+    if (wifiStatus == ESPEASY_WIFI_SERVICES_INITIALIZED)
     {
       long int delta = timePassedSince(gnLastUpdate);
       if (delta>0 || delta<0 )
@@ -1163,6 +1163,7 @@ void ResetFactory(void)
   //NOTE: this is a known ESP8266 bug, not our fault. :)
   delay(1000);
   WiFi.persistent(true); // use SDK storage of SSID/WPA parameters
+  intent_to_reboot = true;
   WiFi.disconnect(); // this will store empty ssid/wpa into sdk storage
   WiFi.persistent(false); // Do not use SDK storage of SSID/WPA parameters
   #if defined(ESP8266)

--- a/src/Networking.ino
+++ b/src/Networking.ino
@@ -12,7 +12,7 @@
   \*********************************************************************************************/
 void syslog(const char *message)
 {
-  if (Settings.Syslog_IP[0] != 0 && WiFi.status() == WL_CONNECTED)
+  if (Settings.Syslog_IP[0] != 0 && wifiStatus == ESPEASY_WIFI_SERVICES_INITIALIZED)
   {
     IPAddress broadcastIP(Settings.Syslog_IP[0], Settings.Syslog_IP[1], Settings.Syslog_IP[2], Settings.Syslog_IP[3]);
     portUDP.beginPacket(broadcastIP, 514);
@@ -596,12 +596,10 @@ bool WiFiConnected(uint32_t timeout_ms) {
     yield(); // Allow at least once time for backgroundtasks
     min_delay = 10;
   }
-  if (!wifiConnected) {
-    // Apparently something needs network, perform check to see if it is ready now.
-    if (tryConnectWiFi())
-      checkWifiJustConnected();
-  }
-  while (WiFi.status() != WL_CONNECTED) {
+  // Apparently something needs network, perform check to see if it is ready now.
+//  if (!tryConnectWiFi())
+//    return false;
+  while (wifiStatus != ESPEASY_WIFI_SERVICES_INITIALIZED) {
     if (timeOutReached(timer)) {
       return false;
     }
@@ -624,8 +622,7 @@ bool hostReachable(const IPAddress& ip) {
     --retry;
   }
   String log = F("Host unreachable: ");
-  // ip.toString() doesn't have const set, so use const_cast
-  log += const_cast<IPAddress&>(ip).toString();
+  log += formatIP(ip);
   addLog(LOG_LEVEL_ERROR, log);
   return false;
 }

--- a/src/StringConverter.ino
+++ b/src/StringConverter.ino
@@ -278,8 +278,8 @@ void parseSystemVariables(String& s, boolean useURLencode)
   repl(F("%CR%"), F("\r"), s, useURLencode);
   repl(F("%LF%"), F("\n"), s, useURLencode);
   SMART_REPL(F("%ip%"),WiFi.localIP().toString())
-  SMART_REPL(F("%rssi%"), String((WiFi.status() == WL_CONNECTED) ? WiFi.RSSI() : 0))
-  SMART_REPL(F("%ssid%"), (WiFi.status() == WL_CONNECTED) ? WiFi.SSID() : F("--"))
+  SMART_REPL(F("%rssi%"), String((wifiStatus == ESPEASY_WIFI_DISCONNECTED) ? 0 : WiFi.RSSI()))
+  SMART_REPL(F("%ssid%"), (wifiStatus == ESPEASY_WIFI_DISCONNECTED) ? F("--") : WiFi.SSID())
   SMART_REPL(F("%unit%"), String(Settings.Unit))
   SMART_REPL(F("%mac%"), String(WiFi.macAddress()))
   #if defined(ESP8266)

--- a/src/_C010.ino
+++ b/src/_C010.ino
@@ -87,7 +87,7 @@ void C010_Send(struct EventStruct *event, byte varIndex, float value, unsigned l
   else
     msg.replace(F("%value%"), toString(value, ExtraTaskSettings.TaskDeviceValueDecimals[varIndex]));
 
-  if (WiFi.status() == WL_CONNECTED) {
+  if (wifiStatus == ESPEASY_WIFI_SERVICES_INITIALIZED) {
     ControllerSettings.beginPacket(portUDP);
     portUDP.write((uint8_t*)msg.c_str(),msg.length());
     portUDP.endPacket();

--- a/src/_C012.ino
+++ b/src/_C012.ino
@@ -33,7 +33,7 @@ boolean CPlugin_012(byte function, struct EventStruct *event, String& string)
 
      case CPLUGIN_PROTOCOL_SEND:
       {
-        if (WiFi.status() != WL_CONNECTED) {
+        if (wifiStatus != ESPEASY_WIFI_SERVICES_INITIALIZED) {
           success = false;
           break;
         }
@@ -63,7 +63,7 @@ boolean CPlugin_012_send(struct EventStruct *event, int nrValues) {
 
 boolean Blynk_get(const String& command, byte controllerIndex, float *data )
 {
-  if (WiFi.status() != WL_CONNECTED) {
+  if (wifiStatus != ESPEASY_WIFI_SERVICES_INITIALIZED) {
     return false;
   }
 

--- a/src/_P036_FrameOLED.ino
+++ b/src/_P036_FrameOLED.ino
@@ -466,7 +466,7 @@ String P36_parseTemplate(String &tmpString, byte lineSize) {
 
 void display_header() {
   static boolean showWiFiName = true;
-  if (showWiFiName && (WiFi.status() == WL_CONNECTED) ) {
+  if (showWiFiName && (wifiStatus == ESPEASY_WIFI_SERVICES_INITIALIZED) ) {
     String newString = WiFi.SSID();
     newString.trim();
     display_title(newString);
@@ -629,7 +629,7 @@ void display_scroll(String outString[], String inString[], int nlines, int scrol
 
 //Draw Signal Strength Bars, return true when there was an update.
 bool display_wifibars() {
-  const bool connected = WiFi.status() == WL_CONNECTED;
+  const bool connected = wifiStatus == ESPEASY_WIFI_SERVICES_INITIALIZED;
   const int nbars_filled = (WiFi.RSSI() + 100) / 8;
   const int newState = connected ? nbars_filled : P36_WIFI_STATE_UNSET;
   if (newState == lastWiFiState)
@@ -651,7 +651,7 @@ bool display_wifibars() {
   display->setColor(BLACK);
   display->fillRect(x , y, size_x, size_y);
   display->setColor(WHITE);
-  if (WiFi.status() == WL_CONNECTED) {
+  if (wifiStatus == ESPEASY_WIFI_SERVICES_INITIALIZED) {
     for (byte ibar = 0; ibar < nbars; ibar++) {
       int16_t height = size_y * (ibar + 1) / nbars;
       int16_t xpos = x + ibar * width;


### PR DESCRIPTION
Now using the core WiFiEvents to act on:

- connect
- disconnect
- gotIP

This will make polling for a status no longer needed.
It also allows to get a better understanding in why diconnects happen, since the disconnect reason is given in the events.
This extra information is also present on the information panel on the webinterface and also in the JSON output.

The entire connect/disconnect/reconnect is now done completely asynchronous and thus takes much less resources from the ESP.
A disconnect will now also send an event: "WiFi#Disconnected"

For deepsleep this means there has to be a minimum awake time set and perhaps use rules to set the ESP into sleep again when done.
Typical connection times to an accesspoint are about 3 seconds + about 1 second for DHCP.

This also resolves the issues where services my try to connect while there is a WiFi connection, but not yet an IP address set.

I already noticed a lot of NTP servers from pool.ntp.org are non responsive the last few weeks, so that may still take some time, but that's another issue.