### PR TITLE
[wifi] Event based wifi, fix set AP and crash on start

### DIFF
--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -575,6 +575,7 @@ struct SecurityStruct
   byte          AllowedIPrangeLow[4]; // TD-er: Use these
   byte          AllowedIPrangeHigh[4];
   byte          IPblockLevel;
+
   //its safe to extend this struct, up to 4096 bytes, default values in config are 0. Make sure crc is last
   uint8_t       ProgmemMd5[16]; // crc of the binary that last saved the struct to file.
   uint8_t       md5[16];
@@ -696,6 +697,9 @@ struct SettingsStruct
   boolean       ArduinoOTAEnable;
   uint16_t      DST_Start;
   uint16_t      DST_End;
+  boolean       UseRTOSMultitasking;
+  int8_t        Pin_Reset;
+
 
   //its safe to extend this struct, up to several bytes, default values in config are 0
   //look in misc.ino how config.dat is used because also other stuff is stored in it at different offsets.
@@ -703,8 +707,6 @@ struct SettingsStruct
   // make sure crc is the last value in the struct
   uint8_t       ProgmemMd5[16]; // crc of the binary that last saved the struct to file.
   uint8_t       md5[16];
-  boolean       UseRTOSMultitasking;
-  int8_t        Pin_Reset;
 } Settings;
 
 struct ControllerSettingsStruct

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -360,8 +360,9 @@ void loop()
     if (wifiStatus == ESPEASY_WIFI_DISCONNECTED) processDisconnect();
   } else if (WiFi.status() != WL_CONNECTED) {
     // Somehow the WiFi has entered a limbo state.
-    addLog(LOG_LEVEL_ERROR, F("Wifi status out sync"));
-    resetWiFi();
+    // FIXME TD-er: This may happen on WiFi config with AP_STA mode active.
+//    addLog(LOG_LEVEL_ERROR, F("Wifi status out sync"));
+//    resetWiFi();
   }
   if (!processedConnectAPmode) processConnectAPmode();
   if (!processedDisconnectAPmode) processDisconnectAPmode();

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -4496,7 +4496,6 @@ void handle_setup() {
     sendHeadandTail(F("TmplAP"),true);
     TXBuffer.endStream();
 
-    wifiSetup = false;
     //setWifiMode(WIFI_STA);  //this forces the iPhone to exit safari and this page was never displayed
     timerAPoff = millis() + 60000L;  //switch the AP off in 1 minute
     return;
@@ -4979,11 +4978,11 @@ void handle_sysinfo() {
      TXBuffer += F(")");
 
      TXBuffer += F("<TR><TD>ESP Chip Freq:<TD>");
-     TXBuffer += ESP.getCpuFreqMHz(); 
+     TXBuffer += ESP.getCpuFreqMHz();
      TXBuffer += F(" MHz");
   #endif
-  
-  
+
+
 
    TXBuffer += F("<TR><TD colspan=2><H3>Storage</H3></TD></TR>");
 


### PR DESCRIPTION
The settings had 2 new values which would be overwriten by the checksum and there was still some issue about when to save the settings.

Also added a check to only save changed settings.

Known issue: 
Sometimes after initial setup of wifi credentials, it is best to perform a reset.