### PR TITLE
[wifi] Prevent starting AP+STA mode with correct settings

### DIFF
--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -96,7 +96,8 @@ int firstEnabledBlynkController() {
 \*********************************************************************************************/
 void setup()
 {
-
+  WiFi.persistent(false); // Do not use SDK storage of SSID/WPA parameters
+  WiFi.setAutoReconnect(false);
 
   checkRAM(F("setup"));
   #if defined(ESP32)
@@ -111,6 +112,7 @@ void setup()
 
   initLog();
 
+  resetWiFi();
 #if defined(ESP32)
   WiFi.onEvent((WiFiEventFullCb)WiFiEvent);
 #else
@@ -168,15 +170,11 @@ void setup()
   saveToRTC();
 
   addLog(LOG_LEVEL_INFO, log);
-  WiFi.setAutoReconnect(false);
 
   fileSystemCheck();
   progMemMD5check();
   LoadSettings();
   checkRuleSets();
-  if (!selectValidWiFiSettings()) {
-    wifiSetup = true;
-  }
 
   ExtraTaskSettings.TaskIndex = 255; // make sure this is an unused nr to prevent cache load on boot
 
@@ -239,7 +237,9 @@ void setup()
     rulesProcessing(event);
   }
 
-  WiFi.persistent(false); // Do not use SDK storage of SSID/WPA parameters
+  if (!selectValidWiFiSettings()) {
+    wifiSetup = true;
+  }
 /*
   // FIXME TD-er:
   // Async scanning for wifi doesn't work yet like it should.

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -135,6 +135,11 @@ void setup()
 
   String log = F("\n\n\rINIT : Booting version: ");
   log += BUILD_GIT;
+  #if defined(ESP8266)
+     log += F(" (core ");
+     log += ESP.getCoreVersion();
+     log += F(")");
+  #endif
   addLog(LOG_LEVEL_INFO, log);
 
 
@@ -231,6 +236,24 @@ void setup()
   PluginInit();
   CPluginInit();
   NPluginInit();
+  log = F("INFO : Plugins: ");
+  log += deviceCount + 1;
+ #ifdef PLUGIN_BUILD_NORMAL
+    log += F(" [Normal]");
+ #endif
+ #ifdef PLUGIN_BUILD_TESTING
+    log += F(" [Testing]");
+ #endif
+ #ifdef PLUGIN_BUILD_DEV
+    log += F(" [Development]");
+ #endif
+ #if defined(ESP8266)
+    log += F(" (core ");
+    log += ESP.getCoreVersion();
+    log += F(")");
+ #endif
+  addLog(LOG_LEVEL_INFO, log);
+
   if (Settings.UseRules)
   {
     String event = F("System#Wake");

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -111,8 +111,8 @@ void setup()
   // Serial.print("\n\n\nBOOOTTT\n\n\n");
 
   initLog();
+  setWifiMode(WIFI_STA);
 
-  resetWiFi();
 #if defined(ESP32)
   WiFi.onEvent((WiFiEventFullCb)WiFiEvent);
 #else

--- a/src/ESPEasyWifi.ino
+++ b/src/ESPEasyWifi.ino
@@ -26,12 +26,18 @@ void processConnect() {
   if (useStaticIP())
   {
     const IPAddress ip = Settings.IP;
-    log = F("IP   : Static IP :");
-    log += ip;
-    addLog(LOG_LEVEL_INFO, log);
     const IPAddress gw = Settings.Gateway;
     const IPAddress subnet = Settings.Subnet;
     const IPAddress dns = Settings.DNS;
+    log = F("IP   : Static IP : ");
+    log += formatIP(ip);
+    log += F(" GW: ");
+    log += formatIP(gw);
+    log += F(" SN: ");
+    log += formatIP(subnet);
+    log += F(" DNS: ");
+    log += formatIP(dns);
+    addLog(LOG_LEVEL_INFO, log);
     WiFi.config(ip, gw, subnet, dns);
   }
   if (Settings.UseRules && bssid_changed) {


### PR DESCRIPTION
WiFi persistent settings were disabled after initialization of the event handler.
This allowed the firmware to start WiFi connection with settings stored in the flash (not our settings, the settings kept by the core library). If these fail, then a connection failed event would occur before a connect attempt was started from ESPeasy, which would lead to strange results on some nodes while others work just fine.

See #1238