### PR TITLE
[wifi] Fix wifi reconnects with static IP

### DIFF
--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -1183,6 +1183,7 @@ enum WifiState {
 WifiState currentWifiState = WifiStart;
 
 void setWifiState(WifiState state);
+bool useStaticIP();
 
 // WiFi related data
 boolean wifiSetup = false;

--- a/src/ESPEasyWiFiEvent.h
+++ b/src/ESPEasyWiFiEvent.h
@@ -23,9 +23,7 @@ void WiFiEvent(system_event_id_t event, system_event_info_t info) {
       wifiStatus = ESPEASY_WIFI_DISCONNECTED;
       break;
     case SYSTEM_EVENT_STA_GOT_IP:
-      lastGetIPmoment = millis();
-      wifiStatus = ESPEASY_WIFI_GOT_IP;
-      processedGetIP = false;
+      markGotIP();
       break;
     case SYSTEM_EVENT_AP_STACONNECTED:
       for (byte i = 0; i < 6; ++i) {
@@ -52,6 +50,12 @@ void WiFiEvent(system_event_id_t event, system_event_info_t info) {
 }
 #else
 
+void markGotIP() {
+  lastGetIPmoment = millis();
+  wifiStatus = ESPEASY_WIFI_GOT_IP;
+  processedGetIP = false;
+}
+
 void onConnected(const WiFiEventStationModeConnected& event){
   lastConnectMoment = millis();
   processedConnect = false;
@@ -64,6 +68,9 @@ void onConnected(const WiFiEventStationModeConnected& event){
       bssid_changed = true;
       lastBSSID[i] = event.bssid[i];
     }
+  }
+  if (useStaticIP()) {
+    markGotIP();
   }
 }
 
@@ -80,9 +87,7 @@ void onDisconnect(const WiFiEventStationModeDisconnected& event){
 }
 
 void onGotIP(const WiFiEventStationModeGotIP& event){
-  lastGetIPmoment = millis();
-  wifiStatus = ESPEASY_WIFI_GOT_IP;
-  processedGetIP = false;
+  markGotIP();
 }
 
 void onConnectedAPmode(const WiFiEventSoftAPModeStationConnected& event) {

--- a/src/TimeESPeasy.ino
+++ b/src/TimeESPeasy.ino
@@ -202,7 +202,7 @@ unsigned long getNtpTime()
     return 0;
   }
   IPAddress timeServerIP;
-  String log = F("NTP  : NTP send to ");
+  String log = F("NTP  : NTP host ");
   if (Settings.NTPHost[0] != 0) {
     WiFi.hostByName(Settings.NTPHost, timeServerIP);
     log += Settings.NTPHost;
@@ -219,7 +219,13 @@ unsigned long getNtpTime()
     nextSyncTime = sysTime + 5;
   }
 
+  log += F(" (");
+  log += timeServerIP.toString();
+  log += F(")");
+
   if (!hostReachable(timeServerIP)) {
+    log += F(" unreachable");
+    addLog(LOG_LEVEL_INFO, log);
     return 0;
   }
 
@@ -229,9 +235,7 @@ unsigned long getNtpTime()
   const int NTP_PACKET_SIZE = 48; // NTP time is in the first 48 bytes of message
   byte packetBuffer[NTP_PACKET_SIZE]; //buffer to hold incoming & outgoing packets
 
-  log += F(" (");
-  log += timeServerIP.toString();
-  log += F(")");
+  log += F(" queried");
   addLog(LOG_LEVEL_DEBUG_MORE, log);
 
   while (udp.parsePacket() > 0) ; // discard any previously received packets


### PR DESCRIPTION
See #1238 , #1251 

When a fixed IP setting is used, there will be no "Got IP" event, which will lead to a timeout and thus reconnect.
As a fix, the "Connected" event will also act like when a "Got IP" event was received when configured to use static IP.