### PR TITLE
Implemented syslog facilities and levels

### DIFF
--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -84,6 +84,8 @@
 #define DEFAULT_USE_SERIAL                      true    // (true|false) Enable Logging to the Serial Port
 #define DEFAULT_SERIAL_BAUD                     115200  // Serial Port Baud Rate
 
+#define DEFAULT_SYSLOG_FACILITY 	0 	// kern
+
 /*
 // --- Experimental Advanced Settings (NOT ACTIVES at this time) ------------------------------------
 
@@ -593,7 +595,7 @@ struct SettingsStruct
     WireClockStretchLimit(0), GlobalSync(false), ConnectionFailuresThreshold(0),
     TimeZone(0), MQTTRetainFlag(false), InitSPI(false),
     Pin_status_led_Inversed(false), deepSleepOnFail(false), UseValueLogger(false),
-    DST_Start(0), DST_End(0)
+    DST_Start(0), DST_End(0), SyslogFacility(0)
     {
       for (byte i = 0; i < CONTROLLER_MAX; ++i) {
         Protocol[i] = 0;
@@ -699,6 +701,7 @@ struct SettingsStruct
   uint16_t      DST_End;
   boolean       UseRTOSMultitasking;
   int8_t        Pin_Reset;
+  byte          SyslogFacility;
 
 
   //its safe to extend this struct, up to several bytes, default values in config are 0

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -1147,6 +1147,7 @@ void ResetFactory(void)
 
 	Settings.SyslogLevel	= DEFAULT_SYSLOG_LEVEL;
 	Settings.SerialLogLevel	= DEFAULT_SERIAL_LOG_LEVEL;
+	Settings.SyslogFacility	= DEFAULT_SYSLOG_FACILITY;
 	Settings.WebLogLevel	= DEFAULT_WEB_LOG_LEVEL;
 	Settings.SDLogLevel		= DEFAULT_SD_LOG_LEVEL;
 	Settings.UseValueLogger = DEFAULT_USE_SD_LOG;
@@ -1298,6 +1299,7 @@ void initLog()
   //make sure addLog doesnt do any stuff before initalisation of Settings is complete.
   Settings.UseSerial=true;
   Settings.SyslogLevel=0;
+  Settings.SyslogFacility=0;
   Settings.SerialLogLevel=2; //logging during initialisation
   Settings.WebLogLevel=2;
   Settings.SDLogLevel=0;
@@ -1367,7 +1369,7 @@ void addLog(byte logLevel, const char *line)
     Serial.println(line);
   }
   if (loglevelActiveFor(LOG_TO_SYSLOG, logLevel)) {
-    syslog(line);
+    syslog(logLevel, line);
   }
   if (loglevelActiveFor(LOG_TO_WEBLOG, logLevel)) {
     Logging.add(line);

--- a/src/Networking.ino
+++ b/src/Networking.ino
@@ -10,7 +10,7 @@
 /*********************************************************************************************\
    Syslog client
   \*********************************************************************************************/
-void syslog(const char *message)
+void syslog(byte logLevel, const char *message)
 {
   if (Settings.Syslog_IP[0] != 0 && wifiStatus == ESPEASY_WIFI_SERVICES_INITIALIZED)
   {
@@ -18,10 +18,18 @@ void syslog(const char *message)
     portUDP.beginPacket(broadcastIP, 514);
     char str[256];
     str[0] = 0;
+    byte prio = Settings.SyslogFacility * 8;
+    if ( logLevel == LOG_LEVEL_ERROR )
+      prio += 3;  // syslog error
+    else if ( logLevel == LOG_LEVEL_INFO )
+      prio += 5;  // syslog notice
+    else
+      prio += 7;
+
 	// An RFC3164 compliant message must be formated like :  "<PRIO>[TimeStamp ]Hostname TaskName: Message"
 
 	// Using Settings.Name as the Hostname (Hostname must NOT content space)
-    snprintf_P(str, sizeof(str), PSTR("<7>%s EspEasy: %s"), Settings.Name, message);
+    snprintf_P(str, sizeof(str), PSTR("<%u>%s EspEasy: %s"), prio, Settings.Name, message);
 
 	// Using Setting.Unit to build a Hostname
     //snprintf_P(str, sizeof(str), PSTR("<7>EspEasy_%u ESP: %s"), Settings.Unit, message);

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -3620,6 +3620,7 @@ void handle_advanced() {
   int dstendhour = WebServer.arg(F("dstendhour")).toInt();
   String dst = WebServer.arg(F("dst"));
   String sysloglevel = WebServer.arg(F("sysloglevel"));
+  String syslogfacility = WebServer.arg(F("syslogfacility"));
   String udpport = WebServer.arg(F("udpport"));
   String useserial = WebServer.arg(F("useserial"));
   String serialloglevel = WebServer.arg(F("serialloglevel"));
@@ -3652,6 +3653,7 @@ void handle_advanced() {
     str2ip(syslogip.c_str(), Settings.Syslog_IP);
     Settings.UDPPort = udpport.toInt();
     Settings.SyslogLevel = sysloglevel.toInt();
+    Settings.SyslogFacility = syslogfacility.toInt();
     Settings.UseSerial = (useserial == "on");
     Settings.SerialLogLevel = serialloglevel.toInt();
     Settings.WebLogLevel = webloglevel.toInt();
@@ -3704,6 +3706,7 @@ void handle_advanced() {
 
   addFormIPBox(F("Syslog IP"), F("syslogip"), Settings.Syslog_IP);
   addFormLogLevelSelect(F("Syslog Level"),      F("sysloglevel"),    Settings.SyslogLevel);
+  addFormLogFacilitySelect(F("Syslog Facility"),F("syslogfacility"), Settings.SyslogFacility);
   addFormLogLevelSelect(F("Serial log Level"),  F("serialloglevel"), Settings.SerialLogLevel);
   addFormLogLevelSelect(F("Web log Level"),     F("webloglevel"),    Settings.WebLogLevel);
 
@@ -3797,6 +3800,19 @@ void addLogLevelSelect(String name, int choice)
   String options[6] = { F("None"), F("Error"), F("Info"), F("Debug"), F("Debug More"), F("Debug dev")};
   int optionValues[6] = { 0 , LOG_LEVEL_ERROR, LOG_LEVEL_INFO, LOG_LEVEL_DEBUG, LOG_LEVEL_DEBUG_MORE, LOG_LEVEL_DEBUG_DEV};
   addSelector(name, 6, options, optionValues, NULL, choice, false);
+}
+
+void addFormLogFacilitySelect(const String& label, const String& id, int choice)
+{
+  addRowLabel(label);
+  addLogFacilitySelect(id, choice);
+}
+
+void addLogFacilitySelect(String name, int choice)
+{
+  String options[12] = { F("Kernel"), F("User"), F("Daemon"), F("Message"), F("Local0"), F("Local1"), F("Local2"), F("Local3"), F("Local4"), F("Local5"), F("Local6"), F("Local7")};
+  int optionValues[12] = { 0, 1, 3, 5, 16, 17, 18, 19, 20, 21, 22, 23 };
+  addSelector(name, 12, options, optionValues, NULL, choice, false);
 }
 
 


### PR DESCRIPTION
Please consider this request in order to be able to make use of different syslog facilities and levels. Sending everything as kernel debug sometimes conflict with other use of syslog services

Implemented sending LOG_LEVEL_ERROR as syslog error messages, LOG_LEVEL_INFO as syslog notice messages, and everything else as syslog debug messages. This enables better filtering capabilities also at the syslog server end.

Also added Settings.SyslogFacility setting, and in web GUI to be able to choose kernel (still default), user, daemon, message and local0-local7 as message facility.