### PR TITLE
[Static IP] Work-around for set _use_static_ip

### DIFF
--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -98,6 +98,7 @@ void setup()
 {
   WiFi.persistent(false); // Do not use SDK storage of SSID/WPA parameters
   WiFi.setAutoReconnect(false);
+  setWifiMode(WIFI_OFF);
 
   checkRAM(F("setup"));
   #if defined(ESP32)
@@ -111,7 +112,7 @@ void setup()
   // Serial.print("\n\n\nBOOOTTT\n\n\n");
 
   initLog();
-  setWifiMode(WIFI_STA);
+
 
 #if defined(ESP32)
   WiFi.onEvent((WiFiEventFullCb)WiFiEvent);
@@ -179,6 +180,8 @@ void setup()
   fileSystemCheck();
   progMemMD5check();
   LoadSettings();
+  setUseStaticIP(useStaticIP());
+  setWifiMode(WIFI_STA);
   checkRuleSets();
 
   ExtraTaskSettings.TaskIndex = 255; // make sure this is an unused nr to prevent cache load on boot

--- a/src/ESPEasyWiFiEvent.h
+++ b/src/ESPEasyWiFiEvent.h
@@ -1,3 +1,30 @@
+//********************************************************************************
+// Work-around for setting _useStaticIP
+// See reported issue: https://github.com/esp8266/Arduino/issues/4114
+//********************************************************************************
+#ifdef ESP32
+class WiFi_Access_Static_IP: public WiFiSTAClass {
+  public:
+    void set_use_static_ip(bool enabled) {
+      _useStaticIp = enabled;
+    }
+};
+#else
+class WiFi_Access_Static_IP: public ESP8266WiFiSTAClass {
+  public:
+    void set_use_static_ip(bool enabled) {
+      _useStaticIp = enabled;
+    }
+};
+#endif
+
+
+void setUseStaticIP(bool enabled) {
+  WiFi_Access_Static_IP tmp_wifi;
+  tmp_wifi.set_use_static_ip(enabled);
+}
+
+
 void markGotIP() {
   lastGetIPmoment = millis();
   wifiStatus = ESPEASY_WIFI_GOT_IP;


### PR DESCRIPTION
See [this bug report](https://github.com/esp8266/Arduino/issues/4114), which is not fixed in 2.4.0.

This work-around will make sure no dhcp-client will be started when connecting to a network.
The active DHCP client could result in IP conflicts, difficulty in reconnect and other strange issues.

See #1251 