### PR TITLE
[issue #1292] Remove CRC from settings, init settings and wifi fixes

### DIFF
--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -163,7 +163,7 @@
   #define VERSION                             3 // Change in config.dat mapping needs a full reset
 #endif
 
-#define BUILD                           20101 // git version 2.1.01
+#define BUILD                           20102 // git version 2.1.02
 #if defined(ESP8266)
   #define BUILD_NOTES                 " - Mega"
 #endif
@@ -604,7 +604,8 @@ struct SettingsStruct
     WireClockStretchLimit(0), GlobalSync(false), ConnectionFailuresThreshold(0),
     TimeZone(0), MQTTRetainFlag(false), InitSPI(false),
     Pin_status_led_Inversed(false), deepSleepOnFail(false), UseValueLogger(false),
-    DST_Start(0), DST_End(0), SyslogFacility(0)
+    DST_Start(0), DST_End(0), UseRTOSMultitasking(false), Pin_Reset(-1),
+    SyslogFacility(DEFAULT_SYSLOG_FACILITY), StructSize(0)
     {
       for (byte i = 0; i < CONTROLLER_MAX; ++i) {
         Protocol[i] = 0;
@@ -711,14 +712,17 @@ struct SettingsStruct
   boolean       UseRTOSMultitasking;
   int8_t        Pin_Reset;
   byte          SyslogFacility;
-
+  uint32_t      StructSize;  // Forced to be 32 bit, to make sure alignment is clear.
 
   //its safe to extend this struct, up to several bytes, default values in config are 0
   //look in misc.ino how config.dat is used because also other stuff is stored in it at different offsets.
   //TODO: document config.dat somewhere here
+
+  // FIXME @TD-er: As discussed in #1292, the CRC for the settings is now disabled.
   // make sure crc is the last value in the struct
-  uint8_t       ProgmemMd5[16]; // crc of the binary that last saved the struct to file.
-  uint8_t       md5[16];
+  // Try to extend settings to make the checksum 4-byte aligned.
+//  uint8_t       ProgmemMd5[16]; // crc of the binary that last saved the struct to file.
+//  uint8_t       md5[16];
 } Settings;
 
 struct ControllerSettingsStruct

--- a/src/ESPEasyWifi.ino
+++ b/src/ESPEasyWifi.ino
@@ -82,8 +82,10 @@ void processGotIP() {
   if (processedGetIP)
     return;
   processedGetIP = true;
-  if (wifiStatus < ESPEASY_WIFI_GOT_IP)
-    return;
+  // FIXME @TD-er: Disabled this check for now.
+  // It may be a possibility the events are processed out of order
+//  if (wifiStatus < ESPEASY_WIFI_GOT_IP)
+//    return;
   IPAddress ip = WiFi.localIP();
   if (ip[0] == 0 && ip[1] == 0 && ip[2] == 0 && ip[3] == 0)
     return;

--- a/src/Networking.ino
+++ b/src/Networking.ino
@@ -632,13 +632,21 @@ bool hostReachable(const IPAddress& ip) {
   String log = F("Host unreachable: ");
   log += formatIP(ip);
   addLog(LOG_LEVEL_ERROR, log);
+  if (ip[1] == 0 && ip[2] == 0 && ip[3] == 0) {
+    // Work-around to fix connected but not able to communicate.
+    addLog(LOG_LEVEL_ERROR, F("Wifi  : Detected strange behavior, reset wifi."));
+    setWifiState(WifiOff);
+    delay(100);
+    setWifiState(WifiTryConnect);
+  }
   return false;
 }
 
 bool hostReachable(const String& hostname) {
   IPAddress remote_addr;
-  if (WiFi.hostByName(hostname.c_str(), remote_addr))
+  if (WiFi.hostByName(hostname.c_str(), remote_addr)) {
     return hostReachable(remote_addr);
+  }
   String log = F("Hostname cannot be resolved: ");
   log += hostname;
   addLog(LOG_LEVEL_ERROR, log);

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -2914,7 +2914,7 @@ void addHelpButton(const String& url)
 {
   TXBuffer += F(" <a class='button help' href='http://www.letscontrolit.com/wiki/index.php/");
   TXBuffer += url;
-  TXBuffer += F("' target='_blank'>&#10067;</a>");
+  TXBuffer += F("' target='_blank'>&#10068;</a>");
 }
 
 


### PR DESCRIPTION
- Reset wifi when DNS lookup returns *.0.0.0 (NTP lookup sometimes returns like these)
- Accept Wifi events out of order.
- Remove CRC from settings struct
- Patch settings with last few added items initialized
- Changed red question mark to white questionmark, for links to wiki.