### PR TITLE
[wifi] Add delay between connection attempts

### DIFF
--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -1132,8 +1132,6 @@ unsigned long timermqtt;
 unsigned long timermqtt_interval;
 unsigned long lastSend;
 unsigned long lastWeb;
-unsigned int NC_Count = 0;
-unsigned int C_Count = 0;
 byte cmd_within_mainloop = 0;
 unsigned long connectionFailures;
 unsigned long wdcounter = 0;
@@ -1246,6 +1244,7 @@ bool processedGetIP = true;
 bool processedConnectAPmode = true;
 bool processedDisconnectAPmode = true;
 bool processedScanDone = true;
+bool processedTryConnect = true;
 
 bool webserver_state = false;
 bool webserver_init = false;


### PR DESCRIPTION
Accesspoints cannot handle lots of (immediate) reconnect attempts.
Added a delay of up-to a second between new attempts.