### PR TITLE
Added "Refresh" command to OLED and LCD plugin

### DIFF
--- a/src/_P012_LCD.ino
+++ b/src/_P012_LCD.ino
@@ -198,6 +198,7 @@ boolean Plugin_012(byte function, struct EventStruct *event, String& string)
           col = 20;
         }
 
+        lcd->clear();  //added lcd clear before refresh 
         for (byte x = 0; x < row; x++)
         {
           String tmpString = deviceTemplate[x];
@@ -239,6 +240,31 @@ boolean Plugin_012(byte function, struct EventStruct *event, String& string)
           }
           else if (tmpString.equalsIgnoreCase(F("Clear"))){
               lcd->clear();
+          }
+          else if (tmpString.equalsIgnoreCase(F("Refresh"))) //giig1967g added command refresh
+          {
+              char deviceTemplate[4][80];
+              LoadCustomTaskSettings(event->TaskIndex, (byte*)&deviceTemplate, sizeof(deviceTemplate));
+
+              byte row = 2;
+              byte col = 16;
+              if (Settings.TaskDevicePluginConfig[event->TaskIndex][1] == 2)
+              {
+                row = 4;
+                col = 20;
+              }
+
+              lcd->clear();
+              for (byte x = 0; x < row; x++)
+              {
+                String tmpString = deviceTemplate[x];
+                if (lcd && tmpString.length())
+                {
+                  String newString = P012_parseTemplate(tmpString, col);
+                  lcd->setCursor(0, x);
+                  lcd->print(newString);
+                }
+              }
           }
         }
         else if (lcd && tmpString.equalsIgnoreCase(F("LCD")))

--- a/src/_P023_OLED.ino
+++ b/src/_P023_OLED.ino
@@ -220,6 +220,23 @@ boolean Plugin_023(byte function, struct EventStruct *event, String& string)
             Plugin_023_displayOn();
           else if (tmpString.equalsIgnoreCase(F("Clear")))
             Plugin_023_clear_display();
+          else if (tmpString.equalsIgnoreCase(F("Refresh"))) //giig1967g added command refresh
+          {
+            Plugin_023_clear_display();
+
+            char deviceTemplate[8][64];
+            LoadCustomTaskSettings(event->TaskIndex, (byte*)&deviceTemplate, sizeof(deviceTemplate));
+
+            for (byte x = 0; x < 8; x++)
+            {
+              String tmpString = deviceTemplate[x];
+              if (tmpString.length())
+              {
+                String newString = P023_parseTemplate(tmpString, 16);
+                Plugin_023_sendStrXY(newString.c_str(), x, 0);
+              }
+            }
+          }
         }
         else if (tmpString.equalsIgnoreCase(F("OLED")))
         {


### PR DESCRIPTION
New Commands are:
OLEDCMD,Refresh
LCDCMD,Refresh

Refresh:
Force the display to refresh according to the format settings defined in the Device page.
Works from rules and http