### PR TITLE
fix for #1170

### DIFF
--- a/src/_P059_Encoder.ino
+++ b/src/_P059_Encoder.ino
@@ -180,7 +180,8 @@ boolean Plugin_059(byte function, struct EventStruct *event, String& string)
                 log = String(F("QEI  : ")) + string;
                 addLog(LOG_LEVEL_INFO, log);
                 Plugin_059_QE->write(event->Par1);
-                UserVar[event->BaseVarIndex] = (float) event->Par1;
+                //Removed as inside PLUGIN_WRITE EventStruct there is no taskID nor BaseVarIndex set.
+                //UserVar[event->BaseVarIndex] = (float) event->Par1;
                 success = true;
               }
             }

--- a/src/_P059_Encoder.ino
+++ b/src/_P059_Encoder.ino
@@ -180,12 +180,10 @@ boolean Plugin_059(byte function, struct EventStruct *event, String& string)
                 log = String(F("QEI  : ")) + string;
                 addLog(LOG_LEVEL_INFO, log);
                 Plugin_059_QE->write(event->Par1);
-                //Removed as inside PLUGIN_WRITE EventStruct there is no taskID nor BaseVarIndex set.
-                //UserVar[event->BaseVarIndex] = (float) event->Par1;
-                success = true;
               }
             }
         }
+        success = true;
         break;
       }
 


### PR DESCRIPTION
The reason is that inside PLUGIN_WRITE the variable [event->BaseVarIndex] is not set and is always = 0.
So actually this PR modifies the 1st value of task 1 and not the encoder counter.
Line 183 of P059_Encoder.ino should be removed:
UserVar[event->BaseVarIndex] = (float) event->Par1;