### PR TITLE
fix for #960: new command: TaskValueSetAndRun

### DIFF
--- a/src/Command.ino
+++ b/src/Command.ino
@@ -125,6 +125,7 @@ Command commandStringToEnum(const char * cmd) {
       else if (strcmp_P(cmd_lc, PSTR("taskclearall")          ) == 0) return cmd_TaskClearAll;
       else if (strcmp_P(cmd_lc, PSTR("taskrun")               ) == 0) return cmd_TaskRun;
       else if (strcmp_P(cmd_lc, PSTR("taskvalueset")          ) == 0) return cmd_TaskValueSet;
+      else if (strcmp_P(cmd_lc, PSTR("taskvaluesetandrun")    ) == 0) return cmd_TaskValueSetAndRun;
       else if (strcmp_P(cmd_lc, PSTR("timerset")              ) == 0) return cmd_TimerSet;
       else if (strcmp_P(cmd_lc, PSTR("timerpause")            ) == 0) return cmd_TimerPause;
       else if (strcmp_P(cmd_lc, PSTR("timerresume")           ) == 0) return cmd_TimerResume;
@@ -450,6 +451,19 @@ void ExecuteCommand(byte source, const char *Line)
       float result = 0;
       Calculate(TmpStr1, &result);
       UserVar[(VARS_PER_TASK * (Par1 - 1)) + Par2 - 1] = result;
+    }
+    break;
+  }
+
+  case cmd_TaskValueSetAndRun:
+  {
+    success = true;
+    if (GetArgv(Line, TmpStr1, 4))
+    {
+      float result = 0;
+      Calculate(TmpStr1, &result);
+      UserVar[(VARS_PER_TASK * (Par1 - 1)) + Par2 - 1] = result;
+      SensorSendTask(Par1 - 1);
     }
     break;
   }

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -536,6 +536,7 @@ enum Command {
   cmd_TaskClearAll,
   cmd_TaskRun,
   cmd_TaskValueSet,
+  cmd_TaskValueSetAndRun,
   cmd_TimerSet,
   cmd_TimerPause,
   cmd_TimerResume,


### PR DESCRIPTION
Added a new global command: TaskValueSetAndRun.

It changes the value of a task and runs it, so new value is pubished on MQTT and rules are executed.