### PR TITLE
[rules] Make rules start working again.

### DIFF
--- a/src/Command.ino
+++ b/src/Command.ino
@@ -43,6 +43,9 @@ Command commandStringToEnum(const char * cmd) {
   String tmpcmd;
   tmpcmd = cmd;
   tmpcmd.toLowerCase();
+  String log = F("Command: ");
+  log += tmpcmd;
+  addLog(LOG_LEVEL_INFO, log);
   char cmd_lc[INPUT_COMMAND_SIZE];
   tmpcmd.toCharArray(cmd_lc, tmpcmd.length() + 1);
   switch (cmd_lc[0]) {
@@ -149,8 +152,10 @@ Command commandStringToEnum(const char * cmd) {
       break;
     }
     default:
+      addLog(LOG_LEVEL_INFO, F("Command unknown"));
       return cmd_Unknown;
   }
+  addLog(LOG_LEVEL_INFO, F("Command unknown"));
   return cmd_Unknown;
 }
 

--- a/src/_P059_Encoder.ino
+++ b/src/_P059_Encoder.ino
@@ -181,12 +181,11 @@ boolean Plugin_059(byte function, struct EventStruct *event, String& string)
                 addLog(LOG_LEVEL_INFO, log);
                 Plugin_059_QE->write(event->Par1);
               }
+              success = true; // Command is handled.
             }
         }
-        success = true;
         break;
       }
-
   }
   return success;
 }


### PR DESCRIPTION
See #1351
Whenever a plugin_write returns success = true, the execute command will no longer be called.
It doesn't matter whether the plugin is enabled or present.
It should only return success = true when the command was actually meant for this plugin.