### PR TITLE
[#1368] Remove call to Plugin_041_update in _P041_NeoClock that caused a hard crash.

### DIFF
--- a/src/_P041_NeoClock.ino
+++ b/src/_P041_NeoClock.ino
@@ -66,7 +66,6 @@ boolean Plugin_041(byte function, struct EventStruct *event, String& string)
         Plugin_041_red = Settings.TaskDevicePluginConfig[event->TaskIndex][0];
         Plugin_041_green = Settings.TaskDevicePluginConfig[event->TaskIndex][1];
         Plugin_041_blue = Settings.TaskDevicePluginConfig[event->TaskIndex][2];
-        Plugin_041_update();
         success = true;
         break;
       }


### PR DESCRIPTION
Plugin_041_update was being called in PLUGIN_WEBFORM_SAVE before the plugin has been initialized, this resulted in an exception 28 hard crash when a save was attempted for the plugin from the web i/f. Plugin_041_update clears the display and isn't required at the time the web i/f data is saved, it will be called later during normal cycling through the plugin.