### PR TITLE
Fix plugin_id visualization

### DIFF
--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -2382,7 +2382,7 @@ void addDeviceSelect(String name,  int choice)
       deviceName = getPluginNameFromDeviceIndex(deviceIndex);
 
 #ifdef PLUGIN_BUILD_DEV
-    int num = deviceIndex + 1;
+    int num = Plugin_id[deviceIndex];
     String plugin = F("P");
     if (num < 10) plugin += F("0");
     if (num < 100) plugin += F("0");


### PR DESCRIPTION
Fix plugin_id visualization on devices view that afflict Development build

### Expected behavior
<!--- Tell us what should happen? --->
Show Correct ID

### Actual behavior
 Show the index+1 

### Steps to reproduce
<!--- How can we trigger this problem? --->
1. go  to devices http://http://192.168.1.x/devices
2.  add new device
3.  on dropdown device selector , you can see that "Weight - HX711 Load Cell" device id show P065 instead of P067


<!--- Does the problem persists after powering off and on? (just resetting isn't enough sometimes) --->
<!--- Please document if you have restarted the unit and if the problem is then gone etc. etc. --->
### System configuration
|                  |                                  |
| ------------- | ------------- |
| Hardware | **Sonoff  TH10/16** |
| ESP Easy version | **20102 - Mega** |
| Libraries | **ESP82xx Core 2_4_1, NONOS SDK 2.2.1(cfd48f3), LWIP: 1.4.0-RC2** |
| GIT version | **mega-20180503** |
| Plugins  | **72 [Normal] [Testing] [Development]** |
| Build Md5 | **605586a9cf8191c86ba991dda2c61ff** |
| Build time | **May  3 2018 02:07:06** |
| Binary filename | **firmware.bin** |

