### PR TITLE
[#1404] Change email notify protocol to better comply with RFC2821. Rewrite line breaks for content-type: text/html

### DIFF
--- a/src/_N001_Email.ino
+++ b/src/_N001_Email.ino
@@ -68,7 +68,6 @@ boolean NPlugin_001(byte function, struct EventStruct *event, String& string)
 boolean NPlugin_001_send(const NotificationSettingsStruct& notificationsettings, const String& aSub, const String& aMesg) {
 //  String& aDomain , String aTo, String aFrom, String aSub, String aMesg, String aHost, int aPort)
   boolean myStatus = false;
-//  String msgBody = notificationsettings.Body;
 
   // Use WiFiClient class to create TCP connections
   WiFiClient client;
@@ -95,7 +94,7 @@ boolean NPlugin_001_send(const NotificationSettingsStruct& notificationsettings,
     mailheader.replace(String(F("$subject")), aSub);
     mailheader.replace(String(F("$espeasyversion")), String(BUILD));
     String bMesg = aMesg;
-    bMesg.replace("\r", "<br/>"); // re-write line breaks for text/html
+    bMesg.replace("\r", "<br/>"); // re-write line breaks for Content-type: text/html
 
     // Wait for Client to Start Sending
     // The MTA Exchange

--- a/src/_N001_Email.ino
+++ b/src/_N001_Email.ino
@@ -65,7 +65,7 @@ boolean NPlugin_001(byte function, struct EventStruct *event, String& string)
   return success;
 }
 
-boolean NPlugin_001_send(const NotificationSettingsStruct& notificationsettings, const String& aSub, const String& aMesg) {
+boolean NPlugin_001_send(const NotificationSettingsStruct& notificationsettings, const String& aSub, String aMesg) {
 //  String& aDomain , String aTo, String aFrom, String aSub, String aMesg, String aHost, int aPort)
   boolean myStatus = false;
 
@@ -93,8 +93,7 @@ boolean NPlugin_001_send(const NotificationSettingsStruct& notificationsettings,
     mailheader.replace(String(F("$ato")), notificationsettings.Receiver);
     mailheader.replace(String(F("$subject")), aSub);
     mailheader.replace(String(F("$espeasyversion")), String(BUILD));
-    String bMesg = aMesg;
-    bMesg.replace("\r", "<br/>"); // re-write line breaks for Content-type: text/html
+    aMesg.replace("\r", "<br/>"); // re-write line breaks for Content-type: text/html
 
     // Wait for Client to Start Sending
     // The MTA Exchange
@@ -106,7 +105,7 @@ boolean NPlugin_001_send(const NotificationSettingsStruct& notificationsettings,
       if (!NPlugin_001_MTA(client, String(F("MAIL FROM:<")) + notificationsettings.Sender + ">", F("250 "))) break;
       if (!NPlugin_001_MTA(client, String(F("RCPT TO:<")) + notificationsettings.Receiver + ">", F("250 "))) break;
       if (!NPlugin_001_MTA(client, F("DATA"),                             F("354 "))) break;
-      if (!NPlugin_001_MTA(client, mailheader + bMesg + String(F("\r\n.\r\n")), F("250 "))) break;
+      if (!NPlugin_001_MTA(client, mailheader + aMesg + String(F("\r\n.\r\n")), F("250 "))) break;
 
       myStatus = true;
       break;

--- a/src/_N001_Email.ino
+++ b/src/_N001_Email.ino
@@ -51,9 +51,6 @@ boolean NPlugin_001(byte function, struct EventStruct *event, String& string)
         LoadNotificationSettings(event->NotificationIndex, (byte*)&NotificationSettings, sizeof(NotificationSettings));
         String subject = NotificationSettings.Subject;
         String body = "";
-        String log = F("String length: ");
-        log += string.length();
-        addLog(LOG_LEVEL_ERROR, log);
         if (string.length() >0)
           body = string;
         else

--- a/src/_N001_Email.ino
+++ b/src/_N001_Email.ino
@@ -51,6 +51,9 @@ boolean NPlugin_001(byte function, struct EventStruct *event, String& string)
         LoadNotificationSettings(event->NotificationIndex, (byte*)&NotificationSettings, sizeof(NotificationSettings));
         String subject = NotificationSettings.Subject;
         String body = "";
+        String log = F("String length: ");
+        log += string.length();
+        addLog(LOG_LEVEL_ERROR, log);
         if (string.length() >0)
           body = string;
         else
@@ -68,7 +71,7 @@ boolean NPlugin_001(byte function, struct EventStruct *event, String& string)
 boolean NPlugin_001_send(const NotificationSettingsStruct& notificationsettings, const String& aSub, const String& aMesg) {
 //  String& aDomain , String aTo, String aFrom, String aSub, String aMesg, String aHost, int aPort)
   boolean myStatus = false;
-  String msgBody = notificationsettings.Body;
+//  String msgBody = notificationsettings.Body;
 
   // Use WiFiClient class to create TCP connections
   WiFiClient client;
@@ -94,7 +97,8 @@ boolean NPlugin_001_send(const NotificationSettingsStruct& notificationsettings,
     mailheader.replace(String(F("$ato")), notificationsettings.Receiver);
     mailheader.replace(String(F("$subject")), aSub);
     mailheader.replace(String(F("$espeasyversion")), String(BUILD));
-    msgBody.replace("\r", "<br/>"); // re-write line breaks for text/html
+    String bMesg = aMesg;
+    bMesg.replace("\r", "<br/>"); // re-write line breaks for text/html
 
     // Wait for Client to Start Sending
     // The MTA Exchange
@@ -106,7 +110,7 @@ boolean NPlugin_001_send(const NotificationSettingsStruct& notificationsettings,
       if (!NPlugin_001_MTA(client, String(F("MAIL FROM:<")) + notificationsettings.Sender + ">", F("250 "))) break;
       if (!NPlugin_001_MTA(client, String(F("RCPT TO:<")) + notificationsettings.Receiver + ">", F("250 "))) break;
       if (!NPlugin_001_MTA(client, F("DATA"),                             F("354 "))) break;
-      if (!NPlugin_001_MTA(client, mailheader + msgBody + String(F("\r\n.\r\n")), F("250 "))) break;
+      if (!NPlugin_001_MTA(client, mailheader + bMesg + String(F("\r\n.\r\n")), F("250 "))) break;
 
       myStatus = true;
       break;

--- a/src/_N001_Email.ino
+++ b/src/_N001_Email.ino
@@ -68,6 +68,7 @@ boolean NPlugin_001(byte function, struct EventStruct *event, String& string)
 boolean NPlugin_001_send(const NotificationSettingsStruct& notificationsettings, const String& aSub, const String& aMesg) {
 //  String& aDomain , String aTo, String aFrom, String aSub, String aMesg, String aHost, int aPort)
   boolean myStatus = false;
+  String msgBody = notificationsettings.Body;
 
   // Use WiFiClient class to create TCP connections
   WiFiClient client;
@@ -93,6 +94,7 @@ boolean NPlugin_001_send(const NotificationSettingsStruct& notificationsettings,
     mailheader.replace(String(F("$ato")), notificationsettings.Receiver);
     mailheader.replace(String(F("$subject")), aSub);
     mailheader.replace(String(F("$espeasyversion")), String(BUILD));
+    msgBody.replace("\r", "<br/>"); // re-write line breaks for text/html
 
     // Wait for Client to Start Sending
     // The MTA Exchange
@@ -101,10 +103,10 @@ boolean NPlugin_001_send(const NotificationSettingsStruct& notificationsettings,
       if (!NPlugin_001_MTA(client, "",                                    F("220 "))) break;
       if (!NPlugin_001_MTA(client, String(F("EHLO ")) + notificationsettings.Domain,          F("250 "))) break;
       if (!NPlugin_001_Auth(client, notificationsettings.User, notificationsettings.Pass)) break;
-      if (!NPlugin_001_MTA(client, String(F("MAIL FROM:")) + notificationsettings.Sender + "",  F("250 "))) break;
-      if (!NPlugin_001_MTA(client, String(F("RCPT TO:")) + notificationsettings.Receiver + "",      F("250 "))) break;
+      if (!NPlugin_001_MTA(client, String(F("MAIL FROM:<")) + notificationsettings.Sender + ">", F("250 "))) break;
+      if (!NPlugin_001_MTA(client, String(F("RCPT TO:<")) + notificationsettings.Receiver + ">", F("250 "))) break;
       if (!NPlugin_001_MTA(client, F("DATA"),                             F("354 "))) break;
-      if (!NPlugin_001_MTA(client, mailheader + aMesg + String(F("\r\n.\r\n")),   F("250 "))) break;
+      if (!NPlugin_001_MTA(client, mailheader + msgBody + String(F("\r\n.\r\n")), F("250 "))) break;
 
       myStatus = true;
       break;


### PR DESCRIPTION
1. RFC2821 requires the sender and receiver to be enclosed in <> in the transfer protocol when sending to an SMTP server. Many servers are permissive and will accept it either way.  This was discovered when trying to talk with Gmail SMTP which is more strict in RFC2821 compliance. It was giving a formatting error and closing the connection.

2. The email content type is specified as text/html in _N001_Email.ino.  The input on the webform results in carriage return for EOL which doesn't result in a line break in html.  This resulted in all the lines being smashed together when the email is read by the recipient.  The second change substituted \<br/\> for all carriage returns in the body.