### PR TITLE
added to addLog overload that supports lambda expressions

### DIFF
--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -357,6 +357,7 @@
 
 #include "WebStaticData.h"
 #include "ESPEasyTimeTypes.h"
+#include <functional>
 #define FS_NO_GLOBALS
 #if defined(ESP8266)
   #include "core_version.h"
@@ -458,6 +459,8 @@ ADC_MODE(ADC_VCC);
 #define ESPEASY_WIFI_CONNECTED               1
 #define ESPEASY_WIFI_GOT_IP                  2
 #define ESPEASY_WIFI_SERVICES_INITIALIZED    3
+
+typedef  std::function<const char *(void)> GetMessageLog;
 
 #if defined(ESP32)
 void WiFiEvent(system_event_id_t event, system_event_info_t info);

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -1506,23 +1506,28 @@ boolean loglevelActive(byte logLevel, byte logLevelSettings) {
 
 void addLog(byte logLevel, const char *line)
 {
+  addLog(logLevel, [&](){return line;});
+}
+
+void addLog(byte logLevel, GetMessageLog get)
+{
   if (loglevelActiveFor(LOG_TO_SERIAL, logLevel)) {
     Serial.print(millis());
     Serial.print(F(" : "));
-    Serial.println(line);
+    Serial.println(get());
   }
   if (loglevelActiveFor(LOG_TO_SYSLOG, logLevel)) {
-    syslog(logLevel, line);
+    syslog(logLevel, get());
   }
   if (loglevelActiveFor(LOG_TO_WEBLOG, logLevel)) {
-    Logging.add(logLevel, line);
+    Logging.add(logLevel, get());
   }
 
 #ifdef FEATURE_SD
   if (loglevelActiveFor(LOG_TO_SDCARD, logLevel)) {
     File logFile = SD.open("log.dat", FILE_WRITE);
     if (logFile)
-      logFile.println(line);
+      logFile.println(get());
     logFile.close();
   }
 #endif


### PR DESCRIPTION
<!--- If you self compile, please state this and PLEASE try to ONLY REPORT ISSUES WITH OFFICIAL BUILDS!  --->
<!--- NOTE: This is not a support forum! For questions and support go here: --->
<!--- https://www.letscontrolit.com/forum/viewforum.php?f=1 --->
<!--- Remove topics that are not applicable to your feature request of issue --->
<!--- Remember to have a "to the point" TITLE --->

### Summarize of the problem/feature request
<!--- Describe the problem or feature request --->
added to addLog overload that supports lambda expressions

### Expected behavior
in the following example, the log string is created only when logLevel condition is satisfied.
```c++
addLog(LOG_LEVEL_INFO, [&]()
{
  String log = F("HX711: GPIO: SCL=");
  log += pinSCL;
  log += F(" DOUT=");
  log += pinDOUT;
  return log.c_str();
});
```

### Actual behavior
in the following example, whatever the logLevel value is, the log string is created.
```c++
  String log = F("HX711: GPIO: SCL=");
  log += pinSCL;
  log += F(" DOUT=");
  log += pinDOUT;
  addLog(LOG_LEVEL_INFO, log);
```


Hardware: **All**

<!--- You should also provide links to hardware pages etc where we can find more info  --->
<!--- If you self compile, please state this and PLEASE try to ONLY REPORT ISSUES WITH OFFICIAL BUILDS!  --->
ESP Easy version:  [mega-20180515](https://github.com/letscontrolit/ESPEasy/releases/tag/mega-20180515)


```

```