### PR TITLE
PCA9685 enhanced

### DIFF
--- a/src/Command.ino
+++ b/src/Command.ino
@@ -186,11 +186,15 @@ void ExecuteCommand(byte source, const char *Line)
   int Par1 = 0;
   int Par2 = 0;
   int Par3 = 0;
+  int Par4 = 0;
+  int Par5 = 0;
 
   GetArgv(Line, cmd, 1);
   if (GetArgv(Line, TmpStr1, 2)) Par1 = str2int(TmpStr1);
   if (GetArgv(Line, TmpStr1, 3)) Par2 = str2int(TmpStr1);
   if (GetArgv(Line, TmpStr1, 4)) Par3 = str2int(TmpStr1);
+  if (GetArgv(Line, TmpStr1, 5)) Par4 = str2int(TmpStr1);
+  if (GetArgv(Line, TmpStr1, 6)) Par5 = str2int(TmpStr1);
 
   const Command cmd_enum = commandStringToEnum(cmd);
   switch (cmd_enum) {

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -917,6 +917,13 @@ struct EventStruct
     Source(0), TaskIndex(0), ControllerIndex(0), ProtocolIndex(0), NotificationIndex(0),
     BaseVarIndex(0), idx(0), sensorType(0), Par1(0), Par2(0), Par3(0), Par4(0), Par5(0),
     OriginTaskIndex(0), Data(NULL) {}
+  EventStruct(const struct EventStruct& event):
+        Source(event.Source), TaskIndex(event.TaskIndex), ControllerIndex(event.ControllerIndex)
+        , ProtocolIndex(event.ProtocolIndex), NotificationIndex(event.NotificationIndex)
+        , BaseVarIndex(event.BaseVarIndex), idx(event.idx), sensorType(event.sensorType)
+        , Par1(event.Par1), Par2(event.Par2), Par3(event.Par3), Par4(event.Par4), Par5(event.Par5)
+        , OriginTaskIndex(event.OriginTaskIndex), Data(event.Data) {}
+
   byte Source;
   byte TaskIndex; // index position in TaskSettings array, 0-11
   byte ControllerIndex; // index position in Settings.Controller, 0-3

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -1126,11 +1126,11 @@ struct systemTimerStruct
   unsigned long timer;
   byte plugin;
   int16_t TaskIndex;
-  byte Par1;
-  byte Par2;
-  byte Par3;
-  byte Par4;
-  byte Par5;
+  int Par1;
+  int Par2;
+  int Par3;
+  int Par4;
+  int Par5;
 } systemTimers[SYSTEM_TIMER_MAX];
 
 #define NOTAVAILABLE_SYSTEM_TIMER_ERROR "There are no system timer available, max parallel timers are " STR(SYSTEM_TIMER_MAX)

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -1121,13 +1121,16 @@ struct NodeStruct
 struct systemTimerStruct
 {
   systemTimerStruct() :
-    timer(0), plugin(0), Par1(0), Par2(0), Par3(0) {}
+    timer(0), plugin(0), TaskIndex(-1), Par1(0), Par2(0), Par3(0), Par4(0), Par5(0) {}
 
   unsigned long timer;
   byte plugin;
+  int16_t TaskIndex;
   byte Par1;
   byte Par2;
   byte Par3;
+  byte Par4;
+  byte Par5;
 } systemTimers[SYSTEM_TIMER_MAX];
 
 #define NOTAVAILABLE_SYSTEM_TIMER_ERROR "There are no system timer available, max parallel timers are " STR(SYSTEM_TIMER_MAX)

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -751,17 +751,22 @@ void SensorSendTask(byte TaskIndex)
 /*********************************************************************************************\
  * set global system timer
 \*********************************************************************************************/
-void setSystemTimer(unsigned long timer, byte plugin, byte Par1, byte Par2, byte Par3)
+void setSystemTimer(unsigned long timer, byte plugin, int Par1, int Par2, int Par3)
 {
   setSystemTimer(timer, plugin, -1, Par1, Par2, Par3, 0, 0);
 }
 
-void setSystemTimer(unsigned long timer, byte plugin, byte Par1, byte Par2, byte Par3, byte Par4)
+void setSystemTimer(unsigned long timer, byte plugin, short taskIndex, int Par1, int Par2, int Par3)
 {
-  setSystemTimer(timer, plugin, -1, Par1, Par2, Par3, Par4, 0);
+  setSystemTimer(timer, plugin, taskIndex , Par1, Par2, Par3, 0, 0);
 }
 
-void setSystemTimer(unsigned long timer, byte plugin,short taskIndex, byte Par1, byte Par2, byte Par3, byte Par4, byte Par5)
+void setSystemTimer(unsigned long timer, byte plugin, short taskIndex, int Par1, int Par2, int Par3, int Par4)
+{
+  setSystemTimer(timer, plugin, taskIndex , Par1, Par2, Par3, Par4, 0);
+}
+
+void setSystemTimer(unsigned long timer, byte plugin, short taskIndex, int Par1, int Par2, int Par3, int Par4, int Par5)
 {
   // plugin number and par1 form a unique key that can be used to restart a timer
   // first check if a timer is not already running for this request

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -753,18 +753,26 @@ void SensorSendTask(byte TaskIndex)
 \*********************************************************************************************/
 void setSystemTimer(unsigned long timer, byte plugin, byte Par1, byte Par2, byte Par3)
 {
+  setSystemTimer(timer, plugin, -1, Par1, Par2, Par3, 0, 0);
+}
+
+void setSystemTimer(unsigned long timer, byte plugin, byte Par1, byte Par2, byte Par3, byte Par4)
+{
+  setSystemTimer(timer, plugin, -1, Par1, Par2, Par3, Par4, 0);
+}
+
+void setSystemTimer(unsigned long timer, byte plugin,short taskIndex, byte Par1, byte Par2, byte Par3, byte Par4, byte Par5)
+{
   // plugin number and par1 form a unique key that can be used to restart a timer
   // first check if a timer is not already running for this request
-  boolean reUse = false;
   byte firstAvailable = SYSTEM_TIMER_MAX;
   for (byte x = 0; x < SYSTEM_TIMER_MAX; x++)
   {
     if (systemTimers[x].timer != 0)
     {
-      if ((systemTimers[x].plugin == plugin) && (systemTimers[x].Par1 == Par1))
-      {
-        systemTimers[x].timer = millis() + timer;
-        reUse = true;
+      if ((systemTimers[x].plugin == plugin) && systemTimers[x].TaskIndex == taskIndex && (systemTimers[x].Par1 == Par1))
+      {        
+        firstAvailable = x;
         break;
       }
     }
@@ -773,23 +781,25 @@ void setSystemTimer(unsigned long timer, byte plugin, byte Par1, byte Par2, byte
       firstAvailable = x;
     }
   }
-  if (!reUse)
+  if (firstAvailable == SYSTEM_TIMER_MAX )
   {
-    if (firstAvailable == SYSTEM_TIMER_MAX )
-    {
-      addLog(LOG_LEVEL_ERROR, F(NOTAVAILABLE_SYSTEM_TIMER_ERROR));
-    }
-    else
-    {
-      systemTimers[firstAvailable].timer = millis() + timer;
-      systemTimers[firstAvailable].plugin = plugin;
-      systemTimers[firstAvailable].Par1 = Par1;
-      systemTimers[firstAvailable].Par2 = Par2;
-      systemTimers[firstAvailable].Par3 = Par3;
-    }
+    addLog(LOG_LEVEL_ERROR, F(NOTAVAILABLE_SYSTEM_TIMER_ERROR));
   }
+  else
+  {    
+    systemTimers[firstAvailable].plugin = plugin;
+    systemTimers[firstAvailable].TaskIndex = taskIndex;
+    systemTimers[firstAvailable].Par1 = Par1;
+    systemTimers[firstAvailable].Par2 = Par2;
+    systemTimers[firstAvailable].Par3 = Par3;
+    systemTimers[firstAvailable].Par4 = Par4;
+    systemTimers[firstAvailable].Par5 = Par5;
+    systemTimers[firstAvailable].timer = timer > 0
+      ? millis() + timer
+      : 0;
+  }
+  
 }
-
 
 //EDWIN: this function seems to be unused?
 /*********************************************************************************************\
@@ -818,13 +828,16 @@ void checkSystemTimers()
       if (timeOutReached(systemTimers[x].timer))
       {
         struct EventStruct TempEvent;
+        TempEvent.TaskIndex = systemTimers[x].TaskIndex;
         TempEvent.Par1 = systemTimers[x].Par1;
         TempEvent.Par2 = systemTimers[x].Par2;
         TempEvent.Par3 = systemTimers[x].Par3;
+        TempEvent.Par4 = systemTimers[x].Par4;
+        TempEvent.Par5 = systemTimers[x].Par5;
+        systemTimers[x].timer = 0;
         for (byte y = 0; y < PLUGIN_MAX; y++)
           if (Plugin_id[y] == systemTimers[x].plugin)
             Plugin_ptr[y](PLUGIN_TIMER_IN, &TempEvent, dummyString);
-        systemTimers[x].timer = 0;
       }
     }
 

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -608,7 +608,7 @@ boolean GetArgv(const char *string, char *argv, unsigned int argc)
     else if  (!parenthesis && c == ',' && d == ' ') {}
     else if  (!parenthesis && c == ' ' && d >= 33 && d <= 126) {}
     else if  (!parenthesis && c == ',' && d >= 33 && d <= 126) {}
-    else if  (c == '"') {
+    else if  (c == '"' || c == '[') {
       parenthesis = true;
     }
     else
@@ -616,9 +616,9 @@ boolean GetArgv(const char *string, char *argv, unsigned int argc)
       argv[argv_pos++] = c;
       argv[argv_pos] = 0;
 
-      if ((!parenthesis && (d == ' ' || d == ',' || d == 0)) || (parenthesis && d == '"')) // end of word
+      if ((!parenthesis && (d == ' ' || d == ',' || d == 0)) || (parenthesis && (d == '"' || d == ']'))) // end of word
       {
-        if (d == '"')
+        if (d == '"' || d == ']')
           parenthesis = false;
         argv[argv_pos] = 0;
         argc_pos++;
@@ -2550,6 +2550,10 @@ boolean ruleMatch(String& event, String& rule)
   boolean match = false;
   String tmpEvent = event;
   String tmpRule = rule;
+
+  //Ignore escape char
+  tmpRule.replace(F("["),F(""));
+  tmpRule.replace(F("]"),F(""));
 
   // Special handling of literal string events, they should start with '!'
   if (event.charAt(0) == '!')

--- a/src/_P022_PCA9685.ino
+++ b/src/_P022_PCA9685.ino
@@ -62,7 +62,25 @@ boolean Plugin_022(byte function, struct EventStruct *event, String& string)
     case PLUGIN_WRITE:
       {
         String log = "";
-        String command = parseString(string, 1);
+        String line = String(string);
+        String command = "";
+        int dotPos = line.indexOf('.');
+        if(dotPos > -1)
+        {
+          LoadTaskSettings(event->TaskIndex);
+          String name = line.substring(0,dotPos);
+          name.replace(F("["),F(""));
+          name.replace(F("]"),F(""));
+          if(name.equalsIgnoreCase(ExtraTaskSettings.TaskDeviceName) == true)
+          {
+            line = line.substring(dotPos + 1);
+          }
+          else
+          {
+             break;
+          }
+        }
+        command = parseString(line, 1);
 
         if (command == F("pcapwm"))
         {
@@ -87,7 +105,7 @@ boolean Plugin_022(byte function, struct EventStruct *event, String& string)
 
         if (command == F("status"))
         {
-          if (parseString(string, 2) == F("pca"))
+          if (parseString(line, 2) == F("pca"))
           {
             if (!IS_INIT(initializeState, port)) Plugin_022_initialize(port);
             success = true;

--- a/src/_P022_PCA9685.ino
+++ b/src/_P022_PCA9685.ino
@@ -14,6 +14,8 @@
 #define PCA9685_ADDRESS 0x40  // I2C address
 #define PCA9685_MAX_PINS  15
 #define PCA9685_MAX_PWM 4095
+#define PCA9685_MIN_FREQUENCY   23.0 // Min possible PWM cycle frequency
+#define PCA9685_MAX_FREQUENCY   1500.0 // Max possible PWM cycle frequency
 
 /*
 is bit flag any bit rapresent the initialization state of PCA9685 
@@ -111,13 +113,21 @@ boolean Plugin_022(byte function, struct EventStruct *event, String& string)
         }
         if (command == F("pcafrq"))
         {
-          if (!IS_INIT(initializeState, port)) Plugin_022_initialize(port);
           success = true;
-          Plugin_022_Frequency(port, event->Par1);
-          setPinState(PLUGIN_ID_022, 99, PIN_MODE_UNDEFINED, event->Par1);
-          log = String(F("PCA 0x")) + String(PCA9685_ADDRESS + port, HEX) + String(F(": FREQ ")) + String(event->Par1);
-          addLog(LOG_LEVEL_INFO, log);
-          SendStatus(event->Source, getPinStateJSON(SEARCH_PIN_STATE, PLUGIN_ID_022, 99, log, 0));
+          if(event->Par1 >= PCA9685_MIN_FREQUENCY && event->Par1 <= PCA9685_MAX_FREQUENCY)
+          {          
+            if (!IS_INIT(initializeState, port)) Plugin_022_initialize(port);
+
+            Plugin_022_Frequency(port, event->Par1);
+            setPinState(PLUGIN_ID_022, 99, PIN_MODE_UNDEFINED, event->Par1);
+            log = String(F("PCA 0x")) + String(PCA9685_ADDRESS + port) + String(F(": FREQ ")) + String(event->Par1);
+            addLog(LOG_LEVEL_INFO, log);
+            SendStatus(event->Source, getPinStateJSON(SEARCH_PIN_STATE, PLUGIN_ID_022, 99, log, 0));
+          }
+          else{
+            addLog(LOG_LEVEL_ERROR,String(F("PCA ")) + String(PCA9685_ADDRESS + port, HEX) + String(F(" The frequesncy ")) + String(event->Par1) + String(F(" is out of range.")));
+          } 
+
         }
 
         if (command == F("status"))

--- a/src/_P022_PCA9685.ino
+++ b/src/_P022_PCA9685.ino
@@ -111,7 +111,7 @@ boolean Plugin_022(byte function, struct EventStruct *event, String& string)
             addLog(LOG_LEVEL_ERROR, log + String(F(" is invalid value.")));
           }
         }
-        if (command == F("pcafrq"))
+        if (command == F("pcafrq") || (istanceCommand && command == F("frq")))
         {
           success = true;
           if(event->Par1 >= PCA9685_MIN_FREQUENCY && event->Par1 <= PCA9685_MAX_FREQUENCY)

--- a/src/_P022_PCA9685.ino
+++ b/src/_P022_PCA9685.ino
@@ -67,6 +67,7 @@ boolean Plugin_022(byte function, struct EventStruct *event, String& string)
         String line = String(string);
         String command = "";
         int dotPos = line.indexOf('.');
+        bool istanceCommand = false;
         if(dotPos > -1)
         {
           LoadTaskSettings(event->TaskIndex);
@@ -76,6 +77,7 @@ boolean Plugin_022(byte function, struct EventStruct *event, String& string)
           if(name.equalsIgnoreCase(ExtraTaskSettings.TaskDeviceName) == true)
           {
             line = line.substring(dotPos + 1);
+            istanceCommand = true;
           }
           else
           {
@@ -84,7 +86,7 @@ boolean Plugin_022(byte function, struct EventStruct *event, String& string)
         }
         command = parseString(line, 1);
 
-        if (command == F("pcapwm"))
+        if (command == F("pcapwm") || (istanceCommand && command == F("pwm")))
         {
           success = true;
           log = String(F("PCA 0x")) + String(PCA9685_ADDRESS + port, HEX) + String(F(": GPIO ")) + String(event->Par1);

--- a/src/_P022_PCA9685.ino
+++ b/src/_P022_PCA9685.ino
@@ -87,8 +87,8 @@ boolean Plugin_022(byte function, struct EventStruct *event, String& string)
         if (command == F("pcapwm"))
         {
           success = true;
-          log = String(F("PCA ")) + String(PCA9685_ADDRESS + port) + String(F(": GPIO ")) + String(event->Par1);
-          if(event->Par1 >=0 && event->Par1 <= PCA9685_MAX_PINS)
+          log = String(F("PCA 0x")) + String(PCA9685_ADDRESS + port, HEX) + String(F(": GPIO ")) + String(event->Par1);
+          if(event->Par1 >= 0 && event->Par1 <= PCA9685_MAX_PINS)
           {
             if(event->Par2 >=0 && event->Par2 <= PCA9685_MAX_PWM)
             {
@@ -96,7 +96,6 @@ boolean Plugin_022(byte function, struct EventStruct *event, String& string)
               
               Plugin_022_Write(port, event->Par1, event->Par2);
               setPinState(PLUGIN_ID_022, event->Par1, PIN_MODE_PWM, event->Par2);
-              log += String(F(" Set PWM to ")) + String(event->Par2);
               addLog(LOG_LEVEL_INFO, log);
               SendStatus(event->Source, getPinStateJSON(SEARCH_PIN_STATE, PLUGIN_ID_022, event->Par1, log, 0));
             }
@@ -114,7 +113,7 @@ boolean Plugin_022(byte function, struct EventStruct *event, String& string)
           success = true;
           Plugin_022_Frequency(port, event->Par1);
           setPinState(PLUGIN_ID_022, 99, PIN_MODE_UNDEFINED, event->Par1);
-          log = String(F("PCA ")) + String(PCA9685_ADDRESS + port) + String(F(": FREQ ")) + String(event->Par1);
+          log = String(F("PCA 0x")) + String(PCA9685_ADDRESS + port, HEX) + String(F(": FREQ ")) + String(event->Par1);
           addLog(LOG_LEVEL_INFO, log);
           SendStatus(event->Source, getPinStateJSON(SEARCH_PIN_STATE, PLUGIN_ID_022, 99, log, 0));
         }

--- a/src/_P022_PCA9685.ino
+++ b/src/_P022_PCA9685.ino
@@ -139,6 +139,34 @@ boolean Plugin_022(byte function, struct EventStruct *event, String& string)
             SendStatus(event->Source, getPinStateJSON(SEARCH_PIN_STATE, PLUGIN_ID_022, event->Par2, dummyString, 0));
           }
         }
+
+        if(dotPos >- 1 && command == F("gpio"))
+        {
+          success = true;
+          log = String(F("PCA 0x")) + String(PCA9685_ADDRESS + port, HEX) + String(F(": GPIO ")) + String(event->Par1);
+          if(event->Par1>=0 && event->Par1 <= PCA9685_MAX_PINS)
+          {
+            if (!IS_INIT(initializeState, port)) Plugin_022_initialize(port);
+
+            if(event->Par2 == 0)
+            {
+              log += F(" off");
+              Plugin_022_Off(port, event->Par1);
+            }
+            else
+            {
+              log += F(" on");
+              Plugin_022_On(port, event->Par1);              
+            }
+            setPinState(PLUGIN_ID_022, event->Par1, PIN_MODE_OUTPUT, event->Par2);
+            addLog(LOG_LEVEL_INFO, log);
+            SendStatus(event->Source, getPinStateJSON(SEARCH_PIN_STATE, PLUGIN_ID_022, event->Par1, log, 0));
+          }
+          else{
+            addLog(LOG_LEVEL_ERROR, log + String(F(" is invalid value.")));
+          }
+
+        }
         break;
       }
   }
@@ -169,6 +197,16 @@ uint8_t Plugin_022_readRegister(int i2cAddress, int regAddress) {
 //********************************************************************************
 // PCA9685 write
 //********************************************************************************
+void Plugin_022_Off(int port, byte pin)
+{
+  Plugin_022_Write(port, pin, 0);
+}
+
+void Plugin_022_On(int port, byte pin)
+{
+  Plugin_022_Write(port, pin, PCA9685_MAX_PWM);
+}
+
 void Plugin_022_Write(int port, byte Par1, int Par2)
 {
   int i2cAddress = PCA9685_ADDRESS + port;
@@ -183,6 +221,7 @@ void Plugin_022_Write(int port, byte Par1, int Par2)
   Wire.write(highByte(LED_OFF));
   Wire.endTransmission();
 }
+
 void Plugin_022_Frequency(int port, uint16_t freq)
 {
   int i2cAddress = PCA9685_ADDRESS + port;

--- a/src/__Plugin.ino
+++ b/src/__Plugin.ino
@@ -1068,6 +1068,8 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
 
   if (event == 0)
     event = &TempEvent;
+  else
+    TempEvent = (*event);
 
   switch (Function)
   {
@@ -1091,24 +1093,9 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
             if (Settings.TaskDeviceDataFeed[y] == 0) // these calls only to tasks with local feed
             {
               byte DeviceIndex = getDeviceIndex(Settings.TaskDeviceNumber[y]);
-              TempEvent.Source = event->Source;
               TempEvent.TaskIndex = y;
               TempEvent.BaseVarIndex = y * VARS_PER_TASK;
               TempEvent.sensorType = Device[DeviceIndex].VType;
-              TempEvent.OriginTaskIndex = event->TaskIndex;
-              TempEvent.Par1 = event->Par1;
-              TempEvent.Par2 = event->Par2;
-              TempEvent.Par3 = event->Par3;
-              TempEvent.Par4 = event->Par4;
-              TempEvent.Par5 = event->Par5;
-              TempEvent.String1 = event->String1;
-              TempEvent.String2 = event->String2;
-              TempEvent.String3 = event->String3;
-              TempEvent.ControllerIndex = event->ControllerIndex;
-              TempEvent.ProtocolIndex = event->ProtocolIndex;
-              TempEvent.NotificationIndex = event->NotificationIndex;
-              TempEvent.Data = event->Data;
-              TempEvent.idx = event->idx;
               for (x = 0; x < PLUGIN_MAX; x++)
               {
                 if (Plugin_id[x] == Settings.TaskDeviceNumber[y])


### PR DESCRIPTION
<!--- If you self compile, please state this and PLEASE try to ONLY REPORT ISSUES WITH OFFICIAL BUILDS!  --->
<!--- NOTE: This is not a support forum! For questions and support go here: --->
<!--- https://www.letscontrolit.com/forum/viewforum.php?f=1 --->
<!--- Remove topics that are not applicable to your feature request of issue --->
<!--- Remember to have a "to the point" TITLE --->

## Summarize of the problem/feature request
<!--- Describe the problem or feature request --->
Added functions and advanced customizations

## Expected behavior
<!--- Tell us what should happen? --->
1. Customization of the i2c address is allowed
2. Multiple instances using the example task name: Extender.pcafrq where "Extender" is the name of the task. If the task name contains spaces you must enclose it in square brackets.
3. Added the **pwm** named instance command as an alias of pcapwm 
4. Added the **frq** named instance command as an alias of pcafrq for the named instance
5. Added the **gpio** named instance command.  
6. Added the **pulse** named instance command

### New commads specs:

#### GPIO
gpio like the standard [gpio](https://www.letscontrolit.com/wiki/index.php/GPIO) command have 2 parameters. 

- The first parameter represent the number of I/O you would control, the valid value are from 0 to 15 and "All". "All" is special value allow to controlling all I/O in same command.
- The second is the state of I/O 1 (HIGH), 2 (LOW) 

Examples:
```c
//Suppesed the task name is extender
extender.gpio 1,1    // set HIGH I/0 number 1
extender.gpio All,0  // set low all I/0
```

#### Pulse
Pulse is similar to the standard command [pulse](https://www.letscontrolit.com/wiki/index.php/GPIO) but has 4 parameters.

- The first parameter represent the number of I/O you would control, the valid value are from 0 to 15.
- The second is the  initial state of I/O 1 (HIGH), 2 (LOW) 
- The third is duration of pulse in milliseconds
- The fourth is optional and rapprensent the number of front changes before stop. The valid values are: auto, -1 and any positive number from 0 to 2.147.483.647.  "Auto" and -1 execute the pulse command indefinitely. 

Examples:
```c
//Suppesed the task name is extender
extender.pulse 2,1,500      // generate front form HIGH to LOW. The transaction duration is 500 ms 
extender.pulse 2,1,500,3    // generate front form HIGH -> LOW-> HIGH. The transaction duration is 500ms
extender.pulse 2,1,500,auto // generate infinite transaction
extender.pulse 2,1,0,0      // Set HIGH the I/O and stop infinite. 
```
## Actual behavior
<!--- Tell us what happens instead? --->

1.  Only one istance of this
2.  i2c Address blocked on 0x40


