### PR TITLE
[MQTT Import] system variables support for topics

### DIFF
--- a/src/_P037_MQTTImport.ino
+++ b/src/_P037_MQTTImport.ino
@@ -219,7 +219,7 @@ boolean Plugin_037(byte function, struct EventStruct *event, String& string)
           if (subscriptionTopic.length() == 0) continue;							// skip blank subscriptions
 
           // Now check if the incoming topic matches one of our subscriptions
-
+          parseSystemVariables(subscriptionTopic, false);
           if (MQTTCheckSubscription_037(Topic, subscriptionTopic))
           {
             UserVar[event->BaseVarIndex + x] = floatPayload;							// Save the new value
@@ -282,6 +282,7 @@ boolean MQTTSubscribe_037()
 
         if (subscribeTo.length() > 0)
         {
+          parseSystemVariables(subscribeTo, false);
           if (MQTTclient_037->subscribe(subscribeTo.c_str()))
           {
             String log = F("IMPT : [");


### PR DESCRIPTION
I was wondering why system variables are not parsed in the MQTT Import plug-in? A use-case would be to use `%sysname%` for topic subscriptions (e.g. `/%sysname%/relay/state`).
In case this was just forgotten, this patch adds this functionality by calling `parseSystemVariables` on the subscription topic strings (as done similarly in `Controller.ino`).

PS: Thank you for ESPEasy - this makes setting up sensors a breeze. Keep up the good work! :+1: