### PR TITLE
[GPIO command] work-around as long as gpio command is still performed in P001

### DIFF
--- a/src/__Plugin.ino
+++ b/src/__Plugin.ino
@@ -1110,6 +1110,11 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
             }
           }
         }
+        // @FIXME TD-er: work-around as long as gpio command is still performed in P001_switch.
+        for (x = 0; x < PLUGIN_MAX; x++)
+          if (Plugin_id[x] != 0)
+            if (Plugin_ptr[x](Function, event, str))
+              return true;
       }
       break;
 


### PR DESCRIPTION
As preparation to remove global commands from P001_switch.
As discussed in #1477