### PR TITLE
[BMx280] Send data from BMP280 as temp_baro, not temp_hum_baro

### DIFF
--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -316,6 +316,7 @@
 #define SENSOR_TYPE_DUAL                    5
 #define SENSOR_TYPE_TRIPLE                  6
 #define SENSOR_TYPE_QUAD                    7
+#define SENSOR_TYPE_TEMP_EMPTY_BARO         8
 #define SENSOR_TYPE_SWITCH                 10
 #define SENSOR_TYPE_DIMMER                 11
 #define SENSOR_TYPE_LONG                   20

--- a/src/_C001.ino
+++ b/src/_C001.ino
@@ -105,6 +105,7 @@ boolean CPlugin_001(byte function, struct EventStruct *event, String& string)
             case SENSOR_TYPE_QUAD:
             case SENSOR_TYPE_TEMP_HUM:
             case SENSOR_TYPE_TEMP_BARO:
+            case SENSOR_TYPE_TEMP_EMPTY_BARO:
             case SENSOR_TYPE_TEMP_HUM_BARO:
             case SENSOR_TYPE_WIND:
             default:

--- a/src/_C002.ino
+++ b/src/_C002.ino
@@ -175,6 +175,7 @@ boolean CPlugin_002(byte function, struct EventStruct *event, String& string)
             case SENSOR_TYPE_QUAD:
             case SENSOR_TYPE_TEMP_HUM:
             case SENSOR_TYPE_TEMP_BARO:
+            case SENSOR_TYPE_TEMP_EMPTY_BARO:
             case SENSOR_TYPE_TEMP_HUM_BARO:
             case SENSOR_TYPE_WIND:
             default:

--- a/src/_CPlugin_DomoticzHelper.ino
+++ b/src/_CPlugin_DomoticzHelper.ino
@@ -82,6 +82,14 @@ String formatDomoticzSensorType(struct EventStruct *event) {
       values += formatUserVarDomoticz(0);         // BAR_FOR = Barometer forecast
       values += formatUserVarDomoticz(0);         // ALTITUDE= Not used at the moment, can be 0
       break;
+    case SENSOR_TYPE_TEMP_EMPTY_BARO:
+      // temp + bar + bar_fore, used for BMP280
+      // http://www.domoticz.com/wiki/Domoticz_API/JSON_URL%27s#Temperature.2Fbarometer
+      values  = formatUserVarDomoticz(event, 0);  // TEMP = Temperature
+      values += formatUserVarDomoticz(event, 2);  // BAR = Barometric pressure
+      values += formatUserVarDomoticz(0);         // BAR_FOR = Barometer forecast
+      values += formatUserVarDomoticz(0);         // ALTITUDE= Not used at the moment, can be 0
+      break;
     case SENSOR_TYPE_TRIPLE:
       values  = formatUserVarDomoticz(event, 0);
       values += formatUserVarDomoticz(event, 1);

--- a/src/_CPlugin_SensorTypeHelper.ino
+++ b/src/_CPlugin_SensorTypeHelper.ino
@@ -16,6 +16,7 @@ byte getValueCountFromSensorType(byte sensorType)
       return 1;
     case SENSOR_TYPE_TEMP_HUM:
     case SENSOR_TYPE_TEMP_BARO:
+    case SENSOR_TYPE_TEMP_EMPTY_BARO:
     case SENSOR_TYPE_DUAL:
       return 2;
     case SENSOR_TYPE_TEMP_HUM_BARO:

--- a/src/_P028_BME280.ino
+++ b/src/_P028_BME280.ino
@@ -279,6 +279,10 @@ boolean Plugin_028(byte function, struct EventStruct *event, String& string)
           success = false;
           break;
         }
+        if (!sensor.hasHumidity()) {
+          // Patch the sensor type to output only the measured values.
+          event->sensorType = SENSOR_TYPE_TEMP_EMPTY_BARO;
+        }
         UserVar[event->BaseVarIndex] = sensor.last_temp_val;
         UserVar[event->BaseVarIndex + 1] = sensor.last_hum_val;
         const int elev = Settings.TaskDevicePluginConfig[event->TaskIndex][1];
@@ -382,6 +386,8 @@ bool Plugin_028_update_measurements(const uint8_t i2cAddress, float tempOffset) 
         log += F("% => ");
         log += sensor.last_hum_val;
         log += F("%");
+      } else {
+        sensor.last_hum_val = 0.0;
       }
       log += F(" temperature ");
       log += sensor.last_temp_val;

--- a/test/controlleremu.py
+++ b/test/controlleremu.py
@@ -14,6 +14,7 @@ SENSOR_TYPE_TEMP_HUM_BARO        =   4
 SENSOR_TYPE_DUAL                 =   5
 SENSOR_TYPE_TRIPLE               =   6
 SENSOR_TYPE_QUAD                 =   7
+SENSOR_TYPE_TEMP_EMPTY_BARO      =   8
 SENSOR_TYPE_SWITCH               =  10
 SENSOR_TYPE_DIMMER               =  11
 SENSOR_TYPE_LONG                 =  20
@@ -173,6 +174,8 @@ class ControllerEmu:
                             return [svalues[0], svalues[1]]
                         elif sensor_type==SENSOR_TYPE_TEMP_BARO and len(svalues)==4:
                             return [svalues[0], svalues[1]]
+                        elif sensor_type==SENSOR_TYPE_TEMP_EMPTY_BARO and len(svalues)==4:
+                            return [svalues[0], svalues[2]]
                         elif sensor_type==SENSOR_TYPE_TRIPLE and len(svalues)==3:
                             return svalues
                         elif sensor_type==SENSOR_TYPE_TEMP_HUM_BARO and len(svalues)==5:
@@ -228,6 +231,8 @@ class ControllerEmu:
                             return [svalues[0], svalues[1]]
                         elif sensor_type==SENSOR_TYPE_TEMP_BARO and len(svalues)==4:
                             return [svalues[0], svalues[1]]
+                        elif sensor_type==SENSOR_TYPE_TEMP_EMPTY_BARO and len(svalues)==4:
+                            return [svalues[0], svalues[2]]
                         elif sensor_type==SENSOR_TYPE_TRIPLE and len(svalues)==3:
                             return svalues
                         elif sensor_type==SENSOR_TYPE_TEMP_HUM_BARO and len(svalues)==5:


### PR DESCRIPTION
The plugin BMx280 can handle BMP280 and BME280.
The BMP version has no humidity sensor.
For Domoticz you have to send the data formatted differently.

Now the same plugin can be used for both BME280 and BMP280 and the settings in Domoticz can be set accordingly.