### PR TITLE
Ammended central I2C fuctions (#1417)

### DIFF
--- a/src/I2C.ino
+++ b/src/I2C.ino
@@ -41,6 +41,24 @@ bool I2C_write8_reg(uint8_t i2caddr, byte reg, byte value) {
 }
 
 //**************************************************************************/
+// Writes an 16 bit value over I2C to a register
+//**************************************************************************/
+bool I2C_write16_reg(uint8_t i2caddr, byte reg, uint16_t value) {
+  Wire.beginTransmission(i2caddr);
+  Wire.write((uint8_t)reg);
+  Wire.write((uint8_t)(value >> 8));
+  Wire.write((uint8_t)value);
+  return (Wire.endTransmission() == 0);
+}
+
+//**************************************************************************/
+// Writes an 16 bit value over I2C to a register
+//**************************************************************************/
+bool I2C_write16_LE_reg(uint8_t i2caddr, byte reg, uint16_t value) {
+  return (I2C_write16_reg(i2caddr, reg, (value << 8)|(value >> 8)));
+}
+
+//**************************************************************************/
 // Reads an 8 bit value from a register over I2C
 //**************************************************************************/
 uint8_t I2C_read8_reg(uint8_t i2caddr, byte reg, bool * is_ok) {
@@ -48,12 +66,13 @@ uint8_t I2C_read8_reg(uint8_t i2caddr, byte reg, bool * is_ok) {
 
   Wire.beginTransmission(i2caddr);
   Wire.write((uint8_t)reg);
-  Wire.endTransmission();
+  Wire.endTransmission(false);
   byte count = Wire.requestFrom(i2caddr, (byte)1);
   if (is_ok != NULL) {
     *is_ok = (count == 1);
   }
   value = Wire.read();
+
   return value;
 }
 
@@ -65,7 +84,7 @@ uint16_t I2C_read16_reg(uint8_t i2caddr, byte reg) {
 
   Wire.beginTransmission(i2caddr);
   Wire.write((uint8_t)reg);
-  Wire.endTransmission();
+  Wire.endTransmission(false);
   Wire.requestFrom(i2caddr, (byte)2);
   value = (Wire.read() << 8) | Wire.read();
 
@@ -80,9 +99,24 @@ int32_t I2C_read24_reg(uint8_t i2caddr, byte reg) {
 
   Wire.beginTransmission(i2caddr);
   Wire.write((uint8_t)reg);
-  Wire.endTransmission();
+  Wire.endTransmission(false);
   Wire.requestFrom(i2caddr, (byte)3);
   value = (((int32_t)Wire.read()) << 16) | (Wire.read() << 8) | Wire.read();
+
+  return value;
+}
+
+//**************************************************************************/
+// Reads a 32 bit value starting at a given register over I2C
+//**************************************************************************/
+int32_t I2C_read32_reg(uint8_t i2caddr, byte reg) {
+  int32_t value;
+
+  Wire.beginTransmission(i2caddr);
+  Wire.write((uint8_t)reg);
+  Wire.endTransmission(false);
+  Wire.requestFrom(i2caddr, (byte)3);
+  value = (((int32_t)Wire.read()) <<24) | (((uint32_t)Wire.read()) << 16) | (Wire.read() << 8) | Wire.read();
 
   return value;
 }


### PR DESCRIPTION
Ammended central I2C functions with 16bit write and 32bit read.
also added "false" parameter to wire.endTransmission before wire.requestForm

all as discussed in issue #1417