### PR TITLE
[ESP8285] PlatformIO set max upload size limit

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -21,11 +21,11 @@
 
 #minimal version for esps with 512K or less flash (only has minimal plugin set)
 ; [env:mini_512]
-; platform         = ${common.platform}
-; framework        = ${common.framework}
+; platform                  = ${common.platform}
+; framework                 = ${common.framework}
 ; board = esp01
-; upload_speed     = ${common.upload_speed}
-; build_flags      = !echo -Wl,-Tesp8266.flash.512k64.ld -D BUILD_GIT=\'\"$(git describe)\"\'
+; upload_speed              = ${common.upload_speed}
+; build_flags               = !echo -Wl,-Tesp8266.flash.512k64.ld -D BUILD_GIT=\'\"$(git describe)\"\'
 ; # upload_port = /dev/ttyUSB0
 
 # add these:
@@ -40,7 +40,7 @@ build_flags =
 ##########################################################################################
 
 ###### Definition cheat sheet:
-# board_flash_mode in terms of performance: QIO > QOUT > DIO > DOUT
+# board_build.flash_mode in terms of performance: QIO > QOUT > DIO > DOUT
 # for lib_ldf_mode, see http://docs.platformio.org/en/latest/librarymanager/ldf.html#ldf
 
 ###### Frequently used build flags:
@@ -48,88 +48,92 @@ build_flags =
 # Set VCC mode to measure Vcc of ESP chip :                   -D FEATURE_ADC_VCC=true
 
 [core_2_3_0]
-platform         = espressif8266@1.5.0
+platform                  = espressif8266@1.5.0
 
 [core_2_4_0]
-platform         = espressif8266@1.6.0
+platform                  = espressif8266@1.6.0
 
 [core_2_4_1]
-platform         = espressif8266@1.7.1
+platform                  = espressif8266@1.7.1
 
 [core_staged]
-platform         = https://github.com/platformio/platform-espressif8266.git#feature/stage
+platform                  = https://github.com/platformio/platform-espressif8266.git#feature/stage
 
 
 [core_esp32_0_12_0]
-platform         = espressif32@0.12.0
+platform                  = espressif32@0.12.0
 
 [core_esp32_1_0_2]
-platform         = espressif32@1.0.2
+platform                  = espressif32@1.0.2
 
 [core_esp32_stage]
-platform         = https://github.com/platformio/platform-espressif32.git#feature/stage
+platform                  = https://github.com/platformio/platform-espressif32.git#feature/stage
 
 [core_esp32]
-platform         = ${core_esp32_0_12_0.platform}
-build_flags      = -D BUILD_GIT='"${env.TRAVIS_TAG}"'
+platform                  = ${core_esp32_0_12_0.platform}
+build_flags               = -D BUILD_GIT='"${env.TRAVIS_TAG}"'
                    -lstdc++ -lsupc++
-lib_ignore       = ESPeasySoftwareSerial, EspESPeasySoftwareSerial, AS_BH1750, ESP8266WiFi, ESP8266Ping, ESP8266WebServer, ESP8266HTTPUpdateServer, ESP8266mDNS, IRremoteESP8266, ESPEasy_ESP8266Ping, SerialSensors
-lib_deps         = ESP32WebServer
+lib_ignore                = ESPeasySoftwareSerial, EspESPeasySoftwareSerial, AS_BH1750, ESP8266WiFi, ESP8266Ping, ESP8266WebServer, ESP8266HTTPUpdateServer, ESP8266mDNS, IRremoteESP8266, ESPEasy_ESP8266Ping, SerialSensors
+lib_deps                  = ESP32WebServer
 
 
 [common]
-build_flags      = -D BUILD_GIT='"${env.TRAVIS_TAG}"'  ; ${compiler_warnings.build_flags}
+build_flags               = -D BUILD_GIT='"${env.TRAVIS_TAG}"'  ; ${compiler_warnings.build_flags}
                    -D PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
                    -D NDEBUG
                    -D VTABLES_IN_FLASH
                    -lstdc++ -lsupc++
-lib_deps         = ""
-lib_ignore       = ESP32_ping, ESP32WebServer
-lib_ldf_mode     = chain
-upload_speed     = 460800
-framework        = arduino
-board            = esp12e
-platform         = ${core_2_4_1.platform}
+lib_deps                  = ""
+lib_ignore                = ESP32_ping, ESP32WebServer
+lib_ldf_mode              = chain
+upload_speed              = 460800
+framework                 = arduino
+board                     = esp12e
+platform                  = ${core_2_4_1.platform}
 
 [normal]
-platform         = ${common.platform}
+platform                  = ${common.platform}
 
 [testing]
-platform         = ${core_2_4_1.platform}
+platform                  = ${core_2_4_1.platform}
 
 [dev]
-platform         = ${core_2_4_1.platform}
+platform                  = ${core_2_4_1.platform}
 
 
 [esp8266_1M]
-board_flash_mode = dout
-build_flags      = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld
+board_build.flash_mode    = dout
+board_upload.maximum_size = 786432
+build_flags               = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld
 
 [esp8285_1M]
-board            = esp8285
-board_flash_mode = ${esp8266_1M.board_flash_mode}
-build_flags      = ${esp8266_1M.build_flags} -DESP8285
+board                     = esp8285
+board_upload.maximum_size = ${esp8266_1M.board_upload.maximum_size}
+board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
+build_flags               = ${esp8266_1M.build_flags} -DESP8285
 
 [Sonoff]
-board            = esp01_1m
-board_flash_mode = ${esp8266_1M.board_flash_mode}
-build_flags      = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld
-platform         = ${core_2_4_1.platform}
+board                     = esp01_1m
+board_upload.maximum_size = ${esp8266_1M.board_upload.maximum_size}
+board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
+build_flags               = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld
+platform                  = ${core_2_4_1.platform}
 
 [Sonoff_8285]
-board_flash_mode = ${esp8285_1M.board_flash_mode}
-board            = ${esp8285_1M.board}
-build_flags      = ${esp8285_1M.build_flags}
-platform         = ${core_2_4_1.platform}
+board_upload.maximum_size = ${esp8285_1M.board_upload.maximum_size}
+board_build.flash_mode    = ${esp8285_1M.board_build.flash_mode}
+board                     = ${esp8285_1M.board}
+build_flags               = ${esp8285_1M.build_flags}
+platform                  = ${core_2_4_1.platform}
 
 [espWroom2M]
-board_flash_mode = dout
-board            = esp_wroom_02
-build_flags      = ${common.build_flags} -Wl,-Tesp8266.flash.2m.ld
+board_build.flash_mode    = dout
+board                     = esp_wroom_02
+build_flags               = ${common.build_flags} -Wl,-Tesp8266.flash.2m.ld
 
 [esp8266_4M]
-board_flash_mode = dio
-build_flags      = ${common.build_flags} -Wl,-Tesp8266.flash.4m1m.ld
+board_build.flash_mode    = dio
+build_flags               = ${common.build_flags} -Wl,-Tesp8266.flash.4m1m.ld
 
 ### ESP32 pre-alpha test build ###########################################################
 # Very limited build for ESP32, to start testing regular building for ESP32.             #
@@ -137,14 +141,14 @@ build_flags      = ${common.build_flags} -Wl,-Tesp8266.flash.4m1m.ld
 # still trying to build the version without reading this warning.                        #
 ##########################################################################################
 [env:esp32dev]
-platform         = ${core_esp32.platform}
-board            = esp32dev
-build_flags      = ${core_esp32.build_flags}  -DPLUGIN_SET_GENERIC_ESP32
-lib_deps         = ${core_esp32.lib_deps}
-lib_ignore       = ${core_esp32.lib_ignore}
-lib_ldf_mode     = ${common.lib_ldf_mode}
-framework        = ${common.framework}
-upload_speed     = ${common.upload_speed}
+platform                  = ${core_esp32.platform}
+board                     = esp32dev
+build_flags               = ${core_esp32.build_flags}  -DPLUGIN_SET_GENERIC_ESP32
+lib_deps                  = ${core_esp32.lib_deps}
+lib_ignore                = ${core_esp32.lib_ignore}
+lib_ldf_mode              = ${common.lib_ldf_mode}
+framework                 = ${common.framework}
+upload_speed              = ${common.upload_speed}
 
 ### NORMAL (STABLE) ######################################################################
 # normal version with stable plugins                                                     #
@@ -152,51 +156,53 @@ upload_speed     = ${common.upload_speed}
 
 # NORMAL: 1024k version --------------------------
 [env:normal_ESP8266_1024]
-platform         = ${common.platform}
-lib_deps         = ${common.lib_deps}
-lib_ignore       = ${common.lib_ignore}
-lib_ldf_mode     = ${common.lib_ldf_mode}
-framework        = ${common.framework}
-upload_speed     = ${common.upload_speed}
-board            = ${common.board}
-board_flash_mode = ${esp8266_1M.board_flash_mode}
-build_flags      = ${esp8266_1M.build_flags}
+platform                  = ${common.platform}
+lib_deps                  = ${common.lib_deps}
+lib_ignore                = ${common.lib_ignore}
+lib_ldf_mode              = ${common.lib_ldf_mode}
+framework                 = ${common.framework}
+upload_speed              = ${common.upload_speed}
+board                     = ${common.board}
+board_upload.maximum_size = ${esp8266_1M.board_upload.maximum_size}
+board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
+build_flags               = ${esp8266_1M.build_flags}
 
 # NORMAL: 1024k for esp8285 ----------------------
 [env:normal_ESP8285_1024]
-platform         = ${common.platform}
-lib_deps         = ${common.lib_deps}
-lib_ignore       = ${common.lib_ignore}
-lib_ldf_mode     = ${common.lib_ldf_mode}
-framework        = ${common.framework}
-upload_speed     = ${common.upload_speed}
-board            = ${esp8285_1M.board}
-board_flash_mode = ${esp8285_1M.board_flash_mode}
-build_flags      = ${esp8285_1M.build_flags}
+platform                  = ${common.platform}
+lib_deps                  = ${common.lib_deps}
+lib_ignore                = ${common.lib_ignore}
+lib_ldf_mode              = ${common.lib_ldf_mode}
+framework                 = ${common.framework}
+upload_speed              = ${common.upload_speed}
+board                     = ${esp8285_1M.board}
+board_upload.maximum_size = ${esp8285_1M.board_upload.maximum_size}
+board_build.flash_mode    = ${esp8285_1M.board_build.flash_mode}
+build_flags               = ${esp8285_1M.build_flags}
 
 # NORMAL: 2048k version --------------------------
 [env:normal_WROOM02_2048]
-platform         = ${common.platform}
-lib_deps         = ${common.lib_deps}
-lib_ignore       = ${common.lib_ignore}
-lib_ldf_mode     = ${common.lib_ldf_mode}
-framework        = ${common.framework}
-upload_speed     = ${common.upload_speed}
-board            = ${espWroom2M.board}
-board_flash_mode = ${espWroom2M.board_flash_mode}
-build_flags      = ${espWroom2M.build_flags}
+platform                  = ${common.platform}
+lib_deps                  = ${common.lib_deps}
+lib_ignore                = ${common.lib_ignore}
+lib_ldf_mode              = ${common.lib_ldf_mode}
+framework                 = ${common.framework}
+upload_speed              = ${common.upload_speed}
+board                     = ${espWroom2M.board}
+board_build.flash_mode    = ${espWroom2M.board_build.flash_mode}
+build_flags               = ${espWroom2M.build_flags}
 
 # NORMAL: 4096k version --------------------------
 [env:normal_ESP8266_4096]
-platform         = ${common.platform}
-lib_deps         = ${common.lib_deps}
-lib_ignore       = ${common.lib_ignore}
-lib_ldf_mode     = ${common.lib_ldf_mode}
-framework        = ${common.framework}
-upload_speed     = ${common.upload_speed}
-board            = ${common.board}
-board_flash_mode = ${esp8266_4M.board_flash_mode}
-build_flags      = ${esp8266_4M.build_flags}
+platform                  = ${common.platform}
+lib_deps                  = ${common.lib_deps}
+lib_ignore                = ${common.lib_ignore}
+lib_ldf_mode              = ${common.lib_ldf_mode}
+framework                 = ${common.framework}
+upload_speed              = ${common.upload_speed}
+board                     = ${common.board}
+board_build.flash_mode    = ${esp8266_4M.board_build.flash_mode}
+build_flags               = ${esp8266_4M.build_flags}
 
 
 
@@ -206,63 +212,65 @@ build_flags      = ${esp8266_4M.build_flags}
 
 # TEST: 1024k version ----------------------------
 [env:test_ESP8266_1024]
-platform         = ${testing.platform}
-lib_deps         = ${common.lib_deps}
-lib_ignore       = ${common.lib_ignore}
-lib_ldf_mode     = ${common.lib_ldf_mode}
-framework        = ${common.framework}
-upload_speed     = ${common.upload_speed}
-board            = ${common.board}
-board_flash_mode = ${esp8266_1M.board_flash_mode}
-build_flags      = ${esp8266_1M.build_flags} -D PLUGIN_BUILD_TESTING
+platform                  = ${testing.platform}
+lib_deps                  = ${common.lib_deps}
+lib_ignore                = ${common.lib_ignore}
+lib_ldf_mode              = ${common.lib_ldf_mode}
+framework                 = ${common.framework}
+upload_speed              = ${common.upload_speed}
+board                     = ${common.board}
+board_upload.maximum_size = ${esp8266_1M.board_upload.maximum_size}
+board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
+build_flags               = ${esp8266_1M.build_flags} -D PLUGIN_BUILD_TESTING
 
 # TEST: 1024k for esp8285 ------------------------
 [env:test_ESP8285_1024]
-platform         = ${testing.platform}
-lib_deps         = ${common.lib_deps}
-lib_ignore       = ${common.lib_ignore}
-lib_ldf_mode     = ${common.lib_ldf_mode}
-framework        = ${common.framework}
-upload_speed     = ${common.upload_speed}
-board_flash_mode = ${esp8285_1M.board_flash_mode}
-board            = ${esp8285_1M.board}
-build_flags      = ${esp8285_1M.build_flags} -D PLUGIN_BUILD_TESTING
+platform                  = ${testing.platform}
+lib_deps                  = ${common.lib_deps}
+lib_ignore                = ${common.lib_ignore}
+lib_ldf_mode              = ${common.lib_ldf_mode}
+framework                 = ${common.framework}
+upload_speed              = ${common.upload_speed}
+board_upload.maximum_size = ${esp8285_1M.board_upload.maximum_size}
+board_build.flash_mode    = ${esp8285_1M.board_build.flash_mode}
+board                     = ${esp8285_1M.board}
+build_flags               = ${esp8285_1M.build_flags} -D PLUGIN_BUILD_TESTING
 
 # TEST: 2048k version ----------------------------
 [env:test_WROOM02_2048]
-platform         = ${testing.platform}
-lib_deps         = ${common.lib_deps}
-lib_ignore       = ${common.lib_ignore}
-lib_ldf_mode     = ${common.lib_ldf_mode}
-framework        = ${common.framework}
-upload_speed     = ${common.upload_speed}
-board_flash_mode = ${espWroom2M.board_flash_mode}
-board            = ${espWroom2M.board}
-build_flags      = ${espWroom2M.build_flags} -D PLUGIN_BUILD_TESTING
+platform                  = ${testing.platform}
+lib_deps                  = ${common.lib_deps}
+lib_ignore                = ${common.lib_ignore}
+lib_ldf_mode              = ${common.lib_ldf_mode}
+framework                 = ${common.framework}
+upload_speed              = ${common.upload_speed}
+board_build.flash_mode    = ${espWroom2M.board_build.flash_mode}
+board                     = ${espWroom2M.board}
+build_flags               = ${espWroom2M.build_flags} -D PLUGIN_BUILD_TESTING
 
 # TEST: 4096k version ----------------------------
 [env:test_ESP8266_4096]
-platform         = ${testing.platform}
-lib_deps         = ${common.lib_deps}
-lib_ignore       = ${common.lib_ignore}
-lib_ldf_mode     = ${common.lib_ldf_mode}
-framework        = ${common.framework}
-board            = ${common.board}
-upload_speed     = ${common.upload_speed}
-board_flash_mode = ${esp8266_4M.board_flash_mode}
-build_flags      = ${esp8266_4M.build_flags} -D PLUGIN_BUILD_TESTING
+platform                  = ${testing.platform}
+lib_deps                  = ${common.lib_deps}
+lib_ignore                = ${common.lib_ignore}
+lib_ldf_mode              = ${common.lib_ldf_mode}
+framework                 = ${common.framework}
+board                     = ${common.board}
+upload_speed              = ${common.upload_speed}
+board_build.flash_mode    = ${esp8266_4M.board_build.flash_mode}
+build_flags               = ${esp8266_4M.build_flags} -D PLUGIN_BUILD_TESTING
 
 # TEST: 4096k version + FEATURE_ADC_VCC ----------
 [env:test_ESP8266_4096_VCC]
-platform         = ${testing.platform}
-lib_deps         = ${common.lib_deps}
-lib_ignore       = ${common.lib_ignore}
-lib_ldf_mode     = ${common.lib_ldf_mode}
-framework        = ${common.framework}
-board            = ${common.board}
-upload_speed     = ${common.upload_speed}
-board_flash_mode = ${esp8266_4M.board_flash_mode}
-build_flags      = ${esp8266_4M.build_flags} -D PLUGIN_BUILD_TESTING -D FEATURE_ADC_VCC=true
+platform                  = ${testing.platform}
+lib_deps                  = ${common.lib_deps}
+lib_ignore                = ${common.lib_ignore}
+lib_ldf_mode              = ${common.lib_ldf_mode}
+framework                 = ${common.framework}
+board                     = ${common.board}
+upload_speed              = ${common.upload_speed}
+board_build.flash_mode    = ${esp8266_4M.board_build.flash_mode}
+build_flags               = ${esp8266_4M.build_flags} -D PLUGIN_BUILD_TESTING -D FEATURE_ADC_VCC=true
 
 
 
@@ -272,51 +280,53 @@ build_flags      = ${esp8266_4M.build_flags} -D PLUGIN_BUILD_TESTING -D FEATURE_
 
 # DEV : 1024k version ----------------------------
 [env:dev_ESP8266_1024]
-platform         = ${dev.platform}
-lib_deps         = ${common.lib_deps}
-lib_ignore       = ${common.lib_ignore}
-lib_ldf_mode     = ${common.lib_ldf_mode}
-framework        = ${common.framework}
-upload_speed     = ${common.upload_speed}
-board_flash_mode = ${esp8266_1M.board_flash_mode}
-board            = ${common.board}
-build_flags      = ${esp8266_1M.build_flags} -D PLUGIN_BUILD_DEV
+platform                  = ${dev.platform}
+lib_deps                  = ${common.lib_deps}
+lib_ignore                = ${common.lib_ignore}
+lib_ldf_mode              = ${common.lib_ldf_mode}
+framework                 = ${common.framework}
+upload_speed              = ${common.upload_speed}
+board_upload.maximum_size = ${esp8266_1M.board_upload.maximum_size}
+board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
+board                     = ${common.board}
+build_flags               = ${esp8266_1M.build_flags} -D PLUGIN_BUILD_DEV
 
 # DEV: 1024k for esp8285 -------------------------
 [env:dev_ESP8285_1024]
-platform         = ${dev.platform}
-lib_deps         = ${common.lib_deps}
-lib_ignore       = ${common.lib_ignore}
-lib_ldf_mode     = ${common.lib_ldf_mode}
-framework        = ${common.framework}
-upload_speed     = ${common.upload_speed}
-board_flash_mode = ${esp8285_1M.board_flash_mode}
-board            = ${esp8285_1M.board}
-build_flags      = ${esp8285_1M.build_flags} -D PLUGIN_BUILD_DEV
+platform                  = ${dev.platform}
+lib_deps                  = ${common.lib_deps}
+lib_ignore                = ${common.lib_ignore}
+lib_ldf_mode              = ${common.lib_ldf_mode}
+framework                 = ${common.framework}
+upload_speed              = ${common.upload_speed}
+board_upload.maximum_size = ${esp8285_1M.board_upload.maximum_size}
+board_build.flash_mode    = ${esp8285_1M.board_build.flash_mode}
+board                     = ${esp8285_1M.board}
+build_flags               = ${esp8285_1M.build_flags} -D PLUGIN_BUILD_DEV
 
 # DEV: 2048k version -----------------------------
 [env:dev_WROOM02_2048]
-platform         = ${dev.platform}
-lib_deps         = ${common.lib_deps}
-lib_ignore       = ${common.lib_ignore}
-lib_ldf_mode     = ${common.lib_ldf_mode}
-framework        = ${common.framework}
-upload_speed     = ${common.upload_speed}
-board_flash_mode = ${espWroom2M.board_flash_mode}
-board            = ${espWroom2M.board}
-build_flags      = ${espWroom2M.build_flags} -D PLUGIN_BUILD_DEV
+platform                  = ${dev.platform}
+lib_deps                  = ${common.lib_deps}
+lib_ignore                = ${common.lib_ignore}
+lib_ldf_mode              = ${common.lib_ldf_mode}
+framework                 = ${common.framework}
+upload_speed              = ${common.upload_speed}
+board_build.flash_mode    = ${espWroom2M.board_build.flash_mode}
+board                     = ${espWroom2M.board}
+build_flags               = ${espWroom2M.build_flags} -D PLUGIN_BUILD_DEV
 
 # DEV : 4096k version ----------------------------
 [env:dev_ESP8266_4096]
-platform         = ${dev.platform}
-lib_deps         = ${common.lib_deps}
-lib_ignore       = ${common.lib_ignore}
-lib_ldf_mode     = ${common.lib_ldf_mode}
-framework        = ${common.framework}
-board            = ${common.board}
-upload_speed     = ${common.upload_speed}
-board_flash_mode = ${esp8266_4M.board_flash_mode}
-build_flags      = ${esp8266_4M.build_flags} -D PLUGIN_BUILD_DEV
+platform                  = ${dev.platform}
+lib_deps                  = ${common.lib_deps}
+lib_ignore                = ${common.lib_ignore}
+lib_ldf_mode              = ${common.lib_ldf_mode}
+framework                 = ${common.framework}
+board                     = ${common.board}
+upload_speed              = ${common.upload_speed}
+board_build.flash_mode    = ${esp8266_4M.board_build.flash_mode}
+build_flags               = ${esp8266_4M.build_flags} -D PLUGIN_BUILD_DEV
 
 
 
@@ -326,27 +336,29 @@ build_flags      = ${esp8266_4M.build_flags} -D PLUGIN_BUILD_DEV
 
 # DEV+PUYA : 1024k version -----------------------
 [env:dev_ESP8266PUYA_1024]
-platform         = ${dev.platform}
-lib_deps         = ${common.lib_deps}
-lib_ignore       = ${common.lib_ignore}
-lib_ldf_mode     = ${common.lib_ldf_mode}
-framework        = ${common.framework}
-board            = ${common.board}
-upload_speed     = ${common.upload_speed}
-board_flash_mode = ${esp8266_1M.board_flash_mode}
-build_flags      = ${esp8266_1M.build_flags} -D PLUGIN_BUILD_DEV -D FLASH_QUIRK_WRITE_0_TO_1
+platform                  = ${dev.platform}
+lib_deps                  = ${common.lib_deps}
+lib_ignore                = ${common.lib_ignore}
+lib_ldf_mode              = ${common.lib_ldf_mode}
+framework                 = ${common.framework}
+board                     = ${common.board}
+upload_speed              = ${common.upload_speed}
+board_upload.maximum_size = ${esp8266_1M.board_upload.maximum_size}
+board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
+build_flags               = ${esp8266_1M.build_flags} -D PLUGIN_BUILD_DEV -D FLASH_QUIRK_WRITE_0_TO_1
 
 # DEV+PUYA : 1024k version + FEATURE_ADC_VCC -----
 [env:dev_ESP8266PUYA_1024_VCC]
-platform         = ${dev.platform}
-lib_deps         = ${common.lib_deps}
-lib_ignore       = ${common.lib_ignore}
-lib_ldf_mode     = ${common.lib_ldf_mode}
-framework        = ${common.framework}
-board            = ${common.board}
-upload_speed     = ${common.upload_speed}
-board_flash_mode = ${esp8266_1M.board_flash_mode}
-build_flags      = ${esp8266_1M.build_flags} -D PLUGIN_BUILD_DEV -D FLASH_QUIRK_WRITE_0_TO_1 -D FEATURE_ADC_VCC=true
+platform                  = ${dev.platform}
+lib_deps                  = ${common.lib_deps}
+lib_ignore                = ${common.lib_ignore}
+lib_ldf_mode              = ${common.lib_ldf_mode}
+framework                 = ${common.framework}
+board                     = ${common.board}
+upload_speed              = ${common.upload_speed}
+board_upload.maximum_size = ${esp8266_1M.board_upload.maximum_size}
+board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
+build_flags               = ${esp8266_1M.build_flags} -D PLUGIN_BUILD_DEV -D FLASH_QUIRK_WRITE_0_TO_1 -D FEATURE_ADC_VCC=true
 
 
 
@@ -359,39 +371,39 @@ build_flags      = ${esp8266_1M.build_flags} -D PLUGIN_BUILD_DEV -D FLASH_QUIRK_
 
 # ITEAD / SONOFF BASIC version ------------------
 #[env:hard_SONOFF_BASIC]
-#upload_speed     = ${common.upload_speed}
-#framework        = ${common.framework}
-#platform         = ${Sonoff.platform}
-#lib_deps         = ${common.lib_deps}
-#lib_ignore       = ${common.lib_ignore}
-#lib_ldf_mode     = ${common.lib_ldf_mode}
-#board_flash_mode = ${Sonoff.board_flash_mode}
-#board            = ${Sonoff.board}
-#build_flags      = ${Sonoff.build_flags} -D PLUGIN_SET_SONOFF_BASIC
+#upload_speed              = ${common.upload_speed}
+#framework                 = ${common.framework}
+#platform                  = ${Sonoff.platform}
+#lib_deps                  = ${common.lib_deps}
+#lib_ignore                = ${common.lib_ignore}
+#lib_ldf_mode              = ${common.lib_ldf_mode}
+#board_build.flash_mode    = ${Sonoff.board_build.flash_mode}
+#board                     = ${Sonoff.board}
+#build_flags               = ${Sonoff.build_flags} -D PLUGIN_SET_SONOFF_BASIC
 
 # ITEAD / SONOFF TH10 version -------------------
 #[env:hard_SONOFF_TH10]
-#upload_speed     = ${common.upload_speed}
-#framework        = ${common.framework}
-#platform         = ${Sonoff.platform}
-#lib_deps         = ${common.lib_deps}
-#lib_ignore       = ${common.lib_ignore}
-#lib_ldf_mode     = ${common.lib_ldf_mode}
-#board_flash_mode = ${Sonoff.board_flash_mode}
-#board            = ${Sonoff.board}
-#build_flags      = ${Sonoff.build_flags} -D PLUGIN_SET_SONOFF_TH10
+#upload_speed              = ${common.upload_speed}
+#framework                 = ${common.framework}
+#platform                  = ${Sonoff.platform}
+#lib_deps                  = ${common.lib_deps}
+#lib_ignore                = ${common.lib_ignore}
+#lib_ldf_mode              = ${common.lib_ldf_mode}
+#board_build.flash_mode    = ${Sonoff.board_build.flash_mode}
+#board                     = ${Sonoff.board}
+#build_flags               = ${Sonoff.build_flags} -D PLUGIN_SET_SONOFF_TH10
 
 # ITEAD / SONOFF TH16 version -------------------
 #[env:hard_SONOFF_TH16]
-#upload_speed     = ${common.upload_speed}
-#framework        = ${common.framework}
-#platform         = ${Sonoff.platform}
-#lib_deps         = ${common.lib_deps}
-#lib_ignore       = ${common.lib_ignore}
-#lib_ldf_mode     = ${common.lib_ldf_mode}
-#board_flash_mode = ${Sonoff.board_flash_mode}
-#board            = ${Sonoff.board}
-#build_flags      = ${Sonoff.build_flags} -D PLUGIN_SET_SONOFF_TH16
+#upload_speed              = ${common.upload_speed}
+#framework                 = ${common.framework}
+#platform                  = ${Sonoff.platform}
+#lib_deps                  = ${common.lib_deps}
+#lib_ignore                = ${common.lib_ignore}
+#lib_ldf_mode              = ${common.lib_ldf_mode}
+#board_build.flash_mode    = ${Sonoff.board_build.flash_mode}
+#board                     = ${Sonoff.board}
+#build_flags               = ${Sonoff.build_flags} -D PLUGIN_SET_SONOFF_TH16
 
 # ITEAD / SONOFF POW version --------------------
 # Sonoff Pow (ESP8266 - HLW8012)
@@ -402,15 +414,15 @@ build_flags      = ${esp8266_1M.build_flags} -D PLUGIN_BUILD_DEV -D FLASH_QUIRK_
 # GPIO14 HLW8012 CF power
 # GPIO15 Blue Led (0 = On, 1 = Off)
 [env:hard_SONOFF_POW]
-upload_speed     = ${common.upload_speed}
-framework        = ${common.framework}
-platform         = ${Sonoff.platform}
-lib_deps         = ${common.lib_deps}
-lib_ignore       = ${common.lib_ignore}
-lib_ldf_mode     = ${common.lib_ldf_mode}
-board_flash_mode = ${Sonoff.board_flash_mode}
-board            = ${Sonoff.board}
-build_flags      = ${Sonoff.build_flags} -D PLUGIN_SET_SONOFF_POW
+upload_speed              = ${common.upload_speed}
+framework                 = ${common.framework}
+platform                  = ${Sonoff.platform}
+lib_deps                  = ${common.lib_deps}
+lib_ignore                = ${common.lib_ignore}
+lib_ldf_mode              = ${common.lib_ldf_mode}
+board_build.flash_mode    = ${Sonoff.board_build.flash_mode}
+board                     = ${Sonoff.board}
+build_flags               = ${Sonoff.build_flags} -D PLUGIN_SET_SONOFF_POW
 
 # Sonoff Pow R2 (ESP8266 - CSE7766)
 # GPIO00 Button
@@ -419,51 +431,51 @@ build_flags      = ${Sonoff.build_flags} -D PLUGIN_SET_SONOFF_POW
 # GPIO12 Red Led and Relay (0 = Off, 1 = On)
 # GPIO13 Blue Led (0 = On, 1 = Off)
 [env:hard_SONOFF_POW_R2]
-upload_speed     = ${common.upload_speed}
-framework        = ${common.framework}
-platform         = ${Sonoff.platform}
-lib_deps         = ${common.lib_deps}
-lib_ignore       = ${common.lib_ignore}
-lib_ldf_mode     = ${common.lib_ldf_mode}
-board_flash_mode = ${Sonoff.board_flash_mode}
-board            = ${Sonoff.board}
-build_flags      = ${Sonoff.build_flags} -D PLUGIN_SET_SONOFF_POW_R2
+upload_speed              = ${common.upload_speed}
+framework                 = ${common.framework}
+platform                  = ${Sonoff.platform}
+lib_deps                  = ${common.lib_deps}
+lib_ignore                = ${common.lib_ignore}
+lib_ldf_mode              = ${common.lib_ldf_mode}
+board_build.flash_mode    = ${Sonoff.board_build.flash_mode}
+board                     = ${Sonoff.board}
+build_flags               = ${Sonoff.build_flags} -D PLUGIN_SET_SONOFF_POW_R2
 
 # ITEAD / SONOFF S20 version --------------------
 #[env:hard_SONOFF_S20]
-#upload_speed     = ${common.upload_speed}
-#framework        = ${common.framework}
-#platform         = ${Sonoff.platform}
-#lib_deps         = ${common.lib_deps}
-#lib_ignore       = ${common.lib_ignore}
-#lib_ldf_mode     = ${common.lib_ldf_mode}
-#board_flash_mode = ${Sonoff.board_flash_mode}
-#board            = ${Sonoff.board}
-#build_flags      = ${Sonoff.build_flags} -D PLUGIN_SET_SONOFF_S20
+#upload_speed              = ${common.upload_speed}
+#framework                 = ${common.framework}
+#platform                  = ${Sonoff.platform}
+#lib_deps                  = ${common.lib_deps}
+#lib_ignore                = ${common.lib_ignore}
+#lib_ldf_mode              = ${common.lib_ldf_mode}
+#board_build.flash_mode    = ${Sonoff.board_build.flash_mode}
+#board                     = ${Sonoff.board}
+#build_flags               = ${Sonoff.build_flags} -D PLUGIN_SET_SONOFF_S20
 
 # ITEAD / SONOFF 4CH version --------------------
 #[env:hard_SONOFF_4CH]
-#upload_speed     = ${common.upload_speed}
-#framework        = ${common.framework}
-#platform         = ${Sonoff.platform}
-#lib_deps         = ${common.lib_deps}
-#lib_ignore       = ${common.lib_ignore}
-#lib_ldf_mode     = ${common.lib_ldf_mode}
-#board_flash_mode = ${Sonoff.board_flash_mode}
-#board            = ${Sonoff.board}
-#build_flags      = ${Sonoff.build_flags} -D PLUGIN_SET_SONOFF_4CH
+#upload_speed              = ${common.upload_speed}
+#framework                 = ${common.framework}
+#platform                  = ${Sonoff.platform}
+#lib_deps                  = ${common.lib_deps}
+#lib_ignore                = ${common.lib_ignore}
+#lib_ldf_mode              = ${common.lib_ldf_mode}
+#board_build.flash_mode    = ${Sonoff.board_build.flash_mode}
+#board                     = ${Sonoff.board}
+#build_flags               = ${Sonoff.build_flags} -D PLUGIN_SET_SONOFF_4CH
 
 # ITEAD / SONOFF TOUCH version ------------------
 #[env:hard_SONOFF_TOUCH]
-#upload_speed     = ${common.upload_speed}
-#framework        = ${common.framework}
-#platform         = ${Sonoff.platform}
-#lib_deps         = ${common.lib_deps}
-#lib_ignore       = ${common.lib_ignore}
-#lib_ldf_mode     = ${common.lib_ldf_mode}
-#board_flash_mode = ${Sonoff.board_flash_mode}
-#board            = ${Sonoff.board}
-#build_flags      = ${Sonoff.build_flags} -D PLUGIN_SET_SONOFF_TOUCH
+#upload_speed              = ${common.upload_speed}
+#framework                 = ${common.framework}
+#platform                  = ${Sonoff.platform}
+#lib_deps                  = ${common.lib_deps}
+#lib_ignore                = ${common.lib_ignore}
+#lib_ldf_mode              = ${common.lib_ldf_mode}
+#board_build.flash_mode    = ${Sonoff.board_build.flash_mode}
+#board                     = ${Sonoff.board}
+#build_flags               = ${Sonoff.build_flags} -D PLUGIN_SET_SONOFF_TOUCH
 
 
 
@@ -471,40 +483,43 @@ build_flags      = ${Sonoff.build_flags} -D PLUGIN_SET_SONOFF_POW_R2
 
 # Huacanxing / H801 ------------------------------
 #[env:hard_HUACANXING_H801]
-#upload_speed     = ${common.upload_speed}
-#framework        = ${common.framework}
-#platform         = ${common.platform}
-#lib_deps         = ${common.lib_deps}
-#lib_ignore       = ${common.lib_ignore}
-#lib_ldf_mode     = ${common.lib_ldf_mode}
-#board_flash_mode = ${esp8266_1M.board_flash_mode}
-#board            = esp01_1m
-#build_flags      = ${esp8266_1M.build_flags} -D PLUGIN_SET_H801
+#upload_speed              = ${common.upload_speed}
+#framework                 = ${common.framework}
+#platform                  = ${common.platform}
+#lib_deps                  = ${common.lib_deps}
+#lib_ignore                = ${common.lib_ignore}
+#lib_ldf_mode              = ${common.lib_ldf_mode}
+#board_upload.maximum_size = ${esp8266_1M.board_upload.maximum_size}
+#board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
+#board                     = esp01_1m
+#build_flags               = ${esp8266_1M.build_flags} -D PLUGIN_SET_H801
 
 # MagicHome / Led Controller ---------------------
 #[env:hard_MAGICHOME]
-#upload_speed     = ${common.upload_speed}
-#upload_speed     = ${common.upload_speed}
-#framework        = ${common.framework}
-#platform         = ${common.platform}
-#lib_deps         = ${common.lib_deps}
-#lib_ignore       = ${common.lib_ignore}
-#lib_ldf_mode     = ${common.lib_ldf_mode}
-#board_flash_mode = ${esp8266_1M.board_flash_mode}
-#board            = esp01_1m
-#build_flags      = ${esp8266_1M.build_flags} -D PLUGIN_SET_MAGICHOME
+#upload_speed              = ${common.upload_speed}
+#upload_speed              = ${common.upload_speed}
+#framework                 = ${common.framework}
+#platform                  = ${common.platform}
+#lib_deps                  = ${common.lib_deps}
+#lib_ignore                = ${common.lib_ignore}
+#lib_ldf_mode              = ${common.lib_ldf_mode}
+#board_upload.maximum_size = ${esp8266_1M.board_upload.maximum_size}
+#board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
+#board                     = esp01_1m
+#build_flags               = ${esp8266_1M.build_flags} -D PLUGIN_SET_MAGICHOME
 
 # MagicHome / Led Controller with IR -------------
 #[env:hard_MAGICHOME_IR]
-#upload_speed     = ${common.upload_speed}
-#framework        = ${common.framework}
-#platform         = ${common.platform}
-#lib_deps         = ${common.lib_deps}
-#lib_ignore       = ${common.lib_ignore}
-#lib_ldf_mode     = ${common.lib_ldf_mode}
-#board_flash_mode = ${esp8266_1M.board_flash_mode}
-#board            = esp01_1m
-#build_flags      = ${esp8266_1M.build_flags} -D PLUGIN_SET_MAGICHOME_IR
+#upload_speed              = ${common.upload_speed}
+#framework                 = ${common.framework}
+#platform                  = ${common.platform}
+#lib_deps                  = ${common.lib_deps}
+#lib_ignore                = ${common.lib_ignore}
+#lib_ldf_mode              = ${common.lib_ldf_mode}
+#board_upload.maximum_size = ${esp8266_1M.board_upload.maximum_size}
+#board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
+#board                     = esp01_1m
+#build_flags               = ${esp8266_1M.build_flags} -D PLUGIN_SET_MAGICHOME_IR
 
 
 
@@ -515,89 +530,96 @@ build_flags      = ${Sonoff.build_flags} -D PLUGIN_SET_SONOFF_POW_R2
 
 # Easy Temperature Sensor ------------------------
 #[env:easy_TEMP]
-#upload_speed     = ${common.upload_speed}
-#framework        = ${common.framework}
-#platform         = ${common.platform}
-#lib_deps         = ${common.lib_deps}
-#lib_ignore       = ${common.lib_ignore}
-#lib_ldf_mode     = ${common.lib_ldf_mode}
-#board_flash_mode = ${esp8266_1M.board_flash_mode}
-#board            = esp01_1m
-#build_flags      = ${esp8266_1M.build_flags} -D PLUGIN_SET_EASY_TEMP
+#upload_speed              = ${common.upload_speed}
+#framework                 = ${common.framework}
+#platform                  = ${common.platform}
+#lib_deps                  = ${common.lib_deps}
+#lib_ignore                = ${common.lib_ignore}
+#lib_ldf_mode              = ${common.lib_ldf_mode}
+#board_upload.maximum_size = ${esp8266_1M.board_upload.maximum_size}
+#board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
+#board                     = esp01_1m
+#build_flags               = ${esp8266_1M.build_flags} -D PLUGIN_SET_EASY_TEMP
 
 
 # Easy Carbon Sensor -----------------------------
 #[env:easy_CARBON]
-#upload_speed     = ${common.upload_speed}
-#framework        = ${common.framework}
-#platform         = ${common.platform}
-#lib_deps         = ${common.lib_deps}
-#lib_ignore       = ${common.lib_ignore}
-#lib_ldf_mode     = ${common.lib_ldf_mode}
-#board_flash_mode = ${esp8266_1M.board_flash_mode}
-#board            = esp01_1m
-#build_flags      = ${esp8266_1M.build_flags} -D PLUGIN_SET_EASY_CARBON
+#upload_speed              = ${common.upload_speed}
+#framework                 = ${common.framework}
+#platform                  = ${common.platform}
+#lib_deps                  = ${common.lib_deps}
+#lib_ignore                = ${common.lib_ignore}
+#lib_ldf_mode              = ${common.lib_ldf_mode}
+#board_upload.maximum_size = ${esp8266_1M.board_upload.maximum_size}
+#board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
+#board                     = esp01_1m
+#build_flags               = ${esp8266_1M.build_flags} -D PLUGIN_SET_EASY_CARBON
 
 ## Easy Nextion ----------------------------------
 ##PLUGIN_SET_EASY_NEXTION
 
 # Easy OLED Display v1 ---------------------------
 #[env:easy_OLED_V1]
-#upload_speed     = ${common.upload_speed}
-#framework        = ${common.framework}
-#platform         = ${common.platform}
-#lib_deps         = ${common.lib_deps}
-#lib_ignore       = ${common.lib_ignore}
-#lib_ldf_mode     = ${common.lib_ldf_mode}
-#board_flash_mode = ${esp8266_1M.board_flash_mode}
-#board            = esp01_1m
-#build_flags      = ${esp8266_1M.build_flags} -D PLUGIN_SET_EASY_OLED1
+#upload_speed              = ${common.upload_speed}
+#framework                 = ${common.framework}
+#platform                  = ${common.platform}
+#lib_deps                  = ${common.lib_deps}
+#lib_ignore                = ${common.lib_ignore}
+#lib_ldf_mode              = ${common.lib_ldf_mode}
+#board_upload.maximum_size = ${esp8266_1M.board_upload.maximum_size}
+#board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
+#board                     = esp01_1m
+#build_flags               = ${esp8266_1M.build_flags} -D PLUGIN_SET_EASY_OLED1
 
 # Easy OLED Display v2 ---------------------------
 #[env:easy_OLED_V2]
-#upload_speed     = ${common.upload_speed}
-#framework        = ${common.framework}
-#platform         = ${common.platform}
-#lib_deps         = ${common.lib_deps}
-#lib_ignore       = ${common.lib_ignore}
-#lib_ldf_mode     = ${common.lib_ldf_mode}
-#board_flash_mode = ${esp8266_1M.board_flash_mode}
-#board            = esp01_1m
-#build_flags      = ${esp8266_1M.build_flags} -D PLUGIN_SET_EASY_OLED2
+#upload_speed              = ${common.upload_speed}
+#framework                 = ${common.framework}
+#platform                  = ${common.platform}
+#lib_deps                  = ${common.lib_deps}
+#lib_ignore                = ${common.lib_ignore}
+#lib_ldf_mode              = ${common.lib_ldf_mode}
+#board_upload.maximum_size = ${esp8266_1M.board_upload.maximum_size}
+#board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
+#board                     = esp01_1m
+#build_flags               = ${esp8266_1M.build_flags} -D PLUGIN_SET_EASY_OLED2
 
 # Easy Relay Switch ------------------------------
 #[env:easy_OLED_V2]
-#upload_speed     = ${common.upload_speed}
-#framework        = ${common.framework}
-#platform         = ${common.platform}
-#lib_deps         = ${common.lib_deps}
-#lib_ignore       = ${common.lib_ignore}
-#lib_ldf_mode     = ${common.lib_ldf_mode}
-#board_flash_mode = ${esp8266_1M.board_flash_mode}
-#board            = esp01_1m
-#build_flags      = ${esp8266_1M.build_flags} -D PLUGIN_SET_EASY_RELAY
+#upload_speed              = ${common.upload_speed}
+#framework                 = ${common.framework}
+#platform                  = ${common.platform}
+#lib_deps                  = ${common.lib_deps}
+#lib_ignore                = ${common.lib_ignore}
+#lib_ldf_mode              = ${common.lib_ldf_mode}
+#board_upload.maximum_size = ${esp8266_1M.board_upload.maximum_size}
+#board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
+#board                     = esp01_1m
+#build_flags               = ${esp8266_1M.build_flags} -D PLUGIN_SET_EASY_RELAY
 
 # Easy  Generic (1M) device ----------------------
 #[env:easy_GENERIC_1M]
-#upload_speed     = ${common.upload_speed}
-#framework        = ${common.framework}
-#platform         = ${common.platform}
-#lib_deps         = ${common.lib_deps}
-#lib_ignore       = ${common.lib_ignore}
-#lib_ldf_mode     = ${common.lib_ldf_mode}
-#board_flash_mode = ${esp8266_1M.board_flash_mode}
-#board            = esp01_1m
-#build_flags      = ${esp8266_1M.build_flags} -D PLUGIN_SET_GENERIC_1M
+#upload_speed              = ${common.upload_speed}
+#framework                 = ${common.framework}
+#platform                  = ${common.platform}
+#lib_deps                  = ${common.lib_deps}
+#lib_ignore                = ${common.lib_ignore}
+#lib_ldf_mode              = ${common.lib_ldf_mode}
+#board_upload.maximum_size = ${esp8266_1M.board_upload.maximum_size}
+#board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
+#board                     = esp01_1m
+#build_flags               = ${esp8266_1M.build_flags} -D PLUGIN_SET_GENERIC_1M
 
 # Ventus W266 weather station
 # https://www.letscontrolit.com/wiki/index.php/VentusW266
 [env:hard_Ventus_W266]
-platform         = ${normal.platform}
-lib_deps         = ${common.lib_deps}
-lib_ignore       = ${common.lib_ignore}
-lib_ldf_mode     = ${common.lib_ldf_mode}
-framework        = ${common.framework}
-upload_speed     = ${common.upload_speed}
-board_flash_mode = ${esp8266_1M.board_flash_mode}
-board            = ${common.board}
-build_flags      = ${esp8266_1M.build_flags} -D PLUGIN_SET_VENTUS_W266
+platform                  = ${normal.platform}
+lib_deps                  = ${common.lib_deps}
+lib_ignore                = ${common.lib_ignore}
+lib_ldf_mode              = ${common.lib_ldf_mode}
+framework                 = ${common.framework}
+upload_speed              = ${common.upload_speed}
+board_upload.maximum_size = ${esp8266_1M.board_upload.maximum_size}
+board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
+board                     = ${common.board}
+build_flags               = ${esp8266_1M.build_flags} -D PLUGIN_SET_VENTUS_W266


### PR DESCRIPTION
With the newer Platform IO versions, builds failed because of wrong size set in board definition of ESP8285 board.
The PlatformIO settings labels have changed.