### PR TITLE
Minor WebUI fixes

### DIFF
--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -2659,7 +2659,7 @@ void addWideButton(const String &url, const String &label, const String &color)
 
 void addSubmitButton()
 {
-  TXBuffer += F("<input class='button link' type='submit' value='Submit'><div id='toastmessage'></div></div><script type='text/javascript'>toasting();</script>");
+  TXBuffer += F("<input class='button link' type='submit' value='Submit'><div id='toastmessage'></div><script type='text/javascript'>toasting();</script>");
 }
 
 //add submit button with different label and name

--- a/src/WebStaticData.h
+++ b/src/WebStaticData.h
@@ -221,7 +221,7 @@ static const char pgDefaultCSS[] PROGMEM = {
     ".logviewer {	color: #F1F1F1; background-color: #272727; 	font-family: 'Lucida Console', Monaco, monospace; "
                 " height:  530px; max-width: 1000px; width: 80%; padding: 4px 8px;  overflow: auto;   border-style: solid; border-color: gray; }"
     // text textarea
-    "textarea {max-width: 1000px; width:80%; padding: 4px 8px;}"
+    "textarea {max-width: 1000px; width:80%; padding: 4px 8px; font-family: 'Lucida Console', Monaco, monospace; }"
     "textarea:hover {background-color: #ccc; }"
     // tables
     "table.normal th {padding: 6px; background-color: #444; color: #FFF; border-color: #888; font-weight: bold; }"


### PR DESCRIPTION
For better readability of rules, switch the text areas to monospace font.
Removed a single `</div>` along the way.