### PR TITLE
Statistics routines to test performance and some stability fixes

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -63,14 +63,14 @@ platform                  = https://github.com/platformio/platform-espressif8266
 [core_esp32_0_12_0]
 platform                  = espressif32@0.12.0
 
-[core_esp32_1_1_0]
-platform                  = espressif32@1.1.0
+[core_esp32_1_1_1]
+platform                  = espressif32@1.1.1
 
 [core_esp32_stage]
 platform                  = https://github.com/platformio/platform-espressif32.git#feature/stage
 
 [core_esp32]
-platform                  = ${core_esp32_1_1_0.platform}
+platform                  = ${core_esp32_1_1_1.platform}
 build_flags               = -D BUILD_GIT='"${sysenv.TRAVIS_TAG}"'
                           -lstdc++ -lsupc++
 lib_ignore                = ESPeasySoftwareSerial, EspESPeasySoftwareSerial, AS_BH1750, ESP8266WiFi, ESP8266Ping, ESP8266WebServer, ESP8266HTTPUpdateServer, ESP8266mDNS, IRremoteESP8266, ESPEasy_ESP8266Ping, SerialSensors

--- a/platformio.ini
+++ b/platformio.ini
@@ -71,7 +71,7 @@ platform                  = https://github.com/platformio/platform-espressif32.g
 
 [core_esp32]
 platform                  = ${core_esp32_1_1_0.platform}
-build_flags               = -D BUILD_GIT='"${env.TRAVIS_TAG}"'
+build_flags               = -D BUILD_GIT='"${sysenv.TRAVIS_TAG}"'
                           -lstdc++ -lsupc++
 lib_ignore                = ESPeasySoftwareSerial, EspESPeasySoftwareSerial, AS_BH1750, ESP8266WiFi, ESP8266Ping, ESP8266WebServer, ESP8266HTTPUpdateServer, ESP8266mDNS, IRremoteESP8266, ESPEasy_ESP8266Ping, SerialSensors
 lib_deps                  = ESP32WebServer
@@ -79,7 +79,7 @@ monitor_speed             = 115200
 
 
 [common]
-build_flags               = -D BUILD_GIT='"${env.TRAVIS_TAG}"'  ; ${compiler_warnings.build_flags}
+build_flags               = -D BUILD_GIT='"${sysenv.TRAVIS_TAG}"'  ; ${compiler_warnings.build_flags}
                    -D PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
                    -D NDEBUG
                    -D VTABLES_IN_FLASH

--- a/platformio.ini
+++ b/platformio.ini
@@ -63,14 +63,14 @@ platform                  = https://github.com/platformio/platform-espressif8266
 [core_esp32_0_12_0]
 platform                  = espressif32@0.12.0
 
-[core_esp32_1_0_2]
-platform                  = espressif32@1.0.2
+[core_esp32_1_1_0]
+platform                  = espressif32@1.1.0
 
 [core_esp32_stage]
 platform                  = https://github.com/platformio/platform-espressif32.git#feature/stage
 
 [core_esp32]
-platform                  = ${core_esp32_0_12_0.platform}
+platform                  = ${core_esp32_1_1_0.platform}
 build_flags               = -D BUILD_GIT='"${env.TRAVIS_TAG}"'
                           -lstdc++ -lsupc++
 lib_ignore                = ESPeasySoftwareSerial, EspESPeasySoftwareSerial, AS_BH1750, ESP8266WiFi, ESP8266Ping, ESP8266WebServer, ESP8266HTTPUpdateServer, ESP8266mDNS, IRremoteESP8266, ESPEasy_ESP8266Ping, SerialSensors

--- a/src/Commands/Diagnostic.h
+++ b/src/Commands/Diagnostic.h
@@ -22,9 +22,9 @@ bool Command_Malloc(struct EventStruct *event, const char* Line)
 bool Command_SysLoad(struct EventStruct *event, const char* Line)
 {
   bool success = true;
-  Serial.print(100 - (100 * loopCounterLast / loopCounterMax));
+  Serial.print(getCPUload());
   Serial.print(F("% (LC="));
-  Serial.print(int(loopCounterLast / 30));
+  Serial.print(getCPUload());
   Serial.println(F(")"));
   return success;
 }

--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -3,6 +3,7 @@
 //********************************************************************************
 void sendData(struct EventStruct *event)
 {
+  START_TIMER;
   checkRAM(F("sendData"));
  LoadTaskSettings(event->TaskIndex);
   if (Settings.UseRules)
@@ -55,6 +56,7 @@ void sendData(struct EventStruct *event)
 
   PluginCall(PLUGIN_EVENT_OUT, event, dummyString);
   lastSend = millis();
+  STOP_TIMER(SEND_DATA_STATS);
 }
 
 boolean validUserVar(struct EventStruct *event) {

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -1182,7 +1182,8 @@ boolean WebLoggedIn = false;
 int WebLoggedInTimer = 300;
 
 boolean (*Plugin_ptr[PLUGIN_MAX])(byte, struct EventStruct*, String&);
-byte Plugin_id[PLUGIN_MAX];
+std::vector<byte> Plugin_id;
+std::vector<int> Task_id_to_Plugin_id;
 
 boolean (*CPlugin_ptr[CPLUGIN_MAX])(byte, struct EventStruct*, String&);
 byte CPlugin_id[CPLUGIN_MAX];
@@ -1293,6 +1294,15 @@ unsigned long elapsed50ps = 0;
 unsigned long loopCounter = 0;
 unsigned long loopCounterLast = 0;
 unsigned long loopCounterMax = 1;
+unsigned long lastLoopStart = 0;
+unsigned long shortestLoop = 10000000;
+unsigned long longestLoop = 0;
+unsigned long loopCounter_full = 1;
+float loop_usec_duration_total = 0.0;
+unsigned long countFindPluginId = 0;
+
+unsigned long systemTimerCalls = 1;
+float systemTimerDurationTotal = 0.0;
 
 unsigned long dailyResetCounter = 0;
 

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -73,7 +73,7 @@
 #define DEFAULT_USE_RULES                       false   // (true|false) Enable Rules?
 
 #define DEFAULT_MQTT_RETAIN                     false   // (true|false) Retain MQTT messages?
-#define DEFAULT_MQTT_DELAY                      1000    // Time in milliseconds to retain MQTT messages
+#define DEFAULT_MQTT_DELAY                      100    // Time in milliseconds to retain MQTT messages
 #define DEFAULT_MQTT_LWT_TOPIC                  ""      // Default lwt topic
 #define DEFAULT_MQTT_LWT_CONNECT_MESSAGE        "Connected" // Default lwt message
 #define DEFAULT_MQTT_LWT_DISCONNECT_MESSAGE     "Connection Lost" // Default lwt message
@@ -510,11 +510,6 @@ class TimingStats;
 
 #define LOADFILE_STATS  0
 #define LOOP_STATS      1
-
-#define START_TIMER const unsigned statisticsTimerStart(micros());
-#define STOP_TIMER_TASK(T)  pluginStats[T].add(usecPassedSince(statisticsTimerStart));
-#define STOP_TIMER_LOADFILE miscStats[LOADFILE_STATS].add(usecPassedSince(statisticsTimerStart));
-#define STOP_TIMER_LOOP     miscStats[LOOP_STATS].add(usecPassedSince(statisticsTimerStart));
 
 struct CRCStruct{
   char compileTimeMD5[16+32+1]= "MD5_MD5_MD5_MD5_BoundariesOfTheSegmentsGoHere...";
@@ -1428,7 +1423,7 @@ String getPluginFunctionName(int function) {
     return F("Unknown");
 }
 
-bool mustLog(int function) {
+bool mustLogFunction(int function) {
     switch(function) {
         case PLUGIN_INIT_ALL:              return false;
         case PLUGIN_INIT:                  return false;
@@ -1471,13 +1466,14 @@ std::map<int,TimingStats> miscStats;
 #define PLUGIN_CALL_1PS   5
 #define CHECK_SENSORS     6
 #define SEND_DATA_STATS   7
+#define COMPUTE_FORMULA_STATS 8
 
 
 
 
 
 #define START_TIMER const unsigned statisticsTimerStart(micros());
-#define STOP_TIMER_TASK(T,F)  if (mustLog(F)) pluginStats[T*32 + F].add(usecPassedSince(statisticsTimerStart));
+#define STOP_TIMER_TASK(T,F)  if (mustLogFunction(F)) pluginStats[T*32 + F].add(usecPassedSince(statisticsTimerStart));
 #define STOP_TIMER_LOADFILE miscStats[LOADFILE_STATS].add(usecPassedSince(statisticsTimerStart));
 #define STOP_TIMER(L)       miscStats[L].add(usecPassedSince(statisticsTimerStart));
 
@@ -1492,6 +1488,7 @@ String getMiscStatsName(int stat) {
         case PLUGIN_CALL_1PS   : return F("Plugin call  1 p/s  ");
         case CHECK_SENSORS:      return F("checkSensors()      ");
         case SEND_DATA_STATS:    return F("sendData()          ");
+        case COMPUTE_FORMULA_STATS: return F("Compute formula  ");
     }
     return F("Unknown");
 }

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -563,9 +563,9 @@ void updateMQTTclient_connected() {
 void run50TimesPerSecond()
 {
   setNextTimeInterval(timer20ms, 20);
-  unsigned long start = micros();
+  START_TIMER;
   PluginCall(PLUGIN_FIFTY_PER_SECOND, 0, dummyString);
-  elapsed50ps += micros() - start;
+  STOP_TIMER(PLUGIN_CALL_50PS);
 }
 
 /*********************************************************************************************\
@@ -574,12 +574,16 @@ void run50TimesPerSecond()
 void run10TimesPerSecond()
 {
   setNextTimeInterval(timer100ms, 100);
-  unsigned long start = micros();
-  PluginCall(PLUGIN_TEN_PER_SECOND, 0, dummyString);
-  elapsed10ps += micros() - start;
-  start = micros();
-  PluginCall(PLUGIN_UNCONDITIONAL_POLL, 0, dummyString);
-  elapsed10psU += micros() - start;
+  {
+    START_TIMER;
+    PluginCall(PLUGIN_TEN_PER_SECOND, 0, dummyString);
+    STOP_TIMER(PLUGIN_CALL_10PS);
+  }
+  {
+    START_TIMER;
+    PluginCall(PLUGIN_UNCONDITIONAL_POLL, 0, dummyString);
+    STOP_TIMER(PLUGIN_CALL_10PSU);
+  }
   if (Settings.UseRules && eventBuffer.length() > 0)
   {
     rulesProcessing(eventBuffer);
@@ -596,6 +600,7 @@ void run10TimesPerSecond()
 \*********************************************************************************************/
 void runOncePerSecond()
 {
+  START_TIMER;
   setNextTimeInterval(timer1s, 1000);
   dailyResetCounter++;
   if (dailyResetCounter > 86400) // 1 day elapsed... //86400
@@ -667,6 +672,7 @@ void runOncePerSecond()
     Wire.endTransmission();
   }
 
+/*
   if (Settings.SerialLogLevel == LOG_LEVEL_DEBUG_DEV)
   {
     Serial.print(F("Plugin calls: 50 ps:"));
@@ -682,7 +688,9 @@ void runOncePerSecond()
     elapsed10ps=0;
     elapsed10psU=0;
   }
+  */
   checkResetFactoryPin();
+  STOP_TIMER(PLUGIN_CALL_1PS);
 }
 
 /*********************************************************************************************\
@@ -693,6 +701,7 @@ void runEach30Seconds()
    extern void checkRAMtoLog();
   checkRAMtoLog();
   updateLoopStats_30sec();
+  logStatistics(true);
   wdcounter++;
   timerwd = millis() + 30000;
   String log;
@@ -727,6 +736,7 @@ void runEach30Seconds()
 \*********************************************************************************************/
 void checkSensors()
 {
+  START_TIMER;
   checkRAM(F("checkSensors"));
   bool isDeepSleep = isDeepSleepEnabled();
   //check all the devices and only run the sendtask if its time, or we if we used deep sleep mode
@@ -744,6 +754,7 @@ void checkSensors()
     }
   }
   saveUserVarToRTC();
+  STOP_TIMER(CHECK_SENSORS);
 }
 
 

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -378,12 +378,12 @@ void updateLoopStats() {
   loop_usec_duration_total += usecSince;
   lastLoopStart = micros();
   if (usecSince <= 0 || usecSince > 10000000) 
-    return; // No loop should take > 1 sec.
-  if (shortestLoop > usecSince) {
+    return; // No loop should take > 10 sec.
+  if (shortestLoop > static_cast<unsigned long>(usecSince)) {
     shortestLoop = usecSince;
     loopCounterMax = 30 * 1000000 / usecSince;
   }
-  if (longestLoop < usecSince)
+  if (longestLoop < static_cast<unsigned long>(usecSince))
     longestLoop = usecSince;
 }
 
@@ -646,9 +646,9 @@ void runOncePerSecond()
   if (Settings.UseNTP)
     checkTime();
 
-  unsigned long start = micros();
+//  unsigned long start = micros();
   PluginCall(PLUGIN_ONCE_A_SECOND, 0, dummyString);
-  unsigned long elapsed = micros() - start;
+//  unsigned long elapsed = micros() - start;
 
   checkSystemTimers();
 
@@ -801,6 +801,7 @@ void SensorSendTask(byte TaskIndex)
 
     if (success)
     {
+      START_TIMER;
       for (byte varNr = 0; varNr < VARS_PER_TASK; varNr++)
       {
         if (ExtraTaskSettings.TaskDeviceFormula[varNr][0] != 0)
@@ -817,6 +818,7 @@ void SensorSendTask(byte TaskIndex)
             UserVar[varIndex + varNr] = result;
         }
       }
+      STOP_TIMER(COMPUTE_FORMULA_STATS);
       sendData(&TempEvent);
     }
   }

--- a/src/ESPEasyStatistics.ino
+++ b/src/ESPEasyStatistics.ino
@@ -1,0 +1,30 @@
+void logStatistics(bool clearLog) {
+    String log;
+    log.reserve(80);
+    for (auto& x: pluginStats) {
+        if (!x.second.isEmpty()) {
+            const int pluginId = x.first/32;
+            String P_name = ""; 
+            Plugin_ptr[pluginId](PLUGIN_GET_DEVICENAME, NULL, P_name);
+            log = F("PluginStats P_");
+            log += pluginId + 1;
+            log += '_';
+            log += P_name;
+            log += ' ';
+            log += getPluginFunctionName(x.first%32);
+            log += ' ';
+            log += getLogLine(x.second);
+            addLog(LOG_LEVEL_DEBUG, log);
+            if (clearLog) x.second.reset();
+        }
+    }
+    for (auto& x: miscStats) {
+        if (!x.second.isEmpty()) {
+            log = getMiscStatsName(x.first);
+            log += F(" stats: ");
+            log += getLogLine(x.second);
+            addLog(LOG_LEVEL_DEBUG, log);
+            if (clearLog) x.second.reset();
+        }
+    }
+}

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -1442,11 +1442,13 @@ boolean isInt(const String& tBuf) {
 }
 
 boolean isNumerical(const String& tBuf, bool mustBeInteger) {
+  const unsigned int bufLength = tBuf.length();
+  if (bufLength == 0) return false;
   boolean decPt = false;
   int firstDec = 0;
   if(tBuf.charAt(0) == '+' || tBuf.charAt(0) == '-')
     firstDec = 1;
-  for(unsigned int x=firstDec; x < tBuf.length(); ++x) {
+  for(unsigned int x=firstDec; x < bufLength; ++x) {
     if(tBuf.charAt(x) == '.') {
       if (mustBeInteger) return false;
       // Only one decimal point allowed

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -1051,6 +1051,8 @@ String ClearInFile(char* fname, int index, int datasize)
   \*********************************************************************************************/
 String LoadFromFile(char* fname, int index, byte* memAddress, int datasize)
 {
+  START_TIMER;
+
   checkRAM(F("LoadFromFile"));
   String log = F("LoadFromFile: ");
   log += fname;
@@ -1065,6 +1067,8 @@ String LoadFromFile(char* fname, int index, byte* memAddress, int datasize)
   SPIFFS_CHECK(f.seek(index, fs::SeekSet), fname);
   SPIFFS_CHECK(f.read(memAddress,datasize), fname);
   f.close();
+
+  STOP_TIMER(LOADFILE_STATS);
 
   return(String());
 }

--- a/src/StringConverter.ino
+++ b/src/StringConverter.ino
@@ -60,6 +60,55 @@ String formatMAC(const uint8_t* mac) {
   return String(str);
 }
 
+String formatToHex(unsigned long value) {
+  String result = F("0x");
+  String hex(value, HEX);
+  hex.toUpperCase();
+  result += hex;
+  return result;
+}
+
+String formatHumanReadable(unsigned long value, unsigned long factor) {
+  float floatValue(value);
+  byte steps = 0;
+  while (value >= factor) {
+    value /= factor;
+    ++steps;
+    floatValue /= float(factor);
+  }
+  String result = toString(floatValue, 2);
+  switch (steps) {
+    case 0: return String(value);
+    case 1: result += 'k'; break;
+    case 2: result += 'M'; break;
+    case 3: result += 'G'; break;
+    case 4: result += 'T'; break;
+    default: 
+      result += '*';
+      result += factor;
+      result += '^';
+      result += steps;
+      break;
+  }
+  return result;
+}
+
+String formatToHex_decimal(unsigned long value) {
+  return formatToHex_decimal(value, 1);
+}
+
+String formatToHex_decimal(unsigned long value, unsigned long factor) {
+  String result = formatToHex(value);
+  result += F(" (");
+  if (factor > 1) {
+    result += formatHumanReadable(value, factor);
+  } else {
+    result += value;
+  }
+  result += ')';
+  return result;
+}
+
 /*********************************************************************************************\
    Workaround for removing trailing white space when String() converts a float with 0 decimals
   \*********************************************************************************************/

--- a/src/StringConverter.ino
+++ b/src/StringConverter.ino
@@ -362,7 +362,7 @@ void parseSystemVariables(String& s, boolean useURLencode)
   #endif
 
   if (s.indexOf(F("%sys")) != -1) {
-    SMART_REPL(F("%sysload%"), String(100 - (100 * loopCounterLast / loopCounterMax)))
+    SMART_REPL(F("%sysload%"), String(getCPUload()))
     SMART_REPL(F("%sysheap%"), String(ESP.getFreeHeap()));
     SMART_REPL(F("%systm_hm%"), getTimeString(':', false))
     SMART_REPL(F("%systm_hm_am%"), getTimeString_ampm(':', false))

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -805,9 +805,9 @@ void handle_root() {
     TXBuffer += F("<TR><TD>Load:<TD>");
     if (wdcounter > 0)
     {
-      TXBuffer += String(100 - (100 * loopCounterLast / loopCounterMax));
+      TXBuffer += String(getCPUload());
       TXBuffer += F("% (LC=");
-      TXBuffer += String(int(loopCounterLast / 30));
+      TXBuffer += String(getLoopCountPerSec());
       TXBuffer += F(")");
     }
 
@@ -3644,8 +3644,8 @@ void handle_json()
 
       if (wdcounter > 0)
       {
-          stream_next_json_object_value(F("Load"), String( 100 - (100 * loopCounterLast / loopCounterMax) ));
-          stream_next_json_object_value(F("Load LC"), String( int(loopCounterLast / 30) ));
+          stream_next_json_object_value(F("Load"), String(getCPUload()));
+          stream_next_json_object_value(F("Load LC"), String(getLoopCountPerSec()));
       }
 
       stream_last_json_object_value(F("Free RAM"), String(ESP.getFreeHeap()));
@@ -5007,9 +5007,9 @@ void handle_sysinfo() {
    TXBuffer += F("<TR><TD>Load<TD>");
   if (wdcounter > 0)
   {
-     TXBuffer += 100 - (100 * loopCounterLast / loopCounterMax);
+     TXBuffer += getCPUload();
      TXBuffer += F("% (LC=");
-     TXBuffer += int(loopCounterLast / 30);
+     TXBuffer += getLoopCountPerSec();
      TXBuffer += F(")");
   }
 

--- a/src/_P026_Sysinfo.ino
+++ b/src/_P026_Sysinfo.ino
@@ -96,7 +96,7 @@ boolean Plugin_026(byte function, struct EventStruct *event, String& string)
           }
           case 4:
           {
-            value = (100 - (100 * loopCounterLast / loopCounterMax));
+            value = getCPUload();
             break;
           }
           case 5:

--- a/src/_P028_BME280.ino
+++ b/src/_P028_BME280.ino
@@ -17,9 +17,6 @@
 #define PLUGIN_028_BME280_DEVICE "BME280"
 #define PLUGIN_028_BMP280_DEVICE "BMP280"
 
-// Minimal interval in msec.
-#define BMx280_MEASUREMENT_INTERVAL_MSEC 50000
-
 #define BMx280_REGISTER_DIG_T1           0x88
 #define BMx280_REGISTER_DIG_T2           0x8A
 #define BMx280_REGISTER_DIG_T3           0x8C
@@ -107,16 +104,24 @@ enum BMx_ChipId {
   BME280_DEVICE = 0x60
 };
 
+enum BMx_state {
+  BMx_Uninitialized = 0,
+  BMx_Initialized,
+  BMx_Wait_for_samples,
+  BMx_New_values,
+  BMx_Values_read
+};
+
 struct P028_sensordata {
   P028_sensordata() :
-    initialized(false),
     last_hum_val(0.0),
     last_press_val(0.0),
     last_temp_val(0.0),
     last_dew_temp_val(0.0),
     last_measurement(0),
     sensorID(Unknown_DEVICE),
-    i2cAddress(0) {}
+    i2cAddress(0),
+    state(BMx_Uninitialized) {}
 
     byte get_config_settings() const {
       switch (sensorID) {
@@ -168,9 +173,16 @@ struct P028_sensordata {
       }
     }
 
+    bool initialized() const {
+      return state != BMx_Uninitialized;
+    }
+
+    void setUninitialized() {
+      state = BMx_Uninitialized;
+    }
+
   bme280_uncomp_data uncompensated;
   bme280_calib_data calib;
-  boolean initialized;
   float last_hum_val;
   float last_press_val;
   float last_temp_val;
@@ -178,6 +190,8 @@ struct P028_sensordata {
   unsigned long last_measurement;
   BMx_ChipId sensorID;
   uint8_t i2cAddress;
+  unsigned long moment_next_step;
+  BMx_state state;
 };
 
 std::map<uint8_t, P028_sensordata> P028_sensors;
@@ -269,16 +283,23 @@ boolean Plugin_028(byte function, struct EventStruct *event, String& string)
         success = true;
         break;
       }
+    case PLUGIN_ONCE_A_SECOND:
+      {
+        const uint8_t i2cAddress = Plugin_028_i2c_addr(event);
+        const float tempOffset = Settings.TaskDevicePluginConfig[event->TaskIndex][2] / 10.0;
+        Plugin_028_update_measurements(i2cAddress, tempOffset);
+        break;
+      }
 
     case PLUGIN_READ:
       {
         const uint8_t i2cAddress = Plugin_028_i2c_addr(event);
         P028_sensordata& sensor = P028_sensors[i2cAddress];
-        const float tempOffset = Settings.TaskDevicePluginConfig[event->TaskIndex][2] / 10.0;
-        if (!Plugin_028_update_measurements(i2cAddress, tempOffset)) {
+        if (sensor.state != BMx_New_values) {
           success = false;
           break;
         }
+        sensor.state = BMx_Values_read;
         if (!sensor.hasHumidity()) {
           // Patch the sensor type to output only the measured values.
           event->sensorType = SENSOR_TYPE_TEMP_EMPTY_BARO;
@@ -324,20 +345,26 @@ boolean Plugin_028(byte function, struct EventStruct *event, String& string)
   return success;
 }
 
+
 // Only perform the measurements with big interval to prevent the sensor from warming up.
 bool Plugin_028_update_measurements(const uint8_t i2cAddress, float tempOffset) {
   P028_sensordata& sensor = P028_sensors[i2cAddress];
   const unsigned long current_time = millis();
-  if (!timeOutReached(sensor.last_measurement + BMx280_MEASUREMENT_INTERVAL_MSEC)) {
-    // Timeout has not yet been reached.
-    return false;
-  }
   Plugin_028_check(i2cAddress); // Check id device is present
-  if (!sensor.initialized) {
-    sensor.initialized = Plugin_028_begin(i2cAddress);
+  if (!sensor.initialized()) {
+    if (!Plugin_028_begin(i2cAddress)) {
+      return false;
+    }
+    sensor.state = BMx_Initialized;
+    sensor.last_measurement = 0;
   }
+  if (sensor.state != BMx_Wait_for_samples) {
+    if (sensor.last_measurement != 0 &&
+        !timeOutReached(sensor.last_measurement + (Settings.MessageDelay * 1000))) {
+      // Timeout has not yet been reached.
+      return false;
+    }
 
-  if (sensor.initialized) {
     sensor.last_measurement = current_time;
     // Set the Sensor in sleep to be make sure that the following configs will be stored
     I2C_write8_reg(i2cAddress, BMx280_REGISTER_CONTROL, 0x00);
@@ -346,66 +373,72 @@ bool Plugin_028_update_measurements(const uint8_t i2cAddress, float tempOffset) 
     }
     I2C_write8_reg(i2cAddress, BMx280_REGISTER_CONFIG, sensor.get_config_settings());
     I2C_write8_reg(i2cAddress, BMx280_REGISTER_CONTROL, sensor.get_control_settings());
-
-    // Start measurement
-    delay(1000); // Wait one second to make sure the filtered values stabilize.
-
-    if (Plugin_028_readUncompensatedData(i2cAddress)) {
-      sensor.last_temp_val = Plugin_028_readTemperature(i2cAddress);
-      sensor.last_press_val = ((float)Plugin_028_readPressure(i2cAddress)) / 100;
-      sensor.last_hum_val = ((float)Plugin_028_readHumidity(i2cAddress));
-    }
-
-    // Set to sleep mode again to prevent the sensor from heating up.
-    I2C_write8_reg(i2cAddress, BMx280_REGISTER_CONTROL, 0x00);
-
-    String log;
-    log.reserve(120); // Prevent re-allocation
-    log = sensor.getDeviceName();
-    log += F(":");
-    boolean logAdded = false;
-    if (sensor.hasHumidity()) {
-      // Apply half of the temp offset, to correct the dew point offset.
-      // The sensor is warmer than the surrounding air, which has effect on the perceived humidity.
-      sensor.last_dew_temp_val = compute_dew_point_temp(sensor.last_temp_val + (tempOffset / 2.0), sensor.last_hum_val);
-    } else {
-      // No humidity measurement, thus set dew point equal to air temperature.
-      sensor.last_dew_temp_val = sensor.last_temp_val;
-    }
-    if (tempOffset > 0.1 || tempOffset < -0.1) {
-      // There is some offset to apply.
-      log += F(" Apply temp offset ");
-      log += tempOffset;
-      log += F("C");
-      if (sensor.hasHumidity()) {
-        log += F(" humidity ");
-        log += sensor.last_hum_val;
-        sensor.last_hum_val = compute_humidity_from_dewpoint(sensor.last_temp_val + tempOffset, sensor.last_dew_temp_val);
-        log += F("% => ");
-        log += sensor.last_hum_val;
-        log += F("%");
-      } else {
-        sensor.last_hum_val = 0.0;
-      }
-      log += F(" temperature ");
-      log += sensor.last_temp_val;
-      sensor.last_temp_val = sensor.last_temp_val + tempOffset;
-      log += F("C => ");
-      log += sensor.last_temp_val;
-      log += F("C");
-      logAdded = true;
-    }
-    if (sensor.hasHumidity()) {
-      log += F(" dew point ");
-      log += sensor.last_dew_temp_val;
-      log += F("C");
-      logAdded = true;
-    }
-    if (logAdded)
-      addLog(LOG_LEVEL_INFO, log);
-    return true;
+    sensor.state = BMx_Wait_for_samples;
+    return false;
   }
-  return false;
+
+  if (!timeOutReached(sensor.last_measurement + 1000)) {
+    // Must wait one second to make sure the filtered values stabilize.
+    return false;
+  }
+  if (!Plugin_028_readUncompensatedData(i2cAddress)) {
+    return false;
+  }
+  // Set to sleep mode again to prevent the sensor from heating up.
+  I2C_write8_reg(i2cAddress, BMx280_REGISTER_CONTROL, 0x00);
+
+  sensor.last_measurement = current_time;
+  sensor.state = BMx_New_values;
+  sensor.last_temp_val = Plugin_028_readTemperature(i2cAddress);
+  sensor.last_press_val = ((float)Plugin_028_readPressure(i2cAddress)) / 100;
+  sensor.last_hum_val = ((float)Plugin_028_readHumidity(i2cAddress));
+
+
+  String log;
+  log.reserve(120); // Prevent re-allocation
+  log = sensor.getDeviceName();
+  log += F(":");
+  boolean logAdded = false;
+  if (sensor.hasHumidity()) {
+    // Apply half of the temp offset, to correct the dew point offset.
+    // The sensor is warmer than the surrounding air, which has effect on the perceived humidity.
+    sensor.last_dew_temp_val = compute_dew_point_temp(sensor.last_temp_val + (tempOffset / 2.0), sensor.last_hum_val);
+  } else {
+    // No humidity measurement, thus set dew point equal to air temperature.
+    sensor.last_dew_temp_val = sensor.last_temp_val;
+  }
+  if (tempOffset > 0.1 || tempOffset < -0.1) {
+    // There is some offset to apply.
+    log += F(" Apply temp offset ");
+    log += tempOffset;
+    log += F("C");
+    if (sensor.hasHumidity()) {
+      log += F(" humidity ");
+      log += sensor.last_hum_val;
+      sensor.last_hum_val = compute_humidity_from_dewpoint(sensor.last_temp_val + tempOffset, sensor.last_dew_temp_val);
+      log += F("% => ");
+      log += sensor.last_hum_val;
+      log += F("%");
+    } else {
+      sensor.last_hum_val = 0.0;
+    }
+    log += F(" temperature ");
+    log += sensor.last_temp_val;
+    sensor.last_temp_val = sensor.last_temp_val + tempOffset;
+    log += F("C => ");
+    log += sensor.last_temp_val;
+    log += F("C");
+    logAdded = true;
+  }
+  if (sensor.hasHumidity()) {
+    log += F(" dew point ");
+    log += sensor.last_dew_temp_val;
+    log += F("C");
+    logAdded = true;
+  }
+  if (logAdded)
+    addLog(LOG_LEVEL_INFO, log);
+  return true;
 }
 
 
@@ -416,7 +449,7 @@ bool Plugin_028_check(uint8_t i2cAddress) {
   bool wire_status = false;
   const uint8_t chip_id = I2C_read8_reg(i2cAddress, BMx280_REGISTER_CHIPID, &wire_status);
   P028_sensordata& sensor = P028_sensors[i2cAddress];
-  if (!wire_status) sensor.initialized = false;
+  if (!wire_status) sensor.setUninitialized();
   switch (chip_id) {
     case BMP280_DEVICE_SAMPLE1:
     case BMP280_DEVICE_SAMPLE2:
@@ -426,7 +459,7 @@ bool Plugin_028_check(uint8_t i2cAddress) {
         // Store detected chip ID when chip found.
         if (sensor.sensorID != chip_id) {
           sensor.sensorID = static_cast<BMx_ChipId>(chip_id);
-          sensor.initialized = false;
+          sensor.setUninitialized();
           String log = F("BMx280 : Detected ");
           log += sensor.getFullDeviceName();
           addLog(LOG_LEVEL_INFO, log);

--- a/src/_P047_i2c-soil-moisture-sensor.ino
+++ b/src/_P047_i2c-soil-moisture-sensor.ino
@@ -75,8 +75,8 @@ boolean Plugin_047(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_WEBFORM_LOAD:
       {
-      	addFormTextBox(F("I2C Address (Hex)"), F("plugin_047_i2cSoilMoisture_i2cAddress"), String(F("0x")) +
-      			String(Settings.TaskDevicePluginConfig[event->TaskIndex][0],HEX), 4);
+      	addFormTextBox(F("I2C Address (Hex)"), F("plugin_047_i2cSoilMoisture_i2cAddress"), 
+            formatToHex_decimal(Settings.TaskDevicePluginConfig[event->TaskIndex][0]), 4);
 
         addFormCheckBox(F("Send sensor to sleep"), F("plugin_047_sleep"), Settings.TaskDevicePluginConfig[event->TaskIndex][1]);
 
@@ -85,8 +85,8 @@ boolean Plugin_047(byte function, struct EventStruct *event, String& string)
         addFormSeparator(2);
 
         addFormCheckBox(F("Change Sensor address"),F("plugin_047_changeAddr"), false);
-      	addFormTextBox(F("Change I2C Addr. to (Hex)"), F("plugin_047_i2cSoilMoisture_changeAddr"), String(F("0x")) +
-      			String(Settings.TaskDevicePluginConfig[event->TaskIndex][0],HEX), 4);
+      	addFormTextBox(F("Change I2C Addr. to (Hex)"), F("plugin_047_i2cSoilMoisture_changeAddr"), 
+            formatToHex_decimal(Settings.TaskDevicePluginConfig[event->TaskIndex][0]), 4);
 
         addFormSeparator(2);
 

--- a/src/_P048_Motorshield_v2.ino
+++ b/src/_P048_Motorshield_v2.ino
@@ -58,8 +58,8 @@ boolean Plugin_048(byte function, struct EventStruct *event, String& string) {
 
 		case PLUGIN_WEBFORM_LOAD: {
 
-    	addFormTextBox(F("I2C Address (Hex)"), F("plugin_048_adr"), String(F("0x")) +
-    			String(Settings.TaskDevicePluginConfig[event->TaskIndex][0],HEX), 4);
+    	addFormTextBox(F("I2C Address (Hex)"), F("plugin_048_adr"),
+		               formatToHex_decimal(Settings.TaskDevicePluginConfig[event->TaskIndex][0]), 4);
 
     	addFormNumericBox(F("Stepper: steps per revolution"), F("plugin_048_MotorStepsPerRevolution")
     			, Settings.TaskDevicePluginConfig[event->TaskIndex][1]);

--- a/src/__Plugin.ino
+++ b/src/__Plugin.ino
@@ -29,6 +29,11 @@ void PluginInit(void)
     Plugin_ptr[x] = 0;
     Plugin_id[x] = 0;
   }
+  // Clear the cache.
+  for (x = 0; x < TASKS_MAX; x++)
+  {
+    Task_id_to_Plugin_id[x] = -1;
+  }
 
   x = 0;
 
@@ -1057,13 +1062,41 @@ void PluginInit(void)
 
 }
 
+int getPluginId(byte taskId) {
+  int retry = 1;
+  while (retry >= 0) {
+    int plugin = Task_id_to_Plugin_id[taskId];
+    if (plugin >= 0 && plugin < PLUGIN_MAX) {
+      if (Plugin_id[plugin] == Settings.TaskDeviceNumber[taskId])
+        return plugin;
+    }
+    updateTaskPluginCache();
+    --retry;
+  }
+  return -1;
+}
+
+void updateTaskPluginCache() {
+  ++countFindPluginId;
+  Task_id_to_Plugin_id.resize(TASKS_MAX +1);
+  for (byte y = 0; y < TASKS_MAX; ++y) {
+    Task_id_to_Plugin_id[y] = -1;
+    bool foundPlugin = false;
+    for (byte x = 0; x < PLUGIN_MAX && !foundPlugin; ++x) {
+      if (Plugin_id[x] != 0 && Plugin_id[x] == Settings.TaskDeviceNumber[y]) {
+        foundPlugin = true;
+        Task_id_to_Plugin_id[y] = x;
+      }
+    }
+  }
+}
+
 
 /*********************************************************************************************\
 * Function call to all or specific plugins
 \*********************************************************************************************/
 byte PluginCall(byte Function, struct EventStruct *event, String& str)
 {
-  int x;
   struct EventStruct TempEvent;
 
   if (event == 0)
@@ -1076,7 +1109,7 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
     // Unconditional calls to all plugins
     case PLUGIN_DEVICE_ADD:
     case PLUGIN_UNCONDITIONAL_POLL:
-      for (x = 0; x < PLUGIN_MAX; x++)
+      for (byte x = 0; x < PLUGIN_MAX; x++)
         if (Plugin_id[x] != 0)
           Plugin_ptr[x](Function, event, str);
       return true;
@@ -1092,26 +1125,23 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
           {
             if (Settings.TaskDeviceDataFeed[y] == 0) // these calls only to tasks with local feed
             {
-              byte DeviceIndex = getDeviceIndex(Settings.TaskDeviceNumber[y]);
-              TempEvent.TaskIndex = y;
-              TempEvent.BaseVarIndex = y * VARS_PER_TASK;
-              TempEvent.sensorType = Device[DeviceIndex].VType;
-              for (x = 0; x < PLUGIN_MAX; x++)
-              {
-                if (Plugin_id[x] == Settings.TaskDeviceNumber[y])
+              const int x = getPluginId(y);
+              if (x >= 0) {
+                byte DeviceIndex = getDeviceIndex(Settings.TaskDeviceNumber[y]);
+                TempEvent.TaskIndex = y;
+                TempEvent.BaseVarIndex = y * VARS_PER_TASK;
+                TempEvent.sensorType = Device[DeviceIndex].VType;
+                checkRAM(F("PluginCall_s"),x);
+                if(Plugin_ptr[x](Function, &TempEvent, str))
                 {
-                  checkRAM(F("PluginCall_s"),x);
-                  if(Plugin_ptr[x](Function, &TempEvent, str))
-                  {
-                    return true;
-                  }
+                  return true;
                 }
               }
             }
           }
         }
         // @FIXME TD-er: work-around as long as gpio command is still performed in P001_switch.
-        for (x = 0; x < PLUGIN_MAX; x++)
+        for (byte x = 0; x < PLUGIN_MAX; x++)
           if (Plugin_id[x] != 0)
             if (Plugin_ptr[x](Function, event, str))
               return true;
@@ -1126,19 +1156,16 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
         {
           if (Settings.TaskDeviceEnabled[y] && Settings.TaskDeviceNumber[y] != 0)
           {
-            for (x = 0; x < PLUGIN_MAX; x++)
-            {
-              if (Plugin_id[x] == Settings.TaskDeviceNumber[y])
-              {
-                byte DeviceIndex = getDeviceIndex(Settings.TaskDeviceNumber[y]);
-                TempEvent.TaskIndex = y;
-                TempEvent.BaseVarIndex = y * VARS_PER_TASK;
-                //TempEvent.idx = Settings.TaskDeviceID[y]; todo check
-                TempEvent.sensorType = Device[DeviceIndex].VType;
-                if (Plugin_ptr[x](Function, event, str)){
-                  checkRAM(F("PluginCallUDP"),x);
-                  return true;
-                }
+            const int x = getPluginId(y);
+            if (x >= 0) {
+              byte DeviceIndex = getDeviceIndex(Settings.TaskDeviceNumber[y]);
+              TempEvent.TaskIndex = y;
+              TempEvent.BaseVarIndex = y * VARS_PER_TASK;
+              //TempEvent.idx = Settings.TaskDeviceID[y]; todo check
+              TempEvent.sensorType = Device[DeviceIndex].VType;
+              if (Plugin_ptr[x](Function, event, str)){
+                checkRAM(F("PluginCallUDP"),x);
+                return true;
               }
             }
           }
@@ -1163,19 +1190,16 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
           {
             if (Settings.TaskDeviceDataFeed[y] == 0) // these calls only to tasks with local feed
             {
-              byte DeviceIndex = getDeviceIndex(Settings.TaskDeviceNumber[y]);
-              TempEvent.TaskIndex = y;
-              TempEvent.BaseVarIndex = y * VARS_PER_TASK;
-              //TempEvent.idx = Settings.TaskDeviceID[y]; todo check
-              TempEvent.sensorType = Device[DeviceIndex].VType;
-              TempEvent.OriginTaskIndex = event->TaskIndex;
-              for (x = 0; x < PLUGIN_MAX; x++)
-              {
-                if (Plugin_id[x] == Settings.TaskDeviceNumber[y])
-                {
-                  checkRAM(F("PluginCall_s"),x);
-                  Plugin_ptr[x](Function, &TempEvent, str);
-                }
+              const int x = getPluginId(y);
+              if (x >= 0) {
+                byte DeviceIndex = getDeviceIndex(Settings.TaskDeviceNumber[y]);
+                TempEvent.TaskIndex = y;
+                TempEvent.BaseVarIndex = y * VARS_PER_TASK;
+                //TempEvent.idx = Settings.TaskDeviceID[y]; todo check
+                TempEvent.sensorType = Device[DeviceIndex].VType;
+                TempEvent.OriginTaskIndex = event->TaskIndex;
+                checkRAM(F("PluginCall_s"),x);
+                Plugin_ptr[x](Function, &TempEvent, str);
               }
             }
           }
@@ -1195,11 +1219,11 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
     case PLUGIN_GET_DEVICEGPIONAMES:
     case PLUGIN_READ:
     case PLUGIN_SET_CONFIG:
-    case PLUGIN_GET_CONFIG:
-      for (x = 0; x < PLUGIN_MAX; x++)
-      {
-        if ((Plugin_id[x] != 0 ) && (Plugin_id[x] == Settings.TaskDeviceNumber[event->TaskIndex]))
-        {
+    case PLUGIN_GET_CONFIG: 
+    {
+      const int x = getPluginId(event->TaskIndex);
+      if (x >= 0) {
+        if (Plugin_id[x] != 0 ) {
           event->BaseVarIndex = event->TaskIndex * VARS_PER_TASK;
           checkRAM(F("PluginCall_init"),x);
           return Plugin_ptr[x](Function, event, str);
@@ -1207,6 +1231,7 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
       }
       return false;
       break;
+    }
 
   }// case
   return false;


### PR DESCRIPTION
BMx280 plugin changed the way that plugin is reading its data.
This did affect other time critical routines quite a lot.

For now there is a number of timing statistics collected to see what takes a lot of time.
Also the default MQTT message delay is now set to 100msec, since 1000 was way too long.
This still has to be changed to make sure a message is just queued, not letting the whole node wait.

N.B. the timing statistics will later be put behind some flag.
For now the collected statistics will be sent to log every 30 seconds.
This log dump is way too big for the web-log to keep up. (nice debug test case though ;) )
Only visible via syslog or serial log.

N.B.2: These statistics render a previous PR outdated ( #1107 ), but I used it to get inspired to start digging into these timings and found a lot of issues.


Updated the ESP32 library to 1.1.0
This does increase the free memory to a very impressive 187k+ free RAM.
But there's still a crash when trying to access the devices tab.

Also made some stability improvements on the Webserver when processing POST values.