### PR TITLE
[#1542] Fix  Domoticz IDX more than 4 characters

### DIFF
--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -2193,7 +2193,7 @@ void handle_devices() {
               TXBuffer += F("<TR><TD>IDX:<TD>");
               id = F("TDID");   //="taskdeviceid"
               id += controllerNr + 1;
-              addNumericBox(id, Settings.TaskDeviceID[controllerNr][taskIndex], 0, 9999);
+              addNumericBox(id, Settings.TaskDeviceID[controllerNr][taskIndex], 0, 999999999); // Looks like it is an unsigned int, so could be up to 4 bln.
             }
           }
         }


### PR DESCRIPTION
Looks like Domoticz uses an unsigned int, so it could be up-to 32 bits.
Just to be sure, I limited it now to 1 bln.