### PR TITLE
[WiFi] Reset wifi when IP is set to 0.0.0.0

### DIFF
--- a/src/ESPEasyWifi.ino
+++ b/src/ESPEasyWifi.ino
@@ -752,6 +752,16 @@ void WifiCheck()
     return;
 
   processDisableAPmode();
+  IPAddress ip = WiFi.localIP();
+  if (!useStaticIP()) {
+    if (ip[0] == 0 && ip[1] == 0 && ip[2] == 0 && ip[3] == 0) {
+      if (WiFiConnected()) {
+        // Some strange situation where the DHCP renew probably has failed and erased the config.
+        resetWiFi();
+      }
+    }
+  }
+
   if (wifiStatus != ESPEASY_WIFI_SERVICES_INITIALIZED) {
     if (timeOutReached(last_wifi_connect_attempt_moment + (1000 + wifi_connect_attempt * 200))) {
       WiFiConnectRelaxed();


### PR DESCRIPTION
As being described a few times and a screenshot shown here: https://github.com/letscontrolit/ESPEasy/issues/1302#issuecomment-393631572
It looks like a DHCP request may fail resulting in a cleared IP setup. The web server then still replies to requests, but no new connections can be made then.

This patch should detect such a situation and then reset the wifi and make a new connection.