### PR TITLE
[ParseString] Make ParseString more efficient and check results when used

### DIFF
--- a/src/Command.ino
+++ b/src/Command.ino
@@ -25,96 +25,96 @@
 \*********************************************************************************************/
 bool doExecuteCommand(const char * cmd, struct EventStruct *event, const char* line) {
   // Simple macro to match command to function call.
-  #define COMMAND_CASE(S,C) if (strcmp_P(cmd_lc, PSTR(S)) == 0) return (C(event,line)); 
-  
-  String tmpcmd; 
-  tmpcmd = cmd; 
-  tmpcmd.toLowerCase(); 
-  String log = F("Command: "); 
-  log += tmpcmd; 
-  addLog(LOG_LEVEL_INFO, log); 
-  char cmd_lc[INPUT_COMMAND_SIZE]; 
-  tmpcmd.toCharArray(cmd_lc, tmpcmd.length() + 1); 
+  #define COMMAND_CASE(S,C) if (strcmp_P(cmd_lc, PSTR(S)) == 0) return (C(event,line));
+
+  String tmpcmd;
+  tmpcmd = cmd;
+  tmpcmd.toLowerCase();
+  String log = F("Command: ");
+  log += tmpcmd;
+  addLog(LOG_LEVEL_INFO, log);
+  char cmd_lc[INPUT_COMMAND_SIZE];
+  tmpcmd.toCharArray(cmd_lc, tmpcmd.length() + 1);
   switch (cmd_lc[0]) {
-    case 'a': { 
+    case 'a': {
 	  COMMAND_CASE("accessinfo"             , Command_AccessInfo_Ls);              // Network Command
-      break; 
-    } 
-    case 'b': { 
+      break;
+    }
+    case 'b': {
 	  COMMAND_CASE("background"             , Command_Background);                 // Diagnostic.h
     #ifdef CPLUGIN_012
 	  COMMAND_CASE("blynkget"               , Command_Blynk_Get);
     #endif
 	  COMMAND_CASE("build"                  , Command_Settings_Build);             // Settings.h
-      break; 
-    } 
-    case 'c': { 
+      break;
+    }
+    case 'c': {
 	  COMMAND_CASE("clearaccessblock"       , Command_AccessInfo_Clear);           // Network Command
 	  COMMAND_CASE("clearrtcram"            , Command_RTC_Clear);                  // RTC.h
 	  COMMAND_CASE("config"                 , Command_Task_RemoteConfig);          // Tasks.h
-      break; 
-    } 
-    case 'd': { 
+      break;
+    }
+    case 'd': {
 	  COMMAND_CASE("debug"                  , Command_Debug);                      // Diagnostic.h
 	  COMMAND_CASE("deepsleep"              , Command_System_deepSleep);           // System.h
 	  COMMAND_CASE("delay"                  , Command_Delay);                      // Timers.h
 	  COMMAND_CASE("dns"                    , Command_DNS);                        // Network Command
 	  COMMAND_CASE("dst"                    , Command_DST);                        // Time.h
-      break; 
-    } 
-    case 'e': { 
+      break;
+    }
+    case 'e': {
 	  COMMAND_CASE("erase"                  , Command_WiFi_Erase);                 // WiFi.h
 	  COMMAND_CASE("event"                  , Command_Rules_Events);               // Rule.h
 	  COMMAND_CASE("executerules"           , Command_Rules_Execute);              // Rule.h
-      break; 
-    } 
-    case 'g': { 
+      break;
+    }
+    case 'g': {
 	  COMMAND_CASE("gateway"                , Command_Gateway);                    // Network Command
-      break; 
-    } 
-    case 'i': { 
+      break;
+    }
+    case 'i': {
 	  COMMAND_CASE("i2cscanner"             , Command_i2c_Scanner);                // i2c.h
 	  COMMAND_CASE("ip"                     , Command_IP);                         // Network Command
-      break; 
-    } 
-    case 'l': { 
+      break;
+    }
+    case 'l': {
 	  COMMAND_CASE("load"                   , Command_Settings_Load);              // Settings.h
 	  COMMAND_CASE("logentry"               , Command_logentry);                   // Diagnostic.h
 	  COMMAND_CASE("lowmem"                 , Command_Lowmem);                     // Diagnostic.h
-      break; 
-    } 
-    case 'm': { 
+      break;
+    }
+    case 'm': {
 	  COMMAND_CASE("malloc"                 , Command_Malloc);                     // Diagnostic.h
 	  COMMAND_CASE("meminfo"                , Command_MenInfo);                    // Diagnostic.h
 	  COMMAND_CASE("messagedelay"           , Command_MQTT_messageDelay);          // MQTT.h
 	  COMMAND_CASE("mqttretainflag"         , Command_MQTT_Retain);                // MQTT.h
-      break; 
-    } 
-    case 'n': { 
+      break;
+    }
+    case 'n': {
 	  COMMAND_CASE("name"                   , Command_Settings_Name);              // Settings.h
 	  COMMAND_CASE("nosleep"                , Command_System_NoSleep);             // System.h
 	  COMMAND_CASE("notify"                 , Command_Notifications_Notify);       // Notifications.h
 	  COMMAND_CASE("ntphost"                , Command_NTPHost);                    // Time.h
-      break; 
-    } 
-    case 'p': { 
+      break;
+    }
+    case 'p': {
 	  COMMAND_CASE("password"               , Command_Settings_Password);          // Settings.h
 	  COMMAND_CASE("publish"                , Command_MQTT_Publish);               // MQTT.h
-      break; 
-    } 
-    case 'r': { 
+      break;
+    }
+    case 'r': {
 	  COMMAND_CASE("reboot"                 , Command_System_Reboot);              // System.h
 	  COMMAND_CASE("reset"                  , Command_Settings_Reset);             // Settings.h
 	  COMMAND_CASE("resetflashwritecounter" , Command_RTC_resetFlashWriteCounter); // RTC.h
 	  COMMAND_CASE("restart"                , Command_System_Restart);             // System.h
 	  COMMAND_CASE("rules"                  , Command_Rules_UseRules);             // Rule.h
-      break; 
-    } 
-    case 's': { 
+      break;
+    }
+    case 's': {
 	  COMMAND_CASE("save"                   , Command_Settings_Save);              // Settings.h
 	#if FEATURE_SD
 	  COMMAND_CASE("sdcard"                 , Command_SD_LS);                      // SDCARDS.h
-	  COMMAND_CASE("sdremove"               , Command_SD_Remove);                  // SDCARDS.h 
+	  COMMAND_CASE("sdremove"               , Command_SD_Remove);                  // SDCARDS.h
 	#endif
 	  COMMAND_CASE("sendto"                 , Command_UPD_SendTo);                 // UDP.h
 	  COMMAND_CASE("sendtohttp"             , Command_HTTP_SendToHTTP);            // HTTP.h
@@ -123,9 +123,9 @@ bool doExecuteCommand(const char * cmd, struct EventStruct *event, const char* l
 	  COMMAND_CASE("settings"               , Command_Settings_Print);             // Settings.h
 	  COMMAND_CASE("subnet"                 , Command_Subnet);                     // Network Command
 	  COMMAND_CASE("sysload"                , Command_SysLoad);                    // Diagnostic.h
-      break; 
-    } 
-    case 't': { 
+      break;
+    }
+    case 't': {
 	  COMMAND_CASE("taskclear"              , Command_Task_Clear);                 // Tasks.h
 	  COMMAND_CASE("taskclearall"           , Command_Task_ClearAll);              // Tasks.h
 	  COMMAND_CASE("taskrun"                , Command_Task_Run);                   // Tasks.h
@@ -135,16 +135,16 @@ bool doExecuteCommand(const char * cmd, struct EventStruct *event, const char* l
 	  COMMAND_CASE("timerresume"            , Command_Timer_Resume);               // Timers.h
 	  COMMAND_CASE("timerset"               , Command_Timer_Set);                  // Timers.h
 	  COMMAND_CASE("timezone"               , Command_TimeZone);                   // Time.h
-      break; 
-    } 
-    case 'u': { 
+      break;
+    }
+    case 'u': {
 	  COMMAND_CASE("udpport"                , Command_UDP_Port);                   // UDP.h
 	  COMMAND_CASE("udptest"                , Command_UDP_Test);                   // UDP.h
 	  COMMAND_CASE("unit"                   , Command_Settings_Unit);              // Settings.h
 	  COMMAND_CASE("usentp"                 , Command_useNTP);                     // Time.h
-      break; 
-    } 
-    case 'w': { 
+      break;
+    }
+    case 'w': {
 	  COMMAND_CASE("wdconfig"               , Command_WD_Config);                  // WD.h
 	  COMMAND_CASE("wdread"                 , Command_WD_Read);                    // WD.h
 	  COMMAND_CASE("wifiapmode"             , Command_Wifi_APMode);                // WiFi.h
@@ -157,12 +157,15 @@ bool doExecuteCommand(const char * cmd, struct EventStruct *event, const char* l
 	  COMMAND_CASE("wifissid"               , Command_Wifi_SSID);                  // WiFi.h
 	  COMMAND_CASE("wifissid2"              , Command_Wifi_SSID2);                 // WiFi.h
 	  COMMAND_CASE("wifistamode"            , Command_Wifi_STAMode);               // WiFi.h
-      break; 
-    } 
-    default: 
       break;
-  } 
-  addLog(LOG_LEVEL_INFO, F("Command unknown")); 
+    }
+    default:
+      break;
+  }
+  String errorUnknown = F("Command unknown: \"");
+  errorUnknown += cmd_lc;
+  errorUnknown += '\"';
+  addLog(LOG_LEVEL_INFO, errorUnknown);
   return false;
 
   #undef COMMAND_CASE
@@ -175,17 +178,17 @@ void ExecuteCommand(byte source, const char *Line)
   boolean success = false;
   char TmpStr1[INPUT_COMMAND_SIZE];
   TmpStr1[0] = 0;
-  char cmd[INPUT_COMMAND_SIZE];   
+  char cmd[INPUT_COMMAND_SIZE];
   cmd[0] = 0;
   struct EventStruct TempEvent;
-  TempEvent.Source = source; 
+  TempEvent.Source = source;
   GetArgv(Line, cmd, 1);
   if (GetArgv(Line, TmpStr1, 2)) TempEvent.Par1 = str2int(TmpStr1);
   if (GetArgv(Line, TmpStr1, 3)) TempEvent.Par2 = str2int(TmpStr1);
   if (GetArgv(Line, TmpStr1, 4)) TempEvent.Par3 = str2int(TmpStr1);
   if (GetArgv(Line, TmpStr1, 5)) TempEvent.Par4 = str2int(TmpStr1);
   if (GetArgv(Line, TmpStr1, 6)) TempEvent.Par5 = str2int(TmpStr1);
-  
+
   success = doExecuteCommand((char*)&cmd[0], &TempEvent, Line);
   yield();
 

--- a/src/Commands/HTTP.h
+++ b/src/Commands/HTTP.h
@@ -8,8 +8,11 @@ bool Command_HTTP_SendToHTTP(struct EventStruct *event, const char* Line)
       String strLine = Line;
       String host = parseString(strLine, 2);
       String port = parseString(strLine, 3);
+      if (!isInt(port)) return false;
       int pathpos = getParamStartPos(strLine, 4);
-      String path = strLine.substring(pathpos);
+      String path;
+      if (pathpos >= 0) 
+        path = strLine.substring(pathpos);
       WiFiClient client;
       if (client.connect(host.c_str(), port.toInt()))
       {
@@ -20,6 +23,7 @@ bool Command_HTTP_SendToHTTP(struct EventStruct *event, const char* Line)
         reply += host;
         reply += F("\r\n");
         reply += F("Connection: close\r\n\r\n");
+        addLog(LOG_LEVEL_DEBUG, reply);
         client.print(reply);
 
         unsigned long timer = millis() + 200;

--- a/src/Commands/UPD.h
+++ b/src/Commands/UPD.h
@@ -39,12 +39,14 @@ bool Command_UDP_SendToUPD(struct EventStruct *event, const char* Line)
 {
   bool success = false;
   if (wifiStatus == ESPEASY_WIFI_SERVICES_INITIALIZED) {
-    success = true;
     String strLine = Line;
     String ip = parseString(strLine, 2);
     String port = parseString(strLine, 3);
+    if (!isInt(port)) return success;
     int msgpos = getParamStartPos(strLine, 4);
-    String message = strLine.substring(msgpos);
+    String message;
+    if (msgpos >= 0)
+      message = strLine.substring(msgpos);
     IPAddress UDP_IP;
     if(UDP_IP.fromString(ip)) {
       portUDP.beginPacket(UDP_IP, port.toInt());
@@ -56,6 +58,7 @@ bool Command_UDP_SendToUPD(struct EventStruct *event, const char* Line)
       #endif
       portUDP.endPacket();
     }
+    success = true;
   }
   return success;  
 }

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -100,7 +100,7 @@ void deepSleepStart(int delay)
   #endif
 }
 
-boolean remoteConfig(struct EventStruct *event, String& string)
+boolean remoteConfig(struct EventStruct *event, const String& string)
 {
   checkRAM(F("remoteConfig"));
   boolean success = false;
@@ -112,7 +112,9 @@ boolean remoteConfig(struct EventStruct *event, String& string)
     if (parseString(string, 2) == F("task"))
     {
       int configCommandPos1 = getParamStartPos(string, 3);
+      if (configCommandPos1 < 0) return success; // TD-er: Should this be return false?
       int configCommandPos2 = getParamStartPos(string, 4);
+      if (configCommandPos2 < 0 || (configCommandPos2 - configCommandPos1) < 1) return success; // TD-er: Should this be return false?
 
       String configTaskName = string.substring(configCommandPos1, configCommandPos2 - 1);
       String configCommand = string.substring(configCommandPos2);

--- a/src/StringConverter.ino
+++ b/src/StringConverter.ino
@@ -135,10 +135,10 @@ String toString(WiFiMode_t mode)
       break;
     case WIFI_AP_STA:
       result = F("AP+STA");
-      break;    
+      break;
     default:
       break;
-  }  
+  }
   return result;
 }
 
@@ -231,47 +231,35 @@ String to_json_object_value(const String& object, const String& value) {
 
 
 /*********************************************************************************************\
-   Parse a string and get the xth command or parameter
+   Parse a string and get the xth command or parameter in lower case
   \*********************************************************************************************/
-String parseString(String& string, byte indexFind)
-{
-  String tmpString = string;
-  tmpString += ',';
-  tmpString.replace(' ', ',');
-  String locateString = "";
-  byte count = 0;
-  int index = tmpString.indexOf(',');
-  while (index > 0)
-  {
-    count++;
-    locateString = tmpString.substring(0, index);
-    tmpString = tmpString.substring(index + 1);
-    index = tmpString.indexOf(',');
-    if (count == indexFind)
-    {
-      locateString.toLowerCase();
-      return locateString;
-    }
-  }
-  return "";
+String parseString(const String& string, byte indexFind) {
+  const int startpos = getParamStartPos(string, indexFind);
+  if (startpos < 0) return "";
+  const int endpos = getParamStartPos(string, indexFind + 1);
+  String result = (endpos < 0) ? string.substring(startpos) : string.substring(startpos, endpos);
+  result.toLowerCase();
+  return result;
 }
-
 
 /*********************************************************************************************\
    Parse a string and get the xth command or parameter
   \*********************************************************************************************/
-int getParamStartPos(String& string, byte indexFind)
+int getParamStartPos(const String& string, byte indexFind)
 {
-  String tmpString = string;
-  byte count = 0;
-  tmpString.replace(' ', ',');
-  for (unsigned int x = 0; x < tmpString.length(); x++)
+  if (indexFind == 0) return 0;
+  byte count = 1;
+  const unsigned int strlength = string.length();
+  if (strlength <= indexFind) return -1;
+  for (unsigned int x = 0; x < (strlength - 1); ++x)
   {
-    if (tmpString.charAt(x) == ',')
+    const char c = string.charAt(x);
+    if (c == ',' || c == ' ')
     {
-      count++;
-      if (count == (indexFind - 1))
+      if (count == indexFind) {
         return x + 1;
+      }
+      ++count;
     }
   }
   return -1;

--- a/src/StringConverter.ino
+++ b/src/StringConverter.ino
@@ -83,7 +83,7 @@ String formatHumanReadable(unsigned long value, unsigned long factor) {
     case 2: result += 'M'; break;
     case 3: result += 'G'; break;
     case 4: result += 'T'; break;
-    default: 
+    default:
       result += '*';
       result += factor;
       result += '^';
@@ -234,10 +234,13 @@ String to_json_object_value(const String& object, const String& value) {
    Parse a string and get the xth command or parameter in lower case
   \*********************************************************************************************/
 String parseString(const String& string, byte indexFind) {
-  const int startpos = getParamStartPos(string, indexFind);
-  if (startpos < 0) return "";
-  const int endpos = getParamStartPos(string, indexFind + 1);
-  String result = (endpos < 0) ? string.substring(startpos) : string.substring(startpos, endpos);
+  int startpos = 0;
+  if (indexFind > 0) {
+    startpos = getParamStartPos(string, indexFind - 1);
+    if (startpos < 0) return string;
+  }
+  const int endpos = getParamStartPos(string, indexFind);
+  String result = (endpos <= 0) ? string.substring(startpos) : string.substring(startpos, endpos - 1);
   result.toLowerCase();
   return result;
 }

--- a/src/_P055_Chiming.ino
+++ b/src/_P055_Chiming.ino
@@ -215,9 +215,11 @@ boolean Plugin_055(byte function, struct EventStruct *event, String& string)
         if (command == F("chime"))
         {
           int paramPos = getParamStartPos(string, 2);
-          String param = string.substring(paramPos);
-          Plugin_055_AddStringFIFO(param);
-          success = true;
+          if (paramPos >= 0) {
+            String param = string.substring(paramPos);
+            Plugin_055_AddStringFIFO(param);
+            success = true;
+          }
         }
         if (command == F("chimeplay"))
         {
@@ -231,10 +233,12 @@ boolean Plugin_055(byte function, struct EventStruct *event, String& string)
         {
           String name = parseString(string, 2);
           int paramPos = getParamStartPos(string, 3);
-          String param = string.substring(paramPos);
-          Plugin_055_WriteChime(name, param);
-          Plugin_055_AddStringFIFO(F("1"));
-          success = true;
+          if (paramPos >= 0) {
+            String param = string.substring(paramPos);
+            Plugin_055_WriteChime(name, param);
+            Plugin_055_AddStringFIFO(F("1"));
+            success = true;
+          }
         }
 
         break;

--- a/src/_P057_HT16K33_LED.ino
+++ b/src/_P057_HT16K33_LED.ino
@@ -157,25 +157,29 @@ boolean Plugin_057(byte function, struct EventStruct *event, String& string)
         if (command == F("mprint"))
         {
           int paramPos = getParamStartPos(lowerString, 2);
-          String text = lowerString.substring(paramPos);
-          byte seg = 0;
+          if (paramPos >= 0) {
+            String text = lowerString.substring(paramPos);
+            byte seg = 0;
 
-          Plugin_057_M->ClearRowBuffer();
-          while (text[seg] && seg < 8)
-          {
-            // uint16_t value = 0;
-            char c = text[seg];
-            Plugin_057_M->SetDigit(seg, c);
-            seg++;
+            Plugin_057_M->ClearRowBuffer();
+            while (text[seg] && seg < 8)
+            {
+              // uint16_t value = 0;
+              char c = text[seg];
+              Plugin_057_M->SetDigit(seg, c);
+              seg++;
+            }
+            Plugin_057_M->TransmitRowBuffer();
+            success = true;
           }
-          Plugin_057_M->TransmitRowBuffer();
-          success = true;
         }
         else if (command == F("mbr")) {
           int paramPos = getParamStartPos(lowerString, 2);
-          uint8_t brightness = lowerString.substring(paramPos).toInt();
-          Plugin_057_M->SetBrightness(brightness);
-          success = true;
+          if (paramPos >= 0) {
+            uint8_t brightness = lowerString.substring(paramPos).toInt();
+            Plugin_057_M->SetBrightness(brightness);
+            success = true;
+          }
         }
         else if (command == F("m") || command == F("mx") || command == F("mnum"))
         {


### PR DESCRIPTION
`ParseString` and `getParamStartPos` made (lots of) copies of the strings.
Also the result of `getParamStartPos` was not checked, which can result in crashes.