### PR TITLE
When clientid = %sysname%, only add %unit% if non-zero (#1155)

### DIFF
--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -142,8 +142,10 @@ bool MQTTConnect(int controller_idx)
   String clientid;
   if(Settings.MQTTUseUnitNameAsClientId){
     clientid = Settings.Name;
-    clientid += F("_");
-    clientid += Settings.Unit;
+    if (Settings.Unit != 0) { // only append non-zero unit number
+      clientid += F("_");
+      clientid += Settings.Unit;
+    }
   }
   else{
     clientid = F("ESPClient_");


### PR DESCRIPTION
Allows option for full control of MQTT clientid by only appending %unit% when non-zero (#1155).

Provides a (limited) level of assurance that clientid will be unique within the network; if the user has multiple units with the same %sysname%, likely they will have incremented the %unit% of each from the default of 0.

Solution can probably be improved upon, but at least this option imposes no further memory overhead.