### PR TITLE
[#1591] Move system timers to main scheduler

### DIFF
--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -297,7 +297,6 @@
 #define NPLUGIN_MAX                         4
 #define UNIT_MAX                           32 // Only relevant for UDP unicast message 'sweeps' and the nodelist.
 #define RULES_TIMER_MAX                     8
-#define SYSTEM_CMD_TIMER_MAX                2
 #define PINSTATE_TABLE_MAX                 32
 #define RULES_MAX_SIZE                   2048
 #define RULES_MAX_NESTING_LEVEL             3
@@ -1119,13 +1118,6 @@ struct systemTimerStruct
 };
 std::map<unsigned long, systemTimerStruct> systemTimers;
 
-struct systemCMDTimerStruct
-{
-  systemCMDTimerStruct() : timer(0) {}
-  unsigned long timer;
-  String action;
-} systemCMDTimers[SYSTEM_CMD_TIMER_MAX];
-
 struct pinStatesStruct
 {
   byte plugin;
@@ -1310,9 +1302,6 @@ unsigned long loopCounter_full = 1;
 float loop_usec_duration_total = 0.0;
 unsigned long countFindPluginId = 0;
 
-unsigned long systemTimerCalls = 1;
-float systemTimerDurationTotal = 0.0;
-
 unsigned long dailyResetCounter = 0;
 
 String eventBuffer = "";
@@ -1470,6 +1459,7 @@ std::map<int,TimingStats> miscStats;
 #define SEND_DATA_STATS   7
 #define COMPUTE_FORMULA_STATS 8
 #define PROC_SYS_TIMER    9
+#define SET_NEW_TIMER    10
 
 
 
@@ -1493,6 +1483,7 @@ String getMiscStatsName(int stat) {
         case SEND_DATA_STATS:    return F("sendData()          ");
         case COMPUTE_FORMULA_STATS: return F("Compute formula  ");
         case PROC_SYS_TIMER:     return F("proc_system_timer() ");
+        case SET_NEW_TIMER:      return F("setNewTimerAt()     ");
     }
     return F("Unknown");
 }

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -1164,7 +1164,6 @@ struct rulesTimerStatus
 
 msecTimerHandlerStruct msecTimerHandler;
 
-unsigned long timerSensor[TASKS_MAX];
 unsigned long timermqtt_interval;
 unsigned long lastSend;
 unsigned long lastWeb;
@@ -1449,17 +1448,17 @@ bool mustLogFunction(int function) {
 std::map<int,TimingStats> pluginStats;
 std::map<int,TimingStats> miscStats;
 
-#define LOADFILE_STATS    0
-#define LOOP_STATS        1
-#define PLUGIN_CALL_50PS  2
-#define PLUGIN_CALL_10PS  3
-#define PLUGIN_CALL_10PSU 4
-#define PLUGIN_CALL_1PS   5
-#define CHECK_SENSORS     6
-#define SEND_DATA_STATS   7
+#define LOADFILE_STATS        0
+#define LOOP_STATS            1
+#define PLUGIN_CALL_50PS      2
+#define PLUGIN_CALL_10PS      3
+#define PLUGIN_CALL_10PSU     4
+#define PLUGIN_CALL_1PS       5
+#define SENSOR_SEND_TASK      6
+#define SEND_DATA_STATS       7
 #define COMPUTE_FORMULA_STATS 8
-#define PROC_SYS_TIMER    9
-#define SET_NEW_TIMER    10
+#define PROC_SYS_TIMER        9
+#define SET_NEW_TIMER        10
 
 
 
@@ -1475,15 +1474,15 @@ String getMiscStatsName(int stat) {
     switch (stat) {
         case LOADFILE_STATS: return F("Load File");
         case LOOP_STATS:     return F("Loop");
-        case PLUGIN_CALL_50PS  : return F("Plugin call 50 p/s  ");
-        case PLUGIN_CALL_10PS  : return F("Plugin call 10 p/s  ");
-        case PLUGIN_CALL_10PSU : return F("Plugin call 10 p/s U");
-        case PLUGIN_CALL_1PS   : return F("Plugin call  1 p/s  ");
-        case CHECK_SENSORS:      return F("checkSensors()      ");
-        case SEND_DATA_STATS:    return F("sendData()          ");
-        case COMPUTE_FORMULA_STATS: return F("Compute formula  ");
-        case PROC_SYS_TIMER:     return F("proc_system_timer() ");
-        case SET_NEW_TIMER:      return F("setNewTimerAt()     ");
+        case PLUGIN_CALL_50PS:      return F("Plugin call 50 p/s  ");
+        case PLUGIN_CALL_10PS:      return F("Plugin call 10 p/s  ");
+        case PLUGIN_CALL_10PSU:     return F("Plugin call 10 p/s U");
+        case PLUGIN_CALL_1PS:       return F("Plugin call  1 p/s  ");
+        case SENSOR_SEND_TASK:      return F("SensorSendTask()    ");
+        case SEND_DATA_STATS:       return F("sendData()          ");
+        case COMPUTE_FORMULA_STATS: return F("Compute formula     ");
+        case PROC_SYS_TIMER:        return F("proc_system_timer() ");
+        case SET_NEW_TIMER:         return F("setNewTimerAt()     ");
     }
     return F("Unknown");
 }

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -297,7 +297,6 @@
 #define NPLUGIN_MAX                         4
 #define UNIT_MAX                           32 // Only relevant for UDP unicast message 'sweeps' and the nodelist.
 #define RULES_TIMER_MAX                     8
-#define SYSTEM_TIMER_MAX                    8
 #define SYSTEM_CMD_TIMER_MAX                2
 #define PINSTATE_TABLE_MAX                 32
 #define RULES_MAX_SIZE                   2048
@@ -380,6 +379,7 @@
 #include "ESPEasyTimeTypes.h"
 #include "I2CTypes.h"
 #include <I2Cdev.h>
+#include <map>
 
 #define FS_NO_GLOBALS
 #if defined(ESP8266)
@@ -1116,9 +1116,8 @@ struct systemTimerStruct
   int Par3;
   int Par4;
   int Par5;
-} systemTimers[SYSTEM_TIMER_MAX];
-
-#define NOTAVAILABLE_SYSTEM_TIMER_ERROR "There are no system timer available, max parallel timers are " STR(SYSTEM_TIMER_MAX)
+};
+std::map<unsigned long, systemTimerStruct> systemTimers;
 
 struct systemCMDTimerStruct
 {
@@ -1330,8 +1329,6 @@ boolean       UseRTOSMultitasking;
 
 void (*MainLoopCall_ptr)(void);
 
-#include <map>
-
 class TimingStats {
     public:
       TimingStats() : _timeTotal(0.0), _count(0), _maxVal(0), _minVal(4294967295) {}
@@ -1448,7 +1445,7 @@ bool mustLogFunction(int function) {
         case PLUGIN_SERIAL_IN:             return true;
         case PLUGIN_UDP_IN:                return true;
         case PLUGIN_CLOCK_IN:              return false;
-        case PLUGIN_TIMER_IN:              return false;
+        case PLUGIN_TIMER_IN:              return true;
         case PLUGIN_FIFTY_PER_SECOND:      return true;
         case PLUGIN_SET_CONFIG:            return false;
         case PLUGIN_GET_DEVICEGPIONAMES:   return false;
@@ -1472,6 +1469,7 @@ std::map<int,TimingStats> miscStats;
 #define CHECK_SENSORS     6
 #define SEND_DATA_STATS   7
 #define COMPUTE_FORMULA_STATS 8
+#define PROC_SYS_TIMER    9
 
 
 
@@ -1494,6 +1492,7 @@ String getMiscStatsName(int stat) {
         case CHECK_SENSORS:      return F("checkSensors()      ");
         case SEND_DATA_STATS:    return F("sendData()          ");
         case COMPUTE_FORMULA_STATS: return F("Compute formula  ");
+        case PROC_SYS_TIMER:     return F("proc_system_timer() ");
     }
     return F("Unknown");
 }

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -409,10 +409,6 @@ void updateLoopStats_30sec(byte loglevel) {
     log += longestLoop;
     log += F(" avgLoopDuration: ");
     log += loop_usec_duration_total / loopCounter_full;
-    log += F(" systemTimerDuration: ");
-    log += systemTimerDurationTotal / systemTimerCalls;
-    log += F(" systemTimerCalls: ");
-    log += systemTimerCalls;
     log += F(" loopCounterMax: ");
     log += loopCounterMax;
     log += F(" loopCounterLast: ");
@@ -424,8 +420,6 @@ void updateLoopStats_30sec(byte loglevel) {
   countFindPluginId = 0;
   loop_usec_duration_total = 0;
   loopCounter_full = 1;
-  systemTimerDurationTotal = 0;
-  systemTimerCalls = 1;
 }
 
 float getCPUload() {
@@ -817,47 +811,6 @@ void SensorSendTask(byte TaskIndex)
       sendData(&TempEvent);
     }
   }
-}
-
-
-//EDWIN: this function seems to be unused?
-/*********************************************************************************************\
- * set global system command timer
-\*********************************************************************************************/
-void setSystemCMDTimer(unsigned long timer, String& action)
-{
-  for (byte x = 0; x < SYSTEM_CMD_TIMER_MAX; x++)
-    if (systemCMDTimers[x].timer == 0)
-    {
-      systemCMDTimers[x].timer = millis() + timer;
-      systemCMDTimers[x].action = action;
-      break;
-    }
-}
-
-
-/*********************************************************************************************\
- * check global system timers
-\*********************************************************************************************/
-void checkSystemTimers()
-{
-  unsigned long start = micros();
-
-  for (byte x = 0; x < SYSTEM_CMD_TIMER_MAX; x++)
-    if (systemCMDTimers[x].timer != 0)
-      if (timeOutReached(systemCMDTimers[x].timer))
-      {
-        struct EventStruct TempEvent;
-        parseCommandString(&TempEvent, systemCMDTimers[x].action);
-        if (!PluginCall(PLUGIN_WRITE, &TempEvent, systemCMDTimers[x].action))
-          ExecuteCommand(VALUE_SOURCE_SYSTEM, systemCMDTimers[x].action.c_str());
-        systemCMDTimers[x].timer = 0;
-        systemCMDTimers[x].action = "";
-      }
-
-  ++systemTimerCalls;
-  systemTimerDurationTotal += usecPassedSince(start);;
-
 }
 
 

--- a/src/ESPEasyTimeTypes.h
+++ b/src/ESPEasyTimeTypes.h
@@ -110,10 +110,6 @@ struct msecTimerHandlerStruct {
     insert(item);
   }
 
-  void registerFromNow(unsigned long id, unsigned long msecFromNow) {
-    registerAt(id, millis() + msecFromNow);
-  }
-
   // Check if timeout has been reached and also return its set timer.
   // Return 0 if no item has reached timeout moment.
   unsigned long getNextId(unsigned long& timer) {

--- a/src/ESPEasyTimeTypes.h
+++ b/src/ESPEasyTimeTypes.h
@@ -70,6 +70,8 @@ long timePassedSince(unsigned long timestamp);
 boolean timeOutReached(unsigned long timer);
 long usecPassedSince(unsigned long timestamp);
 boolean usecTimeOutReached(unsigned long timer);
+void setSystemTimer(unsigned long timer, byte plugin, short taskIndex, int Par1,
+  int Par2 = 0, int Par3 = 0, int Par4 = 0, int Par5 = 0);
 
 
 
@@ -173,11 +175,13 @@ private:
 
     // Make sure only one is present with the same id.
     _timer_ids.remove_if(match_id(item._id));
+    const bool mustSort = !_timer_ids.empty();
     _timer_ids.push_front(item);
-    if (_timer_ids.empty()) {
-      return;
-    }
-    _timer_ids.sort();
+    if (mustSort)
+      _timer_ids.sort(); // TD-er: Must check if this is an expensive operation.
+    // It should be a relative light operation, to insert into a sorted list.
+    // Perhaps it is better to use std::set ????
+    // Keep in mind: order is based on timer, uniqueness is based on id.
   }
 
   void recordIdle() {
@@ -192,15 +196,19 @@ private:
     total_idle_time_usec += usecPassedSince(last_exec_time_usec);
   }
 
-
+  // Statistics
   unsigned long get_called;
   unsigned long get_called_ret_id;
   unsigned long max_queue_length;
+
+  // Compute idle system time
   unsigned long last_exec_time_usec;
   unsigned long total_idle_time_usec;
   unsigned long last_log_start_time;
   bool is_idle;
   float idle_time_pct;
+
+  // The list of set timers
   std::list<timer_id_couple> _timer_ids;
 };
 

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -73,7 +73,7 @@ void deepSleep(int delay)
       return;
     }
   }
-
+  saveUserVarToRTC();
   deepSleepStart(delay); // Call deepSleepStart function after these checks
 }
 

--- a/src/Scheduler.ino
+++ b/src/Scheduler.ino
@@ -15,7 +15,7 @@ void setIntervalTimer(unsigned long id) {
 void setIntervalTimerOverride(unsigned long id, unsigned long msecFromNow) {
   unsigned long timer = millis();
   setNextTimeInterval(timer, msecFromNow);
-  msecTimerHandler.registerAt(getMixedId(CONST_INTERVAL_TIMER, id), timer);
+  setNewTimerAt(getMixedId(CONST_INTERVAL_TIMER, id), timer);
 }
 
 void setIntervalTimer(unsigned long id, unsigned long lasttimer) {
@@ -31,11 +31,11 @@ void setIntervalTimer(unsigned long id, unsigned long lasttimer) {
   }
   unsigned long timer = lasttimer;
   setNextTimeInterval(timer, interval);
-  msecTimerHandler.registerAt(getMixedId(CONST_INTERVAL_TIMER, id), timer);
+  setNewTimerAt(getMixedId(CONST_INTERVAL_TIMER, id), timer);
 }
 
 void setTimer(unsigned long timerType, unsigned long id, unsigned long msecFromNow) {
-  msecTimerHandler.registerFromNow(getMixedId(timerType, id), msecFromNow);
+  setNewTimerAt(getMixedId(timerType, id), millis() + msecFromNow);
 }
 
 void setSystemTimer(unsigned long timer, byte plugin, short taskIndex, int Par1, int Par2, int Par3, int Par4, int Par5)
@@ -52,6 +52,12 @@ void setSystemTimer(unsigned long timer, byte plugin, short taskIndex, int Par1,
   timer_data.Par5 = Par5;
   systemTimers[systemTimerId] = timer_data;
   setTimer(SYSTEM_TIMER, systemTimerId, timer);
+}
+
+void setNewTimerAt(unsigned long id, unsigned long timer) {
+  START_TIMER;
+  msecTimerHandler.registerAt(id, timer);
+  STOP_TIMER(SET_NEW_TIMER);
 }
 
 unsigned long createSystemTimerId(byte plugin, int Par1) {

--- a/src/Scheduler.ino
+++ b/src/Scheduler.ino
@@ -1,7 +1,8 @@
-#define TIMER_ID_SHIFT    16
+#define TIMER_ID_SHIFT    28
 
 #define CONST_INTERVAL_TIMER 1
 #define GENERIC_TIMER        2
+#define SYSTEM_TIMER         3
 
 void setTimer(unsigned long id) {
   setTimer(GENERIC_TIMER, id, 0);
@@ -37,6 +38,43 @@ void setTimer(unsigned long timerType, unsigned long id, unsigned long msecFromN
   msecTimerHandler.registerFromNow(getMixedId(timerType, id), msecFromNow);
 }
 
+void setSystemTimer(unsigned long timer, byte plugin, short taskIndex, int Par1, int Par2, int Par3, int Par4, int Par5)
+{
+  // plugin number and par1 form a unique key that can be used to restart a timer
+  // first check if a timer is not already running for this request
+  const unsigned long systemTimerId = createSystemTimerId(plugin, Par1);
+  systemTimerStruct timer_data;
+  timer_data.TaskIndex = taskIndex;
+  timer_data.Par1 = Par1;
+  timer_data.Par2 = Par2;
+  timer_data.Par3 = Par3;
+  timer_data.Par4 = Par4;
+  timer_data.Par5 = Par5;
+  systemTimers[systemTimerId] = timer_data;
+  setTimer(SYSTEM_TIMER, systemTimerId, timer);
+}
+
+unsigned long createSystemTimerId(byte plugin, int Par1) {
+  const unsigned long mask = (1 << TIMER_ID_SHIFT) -1;
+  const unsigned long mixed = (Par1 << 8) + plugin;
+/*
+  if (mixed & !mask) {
+    String error = F("createSystemTimerId: Information lost for Par1: ");
+    error += Par1;
+    error += F(" with plugin: ");
+    error += plugin;
+    addLog(LOG_LEVEL_ERROR, error);
+  }
+*/
+  return (mixed & mask);
+}
+
+void splitSystemTimerId(const unsigned long mixed_id, byte& plugin, int& Par1) {
+  const unsigned long mask = (1 << TIMER_ID_SHIFT) -1;
+  plugin = mixed_id & 0xFF;
+  Par1 = (mixed_id & mask) >> 8;
+}
+
 unsigned long getMixedId(unsigned long timerType, unsigned long id) {
   return (timerType << TIMER_ID_SHIFT) + id;
 }
@@ -53,6 +91,9 @@ void handle_schedule() {
     case CONST_INTERVAL_TIMER:
       setIntervalTimer(id, timer);
       process_interval_timer(id);
+      break;
+    case SYSTEM_TIMER:
+      process_system_timer(id);
       break;
   }
 }
@@ -79,5 +120,32 @@ void process_interval_timer(unsigned long id) {
       logTimerStatistics();
       break;
   }
+}
 
+void process_system_timer(unsigned long id) {
+  START_TIMER;
+  const systemTimerStruct timer_data = systemTimers[id];
+  struct EventStruct TempEvent;
+  TempEvent.TaskIndex = timer_data.TaskIndex;
+  TempEvent.Par1 = timer_data.Par1;
+  TempEvent.Par2 = timer_data.Par2;
+  TempEvent.Par3 = timer_data.Par3;
+  TempEvent.Par4 = timer_data.Par4;
+  TempEvent.Par5 = timer_data.Par5;
+  // TD-er: Not sure if we have to keep original source for notifications.
+  TempEvent.Source = VALUE_SOURCE_SYSTEM;
+  const int y = getPluginId(timer_data.TaskIndex);
+  String log = F("proc_system_timer: Pluginid: ");
+  log += y;
+  log += F(" taskIndex: ");
+  log += timer_data.TaskIndex;
+  log += F(" sysTimerID: ");
+  log += id;
+  addLog(LOG_LEVEL_INFO, log);
+  if (y >= 0) {
+    String dummy;
+    Plugin_ptr[y](PLUGIN_TIMER_IN, &TempEvent, dummy);
+  }
+  systemTimers.erase(id);
+  STOP_TIMER(PROC_SYS_TIMER);
 }

--- a/src/_P001_Switch.ino
+++ b/src/_P001_Switch.ino
@@ -324,11 +324,15 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
           success = true;
           if (event->Par1 >= 0 && event->Par1 <= PIN_D_MAX)
           {
+            const bool pinStateHigh = event->Par2 != 0;
+            const uint16_t pinStateValue = pinStateHigh ? 1 : 0;
+            const uint16_t inversePinStateValue = pinStateHigh ? 0 : 1;
             pinMode(event->Par1, OUTPUT);
-            digitalWrite(event->Par1, event->Par2);
-            setPinState(PLUGIN_ID_001, event->Par1, PIN_MODE_OUTPUT, event->Par2);
-            setSystemTimer(time_in_msec ? event->Par3 : event->Par3 * 1000,
-                           PLUGIN_ID_001, event->Par1, !event->Par2, 0);
+            digitalWrite(event->Par1, pinStateValue);
+            setPinState(PLUGIN_ID_001, event->Par1, PIN_MODE_OUTPUT, pinStateValue);
+            unsigned long timer = time_in_msec ? event->Par3 : event->Par3 * 1000;
+            // Create a future system timer call to set the GPIO pin back to its normal value.
+            setSystemTimer(timer, PLUGIN_ID_001, event->TaskIndex, event->Par1, inversePinStateValue);
             log = String(F("SW   : GPIO ")) + String(event->Par1) +
                   String(F(" Pulse set for ")) + String(event->Par3) + String(time_in_msec ? F(" msec") : F(" sec"));
             addLog(LOG_LEVEL_INFO, log);

--- a/src/_P009_MCP.ino
+++ b/src/_P009_MCP.ino
@@ -146,7 +146,7 @@ boolean Plugin_009(byte function, struct EventStruct *event, String& string)
           {
             Plugin_009_Write(event->Par1, event->Par2);
             setPinState(PLUGIN_ID_009, event->Par1, PIN_MODE_OUTPUT, event->Par2);
-            setSystemTimer(event->Par3 * 1000, PLUGIN_ID_009, event->Par1, !event->Par2, 0);
+            setSystemTimer(event->Par3 * 1000, PLUGIN_ID_009, event->TaskIndex, event->Par1, !event->Par2);
             log = String(F("MCP  : GPIO ")) + String(event->Par1) + String(F(" Pulse set for ")) + String(event->Par3) + String(F(" S"));
             addLog(LOG_LEVEL_INFO, log);
             SendStatus(event->Source, getPinStateJSON(SEARCH_PIN_STATE, PLUGIN_ID_009, event->Par1, log, 0));

--- a/src/_P011_PME.ino
+++ b/src/_P011_PME.ino
@@ -123,7 +123,7 @@ boolean Plugin_011(byte function, struct EventStruct *event, String& string)
           if (event->Par1 >= 0 && event->Par1 <= 13)
           {
             Plugin_011_Write(event->Par1, event->Par2);
-            setSystemTimer(event->Par3 * 1000, PLUGIN_ID_011, event->Par1, !event->Par2, 0);
+            setSystemTimer(event->Par3 * 1000, PLUGIN_ID_011, event->TaskIndex, event->Par1, !event->Par2);
             setPinState(PLUGIN_ID_011, event->Par1, PIN_MODE_OUTPUT, event->Par2);
             log = String(F("PME  : GPIO ")) + String(event->Par1) + String(F(" Pulse set for ")) + String(event->Par3) + String(F(" S"));
             addLog(LOG_LEVEL_INFO, log);

--- a/src/_P019_PCF8574.ino
+++ b/src/_P019_PCF8574.ino
@@ -145,7 +145,7 @@ boolean Plugin_019(byte function, struct EventStruct *event, String& string)
           success = true;
           Plugin_019_Write(event->Par1, event->Par2);
           setPinState(PLUGIN_ID_019, event->Par1, PIN_MODE_OUTPUT, event->Par2);
-          setSystemTimer(event->Par3 * 1000, PLUGIN_ID_019, event->Par1, !event->Par2, 0);
+          setSystemTimer(event->Par3 * 1000, PLUGIN_ID_019, event->TaskIndex, event->Par1, !event->Par2);
           log = String(F("PCF  : GPIO ")) + String(event->Par1) + String(F(" Pulse set for ")) + String(event->Par3) + String(F(" S"));
           addLog(LOG_LEVEL_INFO, log);
           SendStatus(event->Source, getPinStateJSON(SEARCH_PIN_STATE, PLUGIN_ID_019, event->Par1, log, 0));

--- a/src/_P036_FrameOLED.ino
+++ b/src/_P036_FrameOLED.ino
@@ -168,7 +168,8 @@ boolean Plugin_036(byte function, struct EventStruct *event, String& string)
     case PLUGIN_WEBFORM_SAVE:
       {
         //update now
-        timerSensor[event->TaskIndex] = millis() + (Settings.TaskDeviceTimer[event->TaskIndex] * 1000);
+        schedule_task_device_timer(event->TaskIndex,
+           millis() + (Settings.TaskDeviceTimer[event->TaskIndex] * 1000));
         frameCounter=0;
 
         Settings.TaskDevicePluginConfig[event->TaskIndex][0] = getFormItemInt(F("plugin_036_adr"));

--- a/src/_P049_MHZ19.ino
+++ b/src/_P049_MHZ19.ino
@@ -247,7 +247,7 @@ boolean Plugin_049(byte function, struct EventStruct *event, String& string)
 
         //delay first read, because hardware needs to initialize on cold boot
         //otherwise we get a weird value or read error
-        timerSensor[event->TaskIndex] = millis() + 15000;
+        schedule_task_device_timer(event->TaskIndex, millis() + 15000);
 
         Plugin_049_init = true;
         success = true;

--- a/src/__Plugin.ino
+++ b/src/__Plugin.ino
@@ -1206,6 +1206,10 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
                 TempEvent.sensorType = Device[DeviceIndex].VType;
                 TempEvent.OriginTaskIndex = event->TaskIndex;
                 checkRAM(F("PluginCall_s"),x);
+                if (Function == PLUGIN_INIT) {
+                  // Schedule the plugin to be read.
+                  schedule_task_device_timer_at_init(TempEvent.TaskIndex);
+                }
                 START_TIMER;
                 Plugin_ptr[x](Function, &TempEvent, str);
                 STOP_TIMER_TASK(x,Function);
@@ -1233,6 +1237,10 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
       const int x = getPluginId(event->TaskIndex);
       if (x >= 0) {
         if (Plugin_id[x] != 0 ) {
+          if (Function == PLUGIN_INIT) {
+            // Schedule the plugin to be read.
+            schedule_task_device_timer_at_init(event->TaskIndex);
+          }
           event->BaseVarIndex = event->TaskIndex * VARS_PER_TASK;
           checkRAM(F("PluginCall_init"),x);
           START_TIMER;

--- a/src/__Plugin.ino
+++ b/src/__Plugin.ino
@@ -1137,9 +1137,9 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
                 TempEvent.sensorType = Device[DeviceIndex].VType;
                 checkRAM(F("PluginCall_s"),x);
                 START_TIMER;
-                bool retval = (Plugin_ptr[x](Function, event, str));
+                bool retval = (Plugin_ptr[x](Function, &TempEvent, str));
                 STOP_TIMER_TASK(x,Function);
-                if (retval) return true; 
+                if (retval) return true;
               }
             }
           }
@@ -1168,7 +1168,7 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
               //TempEvent.idx = Settings.TaskDeviceID[y]; todo check
               TempEvent.sensorType = Device[DeviceIndex].VType;
               START_TIMER;
-              bool retval =  (Plugin_ptr[x](Function, event, str));
+              bool retval =  (Plugin_ptr[x](Function, &TempEvent, str));
               STOP_TIMER_TASK(x,Function);
               if (retval){
                 checkRAM(F("PluginCallUDP"),x);
@@ -1228,7 +1228,7 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
     case PLUGIN_GET_DEVICEGPIONAMES:
     case PLUGIN_READ:
     case PLUGIN_SET_CONFIG:
-    case PLUGIN_GET_CONFIG: 
+    case PLUGIN_GET_CONFIG:
     {
       const int x = getPluginId(event->TaskIndex);
       if (x >= 0) {
@@ -1238,7 +1238,7 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
           START_TIMER;
           bool retval =  Plugin_ptr[x](Function, event, str);
           STOP_TIMER_TASK(x,Function);
-          return retval; 
+          return retval;
         }
       }
       return false;


### PR DESCRIPTION
And fix longpulse command

With other plugins active, like the OLED Framed, the set period of `longpulse_ms` may fluctuate and durations below 100 msec are quite useless.

However, when running just a few sensors, the set pulse width is quite accurate.
![espeasy_pulsewidth_ms_50](https://user-images.githubusercontent.com/3751318/42976722-86b6a75a-8bc3-11e8-9b32-a4ceaee5287b.png)
See right column, "-PulseWidth (NW)"

![image](https://user-images.githubusercontent.com/3751318/42976757-b67b27e0-8bc3-11e8-9b46-40c95074a70f.png)



Must still check a few other plugins.