### PR TITLE
Added Special Case to allow Servo to be disabled

### DIFF
--- a/src/_P001_Switch.ino
+++ b/src/_P001_Switch.ino
@@ -365,7 +365,7 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
               case 2:
                 #if defined(ESP8266)
                 if (event->Par3 >= 9000) {
-                  servo2.detach()
+                  servo2.detach();
                 }else{
                   servo2.attach(event->Par2);
                   servo2.write(event->Par3);

--- a/src/_P001_Switch.ino
+++ b/src/_P001_Switch.ino
@@ -352,14 +352,24 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
 
                 //IRAM: doing servo stuff uses 740 bytes IRAM. (doesnt matter how many instances)
                 #if defined(ESP8266)
-                  servo1.attach(event->Par2);
-                  servo1.write(event->Par3);
+                  //SPECIAL CASE TO ALLOW SERVO TO BE DETATTCHED AND SAVE POWER.
+                  if (event->Par3 >= 9000) {
+                    servo1.detach();
+                   
+                  }else{
+                    servo1.attach(event->Par2);
+                    servo1.write(event->Par3);
+                  }
                 #endif
                 break;
               case 2:
                 #if defined(ESP8266)
+                if (event->Par3 >= 9000) {
+                  servo2.detach()
+                }else{
                   servo2.attach(event->Par2);
                   servo2.write(event->Par3);
+                }
                 #endif
                 break;
             }


### PR DESCRIPTION
Servo Motors by default forcefully hold the desired position.  This consumes power.  In some cases for example to turn a value or open a latch once the position is set  there may be no need to hold the new position.  With this update users can pass a special case value above >9000 which is out of normal range 0-180 or 365. when this value is passed the servo is detached and is free to move.