### PR TITLE
Update _P047_i2c-soil-moisture-sensor.ino - Address change on new sensor firmware

### DIFF
--- a/src/_P047_i2c-soil-moisture-sensor.ino
+++ b/src/_P047_i2c-soil-moisture-sensor.ino
@@ -237,6 +237,7 @@ uint8_t Plugin_047_getVersion() {
  *----------------------------------------------------------------------*/
 bool Plugin_047_setAddress(int addr) {
 	I2C_write8_reg(_i2caddrP47, SOILMOISTURESENSOR_SET_ADDRESS, addr);
+	I2C_write8_reg(_i2caddrP47, SOILMOISTURESENSOR_SET_ADDRESS, addr);
 	I2C_write8(_i2caddrP47, SOILMOISTURESENSOR_RESET);
 	delayBackground(1000);
   _i2caddrP47=addr;


### PR DESCRIPTION
Add a duplicate call for changing the address. This is required by the new sensor firmware version 2.6. This is to avoid a stry address change command that happens during hotplugging of the sensor

also see here: https://github.com/Apollon77/I2CSoilMoistureSensor/pull/17