### PR TITLE
Use queue to manage controllers and add timing settings per controller

### DIFF
--- a/src/Commands/Common.h
+++ b/src/Commands/Common.h
@@ -18,36 +18,6 @@ bool IsNumeric(char * source)
 	return result;
 }
 
-bool safeReadStringUntil(Stream &input, String &str, char terminator, unsigned int maxSize = 1024, unsigned int timeout = 1000)
-{
-	int c;
-	const unsigned long timer = millis() + timeout;
-	str = "";
-
-	do {
-		//read character
-		c = input.read();
-		if (c >= 0) {
-			//found terminator, we're ok
-			if (c == terminator) {
-				return(true);
-			}
-			//found character, add to string
-			else{
-				str += char(c);
-				//string at max size?
-				if (str.length() >= maxSize) {
-					addLog(LOG_LEVEL_ERROR, F("Not enough bufferspace to read all input data!"));
-					return(false);
-				}
-			}
-		}
-		yield();
-	} while (!timeOutReached(timer));
-
-	addLog(LOG_LEVEL_ERROR, F("Timeout while reading input data!"));
-	return(false);
-}
 
 String Command_GetORSetIP(struct EventStruct *event,
 	      const __FlashStringHelper *targetDescription,

--- a/src/Commands/HTTP.h
+++ b/src/Commands/HTTP.h
@@ -30,25 +30,9 @@ String Command_HTTP_SendToHTTP(struct EventStruct *event, const char* Line)
 				hostportString += ':';
 				hostportString += port_int;
 			}
-			String reply = do_create_http_request(hostportString, F("GET"), path);
-			addLog(LOG_LEVEL_DEBUG, reply);
-			client.print(reply);
-
-			unsigned long timer = millis() + 200;
-			while (!client.available() && !timeOutReached(timer))
-				delay(1);
-
-			while (client.available()) {
-				// String line = client.readStringUntil('\n');
-				String line;
-				safeReadStringUntil(client, line, '\n');
-
-				if (line.substring(0, 15) == F("HTTP/1.1 200 OK"))
-					addLog(LOG_LEVEL_DEBUG, line);
-				delay(1);
-			}
-			client.flush();
-			client.stop();
+			String request = do_create_http_request(hostportString, F("GET"), path);
+			addLog(LOG_LEVEL_DEBUG, request);
+			send_via_http(F("Command_HTTP_SendToHTTP"), client, request);
 		}
 	}
 	return return_command_success();

--- a/src/Commands/HTTP.h
+++ b/src/Commands/HTTP.h
@@ -24,7 +24,7 @@ String Command_HTTP_SendToHTTP(struct EventStruct *event, const char* Line)
 		}
 		WiFiClient client;
 		const int port_int = port.toInt();
-		if (client.connect(host.c_str(), port_int)) {
+		if (client.connect(host.c_str(), port_int) != 1) {
 			String hostportString = host;
 			if (port_int != 0 && port_int != 80) {
 				hostportString += ':';

--- a/src/Commands/HTTP.h
+++ b/src/Commands/HTTP.h
@@ -23,14 +23,14 @@ String Command_HTTP_SendToHTTP(struct EventStruct *event, const char* Line)
 			addLog(LOG_LEVEL_DEBUG, log);
 		}
 		WiFiClient client;
-		if (client.connect(host.c_str(), port.toInt())) {
-			String reply = F("GET ");
-			reply += path;
-			reply += F(" HTTP/1.1\r\n");
-			reply += F("Host: ");
-			reply += host;
-			reply += F("\r\n");
-			reply += F("Connection: close\r\n\r\n");
+		const int port_int = port.toInt();
+		if (client.connect(host.c_str(), port_int)) {
+			String hostportString = host;
+			if (port_int != 0 && port_int != 80) {
+				hostportString += ':';
+				hostportString += port_int;
+			}
+			String reply = do_create_http_request(hostportString, F("GET"), path);
 			addLog(LOG_LEVEL_DEBUG, reply);
 			client.print(reply);
 

--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -39,21 +39,25 @@ void sendData(struct EventStruct *event)
     event->ControllerIndex = x;
     event->idx = Settings.TaskDeviceID[x][event->TaskIndex];
     if (Settings.TaskDeviceSendData[event->ControllerIndex][event->TaskIndex] &&
-        Settings.ControllerEnabled[event->ControllerIndex] && Settings.Protocol[event->ControllerIndex])
+        Settings.ControllerEnabled[event->ControllerIndex] &&
+        Settings.Protocol[event->ControllerIndex])
     {
       event->ProtocolIndex = getProtocolIndex(Settings.Protocol[event->ControllerIndex]);
       if (validUserVar(event)) {
         CPlugin_ptr[event->ProtocolIndex](CPLUGIN_PROTOCOL_SEND, event, dummyString);
       } else {
-        String log = F("Invalid value detected for controller ");
-        String controllerName;
-        CPlugin_ptr[event->ProtocolIndex](CPLUGIN_GET_DEVICENAME, event, controllerName);
-        log += controllerName;
-        addLog(LOG_LEVEL_DEBUG, log);
+        if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+          String log = F("Invalid value detected for controller ");
+          String controllerName;
+          CPlugin_ptr[event->ProtocolIndex](CPLUGIN_GET_DEVICENAME, event, controllerName);
+          log += controllerName;
+          addLog(LOG_LEVEL_DEBUG, log);
+        }
       }
     }
   }
 
+  // FIXME TD-er: This PLUGIN_EVENT_OUT seems to be unused.
   PluginCall(PLUGIN_EVENT_OUT, event, dummyString);
   lastSend = millis();
   STOP_TIMER(SEND_DATA_STATS);

--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -285,6 +285,7 @@ void scheduleNextMQTTdelayQueue() {
 }
 
 void processMQTTdelayQueue() {
+  START_TIMER;
   MQTT_queue_element element;
   if (!MQTTDelayHandler.getNext(element)) return;
   if (MQTTclient.publish(element._topic.c_str(), element._payload.c_str(), element._retained)) {
@@ -300,6 +301,7 @@ void processMQTTdelayQueue() {
     }
   }
   scheduleNextMQTTdelayQueue();
+  STOP_TIMER(MQTT_DELAY_QUEUE);
 }
 
 /*********************************************************************************************\

--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -272,7 +272,7 @@ void SendStatus(byte source, String status)
 
 boolean MQTTpublish(int controller_idx, const char* topic, const char* payload, boolean retained)
 {
-  const bool success = MQTTDelayHandler.addToQueue(controller_idx, topic, payload, retained);
+  const bool success = MQTTDelayHandler.addToQueue(MQTT_queue_element(controller_idx, topic, payload, retained));
   if (!success) {
     addLog(LOG_LEVEL_DEBUG, F("MQTT : publish failed, queue full"));
   }
@@ -281,11 +281,7 @@ boolean MQTTpublish(int controller_idx, const char* topic, const char* payload, 
 }
 
 void scheduleNextMQTTdelayQueue() {
-  const unsigned long nextTime = MQTTDelayHandler.getNextScheduleTime();
-  if (nextTime != 0) {
-    // Schedule for next process run.
-    setIntervalTimerAt(TIMER_MQTT_DELAY_QUEUE, nextTime);
-  }
+  scheduleNextDelayQueue(TIMER_MQTT_DELAY_QUEUE, MQTTDelayHandler.getNextScheduleTime());
 }
 
 void processMQTTdelayQueue() {

--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -273,9 +273,6 @@ void SendStatus(byte source, String status)
 boolean MQTTpublish(int controller_idx, const char* topic, const char* payload, boolean retained)
 {
   const bool success = MQTTDelayHandler.addToQueue(MQTT_queue_element(controller_idx, topic, payload, retained));
-  if (!success) {
-    addLog(LOG_LEVEL_DEBUG, F("MQTT : publish failed, queue full"));
-  }
   scheduleNextMQTTdelayQueue();
   return success;
 }

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -11,7 +11,6 @@
 // Set default configuration settings if you want (not mandatory)
 // You can always change these during runtime and save to eeprom
 // After loading firmware, issue a 'reset' command to load the defaults.
-
 // --- Basic Config Settings ------------------------------------------------------------------------
 #define DEFAULT_NAME        "ESP_Easy"                  // Enter your device friendly name
 #define UNIT                            0                                       // Unit Number
@@ -205,6 +204,7 @@
 #define TIMER_MQTT_DELAY_QUEUE              7
 #define TIMER_C001_DELAY_QUEUE              8
 #define TIMER_C003_DELAY_QUEUE              9
+#define TIMER_C004_DELAY_QUEUE             10
 
 
 #define PLUGIN_INIT_ALL                     1

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -1692,6 +1692,21 @@ unsigned long timediff_cpu_cycles_total = 0;
 #define PROC_SYS_TIMER        9
 #define SET_NEW_TIMER        10
 #define TIME_DIFF_COMPUTE    11
+#define MQTT_DELAY_QUEUE     12
+#define C001_DELAY_QUEUE     13
+#define C002_DELAY_QUEUE     14
+#define C003_DELAY_QUEUE     15
+#define C004_DELAY_QUEUE     16
+#define C005_DELAY_QUEUE     17
+#define C006_DELAY_QUEUE     18
+#define C007_DELAY_QUEUE     19
+#define C008_DELAY_QUEUE     20
+#define C009_DELAY_QUEUE     21
+#define C010_DELAY_QUEUE     22
+#define C011_DELAY_QUEUE     23
+#define C012_DELAY_QUEUE     24
+#define C013_DELAY_QUEUE     25
+
 
 
 
@@ -1717,6 +1732,25 @@ String getMiscStatsName(int stat) {
         case PROC_SYS_TIMER:        return F("proc_system_timer() ");
         case SET_NEW_TIMER:         return F("setNewTimerAt()     ");
         case TIME_DIFF_COMPUTE:     return F("timeDiff()          ");
+        case MQTT_DELAY_QUEUE:      return F("Delay queue MQTT    ");
+        case C001_DELAY_QUEUE:
+        case C002_DELAY_QUEUE:
+        case C003_DELAY_QUEUE:
+        case C004_DELAY_QUEUE:
+        case C005_DELAY_QUEUE:
+        case C006_DELAY_QUEUE:
+        case C007_DELAY_QUEUE:
+        case C008_DELAY_QUEUE:
+        case C009_DELAY_QUEUE:
+        case C010_DELAY_QUEUE:
+        case C011_DELAY_QUEUE:
+        case C012_DELAY_QUEUE:
+        case C013_DELAY_QUEUE:
+        {
+          String result = F("Delay queue       C");
+          result += static_cast<int>(stat - C001_DELAY_QUEUE + 1);
+          return result;
+        }
     }
     return F("Unknown");
 }

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -1251,9 +1251,9 @@ bool log_to_serial_disabled = false;
 struct DeviceStruct
 {
   DeviceStruct() :
-    Number(0), Type(0), VType(0), Ports(0),
+    Number(0), Type(0), VType(0), Ports(0), ValueCount(0),
     PullUpOption(false), InverseLogicOption(false), FormulaOption(false),
-    ValueCount(0), Custom(false), SendDataOption(false), GlobalSyncOption(false),
+    Custom(false), SendDataOption(false), GlobalSyncOption(false),
     TimerOption(false), TimerOptional(false), DecimalsOnly(false) {}
 
   bool connectedToGPIOpins() {
@@ -1265,17 +1265,19 @@ struct DeviceStruct
   byte Type;    // How the device is connected. e.g. DEVICE_TYPE_SINGLE => connected through 1 datapin
   byte VType;   // Type of value the plugin will return, used only for Domoticz
   byte Ports;   // Port to use when device has multiple I/O pins  (N.B. not used much)
+  byte ValueCount;            // The number of output values of a plugin. The value should match the number of keys PLUGIN_VALUENAME1_xxx
   boolean PullUpOption;       // Allow to set internal pull-up resistors.
   boolean InverseLogicOption; // Allow to invert the boolean state (e.g. a switch)
   boolean FormulaOption;      // Allow to enter a formula to convert values during read. (not possible with Custom enabled)
-  byte ValueCount;            // The number of output values of a plugin. The value should match the number of keys PLUGIN_VALUENAME1_xxx
   boolean Custom;
   boolean SendDataOption;     // Allow to send data to a controller.
   boolean GlobalSyncOption;   // No longer used. Was used for ESPeasy values sync between nodes
   boolean TimerOption;        // Allow to set the "Interval" timer for the plugin.
   boolean TimerOptional;      // When taskdevice timer is not set and not optional, use default "Interval" delay (Settings.Delay)
   boolean DecimalsOnly;       // Allow to set the number of decimals (otherwise treated a 0 decimals)
-} Device[DEVICES_MAX + 1]; // 1 more because first device is empty device
+};
+typedef std::vector<DeviceStruct> DeviceVector;
+DeviceVector Device;
 
 
 /*********************************************************************************************\
@@ -1284,17 +1286,20 @@ struct DeviceStruct
 struct ProtocolStruct
 {
   ProtocolStruct() :
-    Number(0), usesMQTT(false), usesAccount(false), usesPassword(false),
-    defaultPort(0), usesTemplate(false), usesID(false), Custom(false) {}
+    defaultPort(0), Number(0), usesMQTT(false), usesAccount(false), usesPassword(false),
+    usesTemplate(false), usesID(false), Custom(false) {}
+  uint16_t defaultPort;
   byte Number;
   boolean usesMQTT;
   boolean usesAccount;
   boolean usesPassword;
-  int defaultPort;
   boolean usesTemplate;
   boolean usesID;
   boolean Custom;
-} Protocol[CPLUGIN_MAX];
+};
+typedef std::vector<ProtocolStruct> ProtocolVector;
+ProtocolVector Protocol;
+
 
 /*********************************************************************************************\
  * NotificationStruct
@@ -1315,14 +1320,14 @@ struct NotificationStruct
 struct NodeStruct
 {
   NodeStruct() :
-    age(0), build(0), nodeName(NULL), nodeType(0)
+    build(0), age(0), nodeType(0)
     {
       for (byte i = 0; i < 4; ++i) ip[i] = 0;
     }
+  String nodeName;
   byte ip[4];
-  byte age;
   uint16_t build;
-  char* nodeName;
+  byte age;
   byte nodeType;
 };
 typedef std::map<byte, NodeStruct> NodesMap;

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -381,6 +381,15 @@
   #define CONFIG_FILE_SIZE               131072
 #endif
 
+// Forward declaration
+void scheduleNextDelayQueue(unsigned long id, unsigned long nextTime);
+String LoadControllerSettings(int ControllerIndex, byte* memAddress, int datasize);
+String get_formatted_Controller_number(int controller_index);
+bool loglevelActiveFor(byte logLevel);
+void addToLog(byte loglevel, const String& string);
+void addToLog(byte logLevel, const __FlashStringHelper* flashString);
+void statusLED(boolean traffic);
+
 enum SettingsType {
   BasicSettings_Type = 0,
   TaskSettings_Type,
@@ -1732,7 +1741,7 @@ String getMiscStatsName(int stat) {
         case PROC_SYS_TIMER:        return F("proc_system_timer() ");
         case SET_NEW_TIMER:         return F("setNewTimerAt()     ");
         case TIME_DIFF_COMPUTE:     return F("timeDiff()          ");
-        case MQTT_DELAY_QUEUE:      return F("Delay queue MQTT    ");
+        case MQTT_DELAY_QUEUE:      return F("Delay queue     MQTT");
         case C001_DELAY_QUEUE:
         case C002_DELAY_QUEUE:
         case C003_DELAY_QUEUE:
@@ -1747,8 +1756,8 @@ String getMiscStatsName(int stat) {
         case C012_DELAY_QUEUE:
         case C013_DELAY_QUEUE:
         {
-          String result = F("Delay queue       C");
-          result += static_cast<int>(stat - C001_DELAY_QUEUE + 1);
+          String result = F("Delay queue     ");
+          result += get_formatted_Controller_number(static_cast<int>(stat - C001_DELAY_QUEUE + 1));
           return result;
         }
     }

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -796,7 +796,7 @@ struct SettingsStruct
 
 struct ControllerSettingsStruct
 {
-  ControllerSettingsStruct() : UseDNS(false), Port(0) {
+  ControllerSettingsStruct() : UseDNS(false), Port(0), MinimalTimeBetweenMessages(100), MaxBufferDepth(0) {
     for (byte i = 0; i < 4; ++i) {
       IP[i] = 0;
     }
@@ -816,6 +816,8 @@ struct ControllerSettingsStruct
   char          MQTTLwtTopic[129];
   char          LWTMessageConnect[129];
   char          LWTMessageDisconnect[129];
+  unsigned int  MinimalTimeBetweenMessages;
+  unsigned int  MaxBufferDepth;
 
   IPAddress getIP() const {
     IPAddress host(IP[0], IP[1], IP[2], IP[3]);
@@ -913,6 +915,17 @@ private:
     return false;
   }
 
+};
+
+struct ControllerDelayHandler {
+  ControllerDelayHandler() :
+      lastSend(0), minTimeBetweenMessages(100), max_buffer(0), value_index(0) {}
+
+  std::list<struct EventStruct> sendQueue;
+  unsigned long lastSend;
+  unsigned int minTimeBetweenMessages;
+  byte max_buffer;
+  byte value_index; // Some controllers send only 1 value at a time and thus have to process the same event more than once.
 };
 
 struct NotificationSettingsStruct

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -903,21 +903,22 @@ struct ControllerSettingsStruct
     return false;
   }
 
+  // Returns 1 if successful, 0 if there was a problem resolving the hostname or port
   int beginPacket(WiFiUDP &client) {
     if (!checkHostReachable(true)) {
       return 0; // Host not reachable
     }
     byte retry = 2;
     int connected = 0;
-    while (retry > 0 && !connected) {
+    while (retry > 0 && connected == 0) {
       --retry;
       connected = client.beginPacket(getIP(), Port);
       if (connected != 0) return connected;
       if (!checkHostReachable(false))
-        return false;
+        return 0;
       delay(10);
     }
-    return false;
+    return 0;
   }
 
   String getHostPortString() const {

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -317,7 +317,7 @@
 #define PLUGIN_EXTRACONFIGVAR_MAX          16
 #define CPLUGIN_MAX                        16
 #define NPLUGIN_MAX                         4
-#define UNIT_MAX                           32 // Only relevant for UDP unicast message 'sweeps' and the nodelist.
+#define UNIT_MAX                          254 // unit 255 = broadcast
 #define RULES_TIMER_MAX                     8
 #define PINSTATE_TABLE_MAX                 32
 #define RULES_MAX_SIZE                   2048
@@ -1324,7 +1324,9 @@ struct NodeStruct
   uint16_t build;
   char* nodeName;
   byte nodeType;
-} Nodes[UNIT_MAX];
+};
+typedef std::map<byte, NodeStruct> NodesMap;
+NodesMap Nodes;
 
 /*********************************************************************************************\
  * systemTimerStruct

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -204,6 +204,7 @@
 #define TIMER_STATISTICS                    6
 #define TIMER_MQTT_DELAY_QUEUE              7
 #define TIMER_C001_DELAY_QUEUE              8
+#define TIMER_C003_DELAY_QUEUE              9
 
 
 #define PLUGIN_INIT_ALL                     1

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -213,6 +213,17 @@
 #define TIMER_C012_DELAY_QUEUE             16
 #define TIMER_C013_DELAY_QUEUE             17
 
+// Minimum delay between messages for a controller to send in msec.
+#define CONTROLLER_DELAY_QUEUE_DELAY_MAX   3600000
+#define CONTROLLER_DELAY_QUEUE_DELAY_DFLT  100
+// Queue length for controller messages not yet sent.
+#define CONTROLLER_DELAY_QUEUE_DEPTH_MAX   25
+#define CONTROLLER_DELAY_QUEUE_DEPTH_DFLT  10
+// Number of retries to send a message by a controller.
+// N.B. Retries without a connection to wifi do not count as retry.
+#define CONTROLLER_DELAY_QUEUE_RETRY_MAX   10
+#define CONTROLLER_DELAY_QUEUE_RETRY_DFLT  10
+
 
 #define PLUGIN_INIT_ALL                     1
 #define PLUGIN_INIT                         2

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -819,7 +819,8 @@ struct SettingsStruct
 \*********************************************************************************************/
 struct ControllerSettingsStruct
 {
-  ControllerSettingsStruct() : UseDNS(false), Port(0), MinimalTimeBetweenMessages(100), MaxBufferDepth(0), DeleteOldest(false) {
+  ControllerSettingsStruct() : UseDNS(false), Port(0),
+      MinimalTimeBetweenMessages(100), MaxQueueDepth(10), MaxRetry(10), DeleteOldest(false) {
     for (byte i = 0; i < 4; ++i) {
       IP[i] = 0;
     }
@@ -840,7 +841,7 @@ struct ControllerSettingsStruct
   char          LWTMessageConnect[129];
   char          LWTMessageDisconnect[129];
   unsigned int  MinimalTimeBetweenMessages;
-  unsigned int  MaxBufferDepth;
+  unsigned int  MaxQueueDepth;
   unsigned int  MaxRetry;
   boolean       DeleteOldest; // Action to perform when buffer full, delete oldest, or ignore newest.
 

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -203,6 +203,8 @@
 #define TIMER_MQTT                          5
 #define TIMER_STATISTICS                    6
 #define TIMER_MQTT_DELAY_QUEUE              7
+#define TIMER_C001_DELAY_QUEUE              8
+
 
 #define PLUGIN_INIT_ALL                     1
 #define PLUGIN_INIT                         2
@@ -932,109 +934,6 @@ private:
 
 };
 
-/*********************************************************************************************\
- * ControllerDelayHandler
-\*********************************************************************************************/
-class MQTT_queue_element {
-public:
-  MQTT_queue_element() : _controller_idx(0), _retained(false) {}
-
-  MQTT_queue_element(int controller_idx,
-    const String& topic, const String& payload, boolean retained) :
-    _controller_idx(controller_idx), _topic(topic), _payload(payload), _retained(retained)
-     {}
-
-  int _controller_idx;
-  String _topic;
-  String _payload;
-  boolean _retained;
-};
-
-template<class T>
-struct ControllerDelayHandlerStruct {
-  ControllerDelayHandlerStruct() :
-      lastSend(0), minTimeBetweenMessages(100), max_buffer(10), attempt(0), max_attempt(10) {}
-
-  void configureControllerSettings(const ControllerSettingsStruct& settings) {
-    minTimeBetweenMessages = settings.MinimalTimeBetweenMessages;
-    max_buffer = settings.MaxBufferDepth;
-    max_attempt = settings.MaxRetry;
-    delete_oldest = settings.DeleteOldest;
-  }
-
-  // Try to add to the queue, if permitted by "delete_oldest"
-  // Return false when the buffer was full. Success depends on "delete_oldest"
-  bool addToQueue(int controller_idx, const String& topic, const String& payload, boolean retained) {
-    if (delete_oldest) {
-      return forceAddToQueue(controller_idx, topic, payload, retained);
-    }
-    if (sendQueue.size() < max_buffer) {
-      sendQueue.emplace_back(controller_idx, topic, payload, retained);
-      return true;
-    }
-    return false;
-  }
-
-  // Force add to the queue.
-  // If max buffer is reached, the oldest in the queue (first to be served) will be removed.
-  // Return true when no elements removed from queue.
-  bool forceAddToQueue(int controller_idx,
-      const String& topic, const String& payload, boolean retained) {
-    sendQueue.emplace_back(controller_idx, topic, payload, retained);
-    if (sendQueue.size() <= max_buffer) {
-      return true;
-    }
-    sendQueue.pop_front();
-    return false;
-  }
-
-  // Get the next element.
-  // Remove front element when max_attempt is reached.
-  bool getNext(T& element) {
-    if (sendQueue.empty()) return false;
-    if (max_attempt <= attempt) {
-      sendQueue.pop_front();
-      attempt = 0;
-    }
-    element = sendQueue.front();
-    return true;
-  }
-
-  // Mark as processed and return time to schedule for next process.
-  // Return 0 when nothing to process.
-  // @param remove_from_queue indicates whether the elements should be removed from the queue.
-  unsigned long markProcessed(bool remove_from_queue) {
-    if (sendQueue.empty()) return 0;
-    if (remove_from_queue) {
-      sendQueue.pop_front();
-      attempt = 0;
-    } else {
-      ++attempt;
-    }
-    lastSend = millis();
-    return getNextScheduleTime();
-  }
-
-  unsigned long getNextScheduleTime() const {
-    if (sendQueue.empty()) return 0;
-    unsigned long nextTime = lastSend + minTimeBetweenMessages;
-    if (timePassedSince(nextTime) > 0) {
-      nextTime = millis();
-    }
-    if (nextTime == 0) nextTime = 1; // Just to make sure it will be executed
-    return nextTime;
-  }
-
-  std::list<T> sendQueue;
-  unsigned long lastSend;
-  unsigned int minTimeBetweenMessages;
-  byte max_buffer;
-  byte attempt;
-  byte max_attempt;
-  bool delete_oldest;
-};
-
-ControllerDelayHandlerStruct<MQTT_queue_element> MQTTDelayHandler;
 
 /*********************************************************************************************\
  * NotificationSettingsStruct

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -205,6 +205,13 @@
 #define TIMER_C001_DELAY_QUEUE              8
 #define TIMER_C003_DELAY_QUEUE              9
 #define TIMER_C004_DELAY_QUEUE             10
+#define TIMER_C007_DELAY_QUEUE             11
+#define TIMER_C008_DELAY_QUEUE             12
+#define TIMER_C009_DELAY_QUEUE             13
+#define TIMER_C010_DELAY_QUEUE             14
+#define TIMER_C011_DELAY_QUEUE             15
+#define TIMER_C012_DELAY_QUEUE             16
+#define TIMER_C013_DELAY_QUEUE             17
 
 
 #define PLUGIN_INIT_ALL                     1

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -826,6 +826,11 @@ void backgroundtasks()
   //checkRAM(F("backgroundtasks"));
   //always start with a yield
   yield();
+  #ifdef ESP32
+  // Have to find a similar function to call ESP32's esp_task_wdt_feed();
+  #else
+  ESP.wdtFeed();
+  #endif
 
   //prevent recursion!
   if (runningBackgroundTasks)

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -82,6 +82,7 @@
 
 // Define globals before plugin sets to allow a personal override of the selected plugins
 #include "ESPEasy-Globals.h"
+#include "_CPlugin_Helper.h"
 #include "define_plugin_sets.h"
 
 // Blynk_get prototype

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -531,11 +531,32 @@ void runPeriodicalMQTT() {
   }
 }
 
+String getMQTT_state() {
+  switch (MQTTclient.state()) {
+    case MQTT_CONNECTION_TIMEOUT     : return F("Connection timeout");
+    case MQTT_CONNECTION_LOST        : return F("Connection lost");
+    case MQTT_CONNECT_FAILED         : return F("Connect failed");
+    case MQTT_DISCONNECTED           : return F("Disconnected");
+    case MQTT_CONNECTED              : return F("Connected");
+    case MQTT_CONNECT_BAD_PROTOCOL   : return F("Connect bad protocol");
+    case MQTT_CONNECT_BAD_CLIENT_ID  : return F("Connect bad client_id");
+    case MQTT_CONNECT_UNAVAILABLE    : return F("Connect unavailable");
+    case MQTT_CONNECT_BAD_CREDENTIALS: return F("Connect bad credentials");
+    case MQTT_CONNECT_UNAUTHORIZED   : return F("Connect unauthorized");
+    default: return "";
+  }
+}
+
 void updateMQTTclient_connected() {
   if (MQTTclient_connected != MQTTclient.connected()) {
     MQTTclient_connected = !MQTTclient_connected;
-    if (!MQTTclient_connected)
-      addLog(LOG_LEVEL_ERROR, F("MQTT : Connection lost"));
+    if (!MQTTclient_connected) {
+      if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
+        String connectionError = F("MQTT : Connection lost, state: ");
+        connectionError += getMQTT_state();
+        addLog(LOG_LEVEL_ERROR, connectionError);
+      }
+    }
     if (Settings.UseRules) {
       String event = MQTTclient_connected ? F("MQTT#Connected") : F("MQTT#Disconnected");
       rulesProcessing(event);

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -82,8 +82,9 @@
 
 // Define globals before plugin sets to allow a personal override of the selected plugins
 #include "ESPEasy-Globals.h"
-#include "_CPlugin_Helper.h"
 #include "define_plugin_sets.h"
+// Plugin helper needs the defined controller sets, thus include after 'define_plugin_sets.h'
+#include "_CPlugin_Helper.h"
 
 // Blynk_get prototype
 boolean Blynk_get(const String& command, byte controllerIndex,float *data = NULL );

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -464,7 +464,7 @@ void loop()
   if (firstLoopConnectionsEstablished) {
      firstLoop = false;
      timerAwakeFromDeepSleep = millis(); // Allow to run for "awake" number of seconds, now we have wifi.
-     schedule_all_task_device_timers();
+     // schedule_all_task_device_timers(); Disabled for now, since we are now using queues for controllers.
    }
 
   // Deep sleep mode, just run all tasks one (more) time and go back to sleep as fast as possible
@@ -556,6 +556,8 @@ void updateMQTTclient_connected() {
         connectionError += getMQTT_state();
         addLog(LOG_LEVEL_ERROR, connectionError);
       }
+    } else {
+      schedule_all_tasks_using_MQTT_controller();
     }
     if (Settings.UseRules) {
       String event = MQTTclient_connected ? F("MQTT#Connected") : F("MQTT#Disconnected");

--- a/src/ESPEasyWifi.ino
+++ b/src/ESPEasyWifi.ino
@@ -126,6 +126,7 @@ void processGotIP() {
     initTime();
   }
   mqtt_reconnect_count = 0;
+  MQTTclient_should_reconnect = true;
   timermqtt_interval = 100;
   setIntervalTimer(TIMER_MQTT);
   if (Settings.UseRules)

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -1973,6 +1973,7 @@ void rulesProcessing(String& event)
     log += F(" milliSeconds");
     addLog(LOG_LEVEL_DEBUG, log);
   }
+  backgroundtasks();
 
 }
 
@@ -2035,6 +2036,7 @@ String rulesProcessingFile(String fileName, String& event)
             match, codeBlock, isCommand,
             conditional, condition,
             ifBranche, ifBrancheJustMatch);
+          yield();
         }
 
         line = "";

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -1075,7 +1075,7 @@ String getLogLevelDisplayString(byte index, int& logLevel) {
   }
 }
 
-void addToLog(byte loglevel, String& string)
+void addToLog(byte loglevel, const String& string)
 {
   addToLog(loglevel, string.c_str());
 }

--- a/src/Networking.ino
+++ b/src/Networking.ino
@@ -115,12 +115,17 @@ void checkUDP()
                   it->second.age = 0; // reset 'age counter'
                   if (len >= 41) // extended packet size
                   {
-                    // FIXME TD-er: Memory leak waiting to happen.
                     it->second.build = packetBuffer[13] + 256*packetBuffer[14];
-                    if (it->second.nodeName==0)
-                        it->second.nodeName =  (char *)malloc(26);
-                    memcpy(it->second.nodeName,reinterpret_cast<byte*>(&packetBuffer[15]), 25);
-                    it->second.nodeName[25]=0;
+                    String tmpNodeName;
+                    tmpNodeName.reserve(25);
+                    unsigned int pos = 15;
+                    char c = 1; // Something other than 0
+                    while (c != 0 && pos < 40) {
+                      c = packetBuffer[pos];
+                      ++pos;
+                      tmpNodeName += c;
+                    }
+                    it->second.nodeName = tmpNodeName;
                     it->second.nodeType = packetBuffer[40];
                   }
                 }

--- a/src/Networking.ino
+++ b/src/Networking.ino
@@ -107,20 +107,21 @@ void checkUDP()
                 for (byte x = 0; x < 4; x++)
                   ip[x] = packetBuffer[x + 8];
 
-                if (unit < UNIT_MAX)
-                {
+                Nodes[unit].age = 0; // Create a new element when not present
+                NodesMap::iterator it = Nodes.find(unit);
+                if (it != Nodes.end()) {
                   for (byte x = 0; x < 4; x++)
-                    Nodes[unit].ip[x] = packetBuffer[x + 8];
-                  Nodes[unit].age = 0; // reset 'age counter'
+                    it->second.ip[x] = packetBuffer[x + 8];
+                  it->second.age = 0; // reset 'age counter'
                   if (len >= 41) // extended packet size
                   {
                     // FIXME TD-er: Memory leak waiting to happen.
-                    Nodes[unit].build = packetBuffer[13] + 256*packetBuffer[14];
-                    if (Nodes[unit].nodeName==0)
-                        Nodes[unit].nodeName =  (char *)malloc(26);
-                    memcpy(Nodes[unit].nodeName,reinterpret_cast<byte*>(&packetBuffer[15]), 25);
-                    Nodes[unit].nodeName[25]=0;
-                    Nodes[unit].nodeType = packetBuffer[40];
+                    it->second.build = packetBuffer[13] + 256*packetBuffer[14];
+                    if (it->second.nodeName==0)
+                        it->second.nodeName =  (char *)malloc(26);
+                    memcpy(it->second.nodeName,reinterpret_cast<byte*>(&packetBuffer[15]), 25);
+                    it->second.nodeName[25]=0;
+                    it->second.nodeType = packetBuffer[40];
                   }
                 }
 
@@ -166,17 +167,17 @@ void SendUDPCommand(byte destUnit, char* data, byte dataLength)
   if (!WiFiConnected(100)) {
     return;
   }
-  byte firstUnit = 1;
-  byte lastUnit = UNIT_MAX - 1;
   if (destUnit != 0)
   {
-    firstUnit = destUnit;
-    lastUnit = destUnit;
-  }
-  for (int x = firstUnit; x <= lastUnit; x++)
-  {
-    sendUDP(x, (byte*)data, dataLength);
+    sendUDP(destUnit, (byte*)data, dataLength);
     delay(10);
+  } else {
+    for (NodesMap::iterator it = Nodes.begin(); it != Nodes.end(); ++it) {
+      if (it->first != Settings.Unit) {
+        sendUDP(it->first, (byte*)data, dataLength);
+        delay(10);
+      }
+    }
   }
   delay(50);
 }
@@ -190,9 +191,18 @@ void sendUDP(byte unit, byte* data, byte size)
   if (!WiFiConnected(100)) {
     return;
   }
-  if (unit != 255)
-    if (Nodes[unit].ip[0] == 0)
+
+  IPAddress remoteNodeIP;
+  if (unit == 255)
+    remoteNodeIP = {255,255,255,255};
+  else {
+    NodesMap::iterator it = Nodes.find(unit);
+    if (it == Nodes.end())
       return;
+    if (it->second.ip[0] == 0)
+      return;
+    remoteNodeIP = it->second.ip;
+  }
 
   if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE)) {
     String log = F("UDP  : Send UDP message to ");
@@ -201,12 +211,6 @@ void sendUDP(byte unit, byte* data, byte size)
   }
 
   statusLED(true);
-
-  IPAddress remoteNodeIP;
-  if (unit == 255)
-    remoteNodeIP = {255,255,255,255};
-  else
-    remoteNodeIP = Nodes[unit].ip;
   portUDP.beginPacket(remoteNodeIP, Settings.UDPPort);
   portUDP.write(data, size);
   portUDP.endPacket();
@@ -218,14 +222,17 @@ void sendUDP(byte unit, byte* data, byte size)
   \*********************************************************************************************/
 void refreshNodeList()
 {
-  for (byte counter = 0; counter < UNIT_MAX; counter++)
-  {
-    if (Nodes[counter].ip[0] != 0)
-    {
-      Nodes[counter].age++;  // increment age counter
-      if (Nodes[counter].age > 10) // if entry to old, clear this node ip from the list.
-        for (byte x = 0; x < 4; x++)
-          Nodes[counter].ip[x] = 0;
+  for (NodesMap::iterator it = Nodes.begin(); it != Nodes.end(); ) {
+    bool mustRemove = true;
+    if (it->second.ip[0] != 0) {
+      if (it->second.age < 10) {
+        it->second.age++;
+        mustRemove = false;
+        ++it;
+      }
+    }
+    if (mustRemove) {
+      it = Nodes.erase(it);
     }
   }
 }
@@ -277,15 +284,17 @@ void sendSysInfoUDP(byte repeats)
       delay(500);
   }
 
-  // store my own info also in the list...
-  if (Settings.Unit < UNIT_MAX)
+  Nodes[Settings.Unit].age = 0; // Create new node when not already present.
+  // store my own info also in the list
+  NodesMap::iterator it = Nodes.find(Settings.Unit);
+  if (it != Nodes.end())
   {
     IPAddress ip = WiFi.localIP();
     for (byte x = 0; x < 4; x++)
-      Nodes[Settings.Unit].ip[x] = ip[x];
-    Nodes[Settings.Unit].age = 0;
-    Nodes[Settings.Unit].build = Settings.Build;
-    Nodes[Settings.Unit].nodeType = NODE_TYPE_ID;
+      it->second.ip[x] = ip[x];
+    it->second.age = 0;
+    it->second.build = Settings.Build;
+    it->second.nodeType = NODE_TYPE_ID;
   }
 }
 

--- a/src/Networking.ino
+++ b/src/Networking.ino
@@ -116,16 +116,11 @@ void checkUDP()
                   if (len >= 41) // extended packet size
                   {
                     it->second.build = packetBuffer[13] + 256*packetBuffer[14];
-                    String tmpNodeName;
-                    tmpNodeName.reserve(25);
-                    unsigned int pos = 15;
-                    char c = 1; // Something other than 0
-                    while (c != 0 && pos < 40) {
-                      c = packetBuffer[pos];
-                      ++pos;
-                      tmpNodeName += c;
-                    }
+                    char tmpNodeName[26] = {0};
+                    memcpy(&tmpNodeName[0], reinterpret_cast<byte*>(&packetBuffer[15]), 25);
+                    tmpNodeName[25] = 0;
                     it->second.nodeName = tmpNodeName;
+                    it->second.nodeName.trim();
                     it->second.nodeType = packetBuffer[40];
                   }
                 }

--- a/src/Scheduler.ino
+++ b/src/Scheduler.ino
@@ -106,6 +106,7 @@ void setIntervalTimer(unsigned long id, unsigned long lasttimer) {
     // The timers for all delay queues will be set according to their own settings as long as there is something to process.
     case TIMER_MQTT_DELAY_QUEUE:
     case TIMER_C001_DELAY_QUEUE:
+    case TIMER_C003_DELAY_QUEUE:
       interval = 1000; break;
   }
   unsigned long timer = lasttimer;
@@ -142,6 +143,9 @@ void process_interval_timer(unsigned long id, unsigned long lasttimer) {
       break;
     case TIMER_C001_DELAY_QUEUE:
       process_c001_delay_queue();
+      break;
+    case TIMER_C003_DELAY_QUEUE:
+      process_c003_delay_queue();
       break;
   }
 }

--- a/src/Scheduler.ino
+++ b/src/Scheduler.ino
@@ -85,6 +85,13 @@ void setIntervalTimerOverride(unsigned long id, unsigned long msecFromNow) {
   setNewTimerAt(getMixedId(CONST_INTERVAL_TIMER, id), timer);
 }
 
+void scheduleNextDelayQueue(unsigned long id, unsigned long nextTime) {
+  if (nextTime != 0) {
+    // Schedule for next process run.
+    setIntervalTimerAt(id, nextTime);
+  }
+}
+
 void setIntervalTimer(unsigned long id, unsigned long lasttimer) {
   // Set the initial timers for the regular runs
   unsigned long interval = 0;
@@ -95,7 +102,11 @@ void setIntervalTimer(unsigned long id, unsigned long lasttimer) {
     case TIMER_30SEC:      interval = 30000; break;
     case TIMER_MQTT:       interval = timermqtt_interval; break;
     case TIMER_STATISTICS: interval = 30000; break;
-    case TIMER_MQTT_DELAY_QUEUE: interval = 1000; break;
+    // Fall-through for all DelayQueue, which are just the fall-back timers.
+    // The timers for all delay queues will be set according to their own settings as long as there is something to process.
+    case TIMER_MQTT_DELAY_QUEUE:
+    case TIMER_C001_DELAY_QUEUE:
+      interval = 1000; break;
   }
   unsigned long timer = lasttimer;
   setNextTimeInterval(timer, interval);
@@ -128,6 +139,9 @@ void process_interval_timer(unsigned long id, unsigned long lasttimer) {
       break;
     case TIMER_MQTT_DELAY_QUEUE:
       processMQTTdelayQueue();
+      break;
+    case TIMER_C001_DELAY_QUEUE:
+      process_c001_delay_queue();
       break;
   }
 }

--- a/src/Scheduler.ino
+++ b/src/Scheduler.ino
@@ -164,12 +164,12 @@ void process_interval_timer(unsigned long id, unsigned long lasttimer) {
       process_c004_delay_queue();
       break;
   #endif
-/*
   #ifdef USES_C007
     case TIMER_C007_DELAY_QUEUE:
       process_c007_delay_queue();
       break;
   #endif
+/*
   #ifdef USES_C008
     case TIMER_C008_DELAY_QUEUE:
       process_c008_delay_queue();

--- a/src/Scheduler.ino
+++ b/src/Scheduler.ino
@@ -108,6 +108,13 @@ void setIntervalTimer(unsigned long id, unsigned long lasttimer) {
     case TIMER_C001_DELAY_QUEUE:
     case TIMER_C003_DELAY_QUEUE:
     case TIMER_C004_DELAY_QUEUE:
+    case TIMER_C007_DELAY_QUEUE:
+    case TIMER_C008_DELAY_QUEUE:
+    case TIMER_C009_DELAY_QUEUE:
+    case TIMER_C010_DELAY_QUEUE:
+    case TIMER_C011_DELAY_QUEUE:
+    case TIMER_C012_DELAY_QUEUE:
+    case TIMER_C013_DELAY_QUEUE:
       interval = 1000; break;
   }
   unsigned long timer = lasttimer;
@@ -142,15 +149,58 @@ void process_interval_timer(unsigned long id, unsigned long lasttimer) {
     case TIMER_MQTT_DELAY_QUEUE:
       processMQTTdelayQueue();
       break;
+  #ifdef USES_C001
     case TIMER_C001_DELAY_QUEUE:
       process_c001_delay_queue();
       break;
+  #endif
+  #ifdef USES_C003
     case TIMER_C003_DELAY_QUEUE:
       process_c003_delay_queue();
       break;
+  #endif
+  #ifdef USES_C004
     case TIMER_C004_DELAY_QUEUE:
       process_c004_delay_queue();
       break;
+  #endif
+/*
+  #ifdef USES_C007
+    case TIMER_C007_DELAY_QUEUE:
+      process_c007_delay_queue();
+      break;
+  #endif
+  #ifdef USES_C008
+    case TIMER_C008_DELAY_QUEUE:
+      process_c008_delay_queue();
+      break;
+  #endif
+  #ifdef USES_C009
+    case TIMER_C009_DELAY_QUEUE:
+      process_c009_delay_queue();
+      break;
+  #endif
+  #ifdef USES_C010
+    case TIMER_C010_DELAY_QUEUE:
+      process_c010_delay_queue();
+      break;
+  #endif
+  #ifdef USES_C011
+    case TIMER_C011_DELAY_QUEUE:
+      process_c011_delay_queue();
+      break;
+  #endif
+  #ifdef USES_C012
+    case TIMER_C012_DELAY_QUEUE:
+      process_c012_delay_queue();
+      break;
+  #endif
+  #ifdef USES_C013
+    case TIMER_C013_DELAY_QUEUE:
+      process_c013_delay_queue();
+      break;
+  #endif
+*/
   }
 }
 

--- a/src/Scheduler.ino
+++ b/src/Scheduler.ino
@@ -75,6 +75,10 @@ void setIntervalTimer(unsigned long id) {
   setIntervalTimer(id, millis());
 }
 
+void setIntervalTimerAt(unsigned long id, unsigned long newtimer) {
+  setNewTimerAt(getMixedId(CONST_INTERVAL_TIMER, id), newtimer);
+}
+
 void setIntervalTimerOverride(unsigned long id, unsigned long msecFromNow) {
   unsigned long timer = millis();
   setNextTimeInterval(timer, msecFromNow);
@@ -91,6 +95,7 @@ void setIntervalTimer(unsigned long id, unsigned long lasttimer) {
     case TIMER_30SEC:      interval = 30000; break;
     case TIMER_MQTT:       interval = timermqtt_interval; break;
     case TIMER_STATISTICS: interval = 30000; break;
+    case TIMER_MQTT_DELAY_QUEUE: interval = 1000; break;
   }
   unsigned long timer = lasttimer;
   setNextTimeInterval(timer, interval);
@@ -98,6 +103,8 @@ void setIntervalTimer(unsigned long id, unsigned long lasttimer) {
 }
 
 void process_interval_timer(unsigned long id, unsigned long lasttimer) {
+  // Set the interval timer now, it may be altered by the commands below.
+  // This is the default next-run-time.
   setIntervalTimer(id, lasttimer);
   switch (id) {
     case TIMER_20MSEC:
@@ -118,6 +125,9 @@ void process_interval_timer(unsigned long id, unsigned long lasttimer) {
       break;
     case TIMER_STATISTICS:
       logTimerStatistics();
+      break;
+    case TIMER_MQTT_DELAY_QUEUE:
+      processMQTTdelayQueue();
       break;
   }
 }

--- a/src/Scheduler.ino
+++ b/src/Scheduler.ino
@@ -174,12 +174,12 @@ void process_interval_timer(unsigned long id, unsigned long lasttimer) {
       process_c008_delay_queue();
       break;
   #endif
-/*
   #ifdef USES_C009
     case TIMER_C009_DELAY_QUEUE:
       process_c009_delay_queue();
       break;
   #endif
+/*
   #ifdef USES_C010
     case TIMER_C010_DELAY_QUEUE:
       process_c010_delay_queue();

--- a/src/Scheduler.ino
+++ b/src/Scheduler.ino
@@ -189,12 +189,12 @@ void process_interval_timer(unsigned long id, unsigned long lasttimer) {
       process_c011_delay_queue();
       break;
   #endif
-/*
   #ifdef USES_C012
     case TIMER_C012_DELAY_QUEUE:
       process_c012_delay_queue();
       break;
   #endif
+/*
   #ifdef USES_C013
     case TIMER_C013_DELAY_QUEUE:
       process_c013_delay_queue();

--- a/src/Scheduler.ino
+++ b/src/Scheduler.ino
@@ -107,6 +107,7 @@ void setIntervalTimer(unsigned long id, unsigned long lasttimer) {
     case TIMER_MQTT_DELAY_QUEUE:
     case TIMER_C001_DELAY_QUEUE:
     case TIMER_C003_DELAY_QUEUE:
+    case TIMER_C004_DELAY_QUEUE:
       interval = 1000; break;
   }
   unsigned long timer = lasttimer;
@@ -146,6 +147,9 @@ void process_interval_timer(unsigned long id, unsigned long lasttimer) {
       break;
     case TIMER_C003_DELAY_QUEUE:
       process_c003_delay_queue();
+      break;
+    case TIMER_C004_DELAY_QUEUE:
+      process_c004_delay_queue();
       break;
   }
 }

--- a/src/Scheduler.ino
+++ b/src/Scheduler.ino
@@ -169,12 +169,12 @@ void process_interval_timer(unsigned long id, unsigned long lasttimer) {
       process_c007_delay_queue();
       break;
   #endif
-/*
   #ifdef USES_C008
     case TIMER_C008_DELAY_QUEUE:
       process_c008_delay_queue();
       break;
   #endif
+/*
   #ifdef USES_C009
     case TIMER_C009_DELAY_QUEUE:
       process_c009_delay_queue();

--- a/src/Scheduler.ino
+++ b/src/Scheduler.ino
@@ -184,12 +184,12 @@ void process_interval_timer(unsigned long id, unsigned long lasttimer) {
       process_c010_delay_queue();
       break;
   #endif
-/*
   #ifdef USES_C011
     case TIMER_C011_DELAY_QUEUE:
       process_c011_delay_queue();
       break;
   #endif
+/*
   #ifdef USES_C012
     case TIMER_C012_DELAY_QUEUE:
       process_c012_delay_queue();

--- a/src/Scheduler.ino
+++ b/src/Scheduler.ino
@@ -179,12 +179,12 @@ void process_interval_timer(unsigned long id, unsigned long lasttimer) {
       process_c009_delay_queue();
       break;
   #endif
-/*
   #ifdef USES_C010
     case TIMER_C010_DELAY_QUEUE:
       process_c010_delay_queue();
       break;
   #endif
+/*
   #ifdef USES_C011
     case TIMER_C011_DELAY_QUEUE:
       process_c011_delay_queue();
@@ -201,6 +201,8 @@ void process_interval_timer(unsigned long id, unsigned long lasttimer) {
       break;
   #endif
 */
+// When extending this, also extend in _CPlugin_Helper.h
+// Look for DEFINE_Cxxx_DELAY_QUEUE_MACRO
   }
 }
 

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -5397,7 +5397,7 @@ void handle_sysinfo() {
    TXBuffer += F(" kB free)");
   #endif
 
-  html_TR_TD(); TXBuffer += F("SPIFF Size<TD>");
+  html_TR_TD(); TXBuffer += F("SPIFFS Size<TD>");
   {
   #if defined(ESP8266)
     fs::FSInfo fs_info;

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -5397,6 +5397,18 @@ void handle_sysinfo() {
    TXBuffer += F(" kB free)");
   #endif
 
+  html_TR_TD(); TXBuffer += F("SPIFF Size<TD>");
+  {
+  #if defined(ESP8266)
+    fs::FSInfo fs_info;
+    SPIFFS.info(fs_info);
+    TXBuffer += fs_info.totalBytes / 1024;
+    TXBuffer += F(" kB (");
+    TXBuffer += (fs_info.totalBytes - fs_info.usedBytes) / 1024;
+    TXBuffer += F(" kB free)");
+  #endif
+  }
+
   if (showSettingsFileLayout) {
     addTableSeparator(F("Settings Files"), 2, 3);
     html_TR_TD();

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -3117,6 +3117,7 @@ void handle_log() {
 // Web Interface JSON log page
 //********************************************************************************
 void handle_log_JSON() {
+  if (!isLoggedIn()) return;
   TXBuffer.startJsonStream();
   String webrequest = WebServer.arg(F("view"));
   TXBuffer += F("{\"Log\": {");

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -1353,10 +1353,10 @@ void handle_controllers() {
         }
 
         addFormNumericBox( F("Controller Port"), F("controllerport"), ControllerSettings.Port, 1, 65535);
-        addFormNumericBox( F("Minimum Send Interval"), F("minimumsendinterval"), ControllerSettings.MinimalTimeBetweenMessages, 1, 3600000);
+        addFormNumericBox( F("Minimum Send Interval"), F("minimumsendinterval"), ControllerSettings.MinimalTimeBetweenMessages, 1, CONTROLLER_DELAY_QUEUE_DELAY_MAX);
         addUnit(F("ms"));
-        addFormNumericBox( F("Max Queue Depth"), F("maxqueuedepth"), ControllerSettings.MaxQueueDepth, 1, 10);
-        addFormNumericBox( F("Max Retries"), F("maxretry"), ControllerSettings.MaxRetry, 1, 10);
+        addFormNumericBox( F("Max Queue Depth"), F("maxqueuedepth"), ControllerSettings.MaxQueueDepth, 1, CONTROLLER_DELAY_QUEUE_DEPTH_MAX);
+        addFormNumericBox( F("Max Retries"), F("maxretry"), ControllerSettings.MaxRetry, 1, CONTROLLER_DELAY_QUEUE_RETRY_MAX);
         addFormSelector(F("Full Queue Action"), F("deleteoldest"), 2, options_delete_oldest, NULL, NULL, choice_delete_oldest, true);
 
 

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -1342,9 +1342,13 @@ void handle_controllers() {
         }
 
         addFormNumericBox( F("Controller Port"), F("controllerport"), ControllerSettings.Port, 1, 65535);
-        addFormNumericBox( F("Minimum Send Interval"), F("minimumsendinterval"), ControllerSettings.MinimalTimeBetweenMessages, 0, 3600000);
-        addUnit(F("ms"));
-        addFormNumericBox( F("Max Buffer Depth"), F("maxbufferdepth"), ControllerSettings.MaxBufferDepth, 0, 10);
+        if (Protocol[ProtocolIndex].usesMQTT) {
+          // For now, only use this send interval for MQTT controllers, since MQTT can have a buffer.
+          // Other controllers don't have one yet.
+          addFormNumericBox( F("Minimum Send Interval"), F("minimumsendinterval"), ControllerSettings.MinimalTimeBetweenMessages, 0, 3600000);
+          addUnit(F("ms"));
+          addFormNumericBox( F("Max Buffer Depth"), F("maxbufferdepth"), ControllerSettings.MaxBufferDepth, 0, 10);
+        }
 
         if (Protocol[ProtocolIndex].usesAccount)
         {

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -906,13 +906,19 @@ void handle_root() {
       {
         char url[80];
         sprintf_P(url, PSTR("<a class='button link' href='http://%u.%u.%u.%u'>%u.%u.%u.%u</a>"), it->second.ip[0], it->second.ip[1], it->second.ip[2], it->second.ip[3], it->second.ip[0], it->second.ip[1], it->second.ip[2], it->second.ip[3]);
-        html_TR_TD(); TXBuffer += F("Unit ");
+        bool isThisUnit = it->first == Settings.Unit;
+        if (isThisUnit)
+          html_TR_TD_highlight();
+        else
+          html_TR_TD();
+
+        TXBuffer += F("Unit ");
         TXBuffer += String(it->first);
         html_TD();
-        if (it->first != Settings.Unit)
-          TXBuffer += it->second.nodeName;
-        else
+        if (isThisUnit)
           TXBuffer += Settings.Name;
+        else
+          TXBuffer += it->second.nodeName;
         html_TD();
         if (it->second.build)
           TXBuffer += String(it->second.build);
@@ -1449,6 +1455,11 @@ void handle_controllers() {
 // HTML string re-use to keep the executable smaller
 // Flash strings are not checked for duplication.
 //********************************************************************************
+
+void html_TR_TD_highlight() {
+  TXBuffer += F("<TR class=\"highlight\">");
+  html_TD();
+}
 
 void html_TR_TD() {
   TXBuffer += F("<TR>");

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -1164,6 +1164,8 @@ void handle_controllers() {
   String MQTTLwtTopic = WebServer.arg(F("mqttlwttopic"));
   String lwtmessageconnect = WebServer.arg(F("lwtmessageconnect"));
   String lwtmessagedisconnect = WebServer.arg(F("lwtmessagedisconnect"));
+  const int minimumsendinterval = getFormItemInt(F("minimumsendinterval"), 100);
+  const int maxbufferdepth = getFormItemInt(F("maxbufferdepth"), 0);
 
 
   //submitted data
@@ -1182,6 +1184,8 @@ void handle_controllers() {
         //reset (some) default-settings
         byte ProtocolIndex = getProtocolIndex(Settings.Protocol[controllerindex]);
         ControllerSettings.Port = Protocol[ProtocolIndex].defaultPort;
+        ControllerSettings.MinimalTimeBetweenMessages = 100;
+        ControllerSettings.MaxBufferDepth = 0;
         if (Protocol[ProtocolIndex].usesTemplate)
           CPlugin_ptr[ProtocolIndex](CPLUGIN_PROTOCOL_TEMPLATE, &TempEvent, dummyString);
         strncpy(ControllerSettings.Subscribe, TempEvent.String1.c_str(), sizeof(ControllerSettings.Subscribe));
@@ -1241,6 +1245,8 @@ void handle_controllers() {
         strncpy(ControllerSettings.MQTTLwtTopic, MQTTLwtTopic.c_str(), sizeof(ControllerSettings.MQTTLwtTopic));
         strncpy(ControllerSettings.LWTMessageConnect, lwtmessageconnect.c_str(), sizeof(ControllerSettings.LWTMessageConnect));
         strncpy(ControllerSettings.LWTMessageDisconnect, lwtmessagedisconnect.c_str(), sizeof(ControllerSettings.LWTMessageDisconnect));
+        ControllerSettings.MinimalTimeBetweenMessages = minimumsendinterval;
+        ControllerSettings.MaxBufferDepth = maxbufferdepth;
 
         CPlugin_ptr[ProtocolIndex](CPLUGIN_INIT, &TempEvent, dummyString);
       }
@@ -1326,7 +1332,6 @@ void handle_controllers() {
       {
 
         addFormSelector(F("Locate Controller"), F("usedns"), 2, options, NULL, NULL, choice, true);
-
         if (ControllerSettings.UseDNS)
         {
           addFormTextBox( F("Controller Hostname"), F("controllerhostname"), ControllerSettings.HostName, sizeof(ControllerSettings.HostName)-1);
@@ -1337,6 +1342,9 @@ void handle_controllers() {
         }
 
         addFormNumericBox( F("Controller Port"), F("controllerport"), ControllerSettings.Port, 1, 65535);
+        addFormNumericBox( F("Minimum Send Interval"), F("minimumsendinterval"), ControllerSettings.MinimalTimeBetweenMessages, 0, 3600000);
+        addUnit(F("ms"));
+        addFormNumericBox( F("Max Buffer Depth"), F("maxbufferdepth"), ControllerSettings.MaxBufferDepth, 0, 10);
 
         if (Protocol[ProtocolIndex].usesAccount)
         {

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -1353,10 +1353,10 @@ void handle_controllers() {
         }
 
         addFormNumericBox( F("Controller Port"), F("controllerport"), ControllerSettings.Port, 1, 65535);
-        addFormNumericBox( F("Minimum Send Interval"), F("minimumsendinterval"), ControllerSettings.MinimalTimeBetweenMessages, 0, 3600000);
+        addFormNumericBox( F("Minimum Send Interval"), F("minimumsendinterval"), ControllerSettings.MinimalTimeBetweenMessages, 1, 3600000);
         addUnit(F("ms"));
-        addFormNumericBox( F("Max Queue Depth"), F("maxqueuedepth"), ControllerSettings.MaxQueueDepth, 0, 10);
-        addFormNumericBox( F("Max Retries"), F("maxretry"), ControllerSettings.MaxRetry, 0, 10);
+        addFormNumericBox( F("Max Queue Depth"), F("maxqueuedepth"), ControllerSettings.MaxQueueDepth, 1, 10);
+        addFormNumericBox( F("Max Retries"), F("maxretry"), ControllerSettings.MaxRetry, 1, 10);
         addFormSelector(F("Full Queue Action"), F("deleteoldest"), 2, options_delete_oldest, NULL, NULL, choice_delete_oldest, true);
 
 

--- a/src/WebStaticData.h
+++ b/src/WebStaticData.h
@@ -236,6 +236,8 @@ static const char pgDefaultCSS[] PROGMEM = {
     "table.multirow tr {padding: 4px; }"
       "table.multirow tr:nth-child(even){background-color: #DEE6FF; }"
     "table.multirow {color: #000; width: 100%; min-width: 420px; border-collapse: collapse; }"
+    // Highlight row
+    "tr.highlight td { background-color: #dbff0075; }"    
     // inside a form
     ".note {color: #444; font-style: italic; }"
     //header with title and menu

--- a/src/_C001.ino
+++ b/src/_C001.ino
@@ -44,8 +44,7 @@ boolean CPlugin_001(byte function, struct EventStruct *event, String& string)
         if (event->idx != 0)
         {
           // We now create a URI for the request
-          String url = F("/json.htm?type=command&param=udevice&idx=");
-          url += event->idx;
+          String url;
 
           switch (event->sensorType)
           {

--- a/src/_C001.ino
+++ b/src/_C001.ino
@@ -110,16 +110,16 @@ boolean CPlugin_001(byte function, struct EventStruct *event, String& string)
   return success;
 }
 
-bool do_process_c001_delay_queue(const C001_queue_element& element, ControllerSettingsStruct& ControllerSettings) {
+bool do_process_c001_delay_queue(int controller_number, const C001_queue_element& element, ControllerSettingsStruct& ControllerSettings) {
   WiFiClient client;
-  if (!try_connect_host(CPLUGIN_ID_001, client, ControllerSettings))
+  if (!try_connect_host(controller_number, client, ControllerSettings))
     return false;
 
   // This will send the request to the server
-  String request = create_http_request_auth(CPLUGIN_ID_001, ControllerSettings, F("GET"), element.url);
+  String request = create_http_request_auth(controller_number, element.controller_idx, ControllerSettings, F("GET"), element.url);
 
   addLog(LOG_LEVEL_DEBUG, element.url);
-  return send_via_http(CPLUGIN_ID_001, client, request);
+  return send_via_http(controller_number, client, request);
 }
 
 #endif

--- a/src/_C001.ino
+++ b/src/_C001.ino
@@ -31,6 +31,14 @@ boolean CPlugin_001(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case CPLUGIN_INIT:
+      {
+        ControllerSettingsStruct ControllerSettings;
+        LoadControllerSettings(event->ControllerIndex, (byte*)&ControllerSettings, sizeof(ControllerSettings));
+        C001_DelayHandler.configureControllerSettings(ControllerSettings);
+        break;
+      }
+
     case CPLUGIN_PROTOCOL_SEND:
       {
         if (event->idx != 0)
@@ -134,11 +142,11 @@ boolean CPlugin_001(byte function, struct EventStruct *event, String& string)
 }
 
 void process_c001_delay_queue() {
-  C001_queue_element element;
   if (!WiFiConnected(100)) {
     scheduleNextDelayQueue(TIMER_C001_DELAY_QUEUE, C001_DelayHandler.getNextScheduleTime());
     return;
   }
+  C001_queue_element element;
   if (!C001_DelayHandler.getNext(element)) return;
 
   ControllerSettingsStruct ControllerSettings;

--- a/src/_C001.ino
+++ b/src/_C001.ino
@@ -116,9 +116,9 @@ bool do_process_c001_delay_queue(int controller_number, const C001_queue_element
     return false;
 
   // This will send the request to the server
-  String request = create_http_request_auth(controller_number, element.controller_idx, ControllerSettings, F("GET"), element.url);
+  String request = create_http_request_auth(controller_number, element.controller_idx, ControllerSettings, F("GET"), element.txt);
 
-  addLog(LOG_LEVEL_DEBUG, element.url);
+  addLog(LOG_LEVEL_DEBUG, element.txt);
   return send_via_http(controller_number, client, request);
 }
 

--- a/src/_C001.ino
+++ b/src/_C001.ino
@@ -98,9 +98,6 @@ boolean CPlugin_001(byte function, struct EventStruct *event, String& string)
           #endif
 
           success = C001_DelayHandler.addToQueue(C001_queue_element(event->ControllerIndex, url));
-          if (!success) {
-            addLog(LOG_LEVEL_DEBUG, F("C001 : publish failed, queue full"));
-          }
           scheduleNextDelayQueue(TIMER_C001_DELAY_QUEUE, C001_DelayHandler.getNextScheduleTime());
         } // if ixd !=0
         else

--- a/src/_C001.ino
+++ b/src/_C001.ino
@@ -35,10 +35,6 @@ boolean CPlugin_001(byte function, struct EventStruct *event, String& string)
       {
         if (event->idx != 0)
         {
-          if (!WiFiConnected(100)) {
-            success = false;
-            break;
-          }
           ControllerSettingsStruct ControllerSettings;
           LoadControllerSettings(event->ControllerIndex, (byte*)&ControllerSettings, sizeof (ControllerSettings));
 
@@ -57,19 +53,6 @@ boolean CPlugin_001(byte function, struct EventStruct *event, String& string)
           // boolean success = false;
           addLog(LOG_LEVEL_DEBUG, String(F("HTTP : connecting to "))+ControllerSettings.getHostPortString());
 
-
-          // Use WiFiClient class to create TCP connections
-          WiFiClient client;
-          if (!ControllerSettings.connectToHost(client))
-          {
-            connectionFailures++;
-
-            addLog(LOG_LEVEL_ERROR, F("HTTP : connection failed"));
-            return false;
-          }
-          statusLED(true);
-          if (connectionFailures)
-            connectionFailures--;
 
           // We now create a URI for the request
           String url = F("/json.htm?type=command&param=udevice&idx=");
@@ -134,29 +117,11 @@ boolean CPlugin_001(byte function, struct EventStruct *event, String& string)
           request += F("\r\n");
           request += authHeader;
           request += F("Connection: close\r\n\r\n");
-          client.print(request);
-
-          unsigned long timer = millis() + 200;
-          while (!client.available() && !timeOutReached(timer))
-            yield();
-
-          // Read all the lines of the reply from server and log them
-          while (client.available()) {
-            // String line = client.readStringUntil('\n');
-            String line;
-            safeReadStringUntil(client, line, '\n');
-            addLog(LOG_LEVEL_DEBUG_MORE, line);
-            if (line.startsWith(F("HTTP/1.1 200 OK")) )
-            {
-              addLog(LOG_LEVEL_DEBUG, F("HTTP : Success"));
-              success = true;
-            }
-            yield();
+          const bool success = C001_DelayHandler.addToQueue(C001_queue_element(event->ControllerIndex, request));
+          if (!success) {
+            addLog(LOG_LEVEL_DEBUG, F("C001 : publish failed, queue full"));
           }
-          addLog(LOG_LEVEL_DEBUG, F("HTTP : closing connection"));
-
-          client.flush();
-          client.stop();
+          scheduleNextDelayQueue(TIMER_C001_DELAY_QUEUE, C001_DelayHandler.getNextScheduleTime());
         } // if ixd !=0
         else
         {
@@ -167,4 +132,62 @@ boolean CPlugin_001(byte function, struct EventStruct *event, String& string)
   }
   return success;
 }
+
+void process_c001_delay_queue() {
+  C001_queue_element element;
+  if (!WiFiConnected(100)) {
+    scheduleNextDelayQueue(TIMER_C001_DELAY_QUEUE, C001_DelayHandler.getNextScheduleTime());
+    return;
+  }
+  if (!C001_DelayHandler.getNext(element)) return;
+
+  ControllerSettingsStruct ControllerSettings;
+  LoadControllerSettings(element._controller_idx, (byte*)&ControllerSettings, sizeof (ControllerSettings));
+  C001_DelayHandler.configureControllerSettings(ControllerSettings);
+
+  // Use WiFiClient class to create TCP connections
+  WiFiClient client;
+  if (!ControllerSettings.connectToHost(client))
+  {
+    connectionFailures++;
+
+    addLog(LOG_LEVEL_ERROR, F("HTTP : connection failed"));
+    C001_DelayHandler.markProcessed(false);
+    return;
+  }
+  statusLED(true);
+  if (connectionFailures)
+    connectionFailures--;
+
+  client.print(element.request);
+
+  unsigned long timer = millis() + 200;
+  while (!client.available() && !timeOutReached(timer))
+    yield();
+
+  // Read all the lines of the reply from server and log them
+  bool done = false;
+  while (client.available() && !done) {
+    // String line = client.readStringUntil('\n');
+    String line;
+    safeReadStringUntil(client, line, '\n');
+    if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE))
+      addLog(LOG_LEVEL_DEBUG_MORE, line);
+    if (line.startsWith(F("HTTP/1.1 200 OK")) )
+    {
+      if (loglevelActiveFor(LOG_LEVEL_DEBUG))
+        addLog(LOG_LEVEL_DEBUG, F("HTTP : Success"));
+      done = true;
+    }
+    yield();
+  }
+  C001_DelayHandler.markProcessed(done);
+  if (loglevelActiveFor(LOG_LEVEL_DEBUG))
+    addLog(LOG_LEVEL_DEBUG, F("HTTP : closing connection"));
+
+  client.flush();
+  client.stop();
+  scheduleNextDelayQueue(TIMER_C001_DELAY_QUEUE, C001_DelayHandler.getNextScheduleTime());
+}
+
 #endif

--- a/src/_C002.ino
+++ b/src/_C002.ino
@@ -33,6 +33,14 @@ boolean CPlugin_002(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case CPLUGIN_INIT:
+      {
+        ControllerSettingsStruct ControllerSettings;
+        LoadControllerSettings(event->ControllerIndex, (byte*)&ControllerSettings, sizeof(ControllerSettings));
+        MQTTDelayHandler.configureControllerSettings(ControllerSettings);
+        break;
+      }
+
     case CPLUGIN_PROTOCOL_TEMPLATE:
       {
         event->String1 = F("domoticz/out");

--- a/src/_C002.ino
+++ b/src/_C002.ino
@@ -139,10 +139,12 @@ boolean CPlugin_002(byte function, struct EventStruct *event, String& string)
         {
           ControllerSettingsStruct ControllerSettings;
           LoadControllerSettings(event->ControllerIndex, (byte*)&ControllerSettings, sizeof(ControllerSettings));
+/*
           if (!ControllerSettings.checkHostReachable(true)) {
             success = false;
             break;
           }
+*/
           StaticJsonBuffer<200> jsonBuffer;
 
           JsonObject& root = jsonBuffer.createObject();

--- a/src/_C003.ino
+++ b/src/_C003.ino
@@ -30,82 +30,108 @@ boolean CPlugin_003(byte function, struct EventStruct *event, String& string)
         break;
       }
 
-    case CPLUGIN_PROTOCOL_SEND:
+    case CPLUGIN_INIT:
       {
         ControllerSettingsStruct ControllerSettings;
         LoadControllerSettings(event->ControllerIndex, (byte*)&ControllerSettings, sizeof(ControllerSettings));
+        C003_DelayHandler.configureControllerSettings(ControllerSettings);
+        break;
+      }
 
-        boolean success = false;
-        char log[80];
-        addLog(LOG_LEVEL_DEBUG, String(F("TELNT : connecting to ")) + ControllerSettings.getHostPortString());
-        // Use WiFiClient class to create TCP connections
-        WiFiClient client;
-        if (!ControllerSettings.connectToHost(client))
-        {
-          connectionFailures++;
-          strcpy_P(log, PSTR("TELNT: connection failed"));
-          addLog(LOG_LEVEL_ERROR, log);
-          return false;
-        }
-        statusLED(true);
-        if (connectionFailures)
-          connectionFailures--;
-
+    case CPLUGIN_PROTOCOL_SEND:
+      {
         // We now create a URI for the request
         String url = F("variableset ");
         url += event->idx;
         url += ",";
         url += formatUserVarNoCheck(event, 0);
         url += "\n";
-
-        // strcpy_P(log, PSTR("TELNT: Sending enter"));
-        // addLog(LOG_LEVEL_ERROR, log);
-        client.print(" \n");
-
-        unsigned long timer = millis() + 200;
-        while (!client.available() && !timeOutReached(timer))
-          delay(1);
-
-        timer = millis() + 1000;
-        while (client.available() && !timeOutReached(timer) && !success)
-        {
-
-          //   String line = client.readStringUntil('\n');
-          String line;
-          safeReadStringUntil(client, line, '\n');
-
-          if (line.startsWith(F("Enter your password:")))
-          {
-            success = true;
-            strcpy_P(log, PSTR("TELNT: Password request ok"));
-            addLog(LOG_LEVEL_DEBUG, log);
-          }
-          delay(1);
+        success = C003_DelayHandler.addToQueue(C003_queue_element(event->ControllerIndex, url));
+        if (!success) {
+          addLog(LOG_LEVEL_DEBUG, F("C003 : publish failed, queue full"));
         }
-
-        strcpy_P(log, PSTR("TELNT: Sending pw"));
-        addLog(LOG_LEVEL_DEBUG, log);
-        client.println(SecuritySettings.ControllerPassword[event->ControllerIndex]);
-        delay(100);
-        while (client.available())
-          client.read();
-
-        strcpy_P(log, PSTR("TELNT: Sending cmd"));
-        addLog(LOG_LEVEL_DEBUG, log);
-        client.print(url);
-        delay(10);
-        while (client.available())
-          client.read();
-
-        strcpy_P(log, PSTR("TELNT: closing connection"));
-        addLog(LOG_LEVEL_DEBUG, log);
-
-        client.stop();
+        scheduleNextDelayQueue(TIMER_C003_DELAY_QUEUE, C003_DelayHandler.getNextScheduleTime());
 
         break;
       }
 
   }
   return success;
+}
+
+void process_c003_delay_queue() {
+  if (!WiFiConnected(100)) {
+    scheduleNextDelayQueue(TIMER_C003_DELAY_QUEUE, C003_DelayHandler.getNextScheduleTime());
+    return;
+  }
+  C003_queue_element element;
+  if (!C003_DelayHandler.getNext(element)) return;
+
+  ControllerSettingsStruct ControllerSettings;
+  LoadControllerSettings(element._controller_idx, (byte*)&ControllerSettings, sizeof(ControllerSettings));
+  C003_DelayHandler.configureControllerSettings(ControllerSettings);
+
+
+  boolean success = false;
+  char log[80];
+  addLog(LOG_LEVEL_DEBUG, String(F("TELNT : connecting to ")) + ControllerSettings.getHostPortString());
+  // Use WiFiClient class to create TCP connections
+  WiFiClient client;
+  if (!ControllerSettings.connectToHost(client))
+  {
+    connectionFailures++;
+    strcpy_P(log, PSTR("TELNT: connection failed"));
+    addLog(LOG_LEVEL_ERROR, log);
+    scheduleNextDelayQueue(TIMER_C003_DELAY_QUEUE, C003_DelayHandler.getNextScheduleTime());
+    return;
+  }
+  statusLED(true);
+  if (connectionFailures)
+    connectionFailures--;
+
+  // strcpy_P(log, PSTR("TELNT: Sending enter"));
+  // addLog(LOG_LEVEL_ERROR, log);
+  client.print(" \n");
+
+  unsigned long timer = millis() + 200;
+  while (!client.available() && !timeOutReached(timer))
+    delay(1);
+
+  timer = millis() + 1000;
+  while (client.available() && !timeOutReached(timer) && !success)
+  {
+
+    //   String line = client.readStringUntil('\n');
+    String line;
+    safeReadStringUntil(client, line, '\n');
+
+    if (line.startsWith(F("Enter your password:")))
+    {
+      success = true;
+      strcpy_P(log, PSTR("TELNT: Password request ok"));
+      addLog(LOG_LEVEL_DEBUG, log);
+    }
+    delay(1);
+  }
+
+  strcpy_P(log, PSTR("TELNT: Sending pw"));
+  addLog(LOG_LEVEL_DEBUG, log);
+  client.println(SecuritySettings.ControllerPassword[element._controller_idx]);
+  delay(100);
+  while (client.available())
+    client.read();
+
+  strcpy_P(log, PSTR("TELNT: Sending cmd"));
+  addLog(LOG_LEVEL_DEBUG, log);
+  client.print(element.url);
+  delay(10);
+  while (client.available())
+    client.read();
+
+  strcpy_P(log, PSTR("TELNT: closing connection"));
+  addLog(LOG_LEVEL_DEBUG, log);
+
+  client.stop();
+  scheduleNextDelayQueue(TIMER_C003_DELAY_QUEUE, C003_DelayHandler.getNextScheduleTime());
 }
 #endif

--- a/src/_C003.ino
+++ b/src/_C003.ino
@@ -107,7 +107,7 @@ bool do_process_c003_delay_queue(int controller_number, const C003_queue_element
 
   strcpy_P(log, PSTR("TELNT: Sending cmd"));
   addLog(LOG_LEVEL_DEBUG, log);
-  client.print(element.url);
+  client.print(element.txt);
   delay(10);
   while (client.available())
     client.read();

--- a/src/_C003.ino
+++ b/src/_C003.ino
@@ -47,9 +47,6 @@ boolean CPlugin_003(byte function, struct EventStruct *event, String& string)
         url += formatUserVarNoCheck(event, 0);
         url += "\n";
         success = C003_DelayHandler.addToQueue(C003_queue_element(event->ControllerIndex, url));
-        if (!success) {
-          addLog(LOG_LEVEL_DEBUG, F("C003 : publish failed, queue full"));
-        }
         scheduleNextDelayQueue(TIMER_C003_DELAY_QUEUE, C003_DelayHandler.getNextScheduleTime());
 
         break;

--- a/src/_C003.ino
+++ b/src/_C003.ino
@@ -56,7 +56,7 @@ boolean CPlugin_003(byte function, struct EventStruct *event, String& string)
   return success;
 }
 
-bool do_process_c003_delay_queue(const C003_queue_element& element, ControllerSettingsStruct& ControllerSettings) {
+bool do_process_c003_delay_queue(int controller_number, const C003_queue_element& element, ControllerSettingsStruct& ControllerSettings) {
   boolean success = false;
   char log[80];
   addLog(LOG_LEVEL_DEBUG, String(F("TELNT : connecting to ")) + ControllerSettings.getHostPortString());

--- a/src/_C004.ino
+++ b/src/_C004.ino
@@ -30,6 +30,14 @@ boolean CPlugin_004(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case CPLUGIN_INIT:
+      {
+        ControllerSettingsStruct ControllerSettings;
+        LoadControllerSettings(event->ControllerIndex, (byte*)&ControllerSettings, sizeof(ControllerSettings));
+        C004_DelayHandler.configureControllerSettings(ControllerSettings);
+        break;
+      }
+
     case CPLUGIN_GET_PROTOCOL_DISPLAY_NAME:
       {
         success = true;
@@ -48,92 +56,99 @@ boolean CPlugin_004(byte function, struct EventStruct *event, String& string)
 
     case CPLUGIN_PROTOCOL_SEND:
       {
-        ControllerSettingsStruct ControllerSettings;
-        LoadControllerSettings(event->ControllerIndex, (byte*)&ControllerSettings, sizeof(ControllerSettings));
-
-        // boolean success = false;
-        addLog(LOG_LEVEL_DEBUG, String(F("HTTP : connecting to "))+ControllerSettings.getHostPortString());
-        char log[80];
-        // Use WiFiClient class to create TCP connections
-        WiFiClient client;
-        if (!ControllerSettings.connectToHost(client))
-        {
-          connectionFailures++;
-          if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
-            strcpy_P(log, PSTR("HTTP : connection failed"));
-            addLog(LOG_LEVEL_ERROR, log);
-          }
-          return false;
+        success = C004_DelayHandler.addToQueue(C004_queue_element(event));
+        if (!success) {
+          addLog(LOG_LEVEL_DEBUG, F("C004 : publish failed, queue full"));
         }
-        statusLED(true);
-        if (connectionFailures)
-          connectionFailures--;
+        scheduleNextDelayQueue(TIMER_C004_DELAY_QUEUE, C004_DelayHandler.getNextScheduleTime());
 
-        String postDataStr = F("api_key=");
-        postDataStr += SecuritySettings.ControllerPassword[event->ControllerIndex]; // used for API key
-
-        byte valueCount = getValueCountFromSensorType(event->sensorType);
-        for (byte x = 0; x < valueCount; x++)
-        {
-          postDataStr += F("&field");
-          postDataStr += event->idx + x;
-          postDataStr += "=";
-          postDataStr += formatUserVarNoCheck(event, x);
-        }
-        String hostName = F("api.thingspeak.com"); // PM_CZ: HTTP requests must contain host headers.
-        if (ControllerSettings.UseDNS)
-          hostName = ControllerSettings.HostName;
-
-        String postStr = F("POST /update HTTP/1.1\r\n");
-        postStr += F("Host: ");
-        postStr += hostName;
-        postStr += F("\r\n");
-        postStr += F("Connection: close\r\n");
-
-        postStr += F("Content-Type: application/x-www-form-urlencoded\r\n");
-        postStr += F("Content-Length: ");
-        postStr += postDataStr.length();
-        postStr += F("\r\n\r\n");
-        postStr += postDataStr;
-
-        // This will send the request to the server
-        client.print(postStr);
-
-        unsigned long timer = millis() + 200;
-        while (!client.available() && !timeOutReached(timer))
-          delay(1);
-
-        // Read all the lines of the reply from server and print them to Serial
-        while (client.available()) {
-          //   String line = client.readStringUntil('\n');
-          String line;
-          safeReadStringUntil(client, line, '\n');
-
-          if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE)) {
-            line.toCharArray(log, 80);
-            addLog(LOG_LEVEL_DEBUG_MORE, log);
-          }
-          if (line.substring(0, 15) == F("HTTP/1.1 200 OK"))
-          {
-            if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
-              strcpy_P(log, PSTR("HTTP : Success!"));
-              addLog(LOG_LEVEL_DEBUG, log);
-            }
-            success = true;
-          }
-          delay(1);
-        }
-        if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
-          strcpy_P(log, PSTR("HTTP : closing connection"));
-          addLog(LOG_LEVEL_DEBUG, log);
-        }
-
-        client.flush();
-        client.stop();
         break;
       }
 
   }
+  return success;
+}
+
+bool do_process_c004_delay_queue(const C004_queue_element& element, ControllerSettingsStruct& ControllerSettings) {
+  boolean success = false;
+  addLog(LOG_LEVEL_DEBUG, String(F("HTTP : connecting to "))+ControllerSettings.getHostPortString());
+  char log[80];
+  // Use WiFiClient class to create TCP connections
+  WiFiClient client;
+  if (!ControllerSettings.connectToHost(client))
+  {
+    connectionFailures++;
+    if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
+      strcpy_P(log, PSTR("HTTP : connection failed"));
+      addLog(LOG_LEVEL_ERROR, log);
+    }
+    return success;
+  }
+  statusLED(true);
+  if (connectionFailures)
+    connectionFailures--;
+
+  String postDataStr = F("api_key=");
+  postDataStr += SecuritySettings.ControllerPassword[element.controller_idx]; // used for API key
+
+  byte valueCount = getValueCountFromSensorType(element.sensorType);
+  for (byte x = 0; x < valueCount; x++)
+  {
+    postDataStr += F("&field");
+    postDataStr += element.idx + x;
+    postDataStr += "=";
+    postDataStr += formatUserVarNoCheck(element.TaskIndex, x);
+  }
+  String hostName = F("api.thingspeak.com"); // PM_CZ: HTTP requests must contain host headers.
+  if (ControllerSettings.UseDNS)
+    hostName = ControllerSettings.HostName;
+
+  String postStr = F("POST /update HTTP/1.1\r\n");
+  postStr += F("Host: ");
+  postStr += hostName;
+  postStr += F("\r\n");
+  postStr += F("Connection: close\r\n");
+
+  postStr += F("Content-Type: application/x-www-form-urlencoded\r\n");
+  postStr += F("Content-Length: ");
+  postStr += postDataStr.length();
+  postStr += F("\r\n\r\n");
+  postStr += postDataStr;
+
+  // This will send the request to the server
+  client.print(postStr);
+
+  unsigned long timer = millis() + 200;
+  while (!client.available() && !timeOutReached(timer))
+    delay(1);
+
+  // Read all the lines of the reply from server and print them to Serial
+  while (client.available()) {
+    //   String line = client.readStringUntil('\n');
+    String line;
+    safeReadStringUntil(client, line, '\n');
+
+    if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE)) {
+      line.toCharArray(log, 80);
+      addLog(LOG_LEVEL_DEBUG_MORE, log);
+    }
+    if (line.substring(0, 15) == F("HTTP/1.1 200 OK"))
+    {
+      if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+        strcpy_P(log, PSTR("HTTP : Success!"));
+        addLog(LOG_LEVEL_DEBUG, log);
+      }
+      success = true;
+    }
+    delay(1);
+  }
+  if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+    strcpy_P(log, PSTR("HTTP : closing connection"));
+    addLog(LOG_LEVEL_DEBUG, log);
+  }
+
+  client.flush();
+  client.stop();
   return success;
 }
 #endif

--- a/src/_C004.ino
+++ b/src/_C004.ino
@@ -66,9 +66,9 @@ boolean CPlugin_004(byte function, struct EventStruct *event, String& string)
   return success;
 }
 
-bool do_process_c004_delay_queue(const C004_queue_element& element, ControllerSettingsStruct& ControllerSettings) {
+bool do_process_c004_delay_queue(int controller_number, const C004_queue_element& element, ControllerSettingsStruct& ControllerSettings) {
   WiFiClient client;
-  if (!try_connect_host(CPLUGIN_ID_004, client, ControllerSettings))
+  if (!try_connect_host(controller_number, client, ControllerSettings))
     return false;
 
   String postDataStr = F("api_key=");
@@ -94,6 +94,6 @@ bool do_process_c004_delay_queue(const C004_queue_element& element, ControllerSe
     postDataStr.length());
   postStr += postDataStr;
 
-  return send_via_http(CPLUGIN_ID_004, client, postStr);
+  return send_via_http(controller_number, client, postStr);
 }
 #endif

--- a/src/_C004.ino
+++ b/src/_C004.ino
@@ -143,7 +143,7 @@ bool do_process_c004_delay_queue(const C004_queue_element& element, ControllerSe
     delay(1);
   }
   if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
-    strcpy_P(log, PSTR("HTTP : closing connection"));
+    strcpy_P(log, PSTR("HTTP : closing connection (004)"));
     addLog(LOG_LEVEL_DEBUG, log);
   }
 

--- a/src/_C004.ino
+++ b/src/_C004.ino
@@ -57,9 +57,6 @@ boolean CPlugin_004(byte function, struct EventStruct *event, String& string)
     case CPLUGIN_PROTOCOL_SEND:
       {
         success = C004_DelayHandler.addToQueue(C004_queue_element(event));
-        if (!success) {
-          addLog(LOG_LEVEL_DEBUG, F("C004 : publish failed, queue full"));
-        }
         scheduleNextDelayQueue(TIMER_C004_DELAY_QUEUE, C004_DelayHandler.getNextScheduleTime());
 
         break;

--- a/src/_C005.ino
+++ b/src/_C005.ino
@@ -31,6 +31,14 @@ boolean CPlugin_005(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case CPLUGIN_INIT:
+      {
+        ControllerSettingsStruct ControllerSettings;
+        LoadControllerSettings(event->ControllerIndex, (byte*)&ControllerSettings, sizeof(ControllerSettings));
+        MQTTDelayHandler.configureControllerSettings(ControllerSettings);
+        break;
+      }
+
     case CPLUGIN_PROTOCOL_TEMPLATE:
       {
         event->String1 = F("/%sysname%/#");

--- a/src/_C006.ino
+++ b/src/_C006.ino
@@ -31,6 +31,14 @@ boolean CPlugin_006(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case CPLUGIN_INIT:
+      {
+        ControllerSettingsStruct ControllerSettings;
+        LoadControllerSettings(event->ControllerIndex, (byte*)&ControllerSettings, sizeof(ControllerSettings));
+        MQTTDelayHandler.configureControllerSettings(ControllerSettings);
+        break;
+      }
+
     case CPLUGIN_PROTOCOL_TEMPLATE:
       {
         event->String1 = F("/Home/#");

--- a/src/_C007.ino
+++ b/src/_C007.ino
@@ -30,99 +30,108 @@ boolean CPlugin_007(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case CPLUGIN_INIT:
+      {
+        ControllerSettingsStruct ControllerSettings;
+        LoadControllerSettings(event->ControllerIndex, (byte*)&ControllerSettings, sizeof(ControllerSettings));
+        C007_DelayHandler.configureControllerSettings(ControllerSettings);
+        break;
+      }
+
     case CPLUGIN_PROTOCOL_SEND:
       {
-        if (!WiFiConnected(100)) {
-          success = false;
-          break;
-        }
         const byte valueCount = getValueCountFromSensorType(event->sensorType);
         if (valueCount == 0 || valueCount > 3) {
           addLog(LOG_LEVEL_ERROR, F("emoncms : Unknown sensortype or too many sensor values"));
           break;
         }
-
-        ControllerSettingsStruct ControllerSettings;
-        LoadControllerSettings(event->ControllerIndex, (byte*)&ControllerSettings, sizeof(ControllerSettings));
-
-        // boolean success = false;
-        addLog(LOG_LEVEL_DEBUG, String(F("HTTP : connecting to "))+ControllerSettings.getHostPortString());
-        char log[80];
-        // Use WiFiClient class to create TCP connections
-        WiFiClient client;
-        if (!ControllerSettings.connectToHost(client))
-        {
-          connectionFailures++;
-          strcpy_P(log, PSTR("HTTP : connection failed"));
-          addLog(LOG_LEVEL_ERROR, log);
-          return false;
+        const bool success = C007_DelayHandler.addToQueue(C007_queue_element(event));
+        if (!success) {
+          addLog(LOG_LEVEL_DEBUG, F("C007 : publish failed, queue full"));
         }
-        statusLED(true);
-        if (connectionFailures)
-          connectionFailures--;
-
-        String postDataStr = F("GET /emoncms/input/post.json?node=");
-
-        postDataStr += Settings.Unit;
-        postDataStr += F("&json=");
-
-        for (byte i = 0; i < valueCount; ++i) {
-          postDataStr += (i == 0) ? F("{") : F(",");
-          postDataStr += F("field");
-          postDataStr += event->idx + i;
-          postDataStr += ":";
-          postDataStr += formatUserVarNoCheck(event, i);
-        }
-        postDataStr += "}";
-        postDataStr += F("&apikey=");
-        postDataStr += SecuritySettings.ControllerPassword[event->ControllerIndex]; // "0UDNN17RW6XAS2E5" // api key
-
-        String postStr = F(" HTTP/1.1\r\n");
-        postStr += F("Host: ");
-        postStr += ControllerSettings.getHost();
-        postStr += F("\r\n");
-        postStr += F("Connection: close\r\n");
-        postStr += F("\r\n");
-
-        postDataStr += postStr;
-
-        if (Settings.SerialLogLevel >= LOG_LEVEL_DEBUG_MORE)
-          Serial.println(postDataStr);
-
-        // This will send the request to the server
-        client.print(postDataStr);
-
-        unsigned long timer = millis() + 200;
-        while (!client.available() && !timeOutReached(timer))
-          delay(1);
-
-        // Read all the lines of the reply from server and print them to Serial
-        while (client.available()) {
-          //   String line = client.readStringUntil('\n');
-          String line;
-          safeReadStringUntil(client, line, '\n');
-
-          if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE)) {
-            line.toCharArray(log, 80);
-            addLog(LOG_LEVEL_DEBUG_MORE, log);
-          }
-          if (line.substring(0, 15) == F("HTTP/1.1 200 OK"))
-          {
-            strcpy_P(log, PSTR("HTTP : Success!"));
-            addLog(LOG_LEVEL_DEBUG, log);
-            success = true;
-          }
-          delay(1);
-        }
-        strcpy_P(log, PSTR("HTTP : closing connection"));
-        addLog(LOG_LEVEL_DEBUG, log);
-
-        client.flush();
-        client.stop();
+        scheduleNextDelayQueue(TIMER_C007_DELAY_QUEUE, C007_DelayHandler.getNextScheduleTime());
         break;
       }
 
   }
+  return success;
+}
+
+bool do_process_c007_delay_queue(const C007_queue_element& element, ControllerSettingsStruct& ControllerSettings) {
+  boolean success = false;
+  addLog(LOG_LEVEL_DEBUG, String(F("HTTP : connecting to "))+ControllerSettings.getHostPortString());
+  char log[80];
+  // Use WiFiClient class to create TCP connections
+  WiFiClient client;
+  if (!ControllerSettings.connectToHost(client))
+  {
+    connectionFailures++;
+    strcpy_P(log, PSTR("HTTP : connection failed"));
+    addLog(LOG_LEVEL_ERROR, log);
+    return success;
+  }
+  statusLED(true);
+  if (connectionFailures)
+    connectionFailures--;
+
+  String postDataStr = F("GET /emoncms/input/post.json?node=");
+
+  postDataStr += Settings.Unit;
+  postDataStr += F("&json=");
+  const byte valueCount = getValueCountFromSensorType(element.sensorType);
+  for (byte i = 0; i < valueCount; ++i) {
+    postDataStr += (i == 0) ? F("{") : F(",");
+    postDataStr += F("field");
+    postDataStr += element.idx + i;
+    postDataStr += ":";
+    postDataStr += formatUserVarNoCheck(element.TaskIndex, i);
+  }
+  postDataStr += "}";
+  postDataStr += F("&apikey=");
+  postDataStr += SecuritySettings.ControllerPassword[element.controller_idx]; // "0UDNN17RW6XAS2E5" // api key
+
+  String postStr = F(" HTTP/1.1\r\n");
+  postStr += F("Host: ");
+  postStr += ControllerSettings.getHost();
+  postStr += F("\r\n");
+  postStr += F("Connection: close\r\n");
+  postStr += F("\r\n");
+
+  postDataStr += postStr;
+
+  if (Settings.SerialLogLevel >= LOG_LEVEL_DEBUG_MORE)
+    Serial.println(postDataStr);
+
+  // This will send the request to the server
+  client.print(postDataStr);
+
+  unsigned long timer = millis() + 200;
+  while (!client.available() && !timeOutReached(timer))
+    delay(1);
+
+  // Read all the lines of the reply from server and print them to Serial
+  while (client.available()) {
+    //   String line = client.readStringUntil('\n');
+    String line;
+    safeReadStringUntil(client, line, '\n');
+
+    if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE)) {
+      line.toCharArray(log, 80);
+      addLog(LOG_LEVEL_DEBUG_MORE, log);
+    }
+    if (line.substring(0, 15) == F("HTTP/1.1 200 OK"))
+    {
+      strcpy_P(log, PSTR("HTTP : Success!"));
+      addLog(LOG_LEVEL_DEBUG, log);
+      success = true;
+    }
+    delay(1);
+  }
+  strcpy_P(log, PSTR("HTTP : closing connection"));
+  addLog(LOG_LEVEL_DEBUG, log);
+
+  client.flush();
+  client.stop();
   return success;
 }
 #endif

--- a/src/_C007.ino
+++ b/src/_C007.ino
@@ -45,7 +45,7 @@ boolean CPlugin_007(byte function, struct EventStruct *event, String& string)
           addLog(LOG_LEVEL_ERROR, F("emoncms : Unknown sensortype or too many sensor values"));
           break;
         }
-        const bool success = C007_DelayHandler.addToQueue(C007_queue_element(event));
+        success = C007_DelayHandler.addToQueue(C007_queue_element(event));
         if (!success) {
           addLog(LOG_LEVEL_DEBUG, F("C007 : publish failed, queue full"));
         }
@@ -127,7 +127,7 @@ bool do_process_c007_delay_queue(const C007_queue_element& element, ControllerSe
     }
     delay(1);
   }
-  strcpy_P(log, PSTR("HTTP : closing connection"));
+  strcpy_P(log, PSTR("HTTP : closing connection (007)"));
   addLog(LOG_LEVEL_DEBUG, log);
 
   client.flush();

--- a/src/_C007.ino
+++ b/src/_C007.ino
@@ -46,9 +46,6 @@ boolean CPlugin_007(byte function, struct EventStruct *event, String& string)
           break;
         }
         success = C007_DelayHandler.addToQueue(C007_queue_element(event));
-        if (!success) {
-          addLog(LOG_LEVEL_DEBUG, F("C007 : publish failed, queue full"));
-        }
         scheduleNextDelayQueue(TIMER_C007_DELAY_QUEUE, C007_DelayHandler.getNextScheduleTime());
         break;
       }

--- a/src/_C007.ino
+++ b/src/_C007.ino
@@ -54,9 +54,9 @@ boolean CPlugin_007(byte function, struct EventStruct *event, String& string)
   return success;
 }
 
-bool do_process_c007_delay_queue(const C007_queue_element& element, ControllerSettingsStruct& ControllerSettings) {
+bool do_process_c007_delay_queue(int controller_number, const C007_queue_element& element, ControllerSettingsStruct& ControllerSettings) {
   WiFiClient client;
-  if (!try_connect_host(CPLUGIN_ID_007, client, ControllerSettings))
+  if (!try_connect_host(controller_number, client, ControllerSettings))
     return false;
 
   String url = F("/emoncms/input/post.json?node=");
@@ -77,7 +77,7 @@ bool do_process_c007_delay_queue(const C007_queue_element& element, ControllerSe
   if (Settings.SerialLogLevel >= LOG_LEVEL_DEBUG_MORE)
     Serial.println(url);
 
-  return send_via_http(CPLUGIN_ID_007, client,
-    create_http_get_request(CPLUGIN_ID_007, ControllerSettings, url));
+  return send_via_http(controller_number, client,
+    create_http_get_request(controller_number, ControllerSettings, url));
 }
 #endif

--- a/src/_C007.ino
+++ b/src/_C007.ino
@@ -58,80 +58,29 @@ boolean CPlugin_007(byte function, struct EventStruct *event, String& string)
 }
 
 bool do_process_c007_delay_queue(const C007_queue_element& element, ControllerSettingsStruct& ControllerSettings) {
-  boolean success = false;
-  addLog(LOG_LEVEL_DEBUG, String(F("HTTP : connecting to "))+ControllerSettings.getHostPortString());
-  char log[80];
-  // Use WiFiClient class to create TCP connections
   WiFiClient client;
-  if (!ControllerSettings.connectToHost(client))
-  {
-    connectionFailures++;
-    strcpy_P(log, PSTR("HTTP : connection failed"));
-    addLog(LOG_LEVEL_ERROR, log);
-    return success;
-  }
-  statusLED(true);
-  if (connectionFailures)
-    connectionFailures--;
+  if (!try_connect_host(CPLUGIN_ID_007, client, ControllerSettings))
+    return false;
 
-  String postDataStr = F("GET /emoncms/input/post.json?node=");
-
-  postDataStr += Settings.Unit;
-  postDataStr += F("&json=");
+  String url = F("/emoncms/input/post.json?node=");
+  url += Settings.Unit;
+  url += F("&json=");
   const byte valueCount = getValueCountFromSensorType(element.sensorType);
   for (byte i = 0; i < valueCount; ++i) {
-    postDataStr += (i == 0) ? F("{") : F(",");
-    postDataStr += F("field");
-    postDataStr += element.idx + i;
-    postDataStr += ":";
-    postDataStr += formatUserVarNoCheck(element.TaskIndex, i);
+    url += (i == 0) ? F("{") : F(",");
+    url += F("field");
+    url += element.idx + i;
+    url += ":";
+    url += formatUserVarNoCheck(element.TaskIndex, i);
   }
-  postDataStr += "}";
-  postDataStr += F("&apikey=");
-  postDataStr += SecuritySettings.ControllerPassword[element.controller_idx]; // "0UDNN17RW6XAS2E5" // api key
-
-  String postStr = F(" HTTP/1.1\r\n");
-  postStr += F("Host: ");
-  postStr += ControllerSettings.getHost();
-  postStr += F("\r\n");
-  postStr += F("Connection: close\r\n");
-  postStr += F("\r\n");
-
-  postDataStr += postStr;
+  url += "}";
+  url += F("&apikey=");
+  url += SecuritySettings.ControllerPassword[element.controller_idx]; // "0UDNN17RW6XAS2E5" // api key
 
   if (Settings.SerialLogLevel >= LOG_LEVEL_DEBUG_MORE)
-    Serial.println(postDataStr);
+    Serial.println(url);
 
-  // This will send the request to the server
-  client.print(postDataStr);
-
-  unsigned long timer = millis() + 200;
-  while (!client.available() && !timeOutReached(timer))
-    delay(1);
-
-  // Read all the lines of the reply from server and print them to Serial
-  while (client.available()) {
-    //   String line = client.readStringUntil('\n');
-    String line;
-    safeReadStringUntil(client, line, '\n');
-
-    if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE)) {
-      line.toCharArray(log, 80);
-      addLog(LOG_LEVEL_DEBUG_MORE, log);
-    }
-    if (line.substring(0, 15) == F("HTTP/1.1 200 OK"))
-    {
-      strcpy_P(log, PSTR("HTTP : Success!"));
-      addLog(LOG_LEVEL_DEBUG, log);
-      success = true;
-    }
-    delay(1);
-  }
-  strcpy_P(log, PSTR("HTTP : closing connection (007)"));
-  addLog(LOG_LEVEL_DEBUG, log);
-
-  client.flush();
-  client.stop();
-  return success;
+  return send_via_http(CPLUGIN_ID_007, client,
+    create_http_get_request(CPLUGIN_ID_007, ControllerSettings, url));
 }
 #endif

--- a/src/_C008.ino
+++ b/src/_C008.ino
@@ -63,13 +63,13 @@ boolean CPlugin_008(byte function, struct EventStruct *event, String& string)
           bool isvalid;
           String formattedValue = formatUserVar(event, x, isvalid);
           if (isvalid) {
-            element.url[x] = "/";
-            element.url[x] += ControllerSettings.Publish;
-            parseControllerVariables(element.url[x], event, true);
+            element.txt[x] = "/";
+            element.txt[x] += ControllerSettings.Publish;
+            parseControllerVariables(element.txt[x], event, true);
 
-            element.url[x].replace(F("%valname%"), URLEncode(ExtraTaskSettings.TaskDeviceValueNames[x]));
-            element.url[x].replace(F("%value%"), formattedValue);
-            addLog(LOG_LEVEL_DEBUG_MORE, element.url[x]);
+            element.txt[x].replace(F("%valname%"), URLEncode(ExtraTaskSettings.TaskDeviceValueNames[x]));
+            element.txt[x].replace(F("%value%"), formattedValue);
+            addLog(LOG_LEVEL_DEBUG_MORE, element.txt[x]);
           }
         }
         success = C008_DelayHandler.addToQueue(element);
@@ -85,7 +85,7 @@ boolean CPlugin_008(byte function, struct EventStruct *event, String& string)
 // Generic HTTP get request
 //********************************************************************************
 bool do_process_c008_delay_queue(int controller_number, const C008_queue_element& element, ControllerSettingsStruct& ControllerSettings) {
-  while (element.url[element.valuesSent] == "") {
+  while (element.txt[element.valuesSent] == "") {
     // A non valid value, which we are not going to send.
     // Increase sent counter until a valid value is found.
     if (element.checkDone(true))
@@ -96,7 +96,7 @@ bool do_process_c008_delay_queue(int controller_number, const C008_queue_element
   if (!try_connect_host(controller_number, client, ControllerSettings))
     return false;
 
-  String request = create_http_request_auth(controller_number, element.controller_idx, ControllerSettings, F("GET"), element.url[element.valuesSent]);
+  String request = create_http_request_auth(controller_number, element.controller_idx, ControllerSettings, F("GET"), element.txt[element.valuesSent]);
   return element.checkDone(send_via_http(controller_number, client, request));
 }
 

--- a/src/_C008.ino
+++ b/src/_C008.ino
@@ -32,6 +32,14 @@ boolean CPlugin_008(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case CPLUGIN_INIT:
+      {
+        ControllerSettingsStruct ControllerSettings;
+        LoadControllerSettings(event->ControllerIndex, (byte*)&ControllerSettings, sizeof(ControllerSettings));
+        C008_DelayHandler.configureControllerSettings(ControllerSettings);
+        break;
+      }
+
     case CPLUGIN_PROTOCOL_TEMPLATE:
       {
         event->String1 = "";
@@ -41,21 +49,34 @@ boolean CPlugin_008(byte function, struct EventStruct *event, String& string)
 
     case CPLUGIN_PROTOCOL_SEND:
       {
+        // Collect the values at the same run, to make sure all are from the same sample
         byte valueCount = getValueCountFromSensorType(event->sensorType);
+        C008_queue_element element(event, valueCount);
+        if (ExtraTaskSettings.TaskDeviceValueNames[0][0] == 0)
+          PluginCall(PLUGIN_GET_DEVICEVALUENAMES, event, dummyString);
+
+        ControllerSettingsStruct ControllerSettings;
+        LoadControllerSettings(event->ControllerIndex, (byte*)&ControllerSettings, sizeof(ControllerSettings));
+
         for (byte x = 0; x < valueCount; x++)
         {
           bool isvalid;
           String formattedValue = formatUserVar(event, x, isvalid);
-          if (isvalid)
-            HTTPSend(event, x, formattedValue);
-          if (valueCount > 1)
-          {
-            delayBackground(Settings.MessageDelay);
-            // unsigned long timer = millis() + Settings.MessageDelay;
-            // while (!timeOutReached(timer))
-            //   backgroundtasks();
+          if (isvalid) {
+            element.url[x] = "/";
+            element.url[x] += ControllerSettings.Publish;
+            parseControllerVariables(element.url[x], event, true);
+
+            element.url[x].replace(F("%valname%"), URLEncode(ExtraTaskSettings.TaskDeviceValueNames[x]));
+            element.url[x].replace(F("%value%"), formattedValue);
+            addLog(LOG_LEVEL_DEBUG_MORE, element.url[x]);
           }
         }
+        success = C008_DelayHandler.addToQueue(element);
+        if (!success) {
+          addLog(LOG_LEVEL_DEBUG, F("C008 : publish failed, queue full"));
+        }
+        scheduleNextDelayQueue(TIMER_C008_DELAY_QUEUE, C008_DelayHandler.getNextScheduleTime());
         break;
       }
 
@@ -63,30 +84,29 @@ boolean CPlugin_008(byte function, struct EventStruct *event, String& string)
   return success;
 }
 
-
 //********************************************************************************
 // Generic HTTP get request
 //********************************************************************************
-boolean HTTPSend(struct EventStruct *event, byte varIndex, const String& formattedValue)
-{
-  if (!WiFiConnected(100)) {
-    return false;
+bool do_process_c008_delay_queue(const C008_queue_element& element, ControllerSettingsStruct& ControllerSettings) {
+  boolean success = false;
+  while (element.url[element.valuesSent] == "") {
+    // A non valid value, which we are not going to send.
+    // Increase sent counter until a valid value is found.
+    if (element.checkDone(true))
+      return true;
   }
-  ControllerSettingsStruct ControllerSettings;
-  LoadControllerSettings(event->ControllerIndex, (byte*)&ControllerSettings, sizeof(ControllerSettings));
 
   String authHeader = "";
-  if ((SecuritySettings.ControllerUser[event->ControllerIndex][0] != 0) && (SecuritySettings.ControllerPassword[event->ControllerIndex][0] != 0))
+  if ((SecuritySettings.ControllerUser[element.controller_idx][0] != 0) &&
+      (SecuritySettings.ControllerPassword[element.controller_idx][0] != 0))
   {
     base64 encoder;
-    String auth = SecuritySettings.ControllerUser[event->ControllerIndex];
+    String auth = SecuritySettings.ControllerUser[element.controller_idx];
     auth += ":";
-    auth += SecuritySettings.ControllerPassword[event->ControllerIndex];
+    auth += SecuritySettings.ControllerPassword[element.controller_idx];
     authHeader = F("Authorization: Basic ");
     authHeader += encoder.encode(auth) + " \r\n";
   }
-
-  // boolean success = false;
   addLog(LOG_LEVEL_DEBUG, String(F("HTTP : connecting to "))+ControllerSettings.getHostPortString());
 
   // Use WiFiClient class to create TCP connections
@@ -101,21 +121,8 @@ boolean HTTPSend(struct EventStruct *event, byte varIndex, const String& formatt
   if (connectionFailures)
     connectionFailures--;
 
-  if (ExtraTaskSettings.TaskDeviceValueNames[0][0] == 0)
-    PluginCall(PLUGIN_GET_DEVICEVALUENAMES, event, dummyString);
-
-  String url = "/";
-  url += ControllerSettings.Publish;
-  parseControllerVariables(url, event, true);
-
-  url.replace(F("%valname%"), URLEncode(ExtraTaskSettings.TaskDeviceValueNames[varIndex]));
-  url.replace(F("%value%"), formattedValue);
-
-  // url.toCharArray(log, 80);
-  addLog(LOG_LEVEL_DEBUG_MORE, url);
-
   // This will send the request to the server
-  client.print(String(F("GET ")) + url + F(" HTTP/1.1\r\n") +
+  client.print(String(F("GET ")) + element.url[element.valuesSent] + F(" HTTP/1.1\r\n") +
                F("Host: ") + ControllerSettings.getHost() + F("\r\n") + authHeader +
                F("Connection: close\r\n\r\n"));
 
@@ -133,20 +140,17 @@ boolean HTTPSend(struct EventStruct *event, byte varIndex, const String& formatt
     addLog(LOG_LEVEL_DEBUG_MORE, line);
     if (line.startsWith(F("HTTP/1.1 200 OK")))
     {
-      // strcpy_P(log, PSTR("HTTP : Success!"));
-      // addLog(LOG_LEVEL_DEBUG, log);
       addLog(LOG_LEVEL_DEBUG, F("HTTP : Success!"));
-      // success = true;
+      success = true;
     }
     delay(1);
   }
-  // strcpy_P(log, PSTR("HTTP : closing connection"));
-  // addLog(LOG_LEVEL_DEBUG, log);
-  addLog(LOG_LEVEL_DEBUG, F("HTTP : closing connection"));
+  addLog(LOG_LEVEL_DEBUG, F("HTTP : closing connection (008)"));
 
   client.flush();
   client.stop();
 
-  return(true);
+  return element.checkDone(success);
 }
+
 #endif

--- a/src/_C008.ino
+++ b/src/_C008.ino
@@ -88,7 +88,6 @@ boolean CPlugin_008(byte function, struct EventStruct *event, String& string)
 // Generic HTTP get request
 //********************************************************************************
 bool do_process_c008_delay_queue(const C008_queue_element& element, ControllerSettingsStruct& ControllerSettings) {
-  boolean success = false;
   while (element.url[element.valuesSent] == "") {
     // A non valid value, which we are not going to send.
     // Increase sent counter until a valid value is found.
@@ -96,61 +95,12 @@ bool do_process_c008_delay_queue(const C008_queue_element& element, ControllerSe
       return true;
   }
 
-  String authHeader = "";
-  if ((SecuritySettings.ControllerUser[element.controller_idx][0] != 0) &&
-      (SecuritySettings.ControllerPassword[element.controller_idx][0] != 0))
-  {
-    base64 encoder;
-    String auth = SecuritySettings.ControllerUser[element.controller_idx];
-    auth += ":";
-    auth += SecuritySettings.ControllerPassword[element.controller_idx];
-    authHeader = F("Authorization: Basic ");
-    authHeader += encoder.encode(auth) + " \r\n";
-  }
-  addLog(LOG_LEVEL_DEBUG, String(F("HTTP : connecting to "))+ControllerSettings.getHostPortString());
-
-  // Use WiFiClient class to create TCP connections
   WiFiClient client;
-  if (!ControllerSettings.connectToHost(client))
-  {
-    connectionFailures++;
-    addLog(LOG_LEVEL_ERROR, F("HTTP : connection failed"));
+  if (!try_connect_host(CPLUGIN_ID_008, client, ControllerSettings))
     return false;
-  }
-  statusLED(true);
-  if (connectionFailures)
-    connectionFailures--;
 
-  // This will send the request to the server
-  client.print(String(F("GET ")) + element.url[element.valuesSent] + F(" HTTP/1.1\r\n") +
-               F("Host: ") + ControllerSettings.getHost() + F("\r\n") + authHeader +
-               F("Connection: close\r\n\r\n"));
-
-  unsigned long timer = millis() + 200;
-  while (!client.available() && !timeOutReached(timer))
-    yield();
-
-  // Read all the lines of the reply from server and print them to Serial
-  while (client.available()) {
-    // String line = client.readStringUntil('\n');
-    String line;
-    safeReadStringUntil(client, line, '\n');
-
-    // line.toCharArray(log, 80);
-    addLog(LOG_LEVEL_DEBUG_MORE, line);
-    if (line.startsWith(F("HTTP/1.1 200 OK")))
-    {
-      addLog(LOG_LEVEL_DEBUG, F("HTTP : Success!"));
-      success = true;
-    }
-    delay(1);
-  }
-  addLog(LOG_LEVEL_DEBUG, F("HTTP : closing connection (008)"));
-
-  client.flush();
-  client.stop();
-
-  return element.checkDone(success);
+  String request = create_http_request_auth(CPLUGIN_ID_008, ControllerSettings, F("GET"), element.url[element.valuesSent]);
+  return element.checkDone(send_via_http(CPLUGIN_ID_008, client, request));
 }
 
 #endif

--- a/src/_C008.ino
+++ b/src/_C008.ino
@@ -84,7 +84,7 @@ boolean CPlugin_008(byte function, struct EventStruct *event, String& string)
 //********************************************************************************
 // Generic HTTP get request
 //********************************************************************************
-bool do_process_c008_delay_queue(const C008_queue_element& element, ControllerSettingsStruct& ControllerSettings) {
+bool do_process_c008_delay_queue(int controller_number, const C008_queue_element& element, ControllerSettingsStruct& ControllerSettings) {
   while (element.url[element.valuesSent] == "") {
     // A non valid value, which we are not going to send.
     // Increase sent counter until a valid value is found.
@@ -93,11 +93,11 @@ bool do_process_c008_delay_queue(const C008_queue_element& element, ControllerSe
   }
 
   WiFiClient client;
-  if (!try_connect_host(CPLUGIN_ID_008, client, ControllerSettings))
+  if (!try_connect_host(controller_number, client, ControllerSettings))
     return false;
 
-  String request = create_http_request_auth(CPLUGIN_ID_008, ControllerSettings, F("GET"), element.url[element.valuesSent]);
-  return element.checkDone(send_via_http(CPLUGIN_ID_008, client, request));
+  String request = create_http_request_auth(controller_number, element.controller_idx, ControllerSettings, F("GET"), element.url[element.valuesSent]);
+  return element.checkDone(send_via_http(controller_number, client, request));
 }
 
 #endif

--- a/src/_C008.ino
+++ b/src/_C008.ino
@@ -73,9 +73,6 @@ boolean CPlugin_008(byte function, struct EventStruct *event, String& string)
           }
         }
         success = C008_DelayHandler.addToQueue(element);
-        if (!success) {
-          addLog(LOG_LEVEL_DEBUG, F("C008 : publish failed, queue full"));
-        }
         scheduleNextDelayQueue(TIMER_C008_DELAY_QUEUE, C008_DelayHandler.getNextScheduleTime());
         break;
       }

--- a/src/_C009.ino
+++ b/src/_C009.ino
@@ -134,7 +134,7 @@ bool FHEMHTTPsend(String & url, String & buffer, byte index)
     return false;
 
   int len = buffer.length();
-  String request = create_http_request_auth(CPLUGIN_ID_009, ControllerSettings, F("POST"), url, len);
+  String request = create_http_request_auth_no_portnr(CPLUGIN_ID_009, ControllerSettings, F("POST"), url, len);
   request += buffer;
 
   return send_via_http(CPLUGIN_ID_009, client, request);

--- a/src/_C009.ino
+++ b/src/_C009.ino
@@ -126,7 +126,7 @@ bool do_process_c009_delay_queue(const C009_queue_element& element, ControllerSe
   if (!try_connect_host(CPLUGIN_ID_009, client, ControllerSettings))
     return false;
 
-  String request = create_http_request_auth_no_portnr(
+  String request = create_http_request_auth(
       CPLUGIN_ID_009, ControllerSettings, F("POST"), element.url, element.json.length());
   request += element.json;
 

--- a/src/_C009.ino
+++ b/src/_C009.ino
@@ -188,7 +188,7 @@ void FHEMHTTPsend(String & url, String & buffer, byte index)
     yield();
   }
   // strcpy_P(log, PSTR("HTTP : closing connection"));
-  addLog(LOG_LEVEL_DEBUG, F("HTTP : closing connection"));
+  addLog(LOG_LEVEL_DEBUG, F("HTTP : closing connection (009)"));
   client.flush();
   client.stop();
 }

--- a/src/_C009.ino
+++ b/src/_C009.ino
@@ -121,15 +121,16 @@ boolean CPlugin_009(byte function, struct EventStruct *event, String& string)
 /*********************************************************************************************\
  * FHEM HTTP request
 \*********************************************************************************************/
-bool do_process_c009_delay_queue(const C009_queue_element& element, ControllerSettingsStruct& ControllerSettings) {
+bool do_process_c009_delay_queue(int controller_number, const C009_queue_element& element, ControllerSettingsStruct& ControllerSettings) {
   WiFiClient client;
-  if (!try_connect_host(CPLUGIN_ID_009, client, ControllerSettings))
+  if (!try_connect_host(controller_number, client, ControllerSettings))
     return false;
 
   String request = create_http_request_auth(
-      CPLUGIN_ID_009, ControllerSettings, F("POST"), element.url, element.json.length());
+      controller_number, element.controller_idx, ControllerSettings,
+      F("POST"), element.url, element.json.length());
   request += element.json;
 
-  return send_via_http(CPLUGIN_ID_009, client, request);
+  return send_via_http(controller_number, client, request);
 }
 #endif

--- a/src/_C010.ino
+++ b/src/_C010.ino
@@ -53,14 +53,14 @@ boolean CPlugin_010(byte function, struct EventStruct *event, String& string)
           bool isvalid;
           String formattedValue = formatUserVar(event, x, isvalid);
           if (isvalid) {
-            element.url[x] = "";
-            element.url[x] += ControllerSettings.Publish;
-            parseControllerVariables(element.url[x], event, false);
-            element.url[x].replace(F("%valname%"), ExtraTaskSettings.TaskDeviceValueNames[x]);
-            element.url[x].replace(F("%value%"), formattedValue);
+            element.txt[x] = "";
+            element.txt[x] += ControllerSettings.Publish;
+            parseControllerVariables(element.txt[x], event, false);
+            element.txt[x].replace(F("%valname%"), ExtraTaskSettings.TaskDeviceValueNames[x]);
+            element.txt[x].replace(F("%value%"), formattedValue);
             if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE)) {
               char log[80];
-              element.url[x].toCharArray(log, 80);
+              element.txt[x].toCharArray(log, 80);
               addLog(LOG_LEVEL_DEBUG_MORE, log);
             }
           }
@@ -79,19 +79,19 @@ boolean CPlugin_010(byte function, struct EventStruct *event, String& string)
 // Generic UDP message
 //********************************************************************************
 bool do_process_c010_delay_queue(int controller_number, const C010_queue_element& element, ControllerSettingsStruct& ControllerSettings) {
-  while (element.url[element.valuesSent] == "") {
+  while (element.txt[element.valuesSent] == "") {
     // A non valid value, which we are not going to send.
     // Increase sent counter until a valid value is found.
     if (element.checkDone(true))
       return true;
   }
-  
+
   if (!try_connect_host(controller_number, portUDP, ControllerSettings))
     return false;
 
   portUDP.write(
-    (uint8_t*)element.url[element.valuesSent].c_str(),
-              element.url[element.valuesSent].length());
+    (uint8_t*)element.txt[element.valuesSent].c_str(),
+              element.txt[element.valuesSent].length());
   return element.checkDone(portUDP.endPacket() != 0);
 }
 #endif

--- a/src/_C010.ino
+++ b/src/_C010.ino
@@ -41,20 +41,32 @@ boolean CPlugin_010(byte function, struct EventStruct *event, String& string)
     case CPLUGIN_PROTOCOL_SEND:
       {
         byte valueCount = getValueCountFromSensorType(event->sensorType);
+        C010_queue_element element(event, valueCount);
+        if (ExtraTaskSettings.TaskDeviceValueNames[0][0] == 0)
+          PluginCall(PLUGIN_GET_DEVICEVALUENAMES, event, dummyString);
+
+        ControllerSettingsStruct ControllerSettings;
+        LoadControllerSettings(event->ControllerIndex, (byte*)&ControllerSettings, sizeof(ControllerSettings));
+
         for (byte x = 0; x < valueCount; x++)
         {
           bool isvalid;
           String formattedValue = formatUserVar(event, x, isvalid);
-          if (isvalid)
-            C010_Send(event, x, formattedValue);
-          if (valueCount > 1)
-          {
-            delayBackground(Settings.MessageDelay);
-            // unsigned long timer = millis() + Settings.MessageDelay;
-            // while (!timeOutReached(timer))
-            //   backgroundtasks();
+          if (isvalid) {
+            element.url[x] = "";
+            element.url[x] += ControllerSettings.Publish;
+            parseControllerVariables(element.url[x], event, false);
+            element.url[x].replace(F("%valname%"), ExtraTaskSettings.TaskDeviceValueNames[x]);
+            element.url[x].replace(F("%value%"), formattedValue);
+            if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE)) {
+              char log[80];
+              element.url[x].toCharArray(log, 80);
+              addLog(LOG_LEVEL_DEBUG_MORE, log);
+            }
           }
         }
+        success = C010_DelayHandler.addToQueue(element);
+        scheduleNextDelayQueue(TIMER_C010_DELAY_QUEUE, C010_DelayHandler.getNextScheduleTime());
         break;
       }
 
@@ -66,34 +78,20 @@ boolean CPlugin_010(byte function, struct EventStruct *event, String& string)
 //********************************************************************************
 // Generic UDP message
 //********************************************************************************
-void C010_Send(struct EventStruct *event, byte varIndex, const String& formattedValue)
-{
-  ControllerSettingsStruct ControllerSettings;
-  LoadControllerSettings(event->ControllerIndex, (byte*)&ControllerSettings, sizeof(ControllerSettings));
-
-  // boolean success = false;
-  addLog(LOG_LEVEL_DEBUG, String(F("UDP  : sending to ")) + ControllerSettings.getHostPortString());
-  statusLED(true);
-
-  if (ExtraTaskSettings.TaskDeviceValueNames[0][0] == 0)
-    PluginCall(PLUGIN_GET_DEVICEVALUENAMES, event, dummyString);
-
-  String msg = "";
-  msg += ControllerSettings.Publish;
-  parseControllerVariables(msg, event, false);
-  msg.replace(F("%valname%"), ExtraTaskSettings.TaskDeviceValueNames[varIndex]);
-  msg.replace(F("%value%"), formattedValue);
-
-  if (wifiStatus == ESPEASY_WIFI_SERVICES_INITIALIZED) {
-    ControllerSettings.beginPacket(portUDP);
-    portUDP.write((uint8_t*)msg.c_str(),msg.length());
-    portUDP.endPacket();
+bool do_process_c010_delay_queue(int controller_number, const C010_queue_element& element, ControllerSettingsStruct& ControllerSettings) {
+  while (element.url[element.valuesSent] == "") {
+    // A non valid value, which we are not going to send.
+    // Increase sent counter until a valid value is found.
+    if (element.checkDone(true))
+      return true;
   }
+  
+  if (!try_connect_host(controller_number, portUDP, ControllerSettings))
+    return false;
 
-  if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE)) {
-    char log[80];
-    msg.toCharArray(log, 80);
-    addLog(LOG_LEVEL_DEBUG_MORE, log);
-  }
+  portUDP.write(
+    (uint8_t*)element.url[element.valuesSent].c_str(),
+              element.url[element.valuesSent].length());
+  return element.checkDone(portUDP.endPacket() != 0);
 }
 #endif

--- a/src/_C011.ino
+++ b/src/_C011.ino
@@ -130,6 +130,7 @@ boolean CPlugin_011(byte function, struct EventStruct *event, String& string)
 //********************************************************************************
 boolean HTTPSend011(struct EventStruct *event)
 {
+  int controller_number = CPLUGIN_ID_011;
   if (!WiFiConnected(100)) {
     return false;
   }
@@ -141,14 +142,14 @@ boolean HTTPSend011(struct EventStruct *event)
   customConfig.zero_last();
 
   WiFiClient client;
-  if (!try_connect_host(CPLUGIN_ID_011, client, ControllerSettings))
+  if (!try_connect_host(controller_number, client, ControllerSettings))
     return false;
 
   if (ExtraTaskSettings.TaskDeviceValueNames[0][0] == 0)
     PluginCall(PLUGIN_GET_DEVICEVALUENAMES, event, dummyString);
 
   String payload = create_http_request_auth(
-    CPLUGIN_ID_011, ControllerSettings,
+    controller_number, event->ControllerIndex, ControllerSettings,
     String(customConfig.HttpMethod), customConfig.HttpUri);
 
   if (strlen(customConfig.HttpHeader) > 0)
@@ -166,7 +167,7 @@ boolean HTTPSend011(struct EventStruct *event)
   }
   payload += F("\r\n");
 
-  return send_via_http(CPLUGIN_ID_011, client, payload);
+  return send_via_http(controller_number, client, payload);
 }
 
 // parses the string and returns only the the number of name/values we want

--- a/src/_C011.ino
+++ b/src/_C011.ino
@@ -219,7 +219,7 @@ boolean HTTPSend011(struct EventStruct *event)
     }
     yield();
   }
-  addLog(LOG_LEVEL_DEBUG, F("HTTP : closing connection"));
+  addLog(LOG_LEVEL_DEBUG, F("HTTP : closing connection (011)"));
 
   client.flush();
   client.stop();

--- a/src/_C012.ino
+++ b/src/_C012.ino
@@ -70,16 +70,16 @@ boolean Blynk_get(const String& command, byte controllerIndex, float *data )
 
   ControllerSettingsStruct ControllerSettings;
   LoadControllerSettings(controllerIndex, (byte*)&ControllerSettings, sizeof(ControllerSettings));
-  // Use WiFiClient class to create TCP connections
-  WiFiClient client;
-  if ((SecuritySettings.ControllerPassword[controllerIndex][0] == 0) || !ControllerSettings.connectToHost(client))
-  {
-    connectionFailures++;
-    addLog(LOG_LEVEL_ERROR, F("Blynk : connection failed"));
+
+  if ((SecuritySettings.ControllerPassword[controllerIndex][0] == 0)) {
+    addLog(LOG_LEVEL_ERROR, F("Blynk : No password set"));
     return false;
   }
-  if (connectionFailures)
-    connectionFailures--;
+
+  WiFiClient client;
+  if (!try_connect_host(CPLUGIN_ID_012, client, ControllerSettings))
+    return false;
+
 
   // We now create a URI for the request
   char request[300] = {0};

--- a/src/_C012.ino
+++ b/src/_C012.ino
@@ -134,7 +134,7 @@ boolean Blynk_get(const String& command, byte controllerIndex, float *data )
     }
     yield();
   }
-  strcpy_P(log, PSTR("HTTP : closing connection"));
+  strcpy_P(log, PSTR("HTTP : closing connection (012)"));
   addLog(LOG_LEVEL_DEBUG, log);
 
   client.flush();

--- a/src/_C012.ino
+++ b/src/_C012.ino
@@ -34,33 +34,47 @@ boolean CPlugin_012(byte function, struct EventStruct *event, String& string)
 
      case CPLUGIN_PROTOCOL_SEND:
       {
-        if (wifiStatus != ESPEASY_WIFI_SERVICES_INITIALIZED) {
-          success = false;
-          break;
-        }
+        // Collect the values at the same run, to make sure all are from the same sample
+        byte valueCount = getValueCountFromSensorType(event->sensorType);
+        C012_queue_element element(event, valueCount);
+        if (ExtraTaskSettings.TaskDeviceValueNames[0][0] == 0)
+          PluginCall(PLUGIN_GET_DEVICEVALUENAMES, event, dummyString);
 
-        String postDataStr = F("");
-        const byte valueCount = getValueCountFromSensorType(event->sensorType);
-        success = CPlugin_012_send(event, valueCount);
+        ControllerSettingsStruct ControllerSettings;
+        LoadControllerSettings(event->ControllerIndex, (byte*)&ControllerSettings, sizeof(ControllerSettings));
+
+        for (byte x = 0; x < valueCount; x++)
+        {
+          bool isvalid;
+          String formattedValue = formatUserVar(event, x, isvalid);
+          if (isvalid) {
+            element.txt[x] = F("update/V");
+            element.txt[x] += event->idx + x;
+            element.txt[x] += F("?value=");
+            element.txt[x] += formattedValue;
+            addLog(LOG_LEVEL_DEBUG_MORE, element.txt[x]);
+          }
+        }
+        success = C012_DelayHandler.addToQueue(element);
+        scheduleNextDelayQueue(TIMER_C012_DELAY_QUEUE, C012_DelayHandler.getNextScheduleTime());
         break;
       }
   }
   return success;
 }
 
-boolean CPlugin_012_send(struct EventStruct *event, int nrValues) {
-  String postDataStr = F("");
-  boolean success = true;
-  for (int i = 0; i < nrValues && success; ++i) {
-    postDataStr = F("update/V") ;
-    postDataStr += event->idx + i;
-    postDataStr += F("?value=");
-    postDataStr += formatUserVarNoCheck(event, i);
-    success = Blynk_get(postDataStr, event->ControllerIndex);
+//********************************************************************************
+// Process Queued Blynk request, with data set to NULL
+//********************************************************************************
+bool do_process_c012_delay_queue(int controller_number, const C012_queue_element& element, ControllerSettingsStruct& ControllerSettings) {
+  while (element.txt[element.valuesSent] == "") {
+    // A non valid value, which we are not going to send.
+    // Increase sent counter until a valid value is found.
+    if (element.checkDone(true))
+      return true;
   }
-  return success;
+  return element.checkDone(Blynk_get(element.txt[element.valuesSent], element.controller_idx));
 }
-
 
 boolean Blynk_get(const String& command, byte controllerIndex, float *data )
 {

--- a/src/_C013.ino
+++ b/src/_C013.ino
@@ -80,7 +80,7 @@ boolean CPlugin_013(byte function, struct EventStruct *event, String& string)
 
     case CPLUGIN_PROTOCOL_SEND:
       {
-        C013_Send(event, 0, UserVar[event->BaseVarIndex], 0);
+        C013_SendUDPTaskData(0, event->TaskIndex, event->TaskIndex);
         break;
       }
 
@@ -98,14 +98,6 @@ boolean CPlugin_013(byte function, struct EventStruct *event, String& string)
 //********************************************************************************
 // Generic UDP message
 //********************************************************************************
-void C013_Send(struct EventStruct *event, byte varIndex, float value, unsigned long longValue)
-{
-  ControllerSettingsStruct ControllerSettings;
-  LoadControllerSettings(event->ControllerIndex, (byte*)&ControllerSettings, sizeof(ControllerSettings));
-  statusLED(true);
-  C013_SendUDPTaskData(0, event->TaskIndex, event->TaskIndex);
-}
-
 void C013_SendUDPTaskInfo(byte destUnit, byte sourceTaskIndex, byte destTaskIndex)
 {
   if (!WiFiConnected(100)) {

--- a/src/_CPlugin_Helper.h
+++ b/src/_CPlugin_Helper.h
@@ -142,6 +142,12 @@ public:
 \*********************************************************************************************/
 #define C011_queue_element simple_queue_element_string_only
 
+/*********************************************************************************************\
+ * C012_queue_element for queueing requests for 012: Blynk
+ * Using queue_element_single_value_base
+\*********************************************************************************************/
+#define C012_queue_element queue_element_single_value_base
+
 
 
 /*********************************************************************************************\
@@ -306,10 +312,10 @@ ControllerDelayHandlerStruct<MQTT_queue_element> MQTTDelayHandler;
 #ifdef USES_C011
   DEFINE_Cxxx_DELAY_QUEUE_MACRO(011, 11)
 #endif
-/*
 #ifdef USES_C012
   DEFINE_Cxxx_DELAY_QUEUE_MACRO(012, 12)
 #endif
+/*
 #ifdef USES_C013
   DEFINE_Cxxx_DELAY_QUEUE_MACRO(013, 13)
 #endif

--- a/src/_CPlugin_Helper.h
+++ b/src/_CPlugin_Helper.h
@@ -86,14 +86,13 @@ public:
 };
 
 /*********************************************************************************************\
- * C008_queue_element for queueing requests for 008: Generic HTTP
- * This controller only sends a single value per request and thus needs to keep track of the
- * number of values already sent.
+ * Base class for controllers that only send a single value per request and thus needs to
+ * keep track of the number of values already sent.
 \*********************************************************************************************/
-class C008_queue_element {
+class queue_element_single_value_base {
 public:
-  C008_queue_element() : controller_idx(0), TaskIndex(0), idx(0), valuesSent(0) {}
-  C008_queue_element(const struct EventStruct* event, byte value_count) :
+  queue_element_single_value_base() : controller_idx(0), TaskIndex(0), idx(0), valuesSent(0) {}
+  queue_element_single_value_base(const struct EventStruct* event, byte value_count) :
     controller_idx(event->ControllerIndex),
     TaskIndex(event->TaskIndex),
     idx(event->idx),
@@ -108,10 +107,17 @@ public:
   int controller_idx;
   byte TaskIndex;
   int idx;
-  String url[VARS_PER_TASK];
+  String txt[VARS_PER_TASK];
   mutable byte valuesSent;
   byte valueCount;
 };
+
+
+/*********************************************************************************************\
+ * C008_queue_element for queueing requests for 008: Generic HTTP
+ * Using queue_element_single_value_base
+\*********************************************************************************************/
+#define C008_queue_element queue_element_single_value_base
 
 /*********************************************************************************************\
  * C009_queue_element for queueing requests for C009: FHEM HTTP.
@@ -129,31 +135,9 @@ public:
 
 /*********************************************************************************************\
  * C010_queue_element for queueing requests for 010: Generic UDP
- * This controller only sends a single value per request and thus needs to keep track of the
- * number of values already sent.
+ * Using queue_element_single_value_base
 \*********************************************************************************************/
-class C010_queue_element {
-public:
-  C010_queue_element() : controller_idx(0), TaskIndex(0), idx(0), valuesSent(0) {}
-  C010_queue_element(const struct EventStruct* event, byte value_count) :
-    controller_idx(event->ControllerIndex),
-    TaskIndex(event->TaskIndex),
-    idx(event->idx),
-    valuesSent(0),
-    valueCount(value_count) {}
-
-  bool checkDone(bool succesfull) const {
-    if (succesfull) ++valuesSent;
-    return (valuesSent == valueCount);
-  }
-
-  int controller_idx;
-  byte TaskIndex;
-  int idx;
-  String url[VARS_PER_TASK];
-  mutable byte valuesSent;
-  byte valueCount;
-};
+#define C010_queue_element queue_element_single_value_base
 
 
 

--- a/src/_CPlugin_Helper.h
+++ b/src/_CPlugin_Helper.h
@@ -90,15 +90,15 @@ public:
 template<class T>
 struct ControllerDelayHandlerStruct {
   ControllerDelayHandlerStruct() :
-      lastSend(0), minTimeBetweenMessages(100), max_buffer(10), attempt(0), max_attempt(10), delete_oldest(false) {}
+      lastSend(0), minTimeBetweenMessages(100), max_queue_depth(10), attempt(0), max_attempt(10), delete_oldest(false) {}
 
   void configureControllerSettings(const ControllerSettingsStruct& settings) {
     minTimeBetweenMessages = settings.MinimalTimeBetweenMessages;
-    max_buffer = settings.MaxBufferDepth;
+    max_queue_depth = settings.MaxQueueDepth;
     max_attempt = settings.MaxRetry;
     delete_oldest = settings.DeleteOldest;
     // Set some sound limits
-    if (max_buffer == 0) max_buffer = 10;
+    if (max_queue_depth == 0) max_queue_depth = 10;
     if (max_attempt == 0) max_attempt = 10;
     if (minTimeBetweenMessages == 0) minTimeBetweenMessages = 100;
     if (minTimeBetweenMessages < 10) minTimeBetweenMessages = 10;
@@ -110,7 +110,7 @@ struct ControllerDelayHandlerStruct {
     if (delete_oldest) {
       return forceAddToQueue(element);
     }
-    if (sendQueue.size() < max_buffer) {
+    if (sendQueue.size() < max_queue_depth) {
       sendQueue.emplace_back(element);
       return true;
     }
@@ -122,7 +122,7 @@ struct ControllerDelayHandlerStruct {
   // Return true when no elements removed from queue.
   bool forceAddToQueue(const T& element) {
     sendQueue.emplace_back(element);
-    if (sendQueue.size() <= max_buffer) {
+    if (sendQueue.size() <= max_queue_depth) {
       return true;
     }
     sendQueue.pop_front();
@@ -169,7 +169,7 @@ struct ControllerDelayHandlerStruct {
   std::list<T> sendQueue;
   unsigned long lastSend;
   unsigned int minTimeBetweenMessages;
-  byte max_buffer;
+  byte max_queue_depth;
   byte attempt;
   byte max_attempt;
   bool delete_oldest;

--- a/src/_CPlugin_Helper.h
+++ b/src/_CPlugin_Helper.h
@@ -192,10 +192,38 @@ String LoadControllerSettings(int ControllerIndex, byte* memAddress, int datasiz
                 }
 
 // Define the function wrappers to handle the calling to Cxxx_DelayHandler etc.
-DEFINE_Cxxx_DELAY_QUEUE_MACRO(001)
-DEFINE_Cxxx_DELAY_QUEUE_MACRO(003)
-DEFINE_Cxxx_DELAY_QUEUE_MACRO(004)
-
+#ifdef USES_C001
+  DEFINE_Cxxx_DELAY_QUEUE_MACRO(001)
+#endif
+#ifdef USES_C003
+  DEFINE_Cxxx_DELAY_QUEUE_MACRO(003)
+#endif
+#ifdef USES_C004
+  DEFINE_Cxxx_DELAY_QUEUE_MACRO(004)
+#endif
+/*
+#ifdef USES_C007
+  DEFINE_Cxxx_DELAY_QUEUE_MACRO(007)
+#endif
+#ifdef USES_C008
+  DEFINE_Cxxx_DELAY_QUEUE_MACRO(008)
+#endif
+#ifdef USES_C009
+  DEFINE_Cxxx_DELAY_QUEUE_MACRO(009)
+#endif
+#ifdef USES_C010
+  DEFINE_Cxxx_DELAY_QUEUE_MACRO(010)
+#endif
+#ifdef USES_C011
+  DEFINE_Cxxx_DELAY_QUEUE_MACRO(011)
+#endif
+#ifdef USES_C012
+  DEFINE_Cxxx_DELAY_QUEUE_MACRO(012)
+#endif
+#ifdef USES_C013
+  DEFINE_Cxxx_DELAY_QUEUE_MACRO(013)
+#endif
+*/
 
 
 

--- a/src/_CPlugin_Helper.h
+++ b/src/_CPlugin_Helper.h
@@ -150,7 +150,12 @@ public:
 template<class T>
 struct ControllerDelayHandlerStruct {
   ControllerDelayHandlerStruct() :
-      lastSend(0), minTimeBetweenMessages(100), max_queue_depth(10), attempt(0), max_retries(10), delete_oldest(false) {}
+      lastSend(0),
+      minTimeBetweenMessages(CONTROLLER_DELAY_QUEUE_DELAY_DFLT),
+      max_queue_depth(CONTROLLER_DELAY_QUEUE_DEPTH_DFLT),
+      attempt(0),
+      max_retries(CONTROLLER_DELAY_QUEUE_RETRY_DFLT),
+      delete_oldest(false) {}
 
   void configureControllerSettings(const ControllerSettingsStruct& settings) {
     minTimeBetweenMessages = settings.MinimalTimeBetweenMessages;
@@ -158,9 +163,9 @@ struct ControllerDelayHandlerStruct {
     max_retries = settings.MaxRetry;
     delete_oldest = settings.DeleteOldest;
     // Set some sound limits when not configured
-    if (max_queue_depth == 0) max_queue_depth = 10;
-    if (max_retries == 0) max_retries = 10;
-    if (minTimeBetweenMessages == 0) minTimeBetweenMessages = 100;
+    if (max_queue_depth == 0) max_queue_depth = CONTROLLER_DELAY_QUEUE_DEPTH_DFLT;
+    if (max_retries == 0) max_retries = CONTROLLER_DELAY_QUEUE_RETRY_DFLT;
+    if (minTimeBetweenMessages == 0) minTimeBetweenMessages = CONTROLLER_DELAY_QUEUE_DELAY_DFLT;
     // No less than 10 msec between messages.
     if (minTimeBetweenMessages < 10) minTimeBetweenMessages = 10;
   }

--- a/src/_CPlugin_Helper.h
+++ b/src/_CPlugin_Helper.h
@@ -22,30 +22,28 @@ public:
 };
 
 /*********************************************************************************************\
- * C001_queue_element for queueing requests for C001.
+ * Simple queue element, only storing controller index and some String
 \*********************************************************************************************/
-class C001_queue_element {
+class simple_queue_element_string_only {
 public:
-  C001_queue_element() : controller_idx(0) {}
-  C001_queue_element(int ctrl_idx, const String& req) :
-       controller_idx(ctrl_idx), url(req) {}
+  simple_queue_element_string_only() : controller_idx(0) {}
+  simple_queue_element_string_only(int ctrl_idx, const String& req) :
+       controller_idx(ctrl_idx), txt(req) {}
 
   int controller_idx;
-  String url;
+  String txt;
 };
+
+
+/*********************************************************************************************\
+ * C001_queue_element for queueing requests for C001.
+\*********************************************************************************************/
+#define C001_queue_element simple_queue_element_string_only
 
 /*********************************************************************************************\
  * C003_queue_element for queueing requests for C003 Nodo Telnet.
 \*********************************************************************************************/
-class C003_queue_element {
-public:
-  C003_queue_element() : controller_idx(0) {}
-  C003_queue_element(int ctrl_idx, const String& req) :
-       controller_idx(ctrl_idx), url(req) {}
-
-  int controller_idx;
-  String url;
-};
+#define C003_queue_element simple_queue_element_string_only
 
 /*********************************************************************************************\
  * C004_queue_element for queueing requests for C004 ThingSpeak.
@@ -101,14 +99,14 @@ public:
 
   bool checkDone(bool succesfull) const {
     if (succesfull) ++valuesSent;
-    return (valuesSent == valueCount);
+    return (valuesSent >= valueCount || valuesSent >= VARS_PER_TASK);
   }
 
   int controller_idx;
   byte TaskIndex;
   int idx;
   String txt[VARS_PER_TASK];
-  mutable byte valuesSent;
+  mutable byte valuesSent;  // Value must be set by const function checkDone()
   byte valueCount;
 };
 
@@ -138,6 +136,11 @@ public:
  * Using queue_element_single_value_base
 \*********************************************************************************************/
 #define C010_queue_element queue_element_single_value_base
+
+/*********************************************************************************************\
+ * C011_queue_element for queueing requests for 011: Generic HTTP Advanced
+\*********************************************************************************************/
+#define C011_queue_element simple_queue_element_string_only
 
 
 
@@ -295,10 +298,10 @@ ControllerDelayHandlerStruct<MQTT_queue_element> MQTTDelayHandler;
 #ifdef USES_C010
   DEFINE_Cxxx_DELAY_QUEUE_MACRO(010, 10)
 #endif
-/*
 #ifdef USES_C011
   DEFINE_Cxxx_DELAY_QUEUE_MACRO(011, 11)
 #endif
+/*
 #ifdef USES_C012
   DEFINE_Cxxx_DELAY_QUEUE_MACRO(012, 12)
 #endif

--- a/src/_CPlugin_Helper.h
+++ b/src/_CPlugin_Helper.h
@@ -34,6 +34,19 @@ public:
 };
 
 /*********************************************************************************************\
+ * C003_queue_element for queueing requests for C003 Nodo Telnet.
+\*********************************************************************************************/
+class C003_queue_element {
+public:
+  C003_queue_element() : _controller_idx(0) {}
+  C003_queue_element(int controller_idx, const String& req) : _controller_idx(controller_idx), url(req) {}
+
+  int _controller_idx;
+  String url;
+};
+
+
+/*********************************************************************************************\
  * ControllerDelayHandlerStruct
 \*********************************************************************************************/
 template<class T>
@@ -126,6 +139,7 @@ struct ControllerDelayHandlerStruct {
 
 ControllerDelayHandlerStruct<MQTT_queue_element> MQTTDelayHandler;
 ControllerDelayHandlerStruct<C001_queue_element> C001_DelayHandler;
+ControllerDelayHandlerStruct<C003_queue_element> C003_DelayHandler;
 
 
 

--- a/src/_CPlugin_Helper.h
+++ b/src/_CPlugin_Helper.h
@@ -65,6 +65,23 @@ public:
   byte sensorType;
 };
 
+/*********************************************************************************************\
+ * C007_queue_element for queueing requests for C007 Emoncms
+\*********************************************************************************************/
+class C007_queue_element {
+public:
+  C007_queue_element() : controller_idx(0), TaskIndex(0), idx(0), sensorType(0) {}
+  C007_queue_element(const struct EventStruct* event) :
+    controller_idx(event->ControllerIndex),
+    TaskIndex(event->TaskIndex),
+    idx(event->idx),
+    sensorType(event->sensorType) {}
+
+  int controller_idx;
+  byte TaskIndex;
+  int idx;
+  byte sensorType;
+};
 
 
 /*********************************************************************************************\
@@ -201,10 +218,10 @@ String LoadControllerSettings(int ControllerIndex, byte* memAddress, int datasiz
 #ifdef USES_C004
   DEFINE_Cxxx_DELAY_QUEUE_MACRO(004)
 #endif
-/*
 #ifdef USES_C007
   DEFINE_Cxxx_DELAY_QUEUE_MACRO(007)
 #endif
+/*
 #ifdef USES_C008
   DEFINE_Cxxx_DELAY_QUEUE_MACRO(008)
 #endif

--- a/src/_CPlugin_Helper.h
+++ b/src/_CPlugin_Helper.h
@@ -1,0 +1,133 @@
+#ifndef CPLUGIN_HELPER_H
+#define CPLUGIN_HELPER_H CPLUGIN_HELPER_H
+
+// These element classes should be defined as class, to be used as template.
+
+/*********************************************************************************************\
+ * MQTT_queue_element for all MQTT base controllers
+\*********************************************************************************************/
+class MQTT_queue_element {
+public:
+  MQTT_queue_element() : _controller_idx(0), _retained(false) {}
+
+  MQTT_queue_element(int controller_idx,
+    const String& topic, const String& payload, boolean retained) :
+    _controller_idx(controller_idx), _topic(topic), _payload(payload), _retained(retained)
+     {}
+
+  int _controller_idx;
+  String _topic;
+  String _payload;
+  boolean _retained;
+};
+
+/*********************************************************************************************\
+ * C001_queue_element for queueing requests for C001.
+\*********************************************************************************************/
+class C001_queue_element {
+public:
+  C001_queue_element() : _controller_idx(0) {}
+  C001_queue_element(int controller_idx, const String& req) : _controller_idx(controller_idx), request(req) {}
+
+  int _controller_idx;
+  String request;
+};
+
+/*********************************************************************************************\
+ * ControllerDelayHandlerStruct
+\*********************************************************************************************/
+template<class T>
+struct ControllerDelayHandlerStruct {
+  ControllerDelayHandlerStruct() :
+      lastSend(0), minTimeBetweenMessages(100), max_buffer(10), attempt(0), max_attempt(10), delete_oldest(false) {}
+
+  void configureControllerSettings(const ControllerSettingsStruct& settings) {
+    minTimeBetweenMessages = settings.MinimalTimeBetweenMessages;
+    max_buffer = settings.MaxBufferDepth;
+    max_attempt = settings.MaxRetry;
+    delete_oldest = settings.DeleteOldest;
+    // Set some sound limits
+    if (max_buffer == 0) max_buffer = 10;
+    if (max_attempt == 0) max_attempt = 10;
+    if (minTimeBetweenMessages == 0) minTimeBetweenMessages = 100;
+    if (minTimeBetweenMessages < 10) minTimeBetweenMessages = 10;
+  }
+
+  // Try to add to the queue, if permitted by "delete_oldest"
+  // Return false when the buffer was full. Success depends on "delete_oldest"
+  bool addToQueue(const T& element) {
+    if (delete_oldest) {
+      return forceAddToQueue(element);
+    }
+    if (sendQueue.size() < max_buffer) {
+      sendQueue.emplace_back(element);
+      return true;
+    }
+    return false;
+  }
+
+  // Force add to the queue.
+  // If max buffer is reached, the oldest in the queue (first to be served) will be removed.
+  // Return true when no elements removed from queue.
+  bool forceAddToQueue(const T& element) {
+    sendQueue.emplace_back(element);
+    if (sendQueue.size() <= max_buffer) {
+      return true;
+    }
+    sendQueue.pop_front();
+    return false;
+  }
+
+  // Get the next element.
+  // Remove front element when max_attempt is reached.
+  bool getNext(T& element) {
+    if (sendQueue.empty()) return false;
+    if (max_attempt <= attempt) {
+      sendQueue.pop_front();
+      attempt = 0;
+    }
+    element = sendQueue.front();
+    return true;
+  }
+
+  // Mark as processed and return time to schedule for next process.
+  // Return 0 when nothing to process.
+  // @param remove_from_queue indicates whether the elements should be removed from the queue.
+  unsigned long markProcessed(bool remove_from_queue) {
+    if (sendQueue.empty()) return 0;
+    if (remove_from_queue) {
+      sendQueue.pop_front();
+      attempt = 0;
+    } else {
+      ++attempt;
+    }
+    lastSend = millis();
+    return getNextScheduleTime();
+  }
+
+  unsigned long getNextScheduleTime() const {
+    if (sendQueue.empty()) return 0;
+    unsigned long nextTime = lastSend + minTimeBetweenMessages;
+    if (timePassedSince(nextTime) > 0) {
+      nextTime = millis();
+    }
+    if (nextTime == 0) nextTime = 1; // Just to make sure it will be executed
+    return nextTime;
+  }
+
+  std::list<T> sendQueue;
+  unsigned long lastSend;
+  unsigned int minTimeBetweenMessages;
+  byte max_buffer;
+  byte attempt;
+  byte max_attempt;
+  bool delete_oldest;
+};
+
+ControllerDelayHandlerStruct<MQTT_queue_element> MQTTDelayHandler;
+ControllerDelayHandlerStruct<C001_queue_element> C001_DelayHandler;
+
+
+
+
+#endif // CPLUGIN_HELPER_H

--- a/src/_CPlugin_Helper.h
+++ b/src/_CPlugin_Helper.h
@@ -367,6 +367,22 @@ String get_auth_header(int controller_index) {
   return authHeader;
 }
 
+String get_user_agent_request_header_field() {
+  static unsigned int agent_size = 20;
+  String request;
+  request.reserve(agent_size);
+  request = F("User-Agent: ");
+  request += F("ESP Easy/");
+  request += BUILD;
+  request += '/';
+  request += String(CRCValues.compileDate);
+  request += ' ';
+  request += String(CRCValues.compileTime);
+  request += F("\r\n");
+  agent_size = request.length();
+  return request;
+}
+
 String do_create_http_request(
     const String& hostportString,
     const String& method, const String& uri,
@@ -394,6 +410,7 @@ String do_create_http_request(
   request += F("\r\n");
   request += auth_header;
   request += additional_options;
+  request += get_user_agent_request_header_field();
   request += F("Connection: close\r\n");
   request += F("\r\n");
   addLog(LOG_LEVEL_DEBUG, request);

--- a/src/_N001_Email.ino
+++ b/src/_N001_Email.ino
@@ -89,6 +89,24 @@ boolean NPlugin_001_send(const NotificationSettingsStruct& notificationsettings,
 			"X-Mailer: EspEasy v$espeasyversion\r\n\r\n"
 			);
 
+    String email_address = notificationsettings.Sender;
+		int pos_less = email_address.indexOf('<');
+		if (pos_less == -1) {
+			// No email address markup
+			mailheader.replace(String(F("$nodename")), Settings.Name);
+			mailheader.replace(String(F("$emailfrom")), notificationsettings.Sender);
+		} else {
+			String senderName = email_address.substring(0, pos_less);
+			senderName.replace("\"", ""); // Remove quotes
+			String address = email_address.substring(pos_less + 1);
+			address.replace("<", "");
+			address.replace(">", "");
+			address.trim();
+			senderName.trim();
+			mailheader.replace(String(F("$nodename")), senderName);
+			mailheader.replace(String(F("$emailfrom")), address);
+		}
+
 		mailheader.replace(String(F("$nodename")), Settings.Name);
 		mailheader.replace(String(F("$emailfrom")), notificationsettings.Sender);
 		mailheader.replace(String(F("$ato")), notificationsettings.Receiver);

--- a/src/__CPlugin.ino
+++ b/src/__CPlugin.ino
@@ -148,11 +148,19 @@ byte CPluginCall(byte Function, struct EventStruct *event)
   {
     // Unconditional calls to all plugins
     case CPLUGIN_PROTOCOL_ADD:
-      for (x = 0; x < CPLUGIN_MAX; x++)
-        if (CPlugin_id[x] != 0){
+      for (x = 0; x < CPLUGIN_MAX; x++) {
+        if (CPlugin_id[x] != 0) {
+          const unsigned int next_ProtocolIndex = protocolCount + 2;
+          if (next_ProtocolIndex > Protocol.size()) {
+            // Increase with 8 to get some compromise between number of resizes and wasted space
+            unsigned int newSize = Protocol.size();
+            newSize = newSize + 8 - (newSize % 8);
+            Protocol.resize(newSize);
+          }
           checkRAM(F("CPluginCallADD"),x);
           CPlugin_ptr[x](Function, event, dummyString);
         }
+      }
       return true;
       break;
 

--- a/src/__Plugin.ino
+++ b/src/__Plugin.ino
@@ -1113,6 +1113,15 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
     case PLUGIN_UNCONDITIONAL_POLL:
       for (byte x = 0; x < PLUGIN_MAX; x++) {
         if (Plugin_id[x] != 0){
+          if (Function == PLUGIN_DEVICE_ADD) {
+            const unsigned int next_DeviceIndex = deviceCount + 2;
+            if (next_DeviceIndex > Device.size()) {
+              // Increase with 16 to get some compromise between number of resizes and wasted space
+              unsigned int newSize = Device.size();
+              newSize = newSize + 16 - (newSize % 16);
+              Device.resize(newSize);
+            }
+          }
           START_TIMER;
           Plugin_ptr[x](Function, event, str);
           STOP_TIMER_TASK(x,Function);


### PR DESCRIPTION
In short, I did a lot of refactoring to remove a lot of code duplication in the controllers.

All MQTT controllers now use a delay queue and the other controllers use their own queue, since the data per controller request may differ per controller.
This queue does allow some pacing of the data to the receiving end and some buffering to make sure sending is non blocking.
It may also help to send the controller pushes generated when the wifi was not yet available.  (important for deep sleep use cases)

Things that can be set per controller:
![image](https://user-images.githubusercontent.com/3751318/44346593-a11ecc80-a496-11e8-8fa4-693e07924d1f.png)

**Max Queue Depth** is the number of items allowed in the queue.
Since this may take some memory, try to keep this low. Maybe the current limit of 10 is a bit too low?

**Minimum Send Interval** is the minimal time between two controller send actions.
This will mainly be a limiting factor when sending in a burst, since the last send time of that specific controller is taken into account.

**Max Retries** is the maximum number of retries to send a queued value.
For some controllers, which send per plugin value, this value must be at least higher than the number of items per plugin which has to be sent.

**Full Queue Action** is about the used strategy when sending the queue is full.
For example for Thingspeak the send interval is high, so you may want to set the queue length to 1 and this strategy value to "Delete Oldest" so you will always get the last value.

Also a lot of code duplication in the HTTP based controllers is moved to some special functions.
This saves a lot of code and makes it easier to fix issues or add features of which all plugins can benefit.


N.B.
At this moment only controller C001 ... C008 have this queue implemented.
The rest may experience some issues since the MessageDelay variable is now not being used anymore for sending tasks.