### PR TITLE
[sysvar] rename vars with leading zero to %..._0%

### DIFF
--- a/src/StringConverter.ino
+++ b/src/StringConverter.ino
@@ -513,16 +513,25 @@ void parseSystemVariables(String& s, boolean useURLencode)
     // valueString is being used by the macro.
     char valueString[5];
     #define SMART_REPL_TIME(T,F,V) if (s.indexOf(T) != -1) { sprintf_P(valueString, (F), (V)); repl((T),valueString, s, useURLencode);}
-    SMART_REPL_TIME(F("%syshour%"), PSTR("%02d"), hour())
-    SMART_REPL_TIME(F("%sysmin%"), PSTR("%02d"), minute())
-    SMART_REPL_TIME(F("%syssec%"),PSTR("%02d"), second())
+    SMART_REPL_TIME(F("%sysyear%"), PSTR("%d"), year())
+    SMART_REPL_TIME(F("%sysmonth%"),PSTR("%d"), month())
+    SMART_REPL_TIME(F("%sysday%"), PSTR("%d"), day())
+    SMART_REPL_TIME(F("%syshour%"), PSTR("%d"), hour())
+    SMART_REPL_TIME(F("%sysmin%"), PSTR("%d"), minute())
+    SMART_REPL_TIME(F("%syssec%"),PSTR("%d"), second())
     SMART_REPL_TIME(F("%syssec_d%"),PSTR("%d"), ((hour()*60) + minute())*60 + second());
-    SMART_REPL_TIME(F("%sysday%"), PSTR("%02d"), day())
-    SMART_REPL_TIME(F("%sysmonth%"),PSTR("%02d"), month())
-    SMART_REPL_TIME(F("%sysyear%"), PSTR("%04d"), year())
-    SMART_REPL_TIME(F("%sysyears%"),PSTR("%02d"), year()%100)
     SMART_REPL(F("%sysweekday%"), String(weekday()))
     SMART_REPL(F("%sysweekday_s%"), weekday_str())
+
+    // With leading zero
+    SMART_REPL_TIME(F("%sysyears%"),PSTR("%02d"), year()%100)
+    SMART_REPL_TIME(F("%sysyear_0%"), PSTR("%04d"), year())
+    SMART_REPL_TIME(F("%syshour_0%"), PSTR("%02d"), hour())
+    SMART_REPL_TIME(F("%sysday_0%"), PSTR("%02d"), day())
+    SMART_REPL_TIME(F("%sysmin_0%"), PSTR("%02d"), minute())
+    SMART_REPL_TIME(F("%syssec_0%"),PSTR("%02d"), second())
+    SMART_REPL_TIME(F("%sysmonth_0%"),PSTR("%02d"), month())
+
     #undef SMART_REPL_TIME
   }
   SMART_REPL(F("%lcltime%"), getDateTimeString('-',':',' '))

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -5423,10 +5423,14 @@ void handle_sysvars() {
 
   addHeader(true,  TXBuffer.buf);
 
-  TXBuffer += F("<p>This page may load slow. Do not load too often, since it may affect performance of the node.</p>");
+  html_BR();
+  TXBuffer += F("<p>This page may load slow.<BR>Do not load too often, since it may affect performance of the node.</p>");
+  html_BR();
 
   // the table header
   TXBuffer += F("<table class='normal'><TR><TH align='left'>System Variables<TH align='left'>Normal<TH align='left'>URL encoded");
+  addHelpButton(F("ESPEasy_System_Variables"));
+
   addTableSeparator(F("Constants"), 3, 3);
   addSysVar_html(F("%CR%"));
   addSysVar_html(F("%LF%"));
@@ -5456,22 +5460,24 @@ void handle_sysvars() {
 #endif
 
   addTableSeparator(F("Time"), 3, 3);
+  addSysVar_html(F("%lcltime%"));
+  addSysVar_html(F("%lcltime_am%"));
   addSysVar_html(F("%systm_hm%"));
   addSysVar_html(F("%systm_hm_am%"));
   addSysVar_html(F("%systime%"));
   addSysVar_html(F("%systime_am%"));
-  addSysVar_html(F("%syshour%"));
-  addSysVar_html(F("%sysmin%"));
-  addSysVar_html(F("%syssec%"));
-  addSysVar_html(F("%syssec_d%"));
-  addSysVar_html(F("%sysday%"));
-  addSysVar_html(F("%sysmonth%"));
-  addSysVar_html(F("%sysyear%"));
+  addTableSeparator(F("System"), 3, 3);
+  addSysVar_html(F("%sysyear%  // %sysyear_0%"));
   addSysVar_html(F("%sysyears%"));
+  addSysVar_html(F("%sysmonth% // %sysmonth_0%"));
+  addSysVar_html(F("%sysday%   // %sysday_0%"));
+  addSysVar_html(F("%syshour%  // %syshour_0%"));
+  addSysVar_html(F("%sysmin%   // %sysmin_0%"));
+  addSysVar_html(F("%syssec%   // %syssec_0%"));
+  addSysVar_html(F("%syssec_d%"));
   addSysVar_html(F("%sysweekday%"));
   addSysVar_html(F("%sysweekday_s%"));
-  addSysVar_html(F("%lcltime%"));
-  addSysVar_html(F("%lcltime_am%"));
+  addTableSeparator(F("System"), 3, 3);
   addSysVar_html(F("%uptime%"));
   addSysVar_html(F("%unixtime%"));
   addSysVar_html(F("%sunset%"));


### PR DESCRIPTION
For example `%syshour%` to `%syshour_0%` 
Both variables are now supported.
The ones without leading zero can be used in rules. 
The ones with leading zero will probably be used on displays.