### PR TITLE
[#1702] Check for duplicate names bug

### DIFF
--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -404,7 +404,7 @@ String checkTaskSettings(byte taskIndex) {
     }
   }
   for (int i = 0; i < TASKS_MAX; ++i) {
-    if (i != taskIndex) {
+    if (i != taskIndex && Settings.TaskDeviceEnabled[i]) {
       LoadTaskSettings(i);
       if (ExtraTaskSettings.TaskDeviceName[0] != 0) {
         if (strcasecmp(ExtraTaskSettings.TaskDeviceName, deviceName.c_str()) == 0) {

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -1882,6 +1882,7 @@ void handle_devices() {
       PluginCall(PLUGIN_EXIT, &TempEvent, dummyString);
 
       taskClear(taskIndex, false); // clear settings, but do not save
+      ClearCustomTaskSettings(taskIndex);
 
       Settings.TaskDeviceNumber[taskIndex] = taskdevicenumber;
       if (taskdevicenumber != 0) // set default values if a new device has been selected
@@ -1889,8 +1890,9 @@ void handle_devices() {
         //NOTE: do not enable task by default. allow user to enter sensible valus first and let him enable it when ready.
         if (ExtraTaskSettings.TaskDeviceValueNames[0][0] == 0) // if field set empty, reload defaults
           PluginCall(PLUGIN_GET_DEVICEVALUENAMES, &TempEvent, dummyString); //the plugin should populate ExtraTaskSettings with its default values.
-
-        ClearCustomTaskSettings(taskIndex);
+      } else {
+        SaveTaskSettings(taskIndex);
+        SaveSettings();
       }
     }
     else if (taskdevicenumber != 0) //save settings


### PR DESCRIPTION
Make sure only enabled devices are used for checking. (see #1702)
Do a full erase of the task settings when deleting a plugin. Just to make sure no obsolete settings may corrupt behaviour of new settings.