### PR TITLE
Use parameters inside rules when calling commands

### DIFF
--- a/src/Command.ino
+++ b/src/Command.ino
@@ -216,11 +216,11 @@ void ExecuteCommand(byte source, const char *Line)
 	// since commands can originate from anywhere.
 	TempEvent.Source = source;
 	GetArgv(Line, cmd, 1);
-	if (GetArgv(Line, TmpStr1, 2)) TempEvent.Par1 = str2int(TmpStr1);
-	if (GetArgv(Line, TmpStr1, 3)) TempEvent.Par2 = str2int(TmpStr1);
-	if (GetArgv(Line, TmpStr1, 4)) TempEvent.Par3 = str2int(TmpStr1);
-	if (GetArgv(Line, TmpStr1, 5)) TempEvent.Par4 = str2int(TmpStr1);
-	if (GetArgv(Line, TmpStr1, 6)) TempEvent.Par5 = str2int(TmpStr1);
+  if (GetArgv(Line, TmpStr1, 2)) TempEvent.Par1 = CalculateParam(TmpStr1);
+	if (GetArgv(Line, TmpStr1, 3)) TempEvent.Par2 = CalculateParam(TmpStr1);
+	if (GetArgv(Line, TmpStr1, 4)) TempEvent.Par3 = CalculateParam(TmpStr1);
+	if (GetArgv(Line, TmpStr1, 5)) TempEvent.Par4 = CalculateParam(TmpStr1);
+	if (GetArgv(Line, TmpStr1, 6)) TempEvent.Par5 = CalculateParam(TmpStr1);
 
   if (source == VALUE_SOURCE_WEB_FRONTEND) {
     // Must run immediately, to see result in web frontend

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -1961,19 +1961,19 @@ int CalculateParam(char *TmpStr) {
       String errorDesc;
       switch (returnCode) {
         case CALCULATE_ERROR_STACK_OVERFLOW:
-          errorDesc = "Stack Overflow";
+          errorDesc = F("Stack Overflow");
           break;
         case CALCULATE_ERROR_BAD_OPERATOR:
-          errorDesc = "Bad Operator";
+          errorDesc = F("Bad Operator");
           break;
         case CALCULATE_ERROR_PARENTHESES_MISMATCHED:
-          errorDesc = "Parenthesis mismatch";
+          errorDesc = F("Parenthesis mismatch");
           break;
         case CALCULATE_ERROR_UNKNOWN_TOKEN:
-          errorDesc = "Unknown token";
+          errorDesc = F("Unknown token");
           break;
         default:
-          errorDesc = "Unknown error";
+          errorDesc = F("Unknown error");
           break;
         }
         String log = String(F("CALCULATE: Parameter Calculate ERROR: ")) + errorDesc;

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -365,11 +365,11 @@ void parseCommandString(struct EventStruct *event, const String& string)
   event->Par4 = 0;
   event->Par5 = 0;
 
-  if (GetArgv(command, TmpStr1, 2)) event->Par1 = str2int(TmpStr1);
-  if (GetArgv(command, TmpStr1, 3)) event->Par2 = str2int(TmpStr1);
-  if (GetArgv(command, TmpStr1, 4)) event->Par3 = str2int(TmpStr1);
-  if (GetArgv(command, TmpStr1, 5)) event->Par4 = str2int(TmpStr1);
-  if (GetArgv(command, TmpStr1, 6)) event->Par5 = str2int(TmpStr1);
+  if (GetArgv(command, TmpStr1, 2)) event->Par1 = CalculateParam(TmpStr1);
+  if (GetArgv(command, TmpStr1, 3)) event->Par2 = CalculateParam(TmpStr1);
+  if (GetArgv(command, TmpStr1, 4)) event->Par3 = CalculateParam(TmpStr1);
+  if (GetArgv(command, TmpStr1, 5)) event->Par4 = CalculateParam(TmpStr1);
+  if (GetArgv(command, TmpStr1, 6)) event->Par5 = CalculateParam(TmpStr1);
 }
 
 /********************************************************************************************\
@@ -1945,6 +1945,23 @@ int Calculate(const char *input, float* result)
   return CALCULATE_OK;
 }
 
+float CalculateParam(const char *TmpStr) {
+  float param=0;
+  int returnCode=Calculate(TmpStr, &param);
+  if (returnCode!=CALCULATE_OK) {
+    String log = String(F("Parameter Calculate ERROR. Return Code = ")) + String(returnCode);
+    addLog(LOG_LEVEL_INFO, log);
+  } else {
+    if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+      String log = F("Parameter calculated result: ");
+      log += TmpStr;
+      log += F(" = ");
+      log += lround(param);
+      addLog(LOG_LEVEL_DEBUG, log);
+    }
+  }
+  return (lround(param));
+}
 
 void checkRuleSets(){
 for (byte x=0; x < RULESETS_MAX; x++){

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -1947,7 +1947,7 @@ int Calculate(const char *input, float* result)
 
 bool is_digits(const std::string &str)
 {
-    return std::all_of(str.begin(), str.end(), ::isdigit); // C++11
+  return str.find_first_not_of("0123456789") == std::string::npos;
 }
 
 int CalculateParam(char *TmpStr) {

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -1820,6 +1820,12 @@ int Calculate(const char *input, float* result)
   //*sp=0; // bug, it stops calculating after 50 times
   sp = globalstack - 1;
   oc=c=0;
+
+  if (input[0] == '=') {
+    ++strpos;
+    c = *strpos;
+  }
+
   while (strpos < strend)
   {
     // read one token from the input stream
@@ -1945,17 +1951,16 @@ int Calculate(const char *input, float* result)
   return CALCULATE_OK;
 }
 
-bool is_digits(const std::string &str)
-{
-  return str.find_first_not_of("0123456789") == std::string::npos;
-}
-
 int CalculateParam(char *TmpStr) {
   int returnValue;
-  if (is_digits(TmpStr)) { //if the string is made only of digits, do not waste time calling Calculate
+
+  // Minimize calls to the Calulate function.
+  // Only if TmpStr starts with '=' then call Calculate(). Otherwise do not call it
+  if (TmpStr[0] != '=') {
     returnValue=str2int(TmpStr);
   } else {
     float param=0;
+    TmpStr[0] = ' '; //replace '=' with space
     int returnCode=Calculate(TmpStr, &param);
     if (returnCode!=CALCULATE_OK) {
       String errorDesc;
@@ -1976,11 +1981,16 @@ int CalculateParam(char *TmpStr) {
           errorDesc = F("Unknown error");
           break;
         }
-        String log = String(F("CALCULATE: Parameter Calculate ERROR: ")) + errorDesc;
-        addLog(LOG_LEVEL_INFO, log);
+        String log = String(F("CALCULATE PARAM ERROR: ")) + errorDesc;
+        addLog(LOG_LEVEL_ERROR, log);
+        log = F("CALCULATE PARAM ERROR details: ");
+        log += TmpStr;
+        log += F(" = ");
+        log += round(param);
+        addLog(LOG_LEVEL_ERROR, log);
       } else {
       if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
-        String log = F("CALCULATE: ");
+        String log = F("CALCULATE PARAM: ");
         log += TmpStr;
         log += F(" = ");
         log += round(param);


### PR DESCRIPTION
Hi,
here is a PR for using parameters when calling commands from inside the rules.
This will save a lot of text thus reducing processing time during text file rule parsing.
**In order to call the evaluate the formula, a prefix of '=' must be used. See examples.**

The scope is to be able to use formulas instead of an integer when calling a command inside the rules.

Examples:

1)
taskvalueset,1,=%eventvalue%+65,=[Relay1#r1]+1

2)
Assuming you have a PCF8574 with ports from 65 to 72, you can write a rule:

```
on turnOnRelay do
  pcfgpio,=%eventvalue%+64,0
endon

```
And to turn on port 67, the rule can be called like this:

`event,turnOnRelay=3`