### PR TITLE
adding more parameters to EVENT

### DIFF
--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -2254,7 +2254,19 @@ void processMatchedRule(
       if (equalsPos > 0)
       {
         String tmpString = event.substring(equalsPos + 1);
-        action.replace(F("%eventvalue%"), tmpString); // substitute %eventvalue% in actions with the actual value from the event
+
+        char command[INPUT_COMMAND_SIZE];
+        command[0] = 0;
+        char tmpParam[INPUT_COMMAND_SIZE];
+        tmpParam[0] = 0;
+        tmpString.toCharArray(command, INPUT_COMMAND_SIZE);
+
+        if (GetArgv(command,tmpParam,1)) {
+           action.replace(F("%eventvalue%"), tmpParam); // for compatibility issues
+           action.replace(F("%eventvalue1%"), tmpParam); // substitute %eventvalue% in actions with the actual value from the event
+        }
+        if (GetArgv(command,tmpParam,2)) action.replace(F("%eventvalue2%"), tmpParam); // substitute %eventvalue2% in actions with the actual value from the event
+        if (GetArgv(command,tmpParam,3)) action.replace(F("%eventvalue3%"), tmpParam); // substitute %eventvalue3% in actions with the actual value from the event
       }
     }
 

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -2263,10 +2263,11 @@ void processMatchedRule(
 
         if (GetArgv(command,tmpParam,1)) {
            action.replace(F("%eventvalue%"), tmpParam); // for compatibility issues
-           action.replace(F("%eventvalue1%"), tmpParam); // substitute %eventvalue% in actions with the actual value from the event
+           action.replace(F("%eventvalue1%"), tmpParam); // substitute %eventvalue1% in actions with the actual value from the event
         }
         if (GetArgv(command,tmpParam,2)) action.replace(F("%eventvalue2%"), tmpParam); // substitute %eventvalue2% in actions with the actual value from the event
         if (GetArgv(command,tmpParam,3)) action.replace(F("%eventvalue3%"), tmpParam); // substitute %eventvalue3% in actions with the actual value from the event
+        if (GetArgv(command,tmpParam,4)) action.replace(F("%eventvalue4%"), tmpParam); // substitute %eventvalue4% in actions with the actual value from the event
       }
     }
 


### PR DESCRIPTION
Hi,
adding the possibility to have 3 parameters when calling an event:
event,eventname=p1,p2,p3

The variable name are:
param 1: %eventvalue1% (or %eventvalue% for backward compatibility)
param 2: %eventvalue2%
param 3: %eventvalue3%