### PR TITLE
[CrashRecover] Disable failing step based on failed boot count

### DIFF
--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -1382,17 +1382,19 @@ struct pinStatesStruct
 //max 40 bytes: ( 74 - 64 ) * 4
 struct RTCStruct
 {
+  RTCStruct() : ID1(0), ID2(0), unused1(false), factoryResetCounter(0),
+                deepSleepState(0), bootFailedCount(0), flashDayCounter(0),
+                flashCounter(0), bootCounter(0) {}
   byte ID1;
   byte ID2;
   boolean unused1;
   byte factoryResetCounter;
   byte deepSleepState;
-  byte unused2;
+  byte bootFailedCount;
   byte flashDayCounter;
   unsigned long flashCounter;
   unsigned long bootCounter;
 } RTC;
-
 
 int deviceCount = -1;
 int protocolCount = -1;

--- a/src/ESPEasyStorage.ino
+++ b/src/ESPEasyStorage.ino
@@ -220,6 +220,51 @@ String LoadSettings()
 }
 
 /********************************************************************************************\
+  Disable Plugin, based on bootFailedCount
+  \*********************************************************************************************/
+byte disablePlugin(byte bootFailedCount) {
+  for (byte i = 0; i < TASKS_MAX && bootFailedCount > 0; ++i) {
+    if (Settings.TaskDeviceEnabled[i]) {
+      --bootFailedCount;
+      if (bootFailedCount == 0) {
+        Settings.TaskDeviceEnabled[i] = false;
+      }
+    }
+  }
+  return bootFailedCount;
+}
+
+/********************************************************************************************\
+  Disable Controller, based on bootFailedCount
+  \*********************************************************************************************/
+byte disableController(byte bootFailedCount) {
+  for (byte i = 0; i < CONTROLLER_MAX && bootFailedCount > 0; ++i) {
+    if (Settings.ControllerEnabled[i]) {
+      --bootFailedCount;
+      if (bootFailedCount == 0) {
+        Settings.ControllerEnabled[i] = false;
+      }
+    }
+  }
+  return bootFailedCount;
+}
+
+/********************************************************************************************\
+  Disable Notification, based on bootFailedCount
+  \*********************************************************************************************/
+byte disableNotification(byte bootFailedCount) {
+  for (byte i = 0; i < NOTIFICATION_MAX && bootFailedCount > 0; ++i) {
+    if (Settings.NotificationEnabled[i]) {
+      --bootFailedCount;
+      if (bootFailedCount == 0) {
+        Settings.NotificationEnabled[i] = false;
+      }
+    }
+  }
+  return bootFailedCount;
+}
+
+/********************************************************************************************\
   Offsets in settings files
   \*********************************************************************************************/
 bool getSettingsParameters(SettingsType settingsType, int index, int& max_index, int& offset, int& max_size, int& struct_size) {


### PR DESCRIPTION
When the node gets locked in a boot loop, the only recovery is to erase it and start all over.
This fix will count the number of failed boots and above a certain threshold it will start disabling plugin, then controller and then notification.

Only one will be disabled at once, so the user can see which one is giving issues.
The disabled state will not be saved, so make sure to save the failing part when it is accessible again.