### PR TITLE
[Scheduler] Disable command scheduler

### DIFF
--- a/src/Command.ino
+++ b/src/Command.ino
@@ -222,16 +222,20 @@ void ExecuteCommand(byte source, const char *Line)
 	if (GetArgv(Line, TmpStr1, 5)) TempEvent.Par4 = CalculateParam(TmpStr1);
 	if (GetArgv(Line, TmpStr1, 6)) TempEvent.Par5 = CalculateParam(TmpStr1);
 
-  if (source == VALUE_SOURCE_WEB_FRONTEND) {
+  // FIXME: TD-er  Disabling scheduling commands.
+  // Gives too much issues.
+  // if (source == VALUE_SOURCE_WEB_FRONTEND) {
     // Must run immediately, to see result in web frontend
     String status = doExecuteCommand((char*)&cmd[0], &TempEvent, Line);
     yield();
     SendStatus(source, status);
     yield();
+/*
   } else {
     // Schedule to run async
     schedule_command_timer((char*)&cmd[0], &TempEvent, Line);
   }
+*/
 }
 
 #ifdef FEATURE_SD


### PR DESCRIPTION
For now the commands will no longer use the scheduler.
Commands running asynchronous is causing too much issues.