### PR TITLE
Change type of sensor for MCP and PCF devices

### DIFF
--- a/src/_P009_MCP.ino
+++ b/src/_P009_MCP.ino
@@ -20,7 +20,7 @@ boolean Plugin_009(byte function, struct EventStruct *event, String& string)
       {
         Device[++deviceCount].Number = PLUGIN_ID_009;
         Device[deviceCount].Type = DEVICE_TYPE_I2C;
-        Device[deviceCount].VType = SENSOR_TYPE_SINGLE;
+        Device[deviceCount].VType = SENSOR_TYPE_SWITCH;
         Device[deviceCount].Ports = 16;
         Device[deviceCount].PullUpOption = false;
         Device[deviceCount].InverseLogicOption = false;

--- a/src/_P019_PCF8574.ino
+++ b/src/_P019_PCF8574.ino
@@ -20,7 +20,7 @@ boolean Plugin_019(byte function, struct EventStruct *event, String& string)
       {
         Device[++deviceCount].Number = PLUGIN_ID_019;
         Device[deviceCount].Type = DEVICE_TYPE_I2C;
-        Device[deviceCount].VType = SENSOR_TYPE_SINGLE;
+        Device[deviceCount].VType = SENSOR_TYPE_SWITCH;
         Device[deviceCount].Ports = 8;
         Device[deviceCount].PullUpOption = false;
         Device[deviceCount].InverseLogicOption = false;


### PR DESCRIPTION
MCP and PCF devices should be of type SWNSOR_TYPE_SWITCH instead of SENSOR_TYPE_SINGLE so that the controllers can identify them correctly as switches (for GPIO related functions)