### PR TITLE
[MQTT] Work around for lost MQTT connection

### DIFF
--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -161,6 +161,15 @@ bool MQTTConnect(int controller_idx)
     clientid = F("ESPClient_");
     clientid += WiFi.macAddress();
   }
+  // Work-around for 'lost connections' to the MQTT broker.
+  // If the broker thinks the connection is still alive, a reconnect from the
+  // client will be refused.
+  // To overcome this issue, append the number of reconnects to the client ID to
+  // make it different from the previous one.
+  if (wifi_reconnects >= 1) {
+    clientid += F("_");
+    clientid += wifi_reconnects;
+  }
 
   String LWTTopic = ControllerSettings.MQTTLwtTopic;
   if(LWTTopic.length() == 0)


### PR DESCRIPTION
Maybe a fix for #1525
Meant to be a fix for #1530

It looks like the MQTT broker is refusing to accept a new connection from a specific client ID, as long as the broker thinks a client with that ID is still connected.
This work around adds the number of wifi reconnects to the clientID, to make the ID unique when a reconnect has to be made.