### PR TITLE
[ESP32] Change partition size (will clear all settings) and add plugins

### DIFF
--- a/esp32_partition_app1810k_spiffs316k.csv
+++ b/esp32_partition_app1810k_spiffs316k.csv
@@ -1,0 +1,7 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x1D0000,
+app1,     app,  ota_1,   0x1E0000,0x1D0000,
+eeprom,   data, 0x99,    0x3B0000,0x1000,
+spiffs,   data, spiffs,  0x3B1000,0x4F000,

--- a/platformio.ini
+++ b/platformio.ini
@@ -83,6 +83,8 @@ build_flags               = -D BUILD_GIT='"${sysenv.TRAVIS_TAG}"'
 lib_ignore                = AS_BH1750, ESP8266WiFi, ESP8266Ping, ESP8266WebServer, ESP8266HTTPUpdateServer, ESP8266mDNS, IRremoteESP8266, ESPEasy_ESP8266Ping, SerialSensors, SDM
 lib_deps                  = ""
 monitor_speed             = 115200
+board_build.partitions    = esp32_partition_app1810k_spiffs316k.csv
+board_upload.maximum_size = 1900544
 
 
 
@@ -104,7 +106,7 @@ monitor_speed             = 115200
 
 [common]
 board_build.f_cpu         = 80000000L
-build_unflags             = 
+build_unflags             =
 build_flags               = -D BUILD_GIT='"${sysenv.TRAVIS_TAG}"'
                    -D NDEBUG
                    -lstdc++ -lsupc++
@@ -205,6 +207,8 @@ lib_archive               = ${common.lib_archive}
 framework                 = ${common.framework}
 upload_speed              = ${common.upload_speed}
 monitor_speed             = ${common.monitor_speed}
+board_build.partitions    = ${core_esp32.board_build.partitions}
+board_upload.maximum_size = ${core_esp32.board_upload.maximum_size}
 
 
 ;;; NORMAL (STABLE) ; ****; ****; ****; ****; ****; ****; ****; ****; ****; ****; ****;;;;

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -862,8 +862,10 @@ struct SettingsStruct
   // Try to extend settings to make the checksum 4-byte aligned.
 //  uint8_t       ProgmemMd5[16]; // crc of the binary that last saved the struct to file.
 //  uint8_t       md5[16];
-} Settings;
+};
 
+SettingsStruct* SettingsStruct_ptr = new SettingsStruct;
+SettingsStruct& Settings = *SettingsStruct_ptr;
 
 /*********************************************************************************************\
  * ControllerSettingsStruct

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -297,7 +297,11 @@
 #if defined(PLUGIN_BUILD_TESTING) || defined(PLUGIN_BUILD_DEV)
   #define DEVICES_MAX                      75
 #else
-  #define DEVICES_MAX                      50
+  #ifdef ESP32
+    #define DEVICES_MAX                      75
+  #else
+    #define DEVICES_MAX                      50
+  #endif
 #endif
 
 #if defined(ESP8266)

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -5417,6 +5417,8 @@ void handle_sysinfo() {
      TXBuffer += ESP.getCpuFreqMHz();
      TXBuffer += F(" MHz");
   #endif
+  html_TR_TD(); TXBuffer += F("ESP Board Name:<TD>");
+  TXBuffer += ARDUINO_BOARD;
 
 
    addTableSeparator(F("Storage"), 2, 3);

--- a/src/_P073_7DGT.ino
+++ b/src/_P073_7DGT.ino
@@ -458,6 +458,7 @@ void p073_FillBufferWithTemp(long temperature)
   int p073_numlenght = strlen(p073_digit);
   byte p073_dispdigit;
   for (int i=0;i<p073_numlenght;i++) {
+    p073_dispdigit = 10;           // default is space
     if (p073_digit[i] > 47 && p073_digit[i] < 58)
       p073_dispdigit = p073_digit[i]-48;
     else if (p073_digit[i] == 32)  // space

--- a/src/define_plugin_sets.h
+++ b/src/define_plugin_sets.h
@@ -202,12 +202,15 @@ To create/register a plugin, you have to :
     #ifdef ESP8266
         #undef ESP8266
     #endif
-    #define PLUGIN_SET_ONLY_SWITCH
-    #define USES_P036   // FrameOLED
-    #define USES_P027   // INA219
-    #define USES_P028   // BME280
+//    #define PLUGIN_SET_ONLY_SWITCH
 
-    // TODO : Add list of compatible plugins for ESP32 board.
+    #define  PLUGIN_SET_TESTING
+    #define  CONTROLLER_SET_STABLE
+    #define  NOTIFIER_SET_STABLE
+    #define  PLUGIN_SET_STABLE     // add stable
+    // See also PLUGIN_SET_GENERIC_ESP32 section at end,
+    // where incompatible plugins will be disabled.
+    // TODO : Check compatibility of plugins for ESP32 board.
 #endif
 
 
@@ -585,8 +588,22 @@ To create/register a plugin, you have to :
 #ifdef NOTIFIER_SET_EXPERIMENTAL
 #endif
 
+/******************************************************************************\
+ * Remove incompatible plugins ************************************************
+\******************************************************************************/
+#ifdef PLUGIN_SET_GENERIC_ESP32
+  #undef USES_P010   // BH1750          (doesn't work yet on ESP32)
+  #undef USES_P049   // MHZ19           (doesn't work yet on ESP32)
 
+  #undef USES_P052   // SenseAir        (doesn't work yet on ESP32)
+  #undef USES_P053   // PMSx003
 
+  #undef USES_P056   // SDS011-Dust     (doesn't work yet on ESP32)
+  #undef USES_P065   // DRF0299
+  #undef USES_P071   // Kamstrup401
+  #undef USES_P075   // Nextion
+  #undef USES_P078   // Eastron Modbus Energy meters (doesn't work yet on ESP32)
+#endif
 
 
 /******************************************************************************\


### PR DESCRIPTION
The last update to > 0.12 increased the binary size a lot. This is mainly due to the added BLE support.
This makes it almost impossible to use the default partition table layout.

This changes the app partitions to 1.8 MB and reduces the SPIFFS to 320 k.
Changing the partition table will clear all settings, so make a backup of the settings.

Also added all plugins that would compile (not tested) for ESP32.

Known issue:
ESP32 might crash due to stack overflow when saving settings of plugins. (e.g. OLED framed plugin)