### PR TITLE
fixed distance reading

### DIFF
--- a/src/_P013_HCSR04.ino
+++ b/src/_P013_HCSR04.ino
@@ -16,11 +16,13 @@ struct P_013_sensordef {
   P_013_sensordef() : sonar(NULL) {}
 
   P_013_sensordef(byte TRIG_Pin, byte IRQ_Pin, int16_t max_cm_distance) : sonar(NULL) {
+    addLog(LOG_LEVEL_INFO, "constructor P_013_sensordef");
     sonar = new NewPingESP8266(TRIG_Pin, IRQ_Pin, max_cm_distance);
   }
 
   ~P_013_sensordef() {
     if (sonar != NULL) {
+      addLog(LOG_LEVEL_INFO, "delete P_013_sensordef");
       delete sonar;
       sonar = NULL;
     }
@@ -107,8 +109,8 @@ boolean Plugin_013(byte function, struct EventStruct *event, String& string)
         byte Plugin_013_TRIG_Pin = Settings.TaskDevicePin1[event->TaskIndex];
         byte Plugin_013_IRQ_Pin = Settings.TaskDevicePin2[event->TaskIndex];
         int16_t max_cm_distance = Settings.TaskDevicePluginConfig[event->TaskIndex][2];
-        P_013_sensordefs[event->TaskIndex] =
-          P_013_sensordef(Plugin_013_TRIG_Pin, Plugin_013_IRQ_Pin, max_cm_distance);
+        P_013_sensordef *newSensordef = new P_013_sensordef(Plugin_013_TRIG_Pin, Plugin_013_IRQ_Pin, max_cm_distance);
+        P_013_sensordefs[event->TaskIndex] = *newSensordef;
         String log = F("ULTRASONIC : TaskNr: ");
         log += event->TaskIndex +1;
         log += F(" TrigPin: ");
@@ -143,6 +145,7 @@ boolean Plugin_013(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_EXIT:
       {
+        addLog(LOG_LEVEL_INFO, F("P013 exit"));
         P_013_sensordefs.erase(event->TaskIndex);
         break;
       }
@@ -205,7 +208,7 @@ float Plugin_013_read(unsigned int taskIndex)
   if (P_013_sensordefs.count(taskIndex) == 0) return 0;
   if (P_013_sensordefs[taskIndex].sonar == NULL) return 0;
   delay(1);
-  float distance = P_013_sensordefs[taskIndex].sonar->ping_cm();
+  float distance = (P_013_sensordefs[taskIndex].sonar)->ping_cm();
   delay(1);
   return distance;
 }

--- a/src/_P013_HCSR04.ino
+++ b/src/_P013_HCSR04.ino
@@ -21,8 +21,8 @@ struct P_013_sensordef {
   }
 
   ~P_013_sensordef() {
+    addLog(LOG_LEVEL_INFO, "delete P_013_sensordef");
     if (sonar != NULL) {
-      addLog(LOG_LEVEL_INFO, "delete P_013_sensordef");
       delete sonar;
       sonar = NULL;
     }
@@ -109,6 +109,10 @@ boolean Plugin_013(byte function, struct EventStruct *event, String& string)
         byte Plugin_013_TRIG_Pin = Settings.TaskDevicePin1[event->TaskIndex];
         byte Plugin_013_IRQ_Pin = Settings.TaskDevicePin2[event->TaskIndex];
         int16_t max_cm_distance = Settings.TaskDevicePluginConfig[event->TaskIndex][2];
+        // if a device already exists, delete it first and add a new one with new settings
+        if (P_013_sensordefs.count(event->TaskIndex) > 0) {
+          P_013_sensordefs.erase(event->TaskIndex);
+        };
         P_013_sensordef *newSensordef = new P_013_sensordef(Plugin_013_TRIG_Pin, Plugin_013_IRQ_Pin, max_cm_distance);
         P_013_sensordefs[event->TaskIndex] = *newSensordef;
         String log = F("ULTRASONIC : TaskNr: ");


### PR DESCRIPTION
the P_013_sensordef object was created on the stack and the destructor was called after leaving the PLUGIN_INIT. That deleted the included NewPingESP8266 object and using this object failed.

added also a log output for verifying contructor/destructor calls (maybe changed to LOG_LEVEL_DEBUG?)