### PR TITLE
minor change: unit was missing for threshold in 'state' mode

### DIFF
--- a/src/_P013_HCSR04.ino
+++ b/src/_P013_HCSR04.ino
@@ -64,6 +64,7 @@ boolean Plugin_013(byte function, struct EventStruct *event, String& string)
         if (Settings.TaskDevicePluginConfig[event->TaskIndex][0] == 2)
         {
         	addFormNumericBox(F("Threshold"), F("plugin_013_threshold"), Settings.TaskDevicePluginConfig[event->TaskIndex][1]);
+          addUnit(F("cm"));
         }
         addFormNumericBox(F("Max Distance"), F("plugin_013_max_distance"), Settings.TaskDevicePluginConfig[event->TaskIndex][2], 0, 500);
         addUnit(F("cm"));


### PR DESCRIPTION
added unit 'cm' to threshold in state mode.