### PR TITLE
[P013_HCSR04] added error checking and logging

### DIFF
--- a/lib/NewPingESP8266/NewPingESP8266.cpp
+++ b/lib/NewPingESP8266/NewPingESP8266.cpp
@@ -6,12 +6,13 @@
 // ---------------------------------------------------------------------------
 
 #include "NewPingESP8266.h"
-
+//#include "ESPEasy-Globals.h"
 // ---------------------------------------------------------------------------
 // NewPingESP8266 constructor
 // ---------------------------------------------------------------------------
 
 NewPingESP8266::NewPingESP8266(uint32_t trigger_pin, uint32_t echo_pin, unsigned int max_cm_distance) {
+	_errorState = STATUS_SENSOR_READY;
 #if DO_BITWISE == true
 	_triggerBit = digitalPinToBitMask(trigger_pin); // Get the port register bitmask for the trigger pin.
 	_echoBit = digitalPinToBitMask(echo_pin);       // Get the port register bitmask for the echo pin.
@@ -58,7 +59,10 @@ unsigned int NewPingESP8266::ping(unsigned int max_cm_distance) {
 		while (!digitalRead(_echoPin))                // Wait for the ping echo.
 	#endif
 	  {
-			if (micros() > _max_time) return NO_ECHO; // Stop the loop and return NO_ECHO (false) if we're beyond the set maximum distance.
+			if ((_max_cm_distance > 0) && (micros() > _max_time)) {
+				_errorState = STATUS_MAX_DISTANCE_EXCEEDED;
+				return NO_ECHO; // Stop the loop and return NO_ECHO (false) if we're beyond the set maximum distance.
+			}
 	  }
 #else
 	#if DO_BITWISE == true
@@ -67,10 +71,14 @@ unsigned int NewPingESP8266::ping(unsigned int max_cm_distance) {
 		while (digitalRead(_echoPin))                 // Wait for the ping echo.
 	#endif
 		{
-			if (micros() > _max_time) return NO_ECHO; // Stop the loop and return NO_ECHO (false) if we're beyond the set maximum distance.
+			if ((_max_cm_distance > 0) && (micros() > _max_time)) {
+				_errorState = STATUS_MAX_DISTANCE_EXCEEDED;
+				return NO_ECHO; // Stop the loop and return NO_ECHO (false) if we're beyond the set maximum distance.
+			}
 		}
 #endif
 
+	_errorState = STATUS_MEASUREMENT_VALID;
 	return (micros() - (_max_time - _maxEchoTime) - PING_OVERHEAD); // Calculate ping time, include overhead.
 }
 
@@ -144,15 +152,39 @@ boolean NewPingESP8266::ping_trigger() {
 	#endif
 
 	#if URM37_ENABLED == true
-		if (!(*_echoInput & _echoBit)) return false;            // Previous ping hasn't finished, abort.
+		if (!(*_echoInput & _echoBit)) {								      	// Previous ping hasn't finished, abort.{
+			_errorState = STATUS_ECHO_STATE_ERROR;
+			return false;
+		}
 		_max_time = micros() + _maxEchoTime + MAX_SENSOR_DELAY; // Maximum time we'll wait for ping to start (most sensors are <450uS, the SRF06 can take up to 34,300uS!)
 		while (*_echoInput & _echoBit)                          // Wait for ping to start.
-			if (micros() > _max_time) return false;             // Took too long to start, abort.
+		{
+			if (millis() > (start + 50)) {
+				_errorState = STATUS_ECHO_START_TIMEOUT_50ms;
+				return false;
+			}
+			if ((_max_cm_distance > 0) && (micros() > _max_time)) {	// check max. distance if != 0 cm
+				_errorState = STATUS_ECHO_START_TIMEOUT_DISTANCE;
+				return false;             													// echo too late, max distance exceeded
+			}
+		}
 	#else
-		if (*_echoInput & _echoBit) return false;               // Previous ping hasn't finished, abort.
+		if (*_echoInput & _echoBit) { 				              		// Previous ping hasn't finished, abort.
+			_errorState = STATUS_ECHO_STATE_ERROR;
+			return false;
+		}
 		_max_time = micros() + _maxEchoTime + MAX_SENSOR_DELAY; // Maximum time we'll wait for ping to start (most sensors are <450uS, the SRF06 can take up to 34,300uS!)
 		while (!(*_echoInput & _echoBit))                       // Wait for ping to start.
-			if (micros() > _max_time) return false;             // Took too long to start, abort.
+		{
+			if (millis() > (start + 50)) {
+				_errorState = STATUS_ECHO_START_TIMEOUT_50ms;
+				return false;
+			}
+			if ((_max_cm_distance > 0) && (micros() > _max_time)) {	// check max. distance if != 0 cm
+				_errorState = STATUS_ECHO_START_TIMEOUT_DISTANCE;
+				return false;             													// echo too late, max distance exceeded
+			}
+		}
 	#endif
 #else
 	#if ONE_PIN_ENABLED == true
@@ -170,30 +202,51 @@ boolean NewPingESP8266::ping_trigger() {
 	#endif
 
 	#if URM37_ENABLED == true
-		if (!digitalRead(_echoPin)) return false;               // Previous ping hasn't finished, abort.
+		if (!digitalRead(_echoPin)) {
+			_errorState = STATUS_ECHO_STATE_ERROR;
+			return false;                // Previous ping hasn't finished, abort.
+		}
 		_max_time = micros() + _maxEchoTime + MAX_SENSOR_DELAY; // Maximum time we'll wait for ping to start (most sensors are <450uS, the SRF06 can take up to 34,300uS!)
 		while (digitalRead(_echoPin))                           // Wait for ping to start.
 		{
-			if (millis() > (start + 50)) return false;
-			if (micros() > _max_time) return false;             // Took too long to start, abort.
+			if (millis() > (start + 50)) {
+				_errorState = STATUS_ECHO_START_TIMEOUT_50ms;
+				return false;
+			}
+			if ((_max_cm_distance > 0) && (micros() > _max_time)) {	// check max. distance if != 0 cm
+				_errorState = STATUS_ECHO_START_TIMEOUT_DISTANCE;
+				return false;             													// echo too late, max distance exceeded
+			}
 		}
 	#else
-		if (digitalRead(_echoPin)) return false;                // Previous ping hasn't finished, abort.
+		if (digitalRead(_echoPin)) {
+			_errorState = STATUS_ECHO_STATE_ERROR;
+			return false;                // Previous ping hasn't finished, abort.
+		}
 		_max_time = micros() + _maxEchoTime + MAX_SENSOR_DELAY; // Maximum time we'll wait for ping to start (most sensors are <450uS, the SRF06 can take up to 34,300uS!)
 		while (!digitalRead(_echoPin))                          // Wait for ping to start.
 		{
-			if (millis() > (start + 50)) return false;
-			if (micros() > _max_time) return false;             // Took too long to start, abort.
+			if (millis() > (start + 50)) {
+				_errorState = STATUS_ECHO_START_TIMEOUT_50ms;
+				return false;
+			}
+			if ((_max_cm_distance > 0) && (micros() > _max_time)) {	// check max. distance if != 0 cm
+				_errorState = STATUS_ECHO_START_TIMEOUT_DISTANCE;
+				return false;             													// echo too late, max distance exceeded
+			}
   	}
 	#endif
 #endif
 
 	_max_time = micros() + _maxEchoTime; // Ping started, set the time-out.
+	_errorState = STATUS_ECHO_TRIGGERED;
+
 	return true;                         // Ping started successfully.
 }
 
 
 void NewPingESP8266::set_max_distance(unsigned int max_cm_distance) {
+	_max_cm_distance = max_cm_distance;
 #if ROUNDING_ENABLED == false
 	_maxEchoTime = min(max_cm_distance + 1, (unsigned int) MAX_SENSOR_DISTANCE + 1) * US_ROUNDTRIP_CM; // Calculate the maximum distance in uS (no rounding).
 #else

--- a/lib/NewPingESP8266/NewPingESP8266.cpp
+++ b/lib/NewPingESP8266/NewPingESP8266.cpp
@@ -275,3 +275,12 @@ unsigned int NewPingESP8266::convert_in(unsigned int echoTime) {
 	return NewPingESP8266Convert(echoTime, US_ROUNDTRIP_IN); // Convert uS to inches.
 #endif
 }
+
+float NewPingESP8266::convert_cm_F(unsigned int echoTime) {
+	return ((float)echoTime / US_ROUNDTRIP_CM);              // Convert uS to centimeters (no rounding).
+}
+
+
+float NewPingESP8266::convert_in_F(unsigned int echoTime) {
+	return ((float)echoTime / US_ROUNDTRIP_IN);              // Convert uS to inches (no rounding).
+}

--- a/lib/NewPingESP8266/NewPingESP8266.h
+++ b/lib/NewPingESP8266/NewPingESP8266.h
@@ -212,6 +212,8 @@ class NewPingESP8266 {
 		unsigned long ping_median(uint32_t it = 5, unsigned int max_cm_distance = 0);
 		static unsigned int convert_cm(unsigned int echoTime);
 		static unsigned int convert_in(unsigned int echoTime);
+		static float convert_cm_F(unsigned int echoTime);
+		static float convert_in_F(unsigned int echoTime);
 
 		unsigned int getMaxEchoTime() { return _maxEchoTime; };
 		errorState getErrorState() { return _errorState; };

--- a/lib/NewPingESP8266/NewPingESP8266.h
+++ b/lib/NewPingESP8266/NewPingESP8266.h
@@ -194,7 +194,18 @@
 
 class NewPingESP8266 {
 	public:
+		enum errorState {
+			STATUS_SENSOR_READY,  								// no error, no measruement started
+			STATUS_MEASUREMENT_VALID, 						// no errors
+			STATUS_ECHO_TRIGGERED,								// echo triggered, intermediate state
+			STATUS_MAX_DISTANCE_EXCEEDED, 				// echo too late, maximum distance exceeded
+			STATUS_ECHO_START_TIMEOUT_50ms, 			// no echo start signal after 50 ms
+			STATUS_ECHO_START_TIMEOUT_DISTANCE,		// no echo start signal after max. distance
+			STATUS_ECHO_STATE_ERROR 				 			// echopin level not low after triggered
+		};
+
 		NewPingESP8266(uint32_t trigger_pin, uint32_t echo_pin, unsigned int max_cm_distance = MAX_SENSOR_DISTANCE);
+		~NewPingESP8266() { };
 		unsigned int ping(unsigned int max_cm_distance = 0);
 		unsigned long ping_cm(unsigned int max_cm_distance = 0);
 		unsigned long ping_in(unsigned int max_cm_distance = 0);
@@ -202,7 +213,8 @@ class NewPingESP8266 {
 		static unsigned int convert_cm(unsigned int echoTime);
 		static unsigned int convert_in(unsigned int echoTime);
 
-		unsigned int getMaxEchoTime() { return _maxEchoTime; }
+		unsigned int getMaxEchoTime() { return _maxEchoTime; };
+		errorState getErrorState() { return _errorState; };
 	private:
 		boolean ping_trigger();
 		void set_max_distance(unsigned int max_cm_distance);
@@ -218,6 +230,8 @@ class NewPingESP8266 {
 #endif
 		unsigned int _maxEchoTime;
 		unsigned long _max_time;
+		errorState _errorState;
+		unsigned int _max_cm_distance;
 };
 
 

--- a/src/_P013_HCSR04.ino
+++ b/src/_P013_HCSR04.ino
@@ -10,8 +10,20 @@
 
 #include <Arduino.h>
 #include <map>
-//#include <shared_ptr>
 #include <NewPingESP8266.h>
+
+// PlugIn specific defines
+// operatingMode
+#define OPMODE_VALUE        (0)
+#define OPMODE_STATE        (1)
+
+// measuringUnit
+#define UNIT_CM             (0)
+#define UNIT_INCH           (1)
+
+// filterType
+#define FILTER_NONE         (0)
+#define FILTER_MEDIAN       (1)
 
 // map of sensors
 std::map<unsigned int, std::shared_ptr<NewPingESP8266> > P_013_sensordefs;
@@ -37,10 +49,6 @@ boolean Plugin_013(byte function, struct EventStruct *event, String& string)
         Device[deviceCount].TimerOption = true;
         Device[deviceCount].GlobalSyncOption = true;
 
-        // set default values
-        Settings.TaskDevicePluginConfig[event->TaskIndex][2] = 500;   // max. distance
-        Settings.TaskDevicePluginConfig[event->TaskIndex][5] = 5;     // Filtersize
-
         break;
       }
 
@@ -59,41 +67,51 @@ boolean Plugin_013(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_WEBFORM_LOAD:
       {
-        byte choiceMode = Settings.TaskDevicePluginConfig[event->TaskIndex][0];
-        byte choiceUnit = Settings.TaskDevicePluginConfig[event->TaskIndex][3];
-        byte choiceFilter = Settings.TaskDevicePluginConfig[event->TaskIndex][4];
+        int16_t operatingMode = Settings.TaskDevicePluginConfig[event->TaskIndex][0];
+        int16_t threshold = Settings.TaskDevicePluginConfig[event->TaskIndex][1];
+        int16_t max_distance = Settings.TaskDevicePluginConfig[event->TaskIndex][2];
+        int16_t measuringUnit = Settings.TaskDevicePluginConfig[event->TaskIndex][3];
+        int16_t filterType = Settings.TaskDevicePluginConfig[event->TaskIndex][4];
+        int16_t filterSize = Settings.TaskDevicePluginConfig[event->TaskIndex][5];
 
-        String strUnit = (choiceUnit == 1) ? F("cm") : F("inch");
-        String options[2];
-        options[0] = F("Value");
-        options[1] = F("State");
-        int optionValues[2] = { 1, 2 };
-        addFormSelector(F("Mode"), F("plugin_013_mode"), 2, options, optionValues, choiceMode);
+        // default filtersize = 5
+        if (filterSize == 0) {
+          filterSize = 5;
+          Settings.TaskDevicePluginConfig[event->TaskIndex][5] = filterSize;
+        }
 
-        if (Settings.TaskDevicePluginConfig[event->TaskIndex][0] == 2)
+
+        String strUnit = (measuringUnit == UNIT_CM) ? F("cm") : F("inch");
+
+        String optionsOpMode[2];
+        int optionValuesOpMode[2] = { 0, 1 };
+        optionsOpMode[0] = F("Value");
+        optionsOpMode[1] = F("State");
+        addFormSelector(F("Mode"), F("plugin_013_mode"), 2, optionsOpMode, optionValuesOpMode, operatingMode);
+
+        if (operatingMode == OPMODE_STATE)
         {
-        	addFormNumericBox(F("Threshold"), F("plugin_013_threshold"), Settings.TaskDevicePluginConfig[event->TaskIndex][1]);
+        	addFormNumericBox(F("Threshold"), F("plugin_013_threshold"), threshold);
           addUnit(strUnit);
         }
-        addFormNumericBox(F("Max Distance"), F("plugin_013_max_distance"), Settings.TaskDevicePluginConfig[event->TaskIndex][2], 0, 500);
+        addFormNumericBox(F("Max Distance"), F("plugin_013_max_distance"), max_distance, 0, 500);
         addUnit(strUnit);
 
-        String options1[2];
-        options1[0] = F("Metric");
-        options1[1] = F("Imperial");
-        int optionValues1[2] = { 1, 2 };
-        addFormSelector(F("Unit"), F("plugin_013_Unit"), 2, options1, optionValues1, choiceUnit);
+        String optionsUnit[2];
+        int optionValuesUnit[2] = { 0, 1 };
+        optionsUnit[0] = F("Metric");
+        optionsUnit[1] = F("Imperial");
+        addFormSelector(F("Unit"), F("plugin_013_Unit"), 2, optionsUnit, optionValuesUnit, measuringUnit);
 
-        String options2[2];
-        options2[0] = F("None");
-        options2[1] = F("Median");
-        int optionValues2[2] = { 1, 2 };
-        addFormSelector(F("Filter"), F("plugin_013_FilterType"), 2, options2, optionValues2, choiceFilter);
+        String optionsFilter[2];
+        int optionValuesFilter[2] = { 0, 1 };
+        optionsFilter[0] = F("None");
+        optionsFilter[1] = F("Median");
+        addFormSelector(F("Filter"), F("plugin_013_FilterType"), 2, optionsFilter, optionValuesFilter, filterType);
 
-        if (Settings.TaskDevicePluginConfig[event->TaskIndex][4] == 2)
-        {
-        	addFormNumericBox(F("Filter size"), F("Plugin_013_FilterSize"), Settings.TaskDevicePluginConfig[event->TaskIndex][5], 2, 20);
-        }
+        // enable filtersize option if filter is used,
+        if (filterType != FILTER_NONE)
+        	addFormNumericBox(F("Filter size"), F("plugin_013_FilterSize"), filterSize, 2, 20);
 
         success = true;
         break;
@@ -101,16 +119,18 @@ boolean Plugin_013(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_WEBFORM_SAVE:
       {
+        int16_t operatingMode = Settings.TaskDevicePluginConfig[event->TaskIndex][0];
+        int16_t filterType = Settings.TaskDevicePluginConfig[event->TaskIndex][4];
+
         Settings.TaskDevicePluginConfig[event->TaskIndex][0] = getFormItemInt(F("plugin_013_mode"));
-        if (Settings.TaskDevicePluginConfig[event->TaskIndex][0] == 2)
-        {
+        if (operatingMode == OPMODE_STATE)
           Settings.TaskDevicePluginConfig[event->TaskIndex][1] = getFormItemInt(F("plugin_013_threshold"));
-        }
         Settings.TaskDevicePluginConfig[event->TaskIndex][2] = getFormItemInt(F("plugin_013_max_distance"));
 
         Settings.TaskDevicePluginConfig[event->TaskIndex][3] = getFormItemInt(F("plugin_013_Unit"));
         Settings.TaskDevicePluginConfig[event->TaskIndex][4] = getFormItemInt(F("plugin_013_FilterType"));
-        Settings.TaskDevicePluginConfig[event->TaskIndex][5] = getFormItemInt(F("Plugin_013_FilterSize"));
+        if (filterType != FILTER_NONE)
+          Settings.TaskDevicePluginConfig[event->TaskIndex][5] = getFormItemInt(F("plugin_013_FilterSize"));
 
         success = true;
         break;
@@ -118,15 +138,16 @@ boolean Plugin_013(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_INIT:
       {
-        int16_t Plugin_013_TRIG_Pin = Settings.TaskDevicePin1[event->TaskIndex];
-        int16_t Plugin_013_IRQ_Pin = Settings.TaskDevicePin2[event->TaskIndex];
         int16_t max_distance = Settings.TaskDevicePluginConfig[event->TaskIndex][2];
-        int16_t choiceUnit = Settings.TaskDevicePluginConfig[event->TaskIndex][3];
-        int16_t choiceFilter = Settings.TaskDevicePluginConfig[event->TaskIndex][4];
+        int16_t measuringUnit = Settings.TaskDevicePluginConfig[event->TaskIndex][3];
+        int16_t filterType = Settings.TaskDevicePluginConfig[event->TaskIndex][4];
         int16_t filterSize = Settings.TaskDevicePluginConfig[event->TaskIndex][5];
 
-        int16_t max_distance_cm = (choiceUnit == 1) ? max_distance : (float)max_distance * 2.54f;
+        int8_t Plugin_013_TRIG_Pin = Settings.TaskDevicePin1[event->TaskIndex];
+        int8_t Plugin_013_IRQ_Pin = Settings.TaskDevicePin2[event->TaskIndex];
+        int16_t max_distance_cm = (measuringUnit == UNIT_CM) ? max_distance : (float)max_distance * 2.54f;
 
+        // create sensor instance and add to std::map
         P_013_sensordefs.erase(event->TaskIndex);
         P_013_sensordefs[event->TaskIndex] =
           std::shared_ptr<NewPingESP8266> (new NewPingESP8266(Plugin_013_TRIG_Pin, Plugin_013_IRQ_Pin, max_distance_cm));
@@ -138,15 +159,15 @@ boolean Plugin_013(byte function, struct EventStruct *event, String& string)
         log += F(" IRQ_Pin: ");
         log += Plugin_013_IRQ_Pin;
         log += F(" max dist ");
-        log += (choiceUnit == 1) ? F("[cm]: ") : F("[inch]: ");
+        log += (measuringUnit == UNIT_CM) ? F("[cm]: ") : F("[inch]: ");
         log += max_distance;
         log += F(" max echo: ");
         log += P_013_sensordefs[event->TaskIndex]->getMaxEchoTime();
         log += F(" Filter: ");
-        if (choiceFilter == 1)
+        if (filterType == FILTER_NONE)
           log += F("none");
         else
-          if (choiceFilter == 2) {
+          if (filterType == FILTER_MEDIAN) {
             log += F("Median size: ");
             log += filterSize;
           }
@@ -181,17 +202,19 @@ boolean Plugin_013(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_READ: // If we select value mode, read and send the value based on global timer
       {
-        if (Settings.TaskDevicePluginConfig[event->TaskIndex][0] == 1)
+        int16_t operatingMode = Settings.TaskDevicePluginConfig[event->TaskIndex][0];
+        int16_t measuringUnit = Settings.TaskDevicePluginConfig[event->TaskIndex][3];
+
+        if (operatingMode == OPMODE_VALUE)
         {
-          int16_t choiceUnit = Settings.TaskDevicePluginConfig[event->TaskIndex][3];
           float value = Plugin_013_read(event->TaskIndex);
           String log = F("ULTRASONIC : TaskNr: ");
           log += event->TaskIndex +1;
           log += F(" Distance: ");
           UserVar[event->BaseVarIndex] = value;
           log += UserVar[event->BaseVarIndex];
-          log += (choiceUnit == 1) ? F(" cm ") : F(" inch ");
-          if (value == 0)
+          log += (measuringUnit == UNIT_CM) ? F(" cm ") : F(" inch ");
+          if (value == NO_ECHO)
           {
              log += F(" Error: ");
              log += Plugin_013_getErrorStatusString(event->TaskIndex);
@@ -205,13 +228,17 @@ boolean Plugin_013(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_TEN_PER_SECOND: // If we select state mode, do more frequent checks and send only state changes
       {
-        if (Settings.TaskDevicePluginConfig[event->TaskIndex][0] == 2)
+        int16_t operatingMode = Settings.TaskDevicePluginConfig[event->TaskIndex][0];
+        int16_t threshold = Settings.TaskDevicePluginConfig[event->TaskIndex][1];
+        int16_t measuringUnit = Settings.TaskDevicePluginConfig[event->TaskIndex][3];
+
+        if (operatingMode == OPMODE_STATE)
         {
           byte state = 0;
           float value = Plugin_013_read(event->TaskIndex);
-          if (value > 0)
+          if (value != NO_ECHO)
           {
-            if (value < Settings.TaskDevicePluginConfig[event->TaskIndex][1])
+            if (value < threshold)
               state = 1;
             if (state != switchstate[event->TaskIndex])
             {
@@ -246,31 +273,32 @@ boolean Plugin_013(byte function, struct EventStruct *event, String& string)
 float Plugin_013_read(unsigned int taskIndex)
 /*********************************************************************/
 {
-  if (P_013_sensordefs.count(taskIndex) == 0) return 0;
+  if (P_013_sensordefs.count(taskIndex) == 0)
+    return 0;
 
   int16_t max_distance = Settings.TaskDevicePluginConfig[taskIndex][2];
-  int16_t choiceUnit = Settings.TaskDevicePluginConfig[taskIndex][3];
-  int16_t choiceFilter = Settings.TaskDevicePluginConfig[taskIndex][4];
+  int16_t measuringUnit = Settings.TaskDevicePluginConfig[taskIndex][3];
+  int16_t filterType = Settings.TaskDevicePluginConfig[taskIndex][4];
   int16_t filterSize = Settings.TaskDevicePluginConfig[taskIndex][5];
-  int16_t max_distance_cm = (choiceUnit == 1) ? max_distance : (float)max_distance * 2.54f;
+  int16_t max_distance_cm = (measuringUnit == UNIT_CM) ? max_distance : (float)max_distance * 2.54f;
 
-  unsigned int distance = 0;
+  unsigned int echoTime = 0;
 
-  switch  (choiceFilter) {
-    case 1:
-      distance = (P_013_sensordefs[taskIndex])->ping();
+  switch  (filterType) {
+    case FILTER_NONE:
+      echoTime = (P_013_sensordefs[taskIndex])->ping();
       break;
-    case 2:
-      distance = (P_013_sensordefs[taskIndex])->ping_median(filterSize, max_distance_cm);
+    case FILTER_MEDIAN:
+      echoTime = (P_013_sensordefs[taskIndex])->ping_median(filterSize, max_distance_cm);
       break;
     default:
       addLog(LOG_LEVEL_INFO, F("invalid Filter Type setting!"));
   }
 
-  if (choiceUnit == 1)
-    return NewPingESP8266::convert_cm_F(distance);
+  if (measuringUnit == UNIT_CM)
+    return NewPingESP8266::convert_cm_F(echoTime);
   else
-    return NewPingESP8266::convert_in_F(distance);
+    return NewPingESP8266::convert_in_F(echoTime);
 }
 
 /*********************************************************************/

--- a/src/_P013_HCSR04.ino
+++ b/src/_P013_HCSR04.ino
@@ -230,7 +230,6 @@ boolean Plugin_013(byte function, struct EventStruct *event, String& string)
       {
         int16_t operatingMode = Settings.TaskDevicePluginConfig[event->TaskIndex][0];
         int16_t threshold = Settings.TaskDevicePluginConfig[event->TaskIndex][1];
-        int16_t measuringUnit = Settings.TaskDevicePluginConfig[event->TaskIndex][3];
 
         if (operatingMode == OPMODE_STATE)
         {

--- a/src/_P013_HCSR04.ino
+++ b/src/_P013_HCSR04.ino
@@ -125,9 +125,11 @@ boolean Plugin_013(byte function, struct EventStruct *event, String& string)
         int16_t choiceFilter = Settings.TaskDevicePluginConfig[event->TaskIndex][4];
         int16_t filterSize = Settings.TaskDevicePluginConfig[event->TaskIndex][5];
 
+        int16_t max_distance_cm = (choiceUnit == 1) ? max_distance : (float)max_distance * 2.54f;
+
         P_013_sensordefs.erase(event->TaskIndex);
         P_013_sensordefs[event->TaskIndex] =
-          std::shared_ptr<NewPingESP8266> (new NewPingESP8266(Plugin_013_TRIG_Pin, Plugin_013_IRQ_Pin, max_distance));
+          std::shared_ptr<NewPingESP8266> (new NewPingESP8266(Plugin_013_TRIG_Pin, Plugin_013_IRQ_Pin, max_distance_cm));
 
         String log = F("ULTRASONIC : TaskNr: ");
         log += event->TaskIndex +1;
@@ -181,12 +183,14 @@ boolean Plugin_013(byte function, struct EventStruct *event, String& string)
       {
         if (Settings.TaskDevicePluginConfig[event->TaskIndex][0] == 1)
         {
+          int16_t choiceUnit = Settings.TaskDevicePluginConfig[event->TaskIndex][3];
           float value = Plugin_013_read(event->TaskIndex);
           String log = F("ULTRASONIC : TaskNr: ");
           log += event->TaskIndex +1;
           log += F(" Distance: ");
           UserVar[event->BaseVarIndex] = value;
           log += UserVar[event->BaseVarIndex];
+          log += (choiceUnit == 1) ? F(" cm ") : F(" inch ");
           if (value == 0)
           {
              log += F(" Error: ");
@@ -244,10 +248,11 @@ float Plugin_013_read(unsigned int taskIndex)
 {
   if (P_013_sensordefs.count(taskIndex) == 0) return 0;
 
-  int16_t max_cm_distance = Settings.TaskDevicePluginConfig[taskIndex][2];
+  int16_t max_distance = Settings.TaskDevicePluginConfig[taskIndex][2];
   int16_t choiceUnit = Settings.TaskDevicePluginConfig[taskIndex][3];
   int16_t choiceFilter = Settings.TaskDevicePluginConfig[taskIndex][4];
   int16_t filterSize = Settings.TaskDevicePluginConfig[taskIndex][5];
+  int16_t max_distance_cm = (choiceUnit == 1) ? max_distance : (float)max_distance * 2.54f;
 
   unsigned int distance = 0;
 
@@ -256,7 +261,7 @@ float Plugin_013_read(unsigned int taskIndex)
       distance = (P_013_sensordefs[taskIndex])->ping();
       break;
     case 2:
-      distance = (P_013_sensordefs[taskIndex])->ping_median(filterSize, max_cm_distance);
+      distance = (P_013_sensordefs[taskIndex])->ping_median(filterSize, max_distance_cm);
       break;
     default:
       addLog(LOG_LEVEL_INFO, F("invalid Filter Type setting!"));


### PR DESCRIPTION
there were several errors that all resulted in a distance value reading of 0. Added an errorState that is printed to the log and helps troubleshooting.
Max. Distance checking can be turned off by setting max distance to 0 cm. If max. distance is used, exceeding the range will return a distance of 0 cm and print this to the log.