### PR TITLE
[Stack] Move Arduino stack back to top of System stack instead of overlap

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -101,7 +101,9 @@ monitor_speed             = 115200
 ;  -DVTABLES_IN_DRAM
 ; VTABLES in IRAM
 ;  -DVTABLES_IN_IRAM
-
+; NO_EXTRA_4K_HEAP - this forces the default NONOS-SDK user's heap location
+;     Default currently overlaps cont stack (Arduino) with sys stack (System)
+;     to save up-to 4 kB of heap.
 
 [common]
 board_build.f_cpu         = 80000000L
@@ -126,12 +128,15 @@ monitor_speed             = 115200
 
 [normal]
 platform                  = ${common.platform}
+build_flags               = -DNO_EXTRA_4K_HEAP
 
 [testing]
 platform                  = ${core_2_4_2.platform}
+build_flags               = -DNO_EXTRA_4K_HEAP -DPLUGIN_BUILD_TESTING
 
 [dev]
 platform                  = ${core_2_4_2.platform}
+build_flags               = -DNO_EXTRA_4K_HEAP -DPLUGIN_BUILD_DEV
 
 [ir]
 lib_ignore                = ESP32_ping, ESP32WebServer
@@ -242,7 +247,7 @@ board_upload.maximum_size = ${esp8266_1M.board_upload.maximum_size}
 board_build.f_cpu         = ${esp8266_1M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
 build_unflags             = ${esp8266_1M.build_unflags}
-build_flags               = ${esp8266_1M.build_flags}
+build_flags               = ${esp8266_1M.build_flags} ${normal.build_flags}
 
 ; NORMAL: 1024k for esp8285 ----------------------
 [env:normal_ESP8285_1024]
@@ -259,7 +264,7 @@ board_upload.maximum_size = ${esp8285_1M.board_upload.maximum_size}
 board_build.f_cpu         = ${esp8285_1M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8285_1M.board_build.flash_mode}
 build_unflags             = ${esp8285_1M.build_unflags}
-build_flags               = ${esp8285_1M.build_flags}
+build_flags               = ${esp8285_1M.build_flags} ${normal.build_flags}
 
 ; NORMAL: 2048k version --------------------------
 [env:normal_WROOM02_2048]
@@ -275,7 +280,7 @@ board                     = ${espWroom2M.board}
 board_build.f_cpu         = ${espWroom2M.board_build.f_cpu}
 board_build.flash_mode    = ${espWroom2M.board_build.flash_mode}
 build_unflags             = ${espWroom2M.build_unflags}
-build_flags               = ${espWroom2M.build_flags}
+build_flags               = ${espWroom2M.build_flags} ${normal.build_flags}
 
 ; NORMAL: 4096k version --------------------------
 [env:normal_ESP8266_4096]
@@ -291,7 +296,7 @@ board                     = ${common.board}
 board_build.f_cpu         = ${esp8266_4M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_4M.board_build.flash_mode}
 build_unflags             = ${esp8266_4M.build_unflags}
-build_flags               = ${esp8266_4M.build_flags}
+build_flags               = ${esp8266_4M.build_flags} ${normal.build_flags}
 
 
 ; NORMAL IR: 4096k version --------------------------
@@ -309,7 +314,7 @@ board                     = ${common.board}
 board_build.f_cpu         = ${esp8266_4M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_4M.board_build.flash_mode}
 build_unflags             = ${esp8266_4M.build_unflags}
-build_flags               = ${esp8266_4M.build_flags} -DPLUGIN_BUILD_NORMAL_IR
+build_flags               = ${esp8266_4M.build_flags} ${normal.build_flags} -DPLUGIN_BUILD_NORMAL_IR
 
 
 ;;; TESTING ; ****; ****; ****; ****; ****; ****; ****; ****; ****; ****; ****; ****; ****
@@ -331,7 +336,7 @@ board_upload.maximum_size = ${esp8266_1M.board_upload.maximum_size}
 board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
 board_build.f_cpu         = ${esp8266_1M.board_build.f_cpu}
 build_unflags             = ${esp8266_1M.build_unflags}
-build_flags               = ${esp8266_1M.build_flags} -D PLUGIN_BUILD_TESTING
+build_flags               = ${esp8266_1M.build_flags} ${testing.build_flags}
 
 ; TEST: 1024k for esp8285 ------------------------
 [env:test_ESP8285_1024]
@@ -348,7 +353,7 @@ board_build.f_cpu         = ${esp8285_1M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8285_1M.board_build.flash_mode}
 board                     = ${esp8285_1M.board}
 build_unflags             = ${esp8285_1M.build_unflags}
-build_flags               = ${esp8285_1M.build_flags} -D PLUGIN_BUILD_TESTING
+build_flags               = ${esp8285_1M.build_flags} ${testing.build_flags}
 
 ; TEST: 2048k version ----------------------------
 [env:test_WROOM02_2048]
@@ -364,7 +369,7 @@ board_build.f_cpu         = ${espWroom2M.board_build.f_cpu}
 board_build.flash_mode    = ${espWroom2M.board_build.flash_mode}
 board                     = ${espWroom2M.board}
 build_unflags             = ${espWroom2M.build_unflags}
-build_flags               = ${espWroom2M.build_flags} -D PLUGIN_BUILD_TESTING
+build_flags               = ${espWroom2M.build_flags} ${testing.build_flags}
 
 ; TEST: 4096k version ----------------------------
 [env:test_ESP8266_4096]
@@ -380,7 +385,7 @@ monitor_speed             = ${common.monitor_speed}
 board_build.f_cpu         = ${esp8266_4M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_4M.board_build.flash_mode}
 build_unflags             = ${esp8266_4M.build_unflags}
-build_flags               = ${esp8266_4M.build_flags} -D PLUGIN_BUILD_TESTING
+build_flags               = ${esp8266_4M.build_flags} ${testing.build_flags}
 
 ; TEST: 4096k version + FEATURE_ADC_VCC ----------
 [env:test_ESP8266_4096_VCC]
@@ -396,7 +401,7 @@ monitor_speed             = ${common.monitor_speed}
 board_build.f_cpu         = ${esp8266_4M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_4M.board_build.flash_mode}
 build_unflags             = ${esp8266_4M.build_unflags}
-build_flags               = ${esp8266_4M.build_flags} -D PLUGIN_BUILD_TESTING -D FEATURE_ADC_VCC=true
+build_flags               = ${esp8266_4M.build_flags} ${testing.build_flags} -D FEATURE_ADC_VCC=true
 
 
 
@@ -419,7 +424,7 @@ board_build.f_cpu         = ${esp8266_1M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
 board                     = ${common.board}
 build_unflags             = ${esp8266_1M.build_unflags}
-build_flags               = ${esp8266_1M.build_flags} -D PLUGIN_BUILD_DEV
+build_flags               = ${esp8266_1M.build_flags} ${dev.build_flags}
 
 ; DEV: 1024k for esp8285 -------------------------
 [env:dev_ESP8285_1024]
@@ -436,7 +441,7 @@ board_build.f_cpu         = ${esp8285_1M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8285_1M.board_build.flash_mode}
 board                     = ${esp8285_1M.board}
 build_unflags             = ${esp8285_1M.build_unflags}
-build_flags               = ${esp8285_1M.build_flags} -D PLUGIN_BUILD_DEV
+build_flags               = ${esp8285_1M.build_flags} ${dev.build_flags}
 
 ; DEV: 2048k version -----------------------------
 [env:dev_WROOM02_2048]
@@ -452,7 +457,7 @@ board_build.f_cpu         = ${espWroom2M.board_build.f_cpu}
 board_build.flash_mode    = ${espWroom2M.board_build.flash_mode}
 board                     = ${espWroom2M.board}
 build_unflags             = ${espWroom2M.build_unflags}
-build_flags               = ${espWroom2M.build_flags} -D PLUGIN_BUILD_DEV
+build_flags               = ${espWroom2M.build_flags} ${dev.build_flags}
 
 ; DEV : 4096k version ----------------------------
 [env:dev_ESP8266_4096]
@@ -468,7 +473,7 @@ monitor_speed             = ${common.monitor_speed}
 board_build.f_cpu         = ${esp8266_4M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_4M.board_build.flash_mode}
 build_unflags             = ${esp8266_4M.build_unflags}
-build_flags               = ${esp8266_4M.build_flags} -D PLUGIN_BUILD_DEV
+build_flags               = ${esp8266_4M.build_flags} ${dev.build_flags}
 
 
 
@@ -491,7 +496,7 @@ board_upload.maximum_size = ${esp8266_1M.board_upload.maximum_size}
 board_build.f_cpu         = ${esp8266_1M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
 build_unflags             = ${esp8266_1M.build_unflags}
-build_flags               = ${esp8266_1M.build_flags} -D PLUGIN_BUILD_DEV -D FLASH_QUIRK_WRITE_0_TO_1
+build_flags               = ${esp8266_1M.build_flags} ${dev.build_flags} -D FLASH_QUIRK_WRITE_0_TO_1
 
 ; DEV+PUYA : 1024k version + FEATURE_ADC_VCC -----
 [env:dev_ESP8266PUYA_1024_VCC]
@@ -508,7 +513,7 @@ board_upload.maximum_size = ${esp8266_1M.board_upload.maximum_size}
 board_build.f_cpu         = ${esp8266_1M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
 build_unflags             = ${esp8266_1M.build_unflags}
-build_flags               = ${esp8266_1M.build_flags} -D PLUGIN_BUILD_DEV -D FLASH_QUIRK_WRITE_0_TO_1 -D FEATURE_ADC_VCC=true
+build_flags               = ${esp8266_1M.build_flags} ${dev.build_flags} -D FLASH_QUIRK_WRITE_0_TO_1 -D FEATURE_ADC_VCC=true
 
 
 

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -880,10 +880,11 @@ struct SettingsStruct
   // Try to extend settings to make the checksum 4-byte aligned.
 //  uint8_t       ProgmemMd5[16]; // crc of the binary that last saved the struct to file.
 //  uint8_t       md5[16];
-};
-
+} Settings;
+/*
 SettingsStruct* SettingsStruct_ptr = new SettingsStruct;
 SettingsStruct& Settings = *SettingsStruct_ptr;
+*/
 
 /*********************************************************************************************\
  * ControllerSettingsStruct

--- a/src/ESPEasyStorage.ino
+++ b/src/ESPEasyStorage.ino
@@ -535,6 +535,15 @@ String InitFile(const char* fname, int datasize)
   \*********************************************************************************************/
 String SaveToFile(char* fname, int index, byte* memAddress, int datasize)
 {
+#ifndef ESP32
+  if (allocatedOnStack(memAddress)) {
+    String log = F("SaveToFile: ");
+    log += fname;
+    log += F(" ERROR, Data allocated on stack");
+    addLog(LOG_LEVEL_ERROR, log);
+//    return log;  // FIXME TD-er: Should this be considered a breaking error?
+  }
+#endif
   if (index < 0) {
     String log = F("SaveToFile: ");
     log += fname;

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -33,6 +33,13 @@ uint32_t getFreeStackWatermark() {
   return cont_get_free_stack(&g_cont);
 }
 
+bool allocatedOnStack(const void* address) {
+  register uint32_t *sp asm("a1");
+  if (sp < address) return false;
+  return g_cont.stack < address;
+}
+
+
 #else
 // All version from core 2.4.2
 // See: https://github.com/esp8266/Arduino/pull/5018
@@ -50,6 +57,12 @@ uint32_t getCurrentFreeStack() {
 
 uint32_t getFreeStackWatermark() {
   return cont_get_free_stack(g_pcont);
+}
+
+bool allocatedOnStack(const void* address) {
+  register uint32_t *sp asm("a1");
+  if (sp < address) return false;
+  return g_pcont->stack < address;
 }
 
 #endif // ARDUINO_ESP8266_RELEASE_2_x_x


### PR DESCRIPTION
No longer allow an overlap between the two stacks.
