### PR TITLE
[Schedule Commands] Only schedule commands not running Arduino stack

### DIFF
--- a/src/Command.ino
+++ b/src/Command.ino
@@ -222,14 +222,14 @@ void ExecuteCommand(byte source, const char *Line)
 	if (GetArgv(Line, TmpStr1, 5)) TempEvent.Par4 = CalculateParam(TmpStr1);
 	if (GetArgv(Line, TmpStr1, 6)) TempEvent.Par5 = CalculateParam(TmpStr1);
 
-  if (source == VALUE_SOURCE_WEB_FRONTEND) {
-    // Must run immediately, to see result in web frontend
+  if (canYield()) {
+    // Is executed in Arduino stack.
     String status = doExecuteCommand((char*)&cmd[0], &TempEvent, Line);
     yield();
     SendStatus(source, status);
     yield();
   } else {
-    // Schedule to run async
+    // Schedule to run async, which will be executed in Arduino stack space.
     schedule_command_timer((char*)&cmd[0], &TempEvent, Line);
   }
 }

--- a/src/_CPlugin_Helper.h
+++ b/src/_CPlugin_Helper.h
@@ -382,8 +382,9 @@ bool safeReadStringUntil(Stream &input, String &str, char terminator, unsigned i
 	int c;
   const unsigned long start = millis();
 	const unsigned long timer = start + timeout;
-  unsigned long backgroundtasks_timer = start + 100;
+  unsigned long backgroundtasks_timer = start + 10;
 	str = "";
+  input.setTimeout(100);
 
 	do {
 		//read character
@@ -405,7 +406,7 @@ bool safeReadStringUntil(Stream &input, String &str, char terminator, unsigned i
 		}
     // We must run the backgroundtasks every now and then.
     if (timeOutReached(backgroundtasks_timer)) {
-      backgroundtasks_timer += 100;
+      backgroundtasks_timer += 10;
       backgroundtasks();
     } else {
       yield();
@@ -613,8 +614,10 @@ bool send_via_http(const String& logIdentifier, WiFiClient& client, const String
   client.print(postStr);
 
   unsigned long timer = millis() + 200;
-  while (!client.available() && !timeOutReached(timer))
+  while (!client.available()) {
+    if (timeOutReached(timer)) return false;
     delay(1);
+  }
 
   // Read all the lines of the reply from server and print them to Serial
   while (client_available(client) && !success) {


### PR DESCRIPTION
Since command scheduling may be calling `yield`, move commands to the queue only when called from a callback function.