### PR TITLE
[#1830] WiFi client timeout & back to core 2.4.1

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -106,7 +106,7 @@ monitor_speed             = 115200
 ;  -DVTABLES_IN_IRAM
 ; NO_EXTRA_4K_HEAP - this forces the default NONOS-SDK user's heap location
 ;     Default currently overlaps cont stack (Arduino) with sys stack (System)
-;     to save up-to 4 kB of heap.
+;     to save up-to 4 kB of heap. (starting core_2.4.2)
 ; CONT_STACKSIZE to set the 'cont' (Arduino) stack size. Default = 4096
 
 [common]
@@ -126,19 +126,19 @@ lib_archive               = false
 upload_speed              = 460800
 framework                 = arduino
 board                     = esp12e
-platform                  = ${core_2_4_2.platform}
+platform                  = ${core_2_4_1.platform}
 monitor_speed             = 115200
 
 [normal]
 platform                  = ${common.platform}
-build_flags               = -DNO_EXTRA_4K_HEAP -DCONT_STACKSIZE=5120
+build_flags               = -DNO_EXTRA_4K_HEAP
 
 [testing]
-platform                  = ${core_2_4_2.platform}
+platform                  = ${core_2_4_1.platform}
 build_flags               = -DNO_EXTRA_4K_HEAP -DPLUGIN_BUILD_TESTING
 
 [dev]
-platform                  = ${core_2_4_2.platform}
+platform                  = ${core_2_4_1.platform}
 build_flags               = -DNO_EXTRA_4K_HEAP -DPLUGIN_BUILD_DEV
 
 [ir]
@@ -167,7 +167,7 @@ board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
 board_build.f_cpu         = ${esp8266_1M.board_build.f_cpu}
 build_unflags             = ${common.build_unflags}
 build_flags               = ${common.build_flags} -Wl,-Tesp8266.flash.1m128.ld
-platform                  = ${core_2_4_2.platform}
+platform                  = ${core_2_4_1.platform}
 
 [Sonoff_8285]
 board_upload.maximum_size = ${esp8285_1M.board_upload.maximum_size}
@@ -176,7 +176,7 @@ board_build.f_cpu         = ${esp8285_1M.board_build.f_cpu}
 board                     = ${esp8285_1M.board}
 build_unflags             = ${esp8285_1M.build_unflags}
 build_flags               = ${esp8285_1M.build_flags}
-platform                  = ${core_2_4_2.platform}
+platform                  = ${core_2_4_1.platform}
 
 [espWroom2M]
 board_build.flash_mode    = dout

--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -141,6 +141,7 @@ bool MQTTConnect(int controller_idx)
     updateMQTTclient_connected();
   }
   mqtt = WiFiClient(); // workaround see: https://github.com/esp8266/Arduino/issues/4497#issuecomment-373023864
+  mqtt.setTimeout(ControllerSettings.ClientTimeout);
   if (ControllerSettings.UseDNS) {
     MQTTclient.setServer(ControllerSettings.getHost().c_str(), ControllerSettings.Port);
   } else {

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -226,6 +226,9 @@
 // N.B. Retries without a connection to wifi do not count as retry.
 #define CONTROLLER_DELAY_QUEUE_RETRY_MAX   10
 #define CONTROLLER_DELAY_QUEUE_RETRY_DFLT  10
+// Timeout of the client in msec.
+#define CONTROLLER_CLIENTTIMEOUT_MAX 1000
+#define CONTROLLER_CLIENTTIMEOUT_DFLT 100
 
 
 #define PLUGIN_INIT_ALL                     1
@@ -895,7 +898,7 @@ SettingsStruct& Settings = *SettingsStruct_ptr;
 struct ControllerSettingsStruct
 {
   ControllerSettingsStruct() : UseDNS(false), Port(0),
-      MinimalTimeBetweenMessages(100), MaxQueueDepth(10), MaxRetry(10), DeleteOldest(false) {
+      MinimalTimeBetweenMessages(100), MaxQueueDepth(10), MaxRetry(10), DeleteOldest(false), ClientTimeout(100) {
     for (byte i = 0; i < 4; ++i) {
       IP[i] = 0;
     }
@@ -919,13 +922,16 @@ struct ControllerSettingsStruct
   unsigned int  MaxQueueDepth;
   unsigned int  MaxRetry;
   boolean       DeleteOldest; // Action to perform when buffer full, delete oldest, or ignore newest.
+  unsigned int  ClientTimeout;
 
   void validate() {
     if (Port > 65535) Port = 0;
-    if (MinimalTimeBetweenMessages < 1) MinimalTimeBetweenMessages = 100;
-    if (MinimalTimeBetweenMessages > 3600000) MinimalTimeBetweenMessages = 100;
-    if (MaxQueueDepth > 25) MaxQueueDepth = 10;
-    if (MaxRetry > 10) MaxRetry = 10;
+    if (MinimalTimeBetweenMessages < 1  ||  MinimalTimeBetweenMessages > CONTROLLER_DELAY_QUEUE_DELAY_MAX)
+      MinimalTimeBetweenMessages = CONTROLLER_DELAY_QUEUE_DELAY_DFLT;
+    if (MaxQueueDepth > CONTROLLER_DELAY_QUEUE_DEPTH_MAX) MaxQueueDepth = CONTROLLER_DELAY_QUEUE_DEPTH_DFLT;
+    if (MaxRetry > CONTROLLER_DELAY_QUEUE_RETRY_MAX) MaxRetry = CONTROLLER_DELAY_QUEUE_RETRY_MAX;
+    if (ClientTimeout < 10 || ClientTimeout > CONTROLLER_CLIENTTIMEOUT_MAX)
+      ClientTimeout = CONTROLLER_CLIENTTIMEOUT_DFLT;
   }
 
   IPAddress getIP() const {

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -1183,6 +1183,7 @@ void handle_controllers() {
   const int maxqueuedepth = getFormItemInt(F("maxqueuedepth"), 10);
   const int maxretry = getFormItemInt(F("maxretry"), 10);
   String deleteoldest = WebServer.arg(F("deleteoldest"));
+  const int clienttimeout = getFormItemInt(F("clienttimeout"), CONTROLLER_CLIENTTIMEOUT_DFLT);
 
 
   //submitted data
@@ -1201,7 +1202,8 @@ void handle_controllers() {
         //reset (some) default-settings
         byte ProtocolIndex = getProtocolIndex(Settings.Protocol[controllerindex]);
         ControllerSettings.Port = Protocol[ProtocolIndex].defaultPort;
-        ControllerSettings.MinimalTimeBetweenMessages = 100;
+        ControllerSettings.MinimalTimeBetweenMessages = CONTROLLER_DELAY_QUEUE_DELAY_DFLT;
+        ControllerSettings.ClientTimeout = CONTROLLER_CLIENTTIMEOUT_DFLT;
 //        ControllerSettings.MaxQueueDepth = 0;
         if (Protocol[ProtocolIndex].usesTemplate)
           CPlugin_ptr[ProtocolIndex](CPLUGIN_PROTOCOL_TEMPLATE, &TempEvent, dummyString);
@@ -1266,6 +1268,7 @@ void handle_controllers() {
         ControllerSettings.MaxQueueDepth = maxqueuedepth;
         ControllerSettings.MaxRetry = maxretry;
         ControllerSettings.DeleteOldest = deleteoldest.toInt();
+        ControllerSettings.ClientTimeout = clienttimeout;
 
 
         CPlugin_ptr[ProtocolIndex](CPLUGIN_INIT, &TempEvent, dummyString);
@@ -1373,6 +1376,8 @@ void handle_controllers() {
         addFormNumericBox( F("Max Queue Depth"), F("maxqueuedepth"), ControllerSettings.MaxQueueDepth, 1, CONTROLLER_DELAY_QUEUE_DEPTH_MAX);
         addFormNumericBox( F("Max Retries"), F("maxretry"), ControllerSettings.MaxRetry, 1, CONTROLLER_DELAY_QUEUE_RETRY_MAX);
         addFormSelector(F("Full Queue Action"), F("deleteoldest"), 2, options_delete_oldest, NULL, NULL, choice_delete_oldest, true);
+        addFormNumericBox( F("Client Timeout"), F("clienttimeout"), ControllerSettings.ClientTimeout, 10, CONTROLLER_CLIENTTIMEOUT_MAX);
+        addUnit(F("ms"));
 
 
         if (Protocol[ProtocolIndex].usesAccount)

--- a/src/_CPlugin_Helper.h
+++ b/src/_CPlugin_Helper.h
@@ -384,7 +384,6 @@ bool safeReadStringUntil(Stream &input, String &str, char terminator, unsigned i
 	const unsigned long timer = start + timeout;
   unsigned long backgroundtasks_timer = start + 10;
 	str = "";
-  input.setTimeout(100);
 
 	do {
 		//read character
@@ -585,6 +584,7 @@ bool count_connection_results(bool success, const String& prefix, int controller
 }
 
 bool try_connect_host(int controller_number, WiFiUDP& client, ControllerSettingsStruct& ControllerSettings) {
+  client.setTimeout(ControllerSettings.ClientTimeout);
   log_connecting_to(F("UDP  : "), controller_number, ControllerSettings);
   bool success = ControllerSettings.beginPacket(client) != 0;
   return count_connection_results(
@@ -594,6 +594,7 @@ bool try_connect_host(int controller_number, WiFiUDP& client, ControllerSettings
 
 bool try_connect_host(int controller_number, WiFiClient& client, ControllerSettingsStruct& ControllerSettings) {
   // Use WiFiClient class to create TCP connections
+  client.setTimeout(ControllerSettings.ClientTimeout);
   log_connecting_to(F("HTTP : "), controller_number, ControllerSettings);
   bool success = ControllerSettings.connectToHost(client);
   return count_connection_results(

--- a/src/_CPlugin_Helper.h
+++ b/src/_CPlugin_Helper.h
@@ -382,8 +382,9 @@ bool safeReadStringUntil(Stream &input, String &str, char terminator, unsigned i
 	int c;
   const unsigned long start = millis();
 	const unsigned long timer = start + timeout;
-  unsigned long backgroundtasks_timer = start + 100;
+  unsigned long backgroundtasks_timer = start + 10;
 	str = "";
+  input.setTimeout(100);
 
 	do {
 		//read character
@@ -405,7 +406,7 @@ bool safeReadStringUntil(Stream &input, String &str, char terminator, unsigned i
 		}
     // We must run the backgroundtasks every now and then.
     if (timeOutReached(backgroundtasks_timer)) {
-      backgroundtasks_timer += 100;
+      backgroundtasks_timer += 10;
       backgroundtasks();
     } else {
       yield();
@@ -613,8 +614,10 @@ bool send_via_http(const String& logIdentifier, WiFiClient& client, const String
   client.print(postStr);
 
   unsigned long timer = millis() + 200;
-  while (!client.available() && !timeOutReached(timer))
+  while (!client.available()) {
+    if (timeOutReached(timer)) return false;
     delay(1);
+  }
 
   // Read all the lines of the reply from server and print them to Serial
   while (client_available(client) && !success) {

--- a/src/_N001_Email.ino
+++ b/src/_N001_Email.ino
@@ -73,6 +73,7 @@ boolean NPlugin_001_send(const NotificationSettingsStruct& notificationsettings,
 
 	// Use WiFiClient class to create TCP connections
 	WiFiClient client;
+	client.setTimeout(CONTROLLER_CLIENTTIMEOUT_DFLT);
 	String aHost = notificationsettings.Server;
 	addLog(LOG_LEVEL_DEBUG, String(F("EMAIL: Connecting to ")) + aHost + notificationsettings.Port);
 	if (client.connect(aHost.c_str(), notificationsettings.Port) != 1) {

--- a/src/_P037_MQTTImport.ino
+++ b/src/_P037_MQTTImport.ino
@@ -41,6 +41,7 @@ void Plugin_037_try_connect() {
   if (MQTTclient_037_connected) return;
   // workaround see: https://github.com/esp8266/Arduino/issues/4497#issuecomment-373023864
   espclient_037 = WiFiClient();
+  espclient_037.setTimeout(CONTROLLER_CLIENTTIMEOUT_DFLT);
 
   if (MQTTclient_037 == NULL) {
     MQTTclient_037 = new PubSubClient(espclient_037);
@@ -69,6 +70,7 @@ void Plugin_037_update_connect_status() {
     if (!connected) {
       // workaround see: https://github.com/esp8266/Arduino/issues/4497#issuecomment-373023864
       espclient_037 = WiFiClient();
+      espclient_037.setTimeout(CONTROLLER_CLIENTTIMEOUT_DFLT);
       ++reconnectCount;
       addLog(LOG_LEVEL_ERROR, F("IMPT : MQTT 037 Connection lost"));
     }


### PR DESCRIPTION
The default timeout for wificlient is 1000 msec. This may cause all kind of strange effects when the node is being blocked for so long.

Return to PlatformIO `espressif8266@1.7.3` instead of `espressif8266@1.8.0`
2.4.2 has a lot of improvements like 4k of extra free memory.
But also the number of hardware watchdog reboots has increased a lot and the PWM related code no longer seems to work on 2.4.2
So for now, back to 2.4.1 library.