### PR TITLE
Fix XSS-Vulnerabilites on wifi configuration pages

### DIFF
--- a/src/ESPEasyWifi.ino
+++ b/src/ESPEasyWifi.ino
@@ -678,6 +678,7 @@ void WifiScan()
 
 String formatScanResult(int i, const String& separator) {
   String result = WiFi.SSID(i);
+  htmlEscape(result);
   #ifndef ESP32
   if (WiFi.isHidden(i)) {
     result += F("#Hidden#");

--- a/src/StringConverter.ino
+++ b/src/StringConverter.ino
@@ -375,6 +375,28 @@ void htmlEscape(String & html)
   html.replace(">",  F("&gt;"));
 }
 
+void htmlStrongEscape(String & html)
+{
+  String escaped;
+  for (unsigned i = 0; i < html.length(); ++i)
+  {
+    if ((html[i] >= 'a' && html[i] <= 'z') || (html[i] >= 'A' && html[i] <= 'Z') || (html[i] >= '0' && html[i] <= '9'))
+    {
+      escaped += html[i];
+    }
+    else
+    {
+      char s [4];
+      sprintf(s, "%03d", static_cast<int>(html[i]));
+      escaped += "&#";
+      escaped += s;
+      escaped += ";";
+    }
+  }
+  html = escaped;
+}
+
+
 /********************************************************************************************\
   replace other system variables like %sysname%, %systime%, %ip%
   \*********************************************************************************************/

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -4982,7 +4982,11 @@ void handle_setup() {
       {
         html_TR_TD(); TXBuffer += F("<label class='container2'>");
         TXBuffer += F("<input type='radio' name='ssid' value='");
-        TXBuffer += WiFi.SSID(i);
+        {
+          String escapeBuffer = WiFi.SSID(i);
+          htmlStrongEscape(escapeBuffer);
+          TXBuffer += escapeBuffer;
+        }
         TXBuffer += F("'");
         if (WiFi.SSID(i) == ssid)
           TXBuffer += F(" checked ");


### PR DESCRIPTION
Add escaping of wifi network names that can be discovered using the search functionality of for instance the /setup page. As these names are also used inside an html tag, a stronger html encoding variant has been added. This is necessary because a malicious actor could create a wifi-network using a SSID like "<script>javascript_code</script>". The code will then be executed in the browser of the victim when he vists the /setup page.

As a proof-of-Concept one could create a wifi network using the SSID <script>alert(1)</script>. Visit the initial configuration page. If the network with the above SSID is found the message "1" will be displayed in your browser. 

As for the second XSS vulnerability (which originates in the value="" of the option-button on the configuration page) the SSID '><script>alert(1)</script> has to be used in order to exploit the vulnerability. For cases, in which user-controlled content is used within an attribute of an html tag, the owasp XSS prevetion cheat sheet recommends the stronger encoding (Source: https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet#RULE_.232_-_Attribute_Escape_Before_Inserting_Untrusted_Data_into_HTML_Common_Attributes).