### PR TITLE
[Stack] Increase stack to 5k and reduce stack allocations in rules

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -131,15 +131,15 @@ monitor_speed             = 115200
 
 [normal]
 platform                  = ${common.platform}
-build_flags               = -DNO_EXTRA_4K_HEAP
+build_flags               = -DNO_EXTRA_4K_HEAP -DCONT_STACKSIZE=5120
 
 [testing]
 platform                  = ${core_2_4_1.platform}
-build_flags               = -DNO_EXTRA_4K_HEAP -DPLUGIN_BUILD_TESTING
+build_flags               = -DNO_EXTRA_4K_HEAP -DCONT_STACKSIZE=5120 -DPLUGIN_BUILD_TESTING
 
 [dev]
 platform                  = ${core_2_4_1.platform}
-build_flags               = -DNO_EXTRA_4K_HEAP -DPLUGIN_BUILD_DEV
+build_flags               = -DNO_EXTRA_4K_HEAP -DCONT_STACKSIZE=5120 -DPLUGIN_BUILD_DEV
 
 [ir]
 lib_ignore                = ESP32_ping, ESP32WebServer

--- a/platformio.ini
+++ b/platformio.ini
@@ -131,15 +131,15 @@ monitor_speed             = 115200
 
 [normal]
 platform                  = ${common.platform}
-build_flags               = -DNO_EXTRA_4K_HEAP -DCONT_STACKSIZE=5120
+build_flags               = -DCONT_STACKSIZE=5120
 
 [testing]
 platform                  = ${core_2_4_1.platform}
-build_flags               = -DNO_EXTRA_4K_HEAP -DCONT_STACKSIZE=5120 -DPLUGIN_BUILD_TESTING
+build_flags               = -DCONT_STACKSIZE=5120 -DPLUGIN_BUILD_TESTING
 
 [dev]
 platform                  = ${core_2_4_1.platform}
-build_flags               = -DNO_EXTRA_4K_HEAP -DCONT_STACKSIZE=5120 -DPLUGIN_BUILD_DEV
+build_flags               = -DCONT_STACKSIZE=5120 -DPLUGIN_BUILD_DEV
 
 [ir]
 lib_ignore                = ESP32_ping, ESP32WebServer

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -957,6 +957,7 @@ struct ControllerSettingsStruct
     if (!WiFiConnected(10)) {
       return false; // Not connected, so no use in wasting time to connect to a host.
     }
+    delay(1); // Make sure the Watchdog will not trigger a reset.
     if (quick && ipSet()) return true;
     if (UseDNS) {
       if (!updateIPcache()) {

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -191,6 +191,8 @@
 
 #define MAX_FLASHWRITES_PER_DAY           100 // per 24 hour window
 #define INPUT_COMMAND_SIZE                240 // Affects maximum command length in rules and other commands
+// FIXME TD-er: INPUT_COMMAND_SIZE is also used in commands where simply a check for valid parameter is needed
+// and some may need less memory. (which is stack allocated)
 
 #define NODE_TYPE_ID_ESP_EASY_STD           1
 #define NODE_TYPE_ID_ESP_EASYM_STD         17
@@ -1493,6 +1495,7 @@ unsigned long connectionFailures = 0;
 unsigned long wdcounter = 0;
 unsigned long timerAPoff = 0;
 unsigned long timerAwakeFromDeepSleep = 0;
+unsigned long last_system_event_run = 0;
 
 #if FEATURE_ADC_VCC
 float vcc = -1.0;

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -445,23 +445,19 @@ void delayBackground(unsigned long delay)
 void parseCommandString(struct EventStruct *event, const String& string)
 {
   checkRAM(F("parseCommandString"));
-  char command[INPUT_COMMAND_SIZE];
-  command[0] = 0;
   char TmpStr1[INPUT_COMMAND_SIZE];
   TmpStr1[0] = 0;
-
-  string.toCharArray(command, INPUT_COMMAND_SIZE);
   event->Par1 = 0;
   event->Par2 = 0;
   event->Par3 = 0;
   event->Par4 = 0;
   event->Par5 = 0;
 
-  if (GetArgv(command, TmpStr1, 2)) event->Par1 = CalculateParam(TmpStr1);
-  if (GetArgv(command, TmpStr1, 3)) event->Par2 = CalculateParam(TmpStr1);
-  if (GetArgv(command, TmpStr1, 4)) event->Par3 = CalculateParam(TmpStr1);
-  if (GetArgv(command, TmpStr1, 5)) event->Par4 = CalculateParam(TmpStr1);
-  if (GetArgv(command, TmpStr1, 6)) event->Par5 = CalculateParam(TmpStr1);
+  if (GetArgv(string.c_str(), TmpStr1, 2)) { event->Par1 = CalculateParam(TmpStr1); }
+  if (GetArgv(string.c_str(), TmpStr1, 3)) { event->Par2 = CalculateParam(TmpStr1); }
+  if (GetArgv(string.c_str(), TmpStr1, 4)) { event->Par3 = CalculateParam(TmpStr1); }
+  if (GetArgv(string.c_str(), TmpStr1, 5)) { event->Par4 = CalculateParam(TmpStr1); }
+  if (GetArgv(string.c_str(), TmpStr1, 6)) { event->Par5 = CalculateParam(TmpStr1); }
 }
 
 /********************************************************************************************\
@@ -572,15 +568,18 @@ boolean GetArgv(const char *string, char *argv, unsigned int argc) {
 
 boolean GetArgv(const char *string, char *argv, unsigned int argv_size, unsigned int argc)
 {
+  size_t string_len = strlen(string);
   unsigned int string_pos = 0, argv_pos = 0, argc_pos = 0;
   char c, d;
   boolean parenthesis = false;
   char matching_parenthesis = '"';
 
-  while (string_pos < strlen(string))
+  while (string_pos < string_len)
   {
     c = string[string_pos];
-    d = string[string_pos + 1];
+    d = 0;
+    if ((string_pos + 1) < string_len)
+      d = string[string_pos + 1];
 
     if       (!parenthesis && c == ' ' && d == ' ') {}
     else if  (!parenthesis && c == ' ' && d == ',') {}
@@ -2504,19 +2503,16 @@ void processMatchedRule(
       {
         String tmpString = event.substring(equalsPos + 1);
 
-        char command[INPUT_COMMAND_SIZE];
-        command[0] = 0;
         char tmpParam[INPUT_COMMAND_SIZE];
         tmpParam[0] = 0;
-        tmpString.toCharArray(command, INPUT_COMMAND_SIZE);
 
-        if (GetArgv(command,tmpParam,1)) {
+        if (GetArgv(tmpString.c_str(),tmpParam,1)) {
            action.replace(F("%eventvalue%"), tmpParam); // for compatibility issues
            action.replace(F("%eventvalue1%"), tmpParam); // substitute %eventvalue1% in actions with the actual value from the event
         }
-        if (GetArgv(command,tmpParam,2)) action.replace(F("%eventvalue2%"), tmpParam); // substitute %eventvalue2% in actions with the actual value from the event
-        if (GetArgv(command,tmpParam,3)) action.replace(F("%eventvalue3%"), tmpParam); // substitute %eventvalue3% in actions with the actual value from the event
-        if (GetArgv(command,tmpParam,4)) action.replace(F("%eventvalue4%"), tmpParam); // substitute %eventvalue4% in actions with the actual value from the event
+        if (GetArgv(tmpString.c_str(),tmpParam,2)) action.replace(F("%eventvalue2%"), tmpParam); // substitute %eventvalue2% in actions with the actual value from the event
+        if (GetArgv(tmpString.c_str(),tmpParam,3)) action.replace(F("%eventvalue3%"), tmpParam); // substitute %eventvalue3% in actions with the actual value from the event
+        if (GetArgv(tmpString.c_str(),tmpParam,4)) action.replace(F("%eventvalue4%"), tmpParam); // substitute %eventvalue4% in actions with the actual value from the event
       }
     }
 

--- a/src/Scheduler.ino
+++ b/src/Scheduler.ino
@@ -41,18 +41,25 @@ unsigned long getMixedId(unsigned long timerType, unsigned long id) {
 \*********************************************************************************************/
 void handle_schedule() {
   unsigned long timer;
-  const unsigned long mixed_id = msecTimerHandler.getNextId(timer);
+  unsigned long mixed_id = 0;
+  if (timePassedSince(last_system_event_run) < 500) {
+    // Make sure system event queue will be looked at every now and then.
+    mixed_id = msecTimerHandler.getNextId(timer);
+  }
   if (mixed_id == 0) {
     // No id ready to run right now.
     // Events are not that important to run immediately.
     // Make sure normal scheduled jobs run at higher priority.
     backgroundtasks();
     process_system_event_queue();
+    last_system_event_run = millis();
     return;
   }
   const unsigned long timerType = (mixed_id >> TIMER_ID_SHIFT);
   const unsigned long mask = (1 << TIMER_ID_SHIFT) -1;
   const unsigned long id = mixed_id & mask;
+
+  yield(); // See: https://github.com/letscontrolit/ESPEasy/issues/1818#issuecomment-425351328
 
   switch (timerType) {
     case CONST_INTERVAL_TIMER:


### PR DESCRIPTION
Removed some unneeded stack allocations of 240 bytes in the rules processing.

Also gave the `process_system_event_queue()` a bit more priority to make sure it will be looked at at least once every 500 msec.