### PR TITLE
[Docs] Disable travis_terminate for now

### DIFF
--- a/before_deploy
+++ b/before_deploy
@@ -35,7 +35,8 @@ done
 
 
 #create a source structure that is the same as the original ESPEasy project (and works with the howto on the wiki)
-rm -rf dist/* 2>/dev/null
+rm -rf dist/Source 2>/dev/null
+rm -rf dist/Docs 2>/dev/null
 
 mkdir -p dist/Source
 mkdir -p dist/Docs

--- a/preflight.sh
+++ b/preflight.sh
@@ -15,22 +15,22 @@ DOCUMENTATION_CHANGED=False
 for CHANGED_FILE in $CHANGED_FILES; do
   if ! [[ $CHANGED_FILE =~ $MD || $CHANGED_FILE =~ $DOCS ]]; then
     ONLY_READMES=False
-    break
+#    break
   else
     DOCUMENTATION_CHANGED=True
   fi
 done
 
-if [[ $ONLY_READMES == True ]]; then
-  echo "Only documentation files found, exiting."
-  travis_terminate 0
-  exit 1
-else
-  echo "Non-documentation files found, continuing with build."
-fi
+#if [[ $ONLY_READMES == True ]]; then
+#  echo "Only documentation files found, exiting."
+#  travis_terminate 0
+#  exit 1
+#else
+#  echo "Non-documentation files found, continuing with build."
+#fi
 
 if [[ $DOCUMENTATION_CHANGED == True ]]; then
   echo "Generate documentation."
   cd docs
-  ./make html
+  make html
 fi


### PR DESCRIPTION
Apparently `travis_terminate` does not exist anymore as a command to stop the script without failing.