### PR TITLE
DEBOUNCE, DOUBLECLICK and LONGPRESS events for PLUGIN001

### DIFF
--- a/src/_P001_Switch.ino
+++ b/src/_P001_Switch.ino
@@ -251,7 +251,7 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
              if (PinMonitorState[x] != state){
                String eventString = F("GPIO#");
                eventString += x;
-               eventString += F("=");
+               eventString += '=';
                eventString += state;
                rulesProcessing(eventString);
                PinMonitorState[x] = state;
@@ -340,7 +340,7 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
               }
               UserVar[event->BaseVarIndex] = output_value;
               String log = F("SW   : Switch state ");
-              log += state ? F("1") : F("0");
+              log += state ? '1' : '0';
               log += F(" Output value ");
               log += output_value;
               addLog(LOG_LEVEL_INFO, log);
@@ -396,7 +396,7 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
 
               UserVar[event->BaseVarIndex] = output_value;
               String log = F("SW   : LongPress: Switch state ");
-              log += state ? F("1") : F("0");
+              log += state ? '1' : '0';
               log += F(" Output value ");
               log += output_value;
               addLog(LOG_LEVEL_INFO, log);

--- a/src/_P001_Switch.ino
+++ b/src/_P001_Switch.ino
@@ -3,6 +3,31 @@
 //#################################### Plugin 001: Input Switch #########################################
 //#######################################################################################################
 
+/**************************************************\
+CONFIG
+TaskDevicePluginConfig settings:
+0: button type (switch or dimmer)
+1: dim value
+2: button option (normal, push high, push low)
+3: send boot state (0,1)
+4: use doubleclick (0,1)
+5: use longpress (0,1)
+6: LP fired (0,1)
+7: doubleclick counter (=0,1,2,3)
+
+TaskDevicePluginConfigFloat settings:
+0: debounce interval ms
+1: doubleclick interval ms
+2: longpress interval ms
+3:
+
+TaskDevicePluginConfigLong settings:
+0: clickTime debounce ms
+1: clickTime doubleclick ms
+2: clickTime longpress ms
+3:
+\**************************************************/
+
 #define PLUGIN_001
 #define PLUGIN_ID_001         1
 #define PLUGIN_NAME_001       "Switch input - Switch"
@@ -18,18 +43,17 @@
 #define PLUGIN_001_BUTTON_TYPE_NORMAL_SWITCH 0
 #define PLUGIN_001_BUTTON_TYPE_PUSH_ACTIVE_LOW 1
 #define PLUGIN_001_BUTTON_TYPE_PUSH_ACTIVE_HIGH 2
-#define PLUGIN_001_DOUBLECLICK_MIN_MAX_SPEED 500
-#define PLUGIN_001_DOUBLECLICK_MAX_MAX_SPEED 2000
-#define PLUGIN_001_LONGPRESS_MIN_MIN_SPEED 1000
-#define PLUGIN_001_LONGPRESS_MAX_MIN_SPEED 5000
+#define PLUGIN_001_DOUBLECLICK_MIN_INTERVAL 1000
+#define PLUGIN_001_DOUBLECLICK_MAX_INTERVAL 3000
+#define PLUGIN_001_LONGPRESS_MIN_INTERVAL 1000
+#define PLUGIN_001_LONGPRESS_MAX_INTERVAL 5000
 
+//unsigned int Plugin_001_clickCounterDC[TASKS_MAX];
+//unsigned long Plugin_001_clickTimeDC[TASKS_MAX];
+//unsigned long Plugin_001_clickTimeDeBounce[TASKS_MAX];
 
-unsigned int Plugin_001_clickCounter[TASKS_MAX];
-unsigned long Plugin_001_clickTimeDC[TASKS_MAX];
-unsigned long Plugin_001_clickTimePrevious[TASKS_MAX];
-
-boolean  Plugin_001_firedLP[TASKS_MAX];
-unsigned long Plugin_001_clickTimeLP[TASKS_MAX];
+//boolean  Plugin_001_firedLP[TASKS_MAX];
+//unsigned long Plugin_001_clickTimeLP[TASKS_MAX];
 
 boolean Plugin_001_read_switch_state(struct EventStruct *event) {
   return digitalRead(Settings.TaskDevicePin1[event->TaskIndex]) == HIGH;
@@ -103,21 +127,21 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
 
         addFormSubHeader(F("Advanced event management"));
 
-        addFormNumericBox(F("De-bounce (ms)"), F("plugin_001_debounce"), Settings.TaskDevicePluginConfig[event->TaskIndex][4], 0, 250);
+        addFormNumericBox(F("De-bounce (ms)"), F("plugin_001_debounce"), round(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][0]), 0, 250);
 
         //set minimum value for doubleclick MIN max speed
-        if (Settings.TaskDevicePluginConfig[event->TaskIndex][6] < PLUGIN_001_DOUBLECLICK_MIN_MAX_SPEED)
-          Settings.TaskDevicePluginConfig[event->TaskIndex][6] = PLUGIN_001_DOUBLECLICK_MIN_MAX_SPEED;
+        if (Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1] < PLUGIN_001_DOUBLECLICK_MIN_INTERVAL)
+          Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1] = PLUGIN_001_DOUBLECLICK_MIN_INTERVAL;
 
-        addFormCheckBox(F("Doubleclick event (3)"), F("plugin_001_dc"), Settings.TaskDevicePluginConfig[event->TaskIndex][5]);
-        addFormNumericBox(F("Doubleclick max. interval (ms)"), F("plugin_001_dcmaxinterval"), Settings.TaskDevicePluginConfig[event->TaskIndex][6], PLUGIN_001_DOUBLECLICK_MIN_MAX_SPEED, PLUGIN_001_DOUBLECLICK_MAX_MAX_SPEED);
+        addFormCheckBox(F("Doubleclick event (3)"), F("plugin_001_dc"), Settings.TaskDevicePluginConfig[event->TaskIndex][4]);
+        addFormNumericBox(F("Doubleclick max. interval (ms)"), F("plugin_001_dcmaxinterval"), round(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1]), PLUGIN_001_DOUBLECLICK_MIN_INTERVAL, PLUGIN_001_DOUBLECLICK_MAX_INTERVAL);
 
         //set minimum value for longpress MIN max speed
-        if (Settings.TaskDevicePluginConfigLong[event->TaskIndex][0] < PLUGIN_001_LONGPRESS_MIN_MIN_SPEED)
-          Settings.TaskDevicePluginConfigLong[event->TaskIndex][0] = PLUGIN_001_LONGPRESS_MIN_MIN_SPEED;
+        if (Settings.TaskDevicePluginConfigFloat[event->TaskIndex][2] < PLUGIN_001_LONGPRESS_MIN_INTERVAL)
+          Settings.TaskDevicePluginConfigFloat[event->TaskIndex][2] = PLUGIN_001_LONGPRESS_MIN_INTERVAL;
 
-        addFormCheckBox(F("Longpress event (10 & 11)"), F("plugin_001_lp"), Settings.TaskDevicePluginConfig[event->TaskIndex][7]);
-        addFormNumericBox(F("Longpress min. interval (ms)"), F("plugin_001_lpmininterval"), Settings.TaskDevicePluginConfigLong[event->TaskIndex][0], PLUGIN_001_LONGPRESS_MIN_MIN_SPEED, PLUGIN_001_LONGPRESS_MAX_MIN_SPEED);
+        addFormCheckBox(F("Longpress event (10 & 11)"), F("plugin_001_lp"), Settings.TaskDevicePluginConfig[event->TaskIndex][5]);
+        addFormNumericBox(F("Longpress min. interval (ms)"), F("plugin_001_lpmininterval"), round(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][2]), PLUGIN_001_LONGPRESS_MIN_INTERVAL, PLUGIN_001_LONGPRESS_MAX_INTERVAL);
 
         //TO-DO: add Extra-Long Press event
         //addFormCheckBox(F("Extra-Longpress event (20 & 21)"), F("plugin_001_elp"), Settings.TaskDevicePluginConfigLong[event->TaskIndex][1]);
@@ -139,13 +163,13 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
 
         Settings.TaskDevicePluginConfig[event->TaskIndex][3] = isFormItemChecked(F("plugin_001_boot"));
 
-        Settings.TaskDevicePluginConfig[event->TaskIndex][4] = getFormItemInt(F("plugin_001_debounce"));
+        Settings.TaskDevicePluginConfigFloat[event->TaskIndex][0] = getFormItemInt(F("plugin_001_debounce"));
 
-        Settings.TaskDevicePluginConfig[event->TaskIndex][5] = isFormItemChecked(F("plugin_001_dc"));
-        Settings.TaskDevicePluginConfig[event->TaskIndex][6] = getFormItemInt(F("plugin_001_dcmaxinterval"));
+        Settings.TaskDevicePluginConfig[event->TaskIndex][4] = isFormItemChecked(F("plugin_001_dc"));
+        Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1] = getFormItemInt(F("plugin_001_dcmaxinterval"));
 
-        Settings.TaskDevicePluginConfig[event->TaskIndex][7] = isFormItemChecked(F("plugin_001_lp"));
-        Settings.TaskDevicePluginConfigLong[event->TaskIndex][0] = getFormItemInt(F("plugin_001_lpmininterval"));
+        Settings.TaskDevicePluginConfig[event->TaskIndex][5] = isFormItemChecked(F("plugin_001_lp"));
+        Settings.TaskDevicePluginConfigFloat[event->TaskIndex][2] = getFormItemInt(F("plugin_001_lpmininterval"));
 
         //TO-DO: add Extra-Long Press event
         //Settings.TaskDevicePluginConfigLong[event->TaskIndex][1] = isFormItemChecked(F("plugin_001_elp"));
@@ -187,21 +211,23 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
         }
 
         // counter = 0
-        Plugin_001_clickCounter[event->TaskIndex]=0;
-        Plugin_001_firedLP[event->TaskIndex]=false;
+        Settings.TaskDevicePluginConfig[event->TaskIndex][7]=0;
+
+        //used to track if LP has fired
+        Settings.TaskDevicePluginConfig[event->TaskIndex][6]=false;
 
         //store millis for debounce, doubleclick and long press
-        Plugin_001_clickTimeDC[event->TaskIndex]=millis();
-        Plugin_001_clickTimePrevious[event->TaskIndex]=millis();
-        Plugin_001_clickTimeLP[event->TaskIndex]=millis();
+        Settings.TaskDevicePluginConfigLong[event->TaskIndex][0]=millis(); //debounce timer
+        Settings.TaskDevicePluginConfigLong[event->TaskIndex][1]=millis(); //doubleclick timer
+        Settings.TaskDevicePluginConfigLong[event->TaskIndex][2]=millis(); //longpress timer
 
         //set minimum value for doubleclick MIN max speed
-        if (Settings.TaskDevicePluginConfig[event->TaskIndex][6] < PLUGIN_001_DOUBLECLICK_MIN_MAX_SPEED)
-          Settings.TaskDevicePluginConfig[event->TaskIndex][6] = PLUGIN_001_DOUBLECLICK_MIN_MAX_SPEED;
+        if (Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1] < PLUGIN_001_DOUBLECLICK_MIN_INTERVAL)
+          Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1] = PLUGIN_001_DOUBLECLICK_MIN_INTERVAL;
 
         //set minimum value for longpress MIN max speed
-        if (Settings.TaskDevicePluginConfigLong[event->TaskIndex][0] < PLUGIN_001_LONGPRESS_MIN_MIN_SPEED)
-          Settings.TaskDevicePluginConfigLong[event->TaskIndex][0] = PLUGIN_001_LONGPRESS_MIN_MIN_SPEED;
+        if (Settings.TaskDevicePluginConfigFloat[event->TaskIndex][2] < PLUGIN_001_LONGPRESS_MIN_INTERVAL)
+          Settings.TaskDevicePluginConfigFloat[event->TaskIndex][2] = PLUGIN_001_LONGPRESS_MIN_INTERVAL;
 
         success = true;
         break;
@@ -248,8 +274,8 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
         /**************************************************************************\
         20181009 - @giig1967g: new doubleclick logic is:
         if there is a 'state' change, check debounce period.
-        Then if doubleclick interval exceeded, reset Plugin_001_clickCounter to 0
-        Plugin_001_clickCounter contains the current status for doubleclick:
+        Then if doubleclick interval exceeded, reset Plugin_001_clickCounterDC to 0
+        Plugin_001_clickCounterDC contains the current status for doubleclick:
         0: start counting
         1: 1st click
         2: 2nd click
@@ -263,20 +289,20 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
         if (state != switchstate[event->TaskIndex])
         {
           //reset timer for long press
-          Plugin_001_clickTimeLP[event->TaskIndex]=millis();
-          Plugin_001_firedLP[event->TaskIndex] = false;
+          Settings.TaskDevicePluginConfigLong[event->TaskIndex][2]=millis();
+          Settings.TaskDevicePluginConfig[event->TaskIndex][6] = false;
 
-          const unsigned long debounceTime = timePassedSince(Plugin_001_clickTimePrevious[event->TaskIndex]);
-          if (debounceTime >= (unsigned long)Settings.TaskDevicePluginConfig[event->TaskIndex][4]) //de-bounce check
+          const unsigned long debounceTime = timePassedSince(Settings.TaskDevicePluginConfigLong[event->TaskIndex][0]);
+          if (debounceTime >= (unsigned long)lround(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][0])) //de-bounce check
           {
-            const unsigned long deltaDC = timePassedSince(Plugin_001_clickTimeDC[event->TaskIndex]);
-            if (deltaDC >= (unsigned long)Settings.TaskDevicePluginConfig[event->TaskIndex][6])
+            const unsigned long deltaDC = timePassedSince(Settings.TaskDevicePluginConfigLong[event->TaskIndex][1]);
+            if (deltaDC >= (unsigned long)lround(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1]))
             {
               //reset timer for doubleclick
-              Plugin_001_clickCounter[event->TaskIndex]=0;
-              Plugin_001_clickTimeDC[event->TaskIndex]=millis();
+              Settings.TaskDevicePluginConfig[event->TaskIndex][7]=0;
+              Settings.TaskDevicePluginConfigLong[event->TaskIndex][1]=millis();
             }
-            Plugin_001_clickCounter[event->TaskIndex]++;
+            Settings.TaskDevicePluginConfig[event->TaskIndex][7]++;
 
             switchstate[event->TaskIndex] = state;
             const boolean currentOutputState = outputstate[event->TaskIndex];
@@ -305,7 +331,7 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
               if (Settings.TaskDevicePin1Inversed[event->TaskIndex])
                 sendState = !sendState;
 
-              if (Plugin_001_clickCounter[event->TaskIndex]==3 && Settings.TaskDevicePluginConfig[event->TaskIndex][5])
+              if (Settings.TaskDevicePluginConfig[event->TaskIndex][7]==3 && Settings.TaskDevicePluginConfig[event->TaskIndex][4])
               {
                 output_value = 3; //double click
               } else {
@@ -327,11 +353,11 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
               addLog(LOG_LEVEL_INFO, log);
               sendData(event);
             }
-            Plugin_001_clickTimePrevious[event->TaskIndex] = millis();
+            Settings.TaskDevicePluginConfigLong[event->TaskIndex][0] = millis();
           }
         }
         //check if LP is enabled and if LP has not fired yet
-        else if (Settings.TaskDevicePluginConfig[event->TaskIndex][7] && !Plugin_001_firedLP[event->TaskIndex]) {
+        else if (Settings.TaskDevicePluginConfig[event->TaskIndex][5] && !Settings.TaskDevicePluginConfig[event->TaskIndex][6]) {
           /**************************************************************************\
           20181009 - @giig1967g: new longpress logic is:
           if there is no 'state' change, check if longpress interval reached
@@ -345,17 +371,13 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
           on Button#Switch=10 do //will fire if longpress when state = 0
           on Button#Switch=11 do //will fire if longpress when state = 1
           \**************************************************************************/
-
-          //TO DO:
-          //SE PUSH BUTTON HIGH HA SENSO SOLO 11
-          //SE PUSH BUTTON LOW HA SENSO SOLO 10
-          const unsigned long deltaLP = timePassedSince(Plugin_001_clickTimeLP[event->TaskIndex]);
-          if (deltaLP >= (unsigned long)Settings.TaskDevicePluginConfigLong[event->TaskIndex][0])
+          const unsigned long deltaLP = timePassedSince(Settings.TaskDevicePluginConfigLong[event->TaskIndex][2]);
+          if (deltaLP >= (unsigned long)lround(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][2]))
           {
             byte output_value;
             byte needToSendEvent = false;
 
-            Plugin_001_firedLP[event->TaskIndex] = true;
+            Settings.TaskDevicePluginConfig[event->TaskIndex][6] = true;
 
             switch(Settings.TaskDevicePluginConfig[event->TaskIndex][2])
             {

--- a/src/_P001_Switch.ino
+++ b/src/_P001_Switch.ino
@@ -179,6 +179,13 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
           outputstate[event->TaskIndex] = !outputstate[event->TaskIndex];
         }
 
+        // set initial UserVar of the switch
+        if (Settings.TaskDevicePin1Inversed[event->TaskIndex]){
+          UserVar[event->BaseVarIndex] = !switchstate[event->TaskIndex];
+        } else {
+          UserVar[event->BaseVarIndex] = switchstate[event->TaskIndex];
+        }
+
         // counter = 0
         Plugin_001_clickCounter[event->TaskIndex]=0;
         Plugin_001_firedLP[event->TaskIndex]=false;

--- a/src/_P001_Switch.ino
+++ b/src/_P001_Switch.ino
@@ -9,10 +9,10 @@ TaskDevicePluginConfig settings:
 0: button type (switch or dimmer)
 1: dim value
 2: button option (normal, push high, push low)
-3: send boot state (0,1)
-4: use doubleclick (0,1)
-5: use longpress (0,1)
-6: LP fired (0,1)
+3: send boot state (true,false)
+4: use doubleclick (true,false)
+5: use longpress (true,false)
+6: LP fired (true,false)
 7: doubleclick counter (=0,1,2,3)
 
 TaskDevicePluginConfigFloat settings:
@@ -47,13 +47,6 @@ TaskDevicePluginConfigLong settings:
 #define PLUGIN_001_DOUBLECLICK_MAX_INTERVAL 3000
 #define PLUGIN_001_LONGPRESS_MIN_INTERVAL 1000
 #define PLUGIN_001_LONGPRESS_MAX_INTERVAL 5000
-
-//unsigned int Plugin_001_clickCounterDC[TASKS_MAX];
-//unsigned long Plugin_001_clickTimeDC[TASKS_MAX];
-//unsigned long Plugin_001_clickTimeDeBounce[TASKS_MAX];
-
-//boolean  Plugin_001_firedLP[TASKS_MAX];
-//unsigned long Plugin_001_clickTimeLP[TASKS_MAX];
 
 boolean Plugin_001_read_switch_state(struct EventStruct *event) {
   return digitalRead(Settings.TaskDevicePin1[event->TaskIndex]) == HIGH;

--- a/src/_P001_Switch.ino
+++ b/src/_P001_Switch.ino
@@ -19,6 +19,10 @@
 #define PLUGIN_001_BUTTON_TYPE_PUSH_ACTIVE_LOW 1
 #define PLUGIN_001_BUTTON_TYPE_PUSH_ACTIVE_HIGH 2
 #define PLUGIN_001_DOUBLECLICK_MIN_MAX_SPEED 500
+#define PLUGIN_001_DOUBLECLICK_MAX_MAX_SPEED 2000
+#define PLUGIN_001_LONGPRESS_MIN_MIN_SPEED 1000
+#define PLUGIN_001_LONGPRESS_MAX_MIN_SPEED 5000
+
 
 unsigned int Plugin_001_clickCounter[TASKS_MAX];
 unsigned long Plugin_001_clickTimeDC[TASKS_MAX];
@@ -99,17 +103,25 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
 
         addFormSubHeader(F("Advanced event management"));
 
-        addFormNumericBox(F("De-bounce (ms)"), F("plugin_001_debounce"), Settings.TaskDevicePluginConfigLong[event->TaskIndex][0], 0, 250);
+        addFormNumericBox(F("De-bounce (ms)"), F("plugin_001_debounce"), Settings.TaskDevicePluginConfig[event->TaskIndex][4], 0, 250);
 
-        addFormCheckBox(F("Doubleclick event"), F("plugin_001_dc"), Settings.TaskDevicePluginConfigLong[event->TaskIndex][1]);
-        //addFormNumericBox(F("Doubleclick min. speed (ms)"), F("plugin_001_dcminspeed"), Settings.TaskDevicePluginConfigLong[event->TaskIndex][2], 200, 400);
-        addFormNumericBox(F("Doubleclick max. speed (ms)"), F("plugin_001_dcmaxspeed"), Settings.TaskDevicePluginConfigLong[event->TaskIndex][2], PLUGIN_001_DOUBLECLICK_MIN_MAX_SPEED, 2000);
+        //set minimum value for doubleclick MIN max speed
+        if (Settings.TaskDevicePluginConfig[event->TaskIndex][6] < PLUGIN_001_DOUBLECLICK_MIN_MAX_SPEED)
+          Settings.TaskDevicePluginConfig[event->TaskIndex][6] = PLUGIN_001_DOUBLECLICK_MIN_MAX_SPEED;
 
-        //addFormCheckBox(F("Longpress event"), F("plugin_001_lp"), Settings.TaskDevicePluginConfigLong[event->TaskIndex][3]);
-        //addFormNumericBox(F("Longpress min. interval (ms)"), F("plugin_001_lpmininterval"), Settings.TaskDevicePluginConfigLong[event->TaskIndex][4], 500, 2000);
+        addFormCheckBox(F("Doubleclick event (3)"), F("plugin_001_dc"), Settings.TaskDevicePluginConfig[event->TaskIndex][5]);
+        addFormNumericBox(F("Doubleclick max. interval (ms)"), F("plugin_001_dcmaxinterval"), Settings.TaskDevicePluginConfig[event->TaskIndex][6], PLUGIN_001_DOUBLECLICK_MIN_MAX_SPEED, PLUGIN_001_DOUBLECLICK_MAX_MAX_SPEED);
 
-        //addFormCheckBox(F("Extra Longpress event"), F("plugin_001_elp"), Settings.TaskDevicePluginConfigLong[event->TaskIndex][6]);
-        //addFormNumericBox(F("Extra Longpress min. interval (ms)"), F("plugin_001_elpmininterval"), Settings.TaskDevicePluginConfigLong[event->TaskIndex][7], 500, 2000);
+        //set minimum value for longpress MIN max speed
+        if (Settings.TaskDevicePluginConfigLong[event->TaskIndex][0] < PLUGIN_001_LONGPRESS_MIN_MIN_SPEED)
+          Settings.TaskDevicePluginConfigLong[event->TaskIndex][0] = PLUGIN_001_LONGPRESS_MIN_MIN_SPEED;
+
+        addFormCheckBox(F("Longpress event (10 & 11)"), F("plugin_001_lp"), Settings.TaskDevicePluginConfig[event->TaskIndex][7]);
+        addFormNumericBox(F("Longpress min. interval (ms)"), F("plugin_001_lpmininterval"), Settings.TaskDevicePluginConfigLong[event->TaskIndex][0], PLUGIN_001_LONGPRESS_MIN_MIN_SPEED, PLUGIN_001_LONGPRESS_MAX_MIN_SPEED);
+
+        //TO-DO: add Extra-Long Press event
+        //addFormCheckBox(F("Extra-Longpress event (20 & 21)"), F("plugin_001_elp"), Settings.TaskDevicePluginConfigLong[event->TaskIndex][1]);
+        //addFormNumericBox(F("Extra-Longpress min. interval (ms)"), F("plugin_001_elpmininterval"), Settings.TaskDevicePluginConfigLong[event->TaskIndex][2], 500, 2000);
 
         success = true;
         break;
@@ -127,17 +139,17 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
 
         Settings.TaskDevicePluginConfig[event->TaskIndex][3] = isFormItemChecked(F("plugin_001_boot"));
 
-        Settings.TaskDevicePluginConfigLong[event->TaskIndex][0] = getFormItemInt(F("plugin_001_debounce"));
+        Settings.TaskDevicePluginConfig[event->TaskIndex][4] = getFormItemInt(F("plugin_001_debounce"));
 
-        Settings.TaskDevicePluginConfigLong[event->TaskIndex][1] = isFormItemChecked(F("plugin_001_dc"));
-        //Settings.TaskDevicePluginConfigLong[event->TaskIndex][2] = getFormItemInt(F("plugin_001_dcminspeed"));
-        Settings.TaskDevicePluginConfigLong[event->TaskIndex][2] = getFormItemInt(F("plugin_001_dcmaxspeed"));
+        Settings.TaskDevicePluginConfig[event->TaskIndex][5] = isFormItemChecked(F("plugin_001_dc"));
+        Settings.TaskDevicePluginConfig[event->TaskIndex][6] = getFormItemInt(F("plugin_001_dcmaxinterval"));
 
-        //Settings.TaskDevicePluginConfigLong[event->TaskIndex][3] = isFormItemChecked(F("plugin_001_lp"));
-        //Settings.TaskDevicePluginConfigLong[event->TaskIndex][4] = getFormItemInt(F("plugin_001_lpmininterval"));
+        Settings.TaskDevicePluginConfig[event->TaskIndex][7] = isFormItemChecked(F("plugin_001_lp"));
+        Settings.TaskDevicePluginConfigLong[event->TaskIndex][0] = getFormItemInt(F("plugin_001_lpmininterval"));
 
-        //Settings.TaskDevicePluginConfigLong[event->TaskIndex][6] = isFormItemChecked(F("plugin_001_elp"));
-        //Settings.TaskDevicePluginConfigLong[event->TaskIndex][7] = getFormItemInt(F("plugin_001_elpmininterval"));
+        //TO-DO: add Extra-Long Press event
+        //Settings.TaskDevicePluginConfigLong[event->TaskIndex][1] = isFormItemChecked(F("plugin_001_elp"));
+        //Settings.TaskDevicePluginConfigLong[event->TaskIndex][2] = getFormItemInt(F("plugin_001_elpmininterval"));
 
         success = true;
         break;
@@ -177,8 +189,12 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
         Plugin_001_clickTimeLP[event->TaskIndex]=millis();
 
         //set minimum value for doubleclick MIN max speed
-        if (Settings.TaskDevicePluginConfigLong[event->TaskIndex][2]==0)
-          Settings.TaskDevicePluginConfigLong[event->TaskIndex][2] = PLUGIN_001_DOUBLECLICK_MIN_MAX_SPEED;
+        if (Settings.TaskDevicePluginConfig[event->TaskIndex][6] < PLUGIN_001_DOUBLECLICK_MIN_MAX_SPEED)
+          Settings.TaskDevicePluginConfig[event->TaskIndex][6] = PLUGIN_001_DOUBLECLICK_MIN_MAX_SPEED;
+
+        //set minimum value for longpress MIN max speed
+        if (Settings.TaskDevicePluginConfigLong[event->TaskIndex][0] < PLUGIN_001_LONGPRESS_MIN_MIN_SPEED)
+          Settings.TaskDevicePluginConfigLong[event->TaskIndex][0] = PLUGIN_001_LONGPRESS_MIN_MIN_SPEED;
 
         success = true;
         break;
@@ -222,6 +238,21 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
       {
         const boolean state = Plugin_001_read_switch_state(event);
 
+        /**************************************************************************\
+        20181009 - @giig1967g: new doubleclick logic is:
+        if there is a 'state' change, check debounce period.
+        Then if doubleclick interval exceeded, reset Plugin_001_clickCounter to 0
+        Plugin_001_clickCounter contains the current status for doubleclick:
+        0: start counting
+        1: 1st click
+        2: 2nd click
+        3: 3rd click = doubleclick event if inside interval (calculated as: '3rd click time' minus '1st click time')
+
+        Returned EVENT value is = 3 always for doubleclick
+        In rules this can be checked:
+        on Button#Switch=3 do //will fire if doubleclick
+        \**************************************************************************/
+
         if (state != switchstate[event->TaskIndex])
         {
           //reset timer for long press
@@ -229,10 +260,10 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
           Plugin_001_firedLP[event->TaskIndex] = false;
 
           const unsigned long debounceTime = timePassedSince(Plugin_001_clickTimePrevious[event->TaskIndex]);
-          if (debounceTime >= (unsigned long)Settings.TaskDevicePluginConfigLong[event->TaskIndex][0]) //de-bounce check
+          if (debounceTime >= (unsigned long)Settings.TaskDevicePluginConfig[event->TaskIndex][4]) //de-bounce check
           {
             const unsigned long deltaDC = timePassedSince(Plugin_001_clickTimeDC[event->TaskIndex]);
-            if (deltaDC >= (unsigned long)Settings.TaskDevicePluginConfigLong[event->TaskIndex][2])
+            if (deltaDC >= (unsigned long)Settings.TaskDevicePluginConfig[event->TaskIndex][6])
             {
               //reset timer for doubleclick
               Plugin_001_clickCounter[event->TaskIndex]=0;
@@ -267,13 +298,12 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
               if (Settings.TaskDevicePin1Inversed[event->TaskIndex])
                 sendState = !sendState;
 
-              if (Plugin_001_clickCounter[event->TaskIndex]==3 && Settings.TaskDevicePluginConfigLong[event->TaskIndex][1])
-                //double click
-                output_value = 3;
-              else
-                //single click
-                output_value = sendState ? 1 : 0;
-
+              if (Plugin_001_clickCounter[event->TaskIndex]==3 && Settings.TaskDevicePluginConfig[event->TaskIndex][5])
+              {
+                output_value = 3; //double click
+              } else {
+                output_value = sendState ? 1 : 0; //single click
+              }
               event->sensorType = SENSOR_TYPE_SWITCH;
               if (P001_getSwitchType(event) == PLUGIN_001_TYPE_DIMMER) {
                 if (sendState) {
@@ -292,25 +322,64 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
             }
             Plugin_001_clickTimePrevious[event->TaskIndex] = millis();
           }
-          TO DO: AGGIUNGERE VARIABILI PER LUNGHEZZA LP E ABILITARE LP
-          SE PUSH BUTTON HIGH HA SENSO SOLO 11
-          SE PUSH BUTTON LOW HA SENSO SOLO 10
-        } else if (!Plugin_001_firedLP[event->TaskIndex]) { //check if LP is enabled and if LP has not fired yet
+        }
+        //check if LP is enabled and if LP has not fired yet
+        else if (Settings.TaskDevicePluginConfig[event->TaskIndex][7] && !Plugin_001_firedLP[event->TaskIndex]) {
+          /**************************************************************************\
+          20181009 - @giig1967g: new longpress logic is:
+          if there is no 'state' change, check if longpress interval reached
+          When reached send longpress event.
+          Returned Event value = state + 10
+          So if state = 0 => EVENT longpress = 10
+          if state = 1 => EVENT longpress = 11
+          So we can trigger longpress for high or low contact
+
+          In rules this can be checked:
+          on Button#Switch=10 do //will fire if longpress when state = 0
+          on Button#Switch=11 do //will fire if longpress when state = 1
+          \**************************************************************************/
+
+          //TO DO:
+          //SE PUSH BUTTON HIGH HA SENSO SOLO 11
+          //SE PUSH BUTTON LOW HA SENSO SOLO 10
           const unsigned long deltaLP = timePassedSince(Plugin_001_clickTimeLP[event->TaskIndex]);
-          if (deltaLP >= (unsigned long)1000) //(unsigned long)Settings.TaskDevicePluginConfigLong[event->TaskIndex][2])
+          if (deltaLP >= (unsigned long)Settings.TaskDevicePluginConfigLong[event->TaskIndex][0])
           {
             byte output_value;
+            byte needToSendEvent = false;
 
             Plugin_001_firedLP[event->TaskIndex] = true;
 
-            output_value = state + 10;
-            UserVar[event->BaseVarIndex] = output_value;
-            String log = F("SW   : Switch state ");
-            log += state ? F("1") : F("0");
-            log += F(" Output value ");
-            log += output_value;
-            addLog(LOG_LEVEL_INFO, log);
-            sendData(event);
+            switch(Settings.TaskDevicePluginConfig[event->TaskIndex][2])
+            {
+              case PLUGIN_001_BUTTON_TYPE_NORMAL_SWITCH:
+                  needToSendEvent = true;
+                break;
+              case PLUGIN_001_BUTTON_TYPE_PUSH_ACTIVE_LOW:
+                if (!state)
+                  needToSendEvent = true;
+                break;
+              case PLUGIN_001_BUTTON_TYPE_PUSH_ACTIVE_HIGH:
+                if (state)
+                  needToSendEvent = true;
+                break;
+            }
+
+            if (needToSendEvent) {
+              boolean sendState = state;
+              if (Settings.TaskDevicePin1Inversed[event->TaskIndex])
+                sendState = !sendState;
+              output_value = sendState ? 1 : 0;
+              output_value = output_value + 10;
+
+              UserVar[event->BaseVarIndex] = output_value;
+              String log = F("SW   : LongPress: Switch state ");
+              log += state ? F("1") : F("0");
+              log += F(" Output value ");
+              log += output_value;
+              addLog(LOG_LEVEL_INFO, log);
+              sendData(event);
+            }
           }
         }
 


### PR DESCRIPTION
Hi all,
with this PR I am adding to Plugin001 the following features:
- ability to send events for doubleclick 
- ability to send events for longpress events.
- debounce

In case of doubleclick the max time is configurable
In case of longpress, the min time is configurable
I have also added a de-bouncing check configurable,

Finally this PR contains the fix for #1878.

**As soon as this PR is accepted I will develop the same functionalities to MCP and PCF.**

Events:
For doubleclick the EVENT will return = 3
For longpress, the EVENT will return = 10 or 11 according if the long press has been triggered when state was 0 or 1. In other words, if I keep pressed the button on state 0, the longpress event will return 10.

The usage is:
```
on button#switch=3 do //check for doubleclick
on button#switch=10 do //check for longpress high
on button#switch=11 do //check for longpress low
```