### PR TITLE
added Global Variables for rules

### DIFF
--- a/src/Command.ino
+++ b/src/Command.ino
@@ -53,6 +53,7 @@ String doExecuteCommand(const char * cmd, struct EventStruct *event, const char*
 	  COMMAND_CASE("clearaccessblock"       , Command_AccessInfo_Clear);           // Network Command
 	  COMMAND_CASE("clearrtcram"            , Command_RTC_Clear);                  // RTC.h
 	  COMMAND_CASE("config"                 , Command_Task_RemoteConfig);          // Tasks.h
+    COMMAND_CASE("customvar"              , Command_Rules_CustomVar);            // Rules.h
       break;
     }
     case 'd': {

--- a/src/Command.ino
+++ b/src/Command.ino
@@ -53,7 +53,6 @@ String doExecuteCommand(const char * cmd, struct EventStruct *event, const char*
 	  COMMAND_CASE("clearaccessblock"       , Command_AccessInfo_Clear);           // Network Command
 	  COMMAND_CASE("clearrtcram"            , Command_RTC_Clear);                  // RTC.h
 	  COMMAND_CASE("config"                 , Command_Task_RemoteConfig);          // Tasks.h
-    COMMAND_CASE("customvar"              , Command_Rules_CustomVar);            // Rules.h
       break;
     }
     case 'd': {
@@ -80,6 +79,7 @@ String doExecuteCommand(const char * cmd, struct EventStruct *event, const char*
       break;
     }
     case 'l': {
+    COMMAND_CASE("let"                    , Command_Rules_Let);                  // Rules.h
 	  COMMAND_CASE("load"                   , Command_Settings_Load);              // Settings.h
 	  COMMAND_CASE("logentry"               , Command_logentry);                   // Diagnostic.h
 	  COMMAND_CASE("lowmem"                 , Command_Lowmem);                     // Diagnostic.h

--- a/src/Commands/Rules.h
+++ b/src/Commands/Rules.h
@@ -38,7 +38,7 @@ String Command_Rules_CustomVar(struct EventStruct *event, const char* Line)
 {
 	char TmpStr1[INPUT_COMMAND_SIZE];
 	if (GetArgv(Line, TmpStr1, 3)) {
-		Settings.customVar[event->Par1-1] = event->Par2;
+		customFloatVar[event->Par1-1] = event->Par2;
 	}
 	return return_command_success();
 }

--- a/src/Commands/Rules.h
+++ b/src/Commands/Rules.h
@@ -34,11 +34,13 @@ String Command_Rules_Events(struct EventStruct *event, const char* Line)
 	return return_command_success();
 }
 
-String Command_Rules_CustomVar(struct EventStruct *event, const char* Line)
+String Command_Rules_Let(struct EventStruct *event, const char* Line)
 {
 	char TmpStr1[INPUT_COMMAND_SIZE];
 	if (GetArgv(Line, TmpStr1, 3)) {
-		customFloatVar[event->Par1-1] = event->Par2;
+		float result = 0;
+		Calculate(TmpStr1, &result);
+		customFloatVar[event->Par1-1] = result;
 	}
 	return return_command_success();
 }

--- a/src/Commands/Rules.h
+++ b/src/Commands/Rules.h
@@ -34,4 +34,13 @@ String Command_Rules_Events(struct EventStruct *event, const char* Line)
 	return return_command_success();
 }
 
+String Command_Rules_CustomVar(struct EventStruct *event, const char* Line)
+{
+	char TmpStr1[INPUT_COMMAND_SIZE];
+	if (GetArgv(Line, TmpStr1, 3)) {
+		Settings.customVar[event->Par1-1] = event->Par2;
+	}
+	return return_command_success();
+}
+
 #endif // COMMAND_RULES_H

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -676,6 +676,15 @@ struct SecurityStruct
 } SecuritySettings;
 
 /*********************************************************************************************\
+ * Custom Variables for usage in rules and http.
+ * Syntax: %customvarX%
+ * usage:
+ * customvar,1,10
+ * if %customvar1%=10 do ...
+\*********************************************************************************************/
+float         customFloatVar[CUSTOM_VARS_MAX];
+
+/*********************************************************************************************\
  * SettingsStruct
 \*********************************************************************************************/
 struct SettingsStruct
@@ -884,7 +893,6 @@ struct SettingsStruct
   float         Longitude;
   uint32_t      VariousBits1;
 
-  float         customVar[CUSTOM_VARS_MAX];
   // FIXME @TD-er: As discussed in #1292, the CRC for the settings is now disabled.
   // make sure crc is the last value in the struct
   // Try to extend settings to make the checksum 4-byte aligned.

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -338,6 +338,7 @@
 #define RULES_BUFFER_SIZE                  64
 #define NAME_FORMULA_LENGTH_MAX            40
 #define RULES_IF_MAX_NESTING_LEVEL          4
+#define CUSTOM_VARS_MAX                    16
 
 #define UDP_PACKETSIZE_MAX               2048
 
@@ -883,6 +884,7 @@ struct SettingsStruct
   float         Longitude;
   uint32_t      VariousBits1;
 
+  float         customVar[CUSTOM_VARS_MAX];
   // FIXME @TD-er: As discussed in #1292, the CRC for the settings is now disabled.
   // make sure crc is the last value in the struct
   // Try to extend settings to make the checksum 4-byte aligned.

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -677,10 +677,10 @@ struct SecurityStruct
 
 /*********************************************************************************************\
  * Custom Variables for usage in rules and http.
- * Syntax: %customvarX%
+ * Syntax: %vX%
  * usage:
- * customvar,1,10
- * if %customvar1%=10 do ...
+ * let,1,10
+ * if %v1%=10 do ...
 \*********************************************************************************************/
 float         customFloatVar[CUSTOM_VARS_MAX];
 

--- a/src/StringConverter.ino
+++ b/src/StringConverter.ino
@@ -563,6 +563,23 @@ void parseSystemVariables(String& s, boolean useURLencode)
   SMART_REPL(F("%unixtime%"), String(getUnixTime()))
   SMART_REPL_T(F("%sunset"), replSunSetTimeString)
   SMART_REPL_T(F("%sunrise"), replSunRiseTimeString)
+
+  SMART_REPL(F("%customvar1%"), toString(Settings.customVar[0],2))
+  SMART_REPL(F("%customvar2%"), toString(Settings.customVar[1],2))
+  SMART_REPL(F("%customvar3%"), toString(Settings.customVar[2],2))
+  SMART_REPL(F("%customvar4%"), toString(Settings.customVar[3],2))
+  SMART_REPL(F("%customvar5%"), toString(Settings.customVar[4],2))
+  SMART_REPL(F("%customvar6%"), toString(Settings.customVar[5],2))
+  SMART_REPL(F("%customvar7%"), toString(Settings.customVar[6],2))
+  SMART_REPL(F("%customvar8%"), toString(Settings.customVar[7],2))
+  SMART_REPL(F("%customvar9%"), toString(Settings.customVar[8],2))
+  SMART_REPL(F("%customvar10%"), toString(Settings.customVar[9],2))
+  SMART_REPL(F("%customvar11%"), toString(Settings.customVar[10],2))
+  SMART_REPL(F("%customvar12%"), toString(Settings.customVar[11],2))
+  SMART_REPL(F("%customvar13%"), toString(Settings.customVar[12],2))
+  SMART_REPL(F("%customvar14%"), toString(Settings.customVar[13],2))
+  SMART_REPL(F("%customvar15%"), toString(Settings.customVar[14],2))
+  SMART_REPL(F("%customvar16%"), toString(Settings.customVar[15],2))
 }
 
 String getReplacementString(const String& format, String& s) {

--- a/src/StringConverter.ino
+++ b/src/StringConverter.ino
@@ -564,22 +564,9 @@ void parseSystemVariables(String& s, boolean useURLencode)
   SMART_REPL_T(F("%sunset"), replSunSetTimeString)
   SMART_REPL_T(F("%sunrise"), replSunRiseTimeString)
 
-  SMART_REPL(F("%customvar1%"), toString(Settings.customVar[0],2))
-  SMART_REPL(F("%customvar2%"), toString(Settings.customVar[1],2))
-  SMART_REPL(F("%customvar3%"), toString(Settings.customVar[2],2))
-  SMART_REPL(F("%customvar4%"), toString(Settings.customVar[3],2))
-  SMART_REPL(F("%customvar5%"), toString(Settings.customVar[4],2))
-  SMART_REPL(F("%customvar6%"), toString(Settings.customVar[5],2))
-  SMART_REPL(F("%customvar7%"), toString(Settings.customVar[6],2))
-  SMART_REPL(F("%customvar8%"), toString(Settings.customVar[7],2))
-  SMART_REPL(F("%customvar9%"), toString(Settings.customVar[8],2))
-  SMART_REPL(F("%customvar10%"), toString(Settings.customVar[9],2))
-  SMART_REPL(F("%customvar11%"), toString(Settings.customVar[10],2))
-  SMART_REPL(F("%customvar12%"), toString(Settings.customVar[11],2))
-  SMART_REPL(F("%customvar13%"), toString(Settings.customVar[12],2))
-  SMART_REPL(F("%customvar14%"), toString(Settings.customVar[13],2))
-  SMART_REPL(F("%customvar15%"), toString(Settings.customVar[14],2))
-  SMART_REPL(F("%customvar16%"), toString(Settings.customVar[15],2))
+  for (byte i = 0; i < CUSTOM_VARS_MAX; ++i) {
+    SMART_REPL(String(F("%customvar"))+toString(i+1,0)+String(F("%")), toString(customFloatVar[i],2))
+  }
 }
 
 String getReplacementString(const String& format, String& s) {

--- a/src/StringConverter.ino
+++ b/src/StringConverter.ino
@@ -178,11 +178,13 @@ String doFormatUserVar(byte TaskIndex, byte rel_index, bool mustCheck, bool& isv
   float f(UserVar[BaseVarIndex + rel_index]);
   if (mustCheck && !isValidFloat(f)) {
     isvalid = false;
-    String log = F("Invalid float value for TaskIndex: ");
-    log += TaskIndex;
-    log += F(" varnumber: ");
-    log += rel_index;
-    addLog(LOG_LEVEL_DEBUG, log);
+    if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+      String log = F("Invalid float value for TaskIndex: ");
+      log += TaskIndex;
+      log += F(" varnumber: ");
+      log += rel_index;
+      addLog(LOG_LEVEL_DEBUG, log);
+    }
     f = 0;
   }
   return toString(f, ExtraTaskSettings.TaskDeviceValueDecimals[rel_index]);
@@ -564,7 +566,8 @@ void parseSystemVariables(String& s, boolean useURLencode)
   SMART_REPL_T(F("%sunset"), replSunSetTimeString)
   SMART_REPL_T(F("%sunrise"), replSunRiseTimeString)
 
-  if (s.indexOf("%v") != -1 && isDigit(s[2])) {
+  const int v_index = s.indexOf("%v");
+  if (v_index != -1 && isDigit(s[v_index+2])) {
     for (byte i = 0; i < CUSTOM_VARS_MAX; ++i) {
       SMART_REPL("%v"+toString(i+1,0)+'%', String(customFloatVar[i]))
     }
@@ -575,11 +578,13 @@ String getReplacementString(const String& format, String& s) {
   int startpos = s.indexOf(format);
   int endpos = s.indexOf('%', startpos + 1);
   String R = s.substring(startpos, endpos + 1);
-  String log = F("ReplacementString SunTime: ");
-  log += R;
-  log += F(" offset: ");
-  log += getSecOffset(R);
-  addLog(LOG_LEVEL_DEBUG, log);
+  if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+    String log = F("ReplacementString SunTime: ");
+    log += R;
+    log += F(" offset: ");
+    log += getSecOffset(R);
+    addLog(LOG_LEVEL_DEBUG, log);
+  }
   return R;
 }
 

--- a/src/StringConverter.ino
+++ b/src/StringConverter.ino
@@ -565,7 +565,7 @@ void parseSystemVariables(String& s, boolean useURLencode)
   SMART_REPL_T(F("%sunrise"), replSunRiseTimeString)
 
   for (byte i = 0; i < CUSTOM_VARS_MAX; ++i) {
-    SMART_REPL(String(F("%customvar"))+toString(i+1,0)+String(F("%")), toString(customFloatVar[i],2))
+    SMART_REPL(String(F("%v"))+toString(i+1,0)+String(F("%")), toString(customFloatVar[i],2))
   }
 }
 

--- a/src/StringConverter.ino
+++ b/src/StringConverter.ino
@@ -564,8 +564,10 @@ void parseSystemVariables(String& s, boolean useURLencode)
   SMART_REPL_T(F("%sunset"), replSunSetTimeString)
   SMART_REPL_T(F("%sunrise"), replSunRiseTimeString)
 
-  for (byte i = 0; i < CUSTOM_VARS_MAX; ++i) {
-    SMART_REPL(String(F("%v"))+toString(i+1,0)+String(F("%")), toString(customFloatVar[i],2))
+  if (s.indexOf("%v") != -1 && isDigit(s[2])) {
+    for (byte i = 0; i < CUSTOM_VARS_MAX; ++i) {
+      SMART_REPL("%v"+toString(i+1,0)+'%', String(customFloatVar[i]))
+    }
   }
 }
 

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -3666,7 +3666,7 @@ void handle_control() {
   else if (command.equalsIgnoreCase(F("taskrun")) ||
            command.equalsIgnoreCase(F("taskvalueset")) ||
            command.equalsIgnoreCase(F("taskvaluetoggle")) ||
-           command.equalsIgnoreCase(F("customvar")) ||
+           command.equalsIgnoreCase(F("let")) ||
            command.equalsIgnoreCase(F("rules"))) {
     addLog(LOG_LEVEL_INFO,String(F("HTTP : ")) + webrequest);
     ExecuteCommand(VALUE_SOURCE_HTTP,webrequest.c_str());
@@ -5653,7 +5653,7 @@ void handle_sysvars() {
 
   addTableSeparator(F("Custom Variables"), 3, 3);
   for (byte i = 0; i < CUSTOM_VARS_MAX; ++i) {
-    addSysVar_html(String(F("%customvar"))+toString(i+1,0)+String(F("%")));
+    addSysVar_html(String(F("%v"))+toString(i+1,0)+String(F("%")));
   }
 
   addTableSeparator(F("Special Characters"), 3, 2);

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -5650,6 +5650,24 @@ void handle_sysvars() {
   addSysVar_html(F("%sunrise%"));
   addSysVar_html(F("%sunrise+10m%"));
 
+  addTableSeparator(F("Custom Variables"), 3, 3);
+  addSysVar_html(F("%customvar1%"));
+  addSysVar_html(F("%customvar2%"));
+  addSysVar_html(F("%customvar3%"));
+  addSysVar_html(F("%customvar4%"));
+  addSysVar_html(F("%customvar5%"));
+  addSysVar_html(F("%customvar6%"));
+  addSysVar_html(F("%customvar7%"));
+  addSysVar_html(F("%customvar8%"));
+  addSysVar_html(F("%customvar9%"));
+  addSysVar_html(F("%customvar10%"));
+  addSysVar_html(F("%customvar11%"));
+  addSysVar_html(F("%customvar12%"));
+  addSysVar_html(F("%customvar13%"));
+  addSysVar_html(F("%customvar14%"));
+  addSysVar_html(F("%customvar15%"));
+  addSysVar_html(F("%customvar16%"));
+
   addTableSeparator(F("Special Characters"), 3, 2);
   addTableSeparator(F("Degree"), 3, 3);
   addSysVar_html(F("{D}"));

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -5653,7 +5653,7 @@ void handle_sysvars() {
 
   addTableSeparator(F("Custom Variables"), 3, 3);
   for (byte i = 0; i < CUSTOM_VARS_MAX; ++i) {
-    addSysVar_html(String(F("%v"))+toString(i+1,0)+String(F("%")));
+    addSysVar_html("%v"+toString(i+1,0)+'%');
   }
 
   addTableSeparator(F("Special Characters"), 3, 2);

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -3666,6 +3666,7 @@ void handle_control() {
   else if (command.equalsIgnoreCase(F("taskrun")) ||
            command.equalsIgnoreCase(F("taskvalueset")) ||
            command.equalsIgnoreCase(F("taskvaluetoggle")) ||
+           command.equalsIgnoreCase(F("customvar")) ||
            command.equalsIgnoreCase(F("rules"))) {
     addLog(LOG_LEVEL_INFO,String(F("HTTP : ")) + webrequest);
     ExecuteCommand(VALUE_SOURCE_HTTP,webrequest.c_str());
@@ -5651,22 +5652,9 @@ void handle_sysvars() {
   addSysVar_html(F("%sunrise+10m%"));
 
   addTableSeparator(F("Custom Variables"), 3, 3);
-  addSysVar_html(F("%customvar1%"));
-  addSysVar_html(F("%customvar2%"));
-  addSysVar_html(F("%customvar3%"));
-  addSysVar_html(F("%customvar4%"));
-  addSysVar_html(F("%customvar5%"));
-  addSysVar_html(F("%customvar6%"));
-  addSysVar_html(F("%customvar7%"));
-  addSysVar_html(F("%customvar8%"));
-  addSysVar_html(F("%customvar9%"));
-  addSysVar_html(F("%customvar10%"));
-  addSysVar_html(F("%customvar11%"));
-  addSysVar_html(F("%customvar12%"));
-  addSysVar_html(F("%customvar13%"));
-  addSysVar_html(F("%customvar14%"));
-  addSysVar_html(F("%customvar15%"));
-  addSysVar_html(F("%customvar16%"));
+  for (byte i = 0; i < CUSTOM_VARS_MAX; ++i) {
+    addSysVar_html(String(F("%customvar"))+toString(i+1,0)+String(F("%")));
+  }
 
   addTableSeparator(F("Special Characters"), 3, 2);
   addTableSeparator(F("Degree"), 3, 3);


### PR DESCRIPTION
Added a new RULES command:
`customvar,x,y`

that stores in a system variable %customvarx% the value 'y'.
Values are float. x can be 1 to 16.

Example:
```
on event do
  customvar,1,10
endon

on event2 do
  if %customvar1%=10 do
  //code
  endif
endon
```
