### PR TITLE
[safe strncpy] Add warning when entered string is too large

### DIFF
--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -1,3 +1,5 @@
+#define MQTT_MAX_PAYLOAD_LENGTH 384
+
 //********************************************************************************
 // Interface for Sending to Controllers
 //********************************************************************************
@@ -80,8 +82,8 @@ boolean validUserVar(struct EventStruct *event) {
 \*********************************************************************************************/
 // handle MQTT messages
 void callback(char* c_topic, byte* b_payload, unsigned int length) {
-  // char log[256];
-  char c_payload[384];
+  struct EventStruct TempEvent;
+  TempEvent.String1 = c_topic; // This is the topic of the message
 
   statusLED(true);
   int enabledMqttController = firstEnabledMQTTController();
@@ -89,38 +91,23 @@ void callback(char* c_topic, byte* b_payload, unsigned int length) {
     addLog(LOG_LEVEL_ERROR, F("MQTT : No enabled MQTT controller"));
     return;
   }
-  if ((length + 1) > sizeof(c_payload))
+  if ((length + 1) > MQTT_MAX_PAYLOAD_LENGTH)
   {
     addLog(LOG_LEVEL_ERROR, F("MQTT : Ignored too big message"));
     return;
   }
 
-  //convert payload to string, and 0 terminate
-  strncpy(c_payload,(char*)b_payload,length);
-  c_payload[length] = 0;
-
-/*
-  if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE)) {
-    String log;
-    log=F("MQTT : Topic: ");
-    log+=c_topic;
-    addLog(LOG_LEVEL_DEBUG_MORE, log);
-
-    log=F("MQTT : Payload: ");
-    log+=c_payload;
-    addLog(LOG_LEVEL_DEBUG_MORE, log);
+  size_t str_length = strlen((char*)b_payload);
+  if (str_length > MQTT_MAX_PAYLOAD_LENGTH) str_length = MQTT_MAX_PAYLOAD_LENGTH;
+  TempEvent.String2 = ""; // This is the payload
+  TempEvent.String2.reserve(str_length);
+  for (size_t i = 0; i < str_length; ++i) {
+    char c = ((char*)b_payload)[i];
+    TempEvent.String2 += c;
   }
-  */
+  TempEvent.String2.trim();
 
-  // sprintf_P(log, PSTR("%s%s"), "MQTT : Topic: ", c_topic);
-  // addLog(LOG_LEVEL_DEBUG, log);
-  // sprintf_P(log, PSTR("%s%s"), "MQTT : Payload: ", c_payload);
-  // addLog(LOG_LEVEL_DEBUG, log);
-
-  struct EventStruct TempEvent;
   // TD-er: This one cannot set the TaskIndex, but that may seem to work out.... hopefully.
-  TempEvent.String1 = c_topic;
-  TempEvent.String2 = c_payload;
   byte ProtocolIndex = getProtocolIndex(Settings.Protocol[enabledMqttController]);
   schedule_controller_event_timer(ProtocolIndex, CPLUGIN_PROTOCOL_RECV, &TempEvent);
 }

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -605,9 +605,6 @@ WiFiUDP portUDP;
 
 class TimingStats;
 
-#define LOADFILE_STATS  0
-#define LOOP_STATS      1
-
 /*********************************************************************************************\
  * CRCStruct
 \*********************************************************************************************/
@@ -1824,31 +1821,32 @@ unsigned long timediff_calls = 0;
 unsigned long timediff_cpu_cycles_total = 0;
 
 #define LOADFILE_STATS        0
-#define LOOP_STATS            1
-#define PLUGIN_CALL_50PS      2
-#define PLUGIN_CALL_10PS      3
-#define PLUGIN_CALL_10PSU     4
-#define PLUGIN_CALL_1PS       5
-#define SENSOR_SEND_TASK      6
-#define SEND_DATA_STATS       7
-#define COMPUTE_FORMULA_STATS 8
-#define PROC_SYS_TIMER        9
-#define SET_NEW_TIMER        10
-#define TIME_DIFF_COMPUTE    11
-#define MQTT_DELAY_QUEUE     12
-#define C001_DELAY_QUEUE     13
-#define C002_DELAY_QUEUE     14
-#define C003_DELAY_QUEUE     15
-#define C004_DELAY_QUEUE     16
-#define C005_DELAY_QUEUE     17
-#define C006_DELAY_QUEUE     18
-#define C007_DELAY_QUEUE     19
-#define C008_DELAY_QUEUE     20
-#define C009_DELAY_QUEUE     21
-#define C010_DELAY_QUEUE     22
-#define C011_DELAY_QUEUE     23
-#define C012_DELAY_QUEUE     24
-#define C013_DELAY_QUEUE     25
+#define SAVEFILE_STATS        1
+#define LOOP_STATS            2
+#define PLUGIN_CALL_50PS      3
+#define PLUGIN_CALL_10PS      4
+#define PLUGIN_CALL_10PSU     5
+#define PLUGIN_CALL_1PS       6
+#define SENSOR_SEND_TASK      7
+#define SEND_DATA_STATS       8
+#define COMPUTE_FORMULA_STATS 9
+#define PROC_SYS_TIMER       10
+#define SET_NEW_TIMER        11
+#define TIME_DIFF_COMPUTE    12
+#define MQTT_DELAY_QUEUE     13
+#define C001_DELAY_QUEUE     14
+#define C002_DELAY_QUEUE     15
+#define C003_DELAY_QUEUE     16
+#define C004_DELAY_QUEUE     17
+#define C005_DELAY_QUEUE     18
+#define C006_DELAY_QUEUE     19
+#define C007_DELAY_QUEUE     20
+#define C008_DELAY_QUEUE     21
+#define C009_DELAY_QUEUE     22
+#define C010_DELAY_QUEUE     23
+#define C011_DELAY_QUEUE     24
+#define C012_DELAY_QUEUE     25
+#define C013_DELAY_QUEUE     26
 
 
 
@@ -1857,13 +1855,14 @@ unsigned long timediff_cpu_cycles_total = 0;
 
 #define START_TIMER const unsigned statisticsTimerStart(micros());
 #define STOP_TIMER_TASK(T,F)  if (mustLogFunction(F)) pluginStats[T*32 + F].add(usecPassedSince(statisticsTimerStart));
-#define STOP_TIMER_LOADFILE miscStats[LOADFILE_STATS].add(usecPassedSince(statisticsTimerStart));
+//#define STOP_TIMER_LOADFILE miscStats[LOADFILE_STATS].add(usecPassedSince(statisticsTimerStart));
 #define STOP_TIMER(L)       miscStats[L].add(usecPassedSince(statisticsTimerStart));
 
 
 String getMiscStatsName(int stat) {
     switch (stat) {
         case LOADFILE_STATS: return F("Load File");
+        case SAVEFILE_STATS: return F("Save File");
         case LOOP_STATS:     return F("Loop");
         case PLUGIN_CALL_50PS:      return F("Plugin call 50 p/s  ");
         case PLUGIN_CALL_10PS:      return F("Plugin call 10 p/s  ");

--- a/src/ESPEasyWifi.ino
+++ b/src/ESPEasyWifi.ino
@@ -470,7 +470,7 @@ bool prepareWiFi() {
   }
   setSTA(true);
   char hostname[40];
-  strncpy(hostname, WifiGetHostname().c_str(), sizeof(hostname));
+  safe_strncpy(hostname, WifiGetHostname(), sizeof(hostname));
   #if defined(ESP8266)
     wifi_station_set_hostname(hostname);
   #endif

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -1243,12 +1243,14 @@ byte getSerialLogLevel() {
   if (wifiStatus != ESPEASY_WIFI_SERVICES_INITIALIZED){
     logLevelSettings = 2;
   }
+/*
   if (!serialLogActiveRead()) {
     if (logLevelSettings != 0) {
       updateLogLevelCache();
     }
     logLevelSettings = 0;
   }
+*/
   return logLevelSettings;
 }
 
@@ -1348,7 +1350,6 @@ void process_serialLogBuffer() {
       serialLogBuffer.pop_front();
     }
   }
-  updateLogLevelCache();
 }
 
 void tempDisableSerialLog(bool setToDisabled) {

--- a/src/StringConverter.ino
+++ b/src/StringConverter.ino
@@ -288,6 +288,26 @@ String stripQuotes(const String& text) {
   return text;
 }
 
+bool safe_strncpy(char* dest, const String& source, size_t max_size) {
+  return safe_strncpy(dest, source.c_str(), max_size);
+}
+
+bool safe_strncpy(char* dest, const char* source, size_t max_size) {
+  if (max_size < 1) return false;
+  if (dest == NULL) return false;
+  if (source == NULL) return false;
+  bool result = true;
+  memset(dest, 0, max_size);
+  size_t str_length = strlen(source);
+  if (str_length >= max_size) {
+    str_length = max_size;
+    result = false;
+  }
+  strncpy(dest, source, str_length);
+  dest[max_size - 1] = 0;
+  return result;
+}
+
 /*********************************************************************************************\
    Parse a string and get the xth command or parameter in lower case
   \*********************************************************************************************/

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -1041,17 +1041,17 @@ void handle_config() {
       addLog(LOG_LEVEL_INFO, F("Unit Name changed."));
       MQTTclient_should_reconnect = true;
     }
-    strncpy(Settings.Name, name.c_str(), sizeof(Settings.Name));
+    safe_strncpy(Settings.Name, name, sizeof(Settings.Name));
     Settings.appendUnitToHostname(isFormItemChecked(F("appendunittohostname")));
-    //strncpy(SecuritySettings.Password, password.c_str(), sizeof(SecuritySettings.Password));
+    //safe_strncpy(SecuritySettings.Password, password.c_str(), sizeof(SecuritySettings.Password));
     copyFormPassword(F("password"), SecuritySettings.Password, sizeof(SecuritySettings.Password));
-    strncpy(SecuritySettings.WifiSSID, ssid.c_str(), sizeof(SecuritySettings.WifiSSID));
-    //strncpy(SecuritySettings.WifiKey, key.c_str(), sizeof(SecuritySettings.WifiKey));
+    safe_strncpy(SecuritySettings.WifiSSID, ssid, sizeof(SecuritySettings.WifiSSID));
+    //safe_strncpy(SecuritySettings.WifiKey, key.c_str(), sizeof(SecuritySettings.WifiKey));
     copyFormPassword(F("key"), SecuritySettings.WifiKey, sizeof(SecuritySettings.WifiKey));
-    strncpy(SecuritySettings.WifiSSID2, ssid2.c_str(), sizeof(SecuritySettings.WifiSSID2));
-    //strncpy(SecuritySettings.WifiKey2, key2.c_str(), sizeof(SecuritySettings.WifiKey2));
+    safe_strncpy(SecuritySettings.WifiSSID2, ssid2, sizeof(SecuritySettings.WifiSSID2));
+    //safe_strncpy(SecuritySettings.WifiKey2, key2.c_str(), sizeof(SecuritySettings.WifiKey2));
     copyFormPassword(F("key2"), SecuritySettings.WifiKey2, sizeof(SecuritySettings.WifiKey2));
-    //strncpy(SecuritySettings.WifiAPKey, apkey.c_str(), sizeof(SecuritySettings.WifiAPKey));
+    //safe_strncpy(SecuritySettings.WifiAPKey, apkey.c_str(), sizeof(SecuritySettings.WifiAPKey));
     copyFormPassword(F("apkey"), SecuritySettings.WifiAPKey, sizeof(SecuritySettings.WifiAPKey));
 
 
@@ -1210,11 +1210,11 @@ void handle_controllers() {
 //        ControllerSettings.MaxQueueDepth = 0;
         if (Protocol[ProtocolIndex].usesTemplate)
           CPlugin_ptr[ProtocolIndex](CPLUGIN_PROTOCOL_TEMPLATE, &TempEvent, dummyString);
-        strncpy(ControllerSettings.Subscribe, TempEvent.String1.c_str(), sizeof(ControllerSettings.Subscribe));
-        strncpy(ControllerSettings.Publish, TempEvent.String2.c_str(), sizeof(ControllerSettings.Publish));
-        strncpy(ControllerSettings.MQTTLwtTopic, TempEvent.String3.c_str(), sizeof(ControllerSettings.MQTTLwtTopic));
-        strncpy(ControllerSettings.LWTMessageConnect, TempEvent.String4.c_str(), sizeof(ControllerSettings.LWTMessageConnect));
-        strncpy(ControllerSettings.LWTMessageDisconnect, TempEvent.String5.c_str(), sizeof(ControllerSettings.LWTMessageDisconnect));
+        safe_strncpy(ControllerSettings.Subscribe, TempEvent.String1, sizeof(ControllerSettings.Subscribe));
+        safe_strncpy(ControllerSettings.Publish, TempEvent.String2, sizeof(ControllerSettings.Publish));
+        safe_strncpy(ControllerSettings.MQTTLwtTopic, TempEvent.String3, sizeof(ControllerSettings.MQTTLwtTopic));
+        safe_strncpy(ControllerSettings.LWTMessageConnect, TempEvent.String4, sizeof(ControllerSettings.LWTMessageConnect));
+        safe_strncpy(ControllerSettings.LWTMessageDisconnect, TempEvent.String5, sizeof(ControllerSettings.LWTMessageDisconnect));
         TempEvent.String1 = "";
         TempEvent.String2 = "";
         TempEvent.String3 = "";
@@ -1245,7 +1245,7 @@ void handle_controllers() {
         ControllerSettings.UseDNS = usedns.toInt();
         if (ControllerSettings.UseDNS)
         {
-          strncpy(ControllerSettings.HostName, controllerhostname.c_str(), sizeof(ControllerSettings.HostName));
+          safe_strncpy(ControllerSettings.HostName, controllerhostname.c_str(), sizeof(ControllerSettings.HostName));
           IPAddress IP;
           WiFi.hostByName(ControllerSettings.HostName, IP);
           for (byte x = 0; x < 4; x++)
@@ -1259,14 +1259,14 @@ void handle_controllers() {
         //copy settings to struct
         Settings.ControllerEnabled[controllerindex] = isFormItemChecked(F("controllerenabled"));
         ControllerSettings.Port = controllerport;
-        strncpy(SecuritySettings.ControllerUser[controllerindex], controlleruser.c_str(), sizeof(SecuritySettings.ControllerUser[0]));
-        //strncpy(SecuritySettings.ControllerPassword[controllerindex], controllerpassword.c_str(), sizeof(SecuritySettings.ControllerPassword[0]));
+        safe_strncpy(SecuritySettings.ControllerUser[controllerindex], controlleruser.c_str(), sizeof(SecuritySettings.ControllerUser[0]));
+        //safe_strncpy(SecuritySettings.ControllerPassword[controllerindex], controllerpassword.c_str(), sizeof(SecuritySettings.ControllerPassword[0]));
         copyFormPassword(F("controllerpassword"), SecuritySettings.ControllerPassword[controllerindex], sizeof(SecuritySettings.ControllerPassword[0]));
-        strncpy(ControllerSettings.Subscribe, controllersubscribe.c_str(), sizeof(ControllerSettings.Subscribe));
-        strncpy(ControllerSettings.Publish, controllerpublish.c_str(), sizeof(ControllerSettings.Publish));
-        strncpy(ControllerSettings.MQTTLwtTopic, MQTTLwtTopic.c_str(), sizeof(ControllerSettings.MQTTLwtTopic));
-        strncpy(ControllerSettings.LWTMessageConnect, lwtmessageconnect.c_str(), sizeof(ControllerSettings.LWTMessageConnect));
-        strncpy(ControllerSettings.LWTMessageDisconnect, lwtmessagedisconnect.c_str(), sizeof(ControllerSettings.LWTMessageDisconnect));
+        safe_strncpy(ControllerSettings.Subscribe, controllersubscribe.c_str(), sizeof(ControllerSettings.Subscribe));
+        safe_strncpy(ControllerSettings.Publish, controllerpublish.c_str(), sizeof(ControllerSettings.Publish));
+        safe_strncpy(ControllerSettings.MQTTLwtTopic, MQTTLwtTopic.c_str(), sizeof(ControllerSettings.MQTTLwtTopic));
+        safe_strncpy(ControllerSettings.LWTMessageConnect, lwtmessageconnect.c_str(), sizeof(ControllerSettings.LWTMessageConnect));
+        safe_strncpy(ControllerSettings.LWTMessageDisconnect, lwtmessagedisconnect.c_str(), sizeof(ControllerSettings.LWTMessageDisconnect));
         ControllerSettings.MinimalTimeBetweenMessages = minimumsendinterval;
         ControllerSettings.MaxQueueDepth = maxqueuedepth;
         ControllerSettings.MaxRetry = maxretry;
@@ -1573,14 +1573,14 @@ void handle_notifications() {
         NotificationSettings.Pin1 = getFormItemInt(F("pin1"), 0);
         NotificationSettings.Pin2 = getFormItemInt(F("pin2"), 0);
         Settings.NotificationEnabled[notificationindex] = isFormItemChecked(F("notificationenabled"));
-        strncpy(NotificationSettings.Domain, domain.c_str(), sizeof(NotificationSettings.Domain));
-        strncpy(NotificationSettings.Server, server.c_str(), sizeof(NotificationSettings.Server));
-        strncpy(NotificationSettings.Sender, sender.c_str(), sizeof(NotificationSettings.Sender));
-        strncpy(NotificationSettings.Receiver, receiver.c_str(), sizeof(NotificationSettings.Receiver));
-        strncpy(NotificationSettings.Subject, subject.c_str(), sizeof(NotificationSettings.Subject));
-        strncpy(NotificationSettings.User, user.c_str(), sizeof(NotificationSettings.User));
-        strncpy(NotificationSettings.Pass, pass.c_str(), sizeof(NotificationSettings.Pass));
-        strncpy(NotificationSettings.Body, body.c_str(), sizeof(NotificationSettings.Body));
+        safe_strncpy(NotificationSettings.Domain, domain.c_str(), sizeof(NotificationSettings.Domain));
+        safe_strncpy(NotificationSettings.Server, server.c_str(), sizeof(NotificationSettings.Server));
+        safe_strncpy(NotificationSettings.Sender, sender.c_str(), sizeof(NotificationSettings.Sender));
+        safe_strncpy(NotificationSettings.Receiver, receiver.c_str(), sizeof(NotificationSettings.Receiver));
+        safe_strncpy(NotificationSettings.Subject, subject.c_str(), sizeof(NotificationSettings.Subject));
+        safe_strncpy(NotificationSettings.User, user.c_str(), sizeof(NotificationSettings.User));
+        safe_strncpy(NotificationSettings.Pass, pass.c_str(), sizeof(NotificationSettings.Pass));
+        safe_strncpy(NotificationSettings.Body, body.c_str(), sizeof(NotificationSettings.Body));
       }
     }
     // Save the settings.
@@ -3012,7 +3012,7 @@ void copyFormPassword(const String& id, char* pPassword, int maxlength)
   String password = WebServer.arg(id);
   if (password == F("*****"))   //no change?
     return;
-  strncpy(pPassword, password.c_str(), maxlength);
+  safe_strncpy(pPassword, password.c_str(), maxlength);
 }
 
 void addFormIPBox(const String& label, const String& id, const byte ip[4])
@@ -4973,8 +4973,8 @@ void handle_setup() {
   // if ssid config not set and params are both provided
   if (status == 0 && ssid.length() != 0 /*&& strcasecmp(SecuritySettings.WifiSSID, "ssid") == 0 */)
   {
-    strncpy(SecuritySettings.WifiKey, password.c_str(), sizeof(SecuritySettings.WifiKey));
-    strncpy(SecuritySettings.WifiSSID, ssid.c_str(), sizeof(SecuritySettings.WifiSSID));
+    safe_strncpy(SecuritySettings.WifiKey, password.c_str(), sizeof(SecuritySettings.WifiKey));
+    safe_strncpy(SecuritySettings.WifiSSID, ssid.c_str(), sizeof(SecuritySettings.WifiSSID));
     wifiSetupConnect = true;
     if (loglevelActiveFor(LOG_LEVEL_INFO)) {
       String reconnectlog = F("WIFI : Credentials Changed, retry connection. SSID: ");
@@ -5037,7 +5037,7 @@ void handle_setup() {
     if (refreshCount > 0)
     {
       status = 0;
-//      strncpy(SecuritySettings.WifiSSID, "ssid", sizeof(SecuritySettings.WifiSSID));
+//      safe_strncpy(SecuritySettings.WifiSSID, "ssid", sizeof(SecuritySettings.WifiSSID));
 //      SecuritySettings.WifiKey[0] = 0;
       TXBuffer += F("<a class='button' href='setup'>Back to Setup</a><BR><BR>");
     }

--- a/src/_P012_LCD.ino
+++ b/src/_P012_LCD.ino
@@ -21,6 +21,9 @@ int Plugin_012_mode = 1;
 #define PLUGIN_NAME_012       "Display - LCD2004"
 #define PLUGIN_VALUENAME1_012 "LCD"
 
+#define P12_Nlines 4        // The number of different lines which can be displayed
+#define P12_Nchars 80
+
 boolean Plugin_012(byte function, struct EventStruct *event, String& string)
 {
   boolean success = false;
@@ -81,9 +84,9 @@ boolean Plugin_012(byte function, struct EventStruct *event, String& string)
         addFormSelector(F("Display Size"), F("plugin_012_size"), 2, options2, optionValues2, choice2);
 
 
-        char deviceTemplate[4][80];
+        char deviceTemplate[P12_Nlines][P12_Nchars];
         LoadCustomTaskSettings(event->TaskIndex, (byte*)&deviceTemplate, sizeof(deviceTemplate));
-        for (byte varNr = 0; varNr < 4; varNr++)
+        for (byte varNr = 0; varNr < P12_Nlines; varNr++)
         {
           addHtml(F("<TR><TD>Line "));
           addHtml(String(varNr + 1));
@@ -122,17 +125,19 @@ boolean Plugin_012(byte function, struct EventStruct *event, String& string)
         Settings.TaskDevicePluginConfig[event->TaskIndex][2] = getFormItemInt(F("plugin_12_timer"));
         Settings.TaskDevicePluginConfig[event->TaskIndex][3] = getFormItemInt(F("plugin_012_mode"));
 
-        char deviceTemplate[4][80];
-        for (byte varNr = 0; varNr < 4; varNr++)
+        char deviceTemplate[P12_Nlines][P12_Nchars];
+        String error;
+        for (byte varNr = 0; varNr < P12_Nlines; varNr++)
         {
-          char argc[25];
-          String arg = F("Plugin_012_template");
-          arg += varNr + 1;
-          arg.toCharArray(argc, 25);
-          String tmpString = WebServer.arg(argc);
-          strncpy(deviceTemplate[varNr], tmpString.c_str(), sizeof(deviceTemplate[varNr]));
+          String argName = F("Plugin_012_template");
+          argName += varNr + 1;
+          if (!safe_strncpy(deviceTemplate[varNr], WebServer.arg(argName), P12_Nchars)) {
+            error += getCustomTaskSettingsError(varNr);
+          }
         }
-
+        if (error.length() > 0) {
+          addHtmlError(error);
+        }
         SaveCustomTaskSettings(event->TaskIndex, (byte*)&deviceTemplate, sizeof(deviceTemplate));
         success = true;
         break;
@@ -194,7 +199,7 @@ boolean Plugin_012(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_READ:
       {
-        char deviceTemplate[4][80];
+        char deviceTemplate[P12_Nlines][P12_Nchars];
         LoadCustomTaskSettings(event->TaskIndex, (byte*)&deviceTemplate, sizeof(deviceTemplate));
 
         for (byte x = 0; x < Plugin_012_rows; x++)

--- a/src/_P036_FrameOLED.ino
+++ b/src/_P036_FrameOLED.ino
@@ -180,15 +180,18 @@ boolean Plugin_036(byte function, struct EventStruct *event, String& string)
         Settings.TaskDevicePluginConfig[event->TaskIndex][5] = getFormItemInt(F("plugin_036_controler"));
         Settings.TaskDevicePluginConfig[event->TaskIndex][6] = getFormItemInt(F("plugin_036_contrast"));
 
-        String argName;
-
+        String error;
         for (byte varNr = 0; varNr < P36_Nlines; varNr++)
         {
-          argName = F("Plugin_036_template");
+          String argName = F("Plugin_036_template");
           argName += varNr + 1;
-          strncpy(P036_deviceTemplate[varNr], WebServer.arg(argName).c_str(), sizeof(P036_deviceTemplate[varNr]));
+          if (!safe_strncpy(P036_deviceTemplate[varNr], WebServer.arg(argName), P36_Nchars)) {
+            error += getCustomTaskSettingsError(varNr);
+          }
         }
-
+        if (error.length() > 0) {
+          addHtmlError(error);
+        }
         SaveCustomTaskSettings(event->TaskIndex, (byte*)&P036_deviceTemplate, sizeof(P036_deviceTemplate));
 
         success = true;

--- a/src/_P037_MQTTImport.ino
+++ b/src/_P037_MQTTImport.ino
@@ -18,6 +18,11 @@
 
 #define PLUGIN_IMPORT 37		// This is a 'private' function used only by this import module
 
+#define P37_Nlines 4
+#define P37_Nchars 41
+
+#define P37_Payload_max_length  255
+
 // Declare a Wifi client for this plugin only
 
 // TODO TD-er: These must be kept in some vector to allow multiple instances of MQTT import.
@@ -81,7 +86,7 @@ boolean Plugin_037(byte function, struct EventStruct *event, String& string)
 {
   boolean success = false;
 
-  char deviceTemplate[4][41];		// variable for saving the subscription topics
+  char deviceTemplate[P37_Nlines][P37_Nchars];		// variable for saving the subscription topics
 
   switch (function)
   {
@@ -121,10 +126,10 @@ boolean Plugin_037(byte function, struct EventStruct *event, String& string)
 
         LoadCustomTaskSettings(event->TaskIndex, (byte*)&deviceTemplate, sizeof(deviceTemplate));
 
-        for (byte varNr = 0; varNr < 4; varNr++)
+        for (byte varNr = 0; varNr < P37_Nlines; varNr++)
         {
         	addFormTextBox(String(F("MQTT Topic ")) + (varNr + 1), String(F("Plugin_037_template")) +
-        			(varNr + 1), deviceTemplate[varNr], 40);
+        			(varNr + 1), deviceTemplate[varNr], (P37_Nchars - 1));
         }
         success = true;
         break;
@@ -133,14 +138,18 @@ boolean Plugin_037(byte function, struct EventStruct *event, String& string)
     case PLUGIN_WEBFORM_SAVE:
       {
         String argName;
-
-        for (byte varNr = 0; varNr < 4; varNr++)
+        String error;
+        for (byte varNr = 0; varNr < P37_Nlines; varNr++)
         {
           argName = F("Plugin_037_template");
           argName += varNr + 1;
-          strncpy(deviceTemplate[varNr], WebServer.arg(argName).c_str(), sizeof(deviceTemplate[varNr]));
+          if (!safe_strncpy(deviceTemplate[varNr], WebServer.arg(argName), P37_Nchars)) {
+            error += getCustomTaskSettingsError(varNr);
+          }
         }
-
+        if (error.length() > 0) {
+          addHtmlError(error);
+        }
         SaveCustomTaskSettings(event->TaskIndex, (byte*)&deviceTemplate, sizeof(deviceTemplate));
 
         success = true;
@@ -287,7 +296,7 @@ boolean MQTTSubscribe_037()
   // Subscribe to the topics requested by ALL calls to this plugin.
   // We do this because if the connection to the broker is lost, we want to resubscribe for all instances.
 
-  char deviceTemplate[4][41];
+  char deviceTemplate[P37_Nlines][P37_Nchars];
 
   //	Loop over all tasks looking for a 037 instance
 
@@ -334,25 +343,24 @@ boolean MQTTSubscribe_037()
 //
 // handle MQTT messages
 //
-void mqttcallback_037(char* c_topic, byte* b_payload, unsigned int length)
+void mqttcallback_037(char* c_topic, byte* b_payload, unsigned int length_given)
 {
   // Here we have incomng MQTT messages from the mqtt import module
-  String topic = c_topic;
+  // We generate a temp event structure to pass to the plugins
+  struct EventStruct TempEvent;
+  TempEvent.String1 = c_topic; // This is the topic of the message
 
-  char cpayload[256];
-  strncpy(cpayload, (char*)b_payload, length);
-  cpayload[length] = 0;
-  String payload = cpayload;		// convert byte to char string
-  payload.trim();
+  size_t str_length = strlen((char*)b_payload);
+  if (str_length > P37_Payload_max_length) str_length = P37_Payload_max_length;
+  TempEvent.String2 = ""; // This is the payload
+  TempEvent.String2.reserve(str_length);
+  for (size_t i = 0; i < str_length; ++i) {
+    char c = ((char*)b_payload)[i];
+    TempEvent.String2 += c;
+  }
+  TempEvent.String2.trim();
 
   byte DeviceIndex = getDeviceIndex(PLUGIN_ID_037);   // This is the device index of 037 modules -there should be one!
-
-  // We generate a temp event structure to pass to the plugins
-
-  struct EventStruct TempEvent;
-
-  TempEvent.String1 = topic;                            // This is the topic of the message
-  TempEvent.String2 = payload;                          // This is the payload
 
   //  Here we loop over all tasks and call each 037 plugin with function PLUGIN_IMPORT
 

--- a/src/_P075_Nextion.ino
+++ b/src/_P075_Nextion.ino
@@ -2,7 +2,7 @@
 //#######################################################################################################
 //################################### Plugin 075: Nextion <info@sensorio.cz>  ###########################
 //###################################   Created on the work of  majklovec     ###########################
-//###################################    Revisions by BertB and ThomasB       ########################### 
+//###################################    Revisions by BertB and ThomasB       ###########################
 //###################################    Last Revision: Oct-03-2018 (TB)      ###########################
 //#######################################################################################################
 //
@@ -36,18 +36,18 @@
 #define PLUGIN_VALUENAME2_075 "value"
 
 // Configuration Settings. Custom Configuration Memory must be less than 1024 Bytes (per TD'er findings).
-//#define Nlines 12             // Custom Config, Number of user entered Command Statment Lines. DO NOT USE!
-//#define Lenlines 64           // Custom Config, Length of user entered Command Statment Lines. DO NOT USE!
-#define Nlines 10               // Custom Config, Number of user entered Command Statments. 
-#define Lenlines 51             // Custom Config, Length of user entered Command Statments.
+//#define P75_Nlines 12             // Custom Config, Number of user entered Command Statment Lines. DO NOT USE!
+//#define P75_Nchars 64           // Custom Config, Length of user entered Command Statment Lines. DO NOT USE!
+#define P75_Nlines 10               // Custom Config, Number of user entered Command Statments.
+#define P75_Nchars 51             // Custom Config, Length of user entered Command Statments.
 
 // Nextion defines
-#define RXBUFFSZ  64            // Serial RxD buffer (Local staging buffer and ESPeasySoftwareSerial).  
+#define RXBUFFSZ  64            // Serial RxD buffer (Local staging buffer and ESPeasySoftwareSerial).
 #define RXBUFFWARN RXBUFFSZ-16  // Warning, Rx buffer close to being full.
 #define TOUCH_BASE 500          // Base offset for 0X65 Touch Event Send Component ID.
 
 // Serial defines
-#define B9600    0  
+#define B9600    0
 #define B38400   1
 #define B57600   2
 #define B115200  3
@@ -58,7 +58,7 @@
 
 // Global vars
 ESPeasySoftwareSerial *SoftSerial = NULL;
-char deviceTemplate[Nlines][Lenlines]; 
+char deviceTemplate[P75_Nlines][P75_Nchars];
 int rxPin = -1;
 int txPin = -1;
 
@@ -67,10 +67,10 @@ int txPin = -1;
 // PlugIn starts here
 // *****************************************************************************************************
 
-boolean Plugin_075(byte function, struct EventStruct *event, String& string) 
+boolean Plugin_075(byte function, struct EventStruct *event, String& string)
 {
   boolean success = false;
-  static uint8_t BaudCode = 0;                          // Web GUI baud rate drop down. 9600 if 0, See array for other rates. 
+  static uint8_t BaudCode = 0;                          // Web GUI baud rate drop down. 9600 if 0, See array for other rates.
   static boolean HwSerial = SOFTSERIAL;                 // Serial mode, hardware uart or softserial.
   static boolean AdvHwSerial = false;                   // Web GUI checkbox flag; false = softserial mode, true = hardware UART serial.
   static boolean IncludeValues = false;                 // Web GUI checkbox flag; false = don't send idx & value data at interval.
@@ -134,7 +134,7 @@ boolean Plugin_075(byte function, struct EventStruct *event, String& string)
       if (!((rxPin == 3 && txPin == 1) || (rxPin == 13 && txPin == 15))) { // Hardware Serial Compatible?
         Settings.TaskDevicePluginConfig[event->TaskIndex][0] = false;      // Not HW serial compatible, Reset Check Box.
       }
-      
+
       if (rxPin == 3 && txPin == 1) {                                      // UART USB Port?
         if(Settings.TaskDevicePluginConfig[event->TaskIndex][0]==false &&  // Hardware serial currently disabled.
          Settings.TaskDeviceEnabled[event->TaskIndex] == true) {           // Plugin is enabled.
@@ -142,10 +142,10 @@ boolean Plugin_075(byte function, struct EventStruct *event, String& string)
         }
       }
 
-      if (Settings.TaskDevicePluginConfig[event->TaskIndex][0] == false) { // SoftSerial mode. 
+      if (Settings.TaskDevicePluginConfig[event->TaskIndex][0] == false) { // SoftSerial mode.
         Settings.TaskDevicePluginConfig[event->TaskIndex][1] = B9600;      // Reset to 9600 baud.
       }
-      
+
       if(rxPin <0 || txPin <0) {                                            // Missing serial I/O pins!
         addFormNote(F("Please configure the RX and TX sensor pins before enabling this plugin."));
         addFormSubHeader(F("")); // Blank line, vertical space.
@@ -161,13 +161,13 @@ boolean Plugin_075(byte function, struct EventStruct *event, String& string)
       options[1] = F("38400");
       options[2] = F("57600");
       options[3] = F("115200");
-      
-      addFormSelector(F("Baud Rate"), F("plugin_075_baud"), 4, options, NULL, choice);      
+
+      addFormSelector(F("Baud Rate"), F("plugin_075_baud"), 4, options, NULL, choice);
       addFormNote(F("Un-check box for Soft Serial communication (low performance mode, 9600 Baud)."));
       addFormNote(F("Hardware Serial is available when the GPIO pins are RX=D7 and TX=D8."));
       addFormNote(F("D8 (GPIO-15) requires a Buffer Circuit (PNP transistor) or ESP boot may fail."));
       addFormNote(F("Do <b>NOT</b> enable the Serial Log file on Tools->Advanced->Serial Port."));
-      
+
 //    ** DEVELOPER DEBUG MESSAGE AREA **
 //    int datax = (int)(Settings.TaskDeviceEnabled[event->TaskIndex]); // Debug value.
 //    String Data = "Debug. Plugin Enable State: ";
@@ -176,12 +176,12 @@ boolean Plugin_075(byte function, struct EventStruct *event, String& string)
 
       addFormSubHeader(F(""));                          // Blank line, vertical space.
       addFormHeader(F("Nextion Command Statements (Optional)"));
-      
-      char deviceTemplate[Nlines][Lenlines];
+
+      char deviceTemplate[P75_Nlines][P75_Nchars];
       LoadCustomTaskSettings(event->TaskIndex, (byte*)&deviceTemplate, sizeof(deviceTemplate));
-      for (byte varNr = 0; varNr < Nlines; varNr++) {
-        addFormTextBox(String(F("Line ")) + (varNr + 1), String(F("Plugin_075_template")) + (varNr + 1), deviceTemplate[varNr], Lenlines-1);
-  
+      for (byte varNr = 0; varNr < P75_Nlines; varNr++) {
+        addFormTextBox(String(F("Line ")) + (varNr + 1), String(F("Plugin_075_template")) + (varNr + 1), deviceTemplate[varNr], P75_Nchars-1);
+
       }
       if( Settings.TaskDeviceTimer[event->TaskIndex]==0) { // Is interval timer disabled?
         if(IncludeValues) {
@@ -202,17 +202,18 @@ boolean Plugin_075(byte function, struct EventStruct *event, String& string)
 
 
     case PLUGIN_WEBFORM_SAVE: {
-
-        String argName;
-
-        char deviceTemplate[Nlines][Lenlines];
-        for (byte varNr = 0; varNr < Nlines; varNr++)
+        char deviceTemplate[P75_Nlines][P75_Nchars];
+        String error;
+        for (byte varNr = 0; varNr < P75_Nlines; varNr++)
         {
-          String arg = F("Plugin_075_template");
-          arg += varNr + 1;
-          String tmpString = WebServer.arg(arg);
-          strncpy(deviceTemplate[varNr], tmpString.c_str(), sizeof(deviceTemplate[varNr])-1);
-            deviceTemplate[varNr][Lenlines-1]=0;
+          String argName = F("Plugin_075_template");
+          argName += varNr + 1;
+          if (!safe_strncpy(deviceTemplate[varNr], WebServer.arg(argName), P75_Nchars)) {
+            error += getCustomTaskSettingsError(varNr);
+          }
+        }
+        if (error.length() > 0) {
+          addHtmlError(error);
         }
         if(getTaskDeviceName(event->TaskIndex) == "") {         // Check to see if user entered device name.
             strcpy(ExtraTaskSettings.TaskDeviceName,PLUGIN_DEFAULT_NAME); // Name missing, populate default name.
@@ -244,7 +245,7 @@ boolean Plugin_075(byte function, struct EventStruct *event, String& string)
         txPin = Settings.TaskDevicePin2[event->TaskIndex];
       }
 
-      if (SoftSerial != NULL) { 
+      if (SoftSerial != NULL) {
         delete SoftSerial;
         SoftSerial = NULL;
       }
@@ -293,7 +294,7 @@ boolean Plugin_075(byte function, struct EventStruct *event, String& string)
             HwSerial = SOFTSERIAL;
             if (SoftSerial == NULL) {
                 SoftSerial = new ESPeasySoftwareSerial(rxPin, txPin, false, RXBUFFSZ);
-            } 
+            }
             SoftSerial->begin(9600);
             SoftSerial->flush();
         }
@@ -305,8 +306,8 @@ boolean Plugin_075(byte function, struct EventStruct *event, String& string)
     }
 
 
-    case PLUGIN_READ: {    
-        char deviceTemplate[Nlines][Lenlines];
+    case PLUGIN_READ: {
+        char deviceTemplate[P75_Nlines][P75_Nchars];
         int RssiIndex;
         String newString;
         String tmpString;
@@ -315,7 +316,7 @@ boolean Plugin_075(byte function, struct EventStruct *event, String& string)
         LoadCustomTaskSettings(event->TaskIndex, (byte*)&deviceTemplate, sizeof(deviceTemplate));
 
 // Get optional LINE command statements. Special RSSIBAR bargraph keyword is supported.
-        for (byte x = 0; x < Nlines; x++) {
+        for (byte x = 0; x < P75_Nlines; x++) {
           tmpString = deviceTemplate[x];
           if (tmpString.length()) {
             UcTmpString = deviceTemplate[x];
@@ -323,7 +324,7 @@ boolean Plugin_075(byte function, struct EventStruct *event, String& string)
             RssiIndex = UcTmpString.indexOf(F("RSSIBAR"));  // RSSI bargraph Keyword found, wifi value in dBm.
             if(RssiIndex >= 0) {
               int barVal;
-              newString.reserve(Lenlines+10);               // Prevent re-allocation
+              newString.reserve(P75_Nchars+10);               // Prevent re-allocation
               newString = tmpString.substring(0, RssiIndex);
               int nbars = WiFi.RSSI();
               if (nbars < -100 || nbars >= 0)
@@ -356,9 +357,9 @@ boolean Plugin_075(byte function, struct EventStruct *event, String& string)
             }
 
             sendCommand(newString.c_str(), HwSerial);
-            #ifdef DEBUG_LOG 
+            #ifdef DEBUG_LOG
               String log;
-              log.reserve(Lenlines+50);                 // Prevent re-allocation
+              log.reserve(P75_Nchars+50);                 // Prevent re-allocation
               log = F("NEXTION075 : Cmd Statement Line-");
               log += String(x+1);
               log += F(" Sent: ");
@@ -389,31 +390,31 @@ boolean Plugin_075(byte function, struct EventStruct *event, String& string)
             #endif
 
             success = false;
-        } 
+        }
 
         break;
     }
 
-// Nextion commands received from events (including http) get processed here. PLUGIN_WRITE 
+// Nextion commands received from events (including http) get processed here. PLUGIN_WRITE
 // does NOT process publish commands that are sent.
     case PLUGIN_WRITE: {
-        
+
         String tmpString = string;
         int argIndex = tmpString.indexOf(',');
         if (argIndex) tmpString = tmpString.substring(0, argIndex);
-        
+
 // Enable addLog() code below to help debug plugin write problems.
 /*
         String log;
         log.reserve(140);                               // Prevent re-allocation
         String log = F("Nextion arg0: ");
-        log += tmpString; 
+        log += tmpString;
         log += F(", TaskDeviceName: ");
         log += getTaskDeviceName(event->TaskIndex);
         log += F(", event->TaskIndex: ");
-        log += String(event->TaskIndex); 
+        log += String(event->TaskIndex);
         log += F(", cmd str: ");
-        log += string;      
+        log += string;
         addLog(LOG_LEVEL_INFO, log);
 */
         if (tmpString.equalsIgnoreCase(getTaskDeviceName(event->TaskIndex)) == true) { // If device names match we have a command to write.
@@ -425,7 +426,7 @@ boolean Plugin_075(byte function, struct EventStruct *event, String& string)
             log.reserve(110);                           // Prevent re-allocation
             log = F("NEXTION075 : WRITE = ");
             log += tmpString;
-            #ifdef DEBUG_LOG  
+            #ifdef DEBUG_LOG
               addLog(LOG_LEVEL_INFO, log);
             #endif
             SendStatus(event->Source, log);             // Reply (echo) to sender. This will print message on browser.
@@ -457,7 +458,7 @@ boolean Plugin_075(byte function, struct EventStruct *event, String& string)
         break;
     }
 
-    
+
     case PLUGIN_TEN_PER_SECOND: {
       uint16_t i;
       uint8_t c;
@@ -467,7 +468,7 @@ boolean Plugin_075(byte function, struct EventStruct *event, String& string)
       String Svalue;
       String Nswitch;
       char __buffer[RXBUFFSZ+1];                        // Staging buffer.
-      
+
       if(rxPin < 0) {
         String log = F("NEXTION075 : Missing RxD Pin, aborted serial receive");
         addLog(LOG_LEVEL_INFO, log);
@@ -534,7 +535,7 @@ boolean Plugin_075(byte function, struct EventStruct *event, String& string)
               #endif
             }
           }
-        } 
+        }
         else {
           if (c == '|') {
             __buffer[0] = c;                                  // Store in staging buffer.
@@ -545,7 +546,7 @@ boolean Plugin_075(byte function, struct EventStruct *event, String& string)
             else charCount = SoftSerial->available();
 
             if(HwSerial == UARTSERIAL) {
-                i = 1;            
+                i = 1;
                 while (Serial.available() > 0 && i<RXBUFFSZ) { // Copy global serial buffer to local buffer.
                   __buffer[i] = Serial.read();
                   if (__buffer[i]==0x0a || __buffer[i]==0x0d) break;
@@ -553,7 +554,7 @@ boolean Plugin_075(byte function, struct EventStruct *event, String& string)
                 }
             }
             else {
-                i = 1;            
+                i = 1;
                 while (SoftSerial->available() > 0 && i<RXBUFFSZ) { // Copy global serial buffer to local buffer.
                   __buffer[i] = SoftSerial->read();
                   if (__buffer[i]==0x0a || __buffer[i]==0x0d) break;
@@ -562,7 +563,7 @@ boolean Plugin_075(byte function, struct EventStruct *event, String& string)
             }
 
             __buffer[i] = 0x00;
-            
+
             String tmpString = __buffer;
 
             #ifdef DEBUG_LOG
@@ -632,7 +633,7 @@ boolean Plugin_075(byte function, struct EventStruct *event, String& string)
 }
 
 
-void sendCommand(const char *cmd, boolean SerialMode) 
+void sendCommand(const char *cmd, boolean SerialMode)
 {
     if(txPin < 0) {
         String log = F("NEXTION075 : Missing TxD Pin Number, aborted sendCommand");


### PR DESCRIPTION
Started with this issue:
"Framed Oled Display mixing up multiple values in different lines" #1904

Now almost all calls to `strncpy` are replaced with this safe variant which does some checking and zero-ing the buffer.