### PR TITLE
[#1891] Send all values for Generic UDP controller

### DIFF
--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -293,9 +293,9 @@ void scheduleNextMQTTdelayQueue() {
 
 void processMQTTdelayQueue() {
   START_TIMER;
-  MQTT_queue_element element;
-  if (!MQTTDelayHandler.getNext(element)) return;
-  if (MQTTclient.publish(element._topic.c_str(), element._payload.c_str(), element._retained)) {
+  MQTT_queue_element* element(MQTTDelayHandler.getNext());
+  if (element == NULL) return;
+  if (MQTTclient.publish(element->_topic.c_str(), element->_payload.c_str(), element->_retained)) {
     setIntervalTimerOverride(TIMER_MQTT, 10); // Make sure the MQTT is being processed as soon as possible.
     MQTTDelayHandler.markProcessed(true);
   } else {

--- a/src/_CPlugin_Helper.h
+++ b/src/_CPlugin_Helper.h
@@ -265,15 +265,14 @@ struct ControllerDelayHandlerStruct {
 
   // Get the next element.
   // Remove front element when max_retries is reached.
-  bool getNext(T& element) {
-    if (sendQueue.empty()) return false;
+  T* getNext() {
+    if (sendQueue.empty()) return NULL;
     if (attempt > max_retries) {
       sendQueue.pop_front();
       attempt = 0;
-      if (sendQueue.empty()) return false;
+      if (sendQueue.empty()) return NULL;
     }
-    element = sendQueue.front();
-    return true;
+    return &sendQueue.front();
   }
 
   // Mark as processed and return time to schedule for next process.
@@ -336,17 +335,17 @@ ControllerDelayHandlerStruct<MQTT_queue_element> MQTTDelayHandler;
                 ControllerDelayHandlerStruct<C##NNN##_queue_element> C##NNN##_DelayHandler; \
                 bool do_process_c##NNN##_delay_queue(int controller_number, const C##NNN##_queue_element& element, ControllerSettingsStruct& ControllerSettings); \
                 void process_c##NNN##_delay_queue() { \
-                  C##NNN##_queue_element element; \
-                  if (!C##NNN##_DelayHandler.getNext(element)) return; \
+                  C##NNN##_queue_element* element(C##NNN##_DelayHandler.getNext()); \
+                  if (element == NULL) return; \
                   MakeControllerSettings(ControllerSettings); \
-                  LoadControllerSettings(element.controller_idx, ControllerSettings); \
+                  LoadControllerSettings(element->controller_idx, ControllerSettings); \
                   C##NNN##_DelayHandler.configureControllerSettings(ControllerSettings); \
                   if (!WiFiConnected(100)) { \
                     scheduleNextDelayQueue(TIMER_C##NNN##_DELAY_QUEUE, C##NNN##_DelayHandler.getNextScheduleTime()); \
                     return; \
                   } \
                   START_TIMER; \
-                  C##NNN##_DelayHandler.markProcessed(do_process_c##NNN##_delay_queue(M, element, ControllerSettings)); \
+                  C##NNN##_DelayHandler.markProcessed(do_process_c##NNN##_delay_queue(M, *element, ControllerSettings)); \
                   STOP_TIMER(C##NNN##_DELAY_QUEUE); \
                   scheduleNextDelayQueue(TIMER_C##NNN##_DELAY_QUEUE, C##NNN##_DelayHandler.getNextScheduleTime()); \
                 }


### PR DESCRIPTION
See https://github.com/letscontrolit/ESPEasy/issues/1891#issuecomment-431612051

A copy of the element from the queue was used, not a reference to it.
Therefore increasing the internal counter to send the next value was only executed on the copy, not the element in the list.

See also:

- https://github.com/letscontrolit/ESPEasy/issues/1835
- https://github.com/letscontrolit/ESPEasy/issues/1891
- https://github.com/letscontrolit/ESPEasy/issues/1892#issuecomment-431509455
