### PR TITLE
doubleclick and longpress for PCF and MCP

### DIFF
--- a/src/_P001_Switch.ino
+++ b/src/_P001_Switch.ino
@@ -269,8 +269,8 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
         /**************************************************************************\
         20181009 - @giig1967g: new doubleclick logic is:
         if there is a 'state' change, check debounce period.
-        Then if doubleclick interval exceeded, reset Plugin_001_clickCounterDC to 0
-        Plugin_001_clickCounterDC contains the current status for doubleclick:
+        Then if doubleclick interval exceeded, reset Settings.TaskDevicePluginConfig[event->TaskIndex][7] to 0
+        Settings.TaskDevicePluginConfig[event->TaskIndex][7] contains the current status for doubleclick:
         0: start counting
         1: 1st click
         2: 2nd click
@@ -323,8 +323,6 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
               byte output_value;
               outputstate[event->TaskIndex] = new_outputState;
               boolean sendState = new_outputState;
-              if (Settings.TaskDevicePin1Inversed[event->TaskIndex])
-                sendState = !sendState;
 
               if (Settings.TaskDevicePluginConfig[event->TaskIndex][7]==3 && Settings.TaskDevicePluginConfig[event->TaskIndex][4])
               {
@@ -343,10 +341,13 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
               UserVar[event->BaseVarIndex] = output_value;
               String log = F("SW   : Switch state ");
               log += state ? '1' : '0';
-              log += F(" Output value ");
+              log += output_value<=1 ? F(" Output value=") : F(" Doubleclick=");
               log += output_value;
               addLog(LOG_LEVEL_INFO, log);
               sendData(event);
+
+              //reset Userdata so it displays the correct state value in the web page
+              UserVar[event->BaseVarIndex] = sendState ? 1 : 0;
             }
             Settings.TaskDevicePluginConfigLong[event->TaskIndex][0] = millis();
           }
@@ -403,6 +404,9 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
               log += output_value;
               addLog(LOG_LEVEL_INFO, log);
               sendData(event);
+
+              //reset Userdata so it displays the correct state value in the web page
+              UserVar[event->BaseVarIndex] = sendState ? 1 : 0;
             }
           }
         }

--- a/src/_P001_Switch.ino
+++ b/src/_P001_Switch.ino
@@ -55,8 +55,8 @@ boolean Plugin_001_read_switch_state(struct EventStruct *event) {
 boolean Plugin_001(byte function, struct EventStruct *event, String& string)
 {
   boolean success = false;
-  static boolean switchstate[TASKS_MAX];
-  static boolean outputstate[TASKS_MAX];
+  static byte switchstate[TASKS_MAX];
+  static byte outputstate[TASKS_MAX];
   static int8_t PinMonitor[GPIO_MAX];
   static int8_t PinMonitorState[GPIO_MAX];
 

--- a/src/_P001_Switch.ino
+++ b/src/_P001_Switch.ino
@@ -10,8 +10,8 @@ TaskDevicePluginConfig settings:
 1: dim value
 2: button option (normal, push high, push low)
 3: send boot state (true,false)
-4: use doubleclick (true,false)
-5: use longpress (true,false)
+4: use doubleclick (0,1,2,3)
+5: use longpress (0,1,2,3)
 6: LP fired (true,false)
 7: doubleclick counter (=0,1,2,3)
 
@@ -47,6 +47,14 @@ TaskDevicePluginConfigLong settings:
 #define PLUGIN_001_DOUBLECLICK_MAX_INTERVAL 3000
 #define PLUGIN_001_LONGPRESS_MIN_INTERVAL 1000
 #define PLUGIN_001_LONGPRESS_MAX_INTERVAL 5000
+#define PLUGIN_001_DC_DISABLED 0
+#define PLUGIN_001_DC_LOW 1
+#define PLUGIN_001_DC_HIGH 2
+#define PLUGIN_001_DC_BOTH 3
+#define PLUGIN_001_LONGPRESS_DISABLED 0
+#define PLUGIN_001_LONGPRESS_LOW 1
+#define PLUGIN_001_LONGPRESS_HIGH 2
+#define PLUGIN_001_LONGPRESS_BOTH 3
 
 boolean Plugin_001_read_switch_state(struct EventStruct *event) {
   return digitalRead(Settings.TaskDevicePin1[event->TaskIndex]) == HIGH;
@@ -126,14 +134,33 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
         if (Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1] < PLUGIN_001_DOUBLECLICK_MIN_INTERVAL)
           Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1] = PLUGIN_001_DOUBLECLICK_MIN_INTERVAL;
 
-        addFormCheckBox(F("Doubleclick event (3)"), F("plugin_001_dc"), Settings.TaskDevicePluginConfig[event->TaskIndex][4]);
+        byte choiceDC = Settings.TaskDevicePluginConfig[event->TaskIndex][4];
+        String buttonDC[4];
+        buttonDC[0] = F("Disabled");
+        buttonDC[1] = F("Active only on LOW (EVENT=3)");
+        buttonDC[2] = F("Active only on HIGH (EVENT=3)");
+        buttonDC[3] = F("Active on LOW & HIGH (EVENT=3)");
+        int buttonDCValues[4] = {PLUGIN_001_DC_DISABLED, PLUGIN_001_DC_LOW, PLUGIN_001_DC_HIGH,PLUGIN_001_DC_BOTH};
+
+        addFormSelector(F("Doubleclick event"), F("plugin_001_dc"), 4, buttonDC, buttonDCValues, choiceDC);
+
+        //addFormCheckBox(F("Doubleclick event (3)"), F("plugin_001_dc"), Settings.TaskDevicePluginConfig[event->TaskIndex][4]);
         addFormNumericBox(F("Doubleclick max. interval (ms)"), F("plugin_001_dcmaxinterval"), round(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1]), PLUGIN_001_DOUBLECLICK_MIN_INTERVAL, PLUGIN_001_DOUBLECLICK_MAX_INTERVAL);
 
         //set minimum value for longpress MIN max speed
         if (Settings.TaskDevicePluginConfigFloat[event->TaskIndex][2] < PLUGIN_001_LONGPRESS_MIN_INTERVAL)
           Settings.TaskDevicePluginConfigFloat[event->TaskIndex][2] = PLUGIN_001_LONGPRESS_MIN_INTERVAL;
 
-        addFormCheckBox(F("Longpress event (10 & 11)"), F("plugin_001_lp"), Settings.TaskDevicePluginConfig[event->TaskIndex][5]);
+        byte choiceLP = Settings.TaskDevicePluginConfig[event->TaskIndex][5];
+        String buttonLP[4];
+        buttonLP[0] = F("Disabled");
+        buttonLP[1] = F("Active only on LOW (EVENT= 10 [NORMAL] or 11 [INVERSED])");
+        buttonLP[2] = F("Active only on HIGH (EVENT= 11 [NORMAL] or 10 [INVERSED])");
+        buttonLP[3] = F("Active on LOW & HIGH (EVENT= 10 or 11)");
+        int buttonLPValues[4] = {PLUGIN_001_LONGPRESS_DISABLED, PLUGIN_001_LONGPRESS_LOW, PLUGIN_001_LONGPRESS_HIGH,PLUGIN_001_LONGPRESS_BOTH};
+        addFormSelector(F("Longpress event"), F("plugin_001_lp"), 4, buttonLP, buttonLPValues, choiceLP);
+
+        //addFormCheckBox(F("Longpress event (10 & 11)"), F("plugin_001_lp"), Settings.TaskDevicePluginConfig[event->TaskIndex][5]);
         addFormNumericBox(F("Longpress min. interval (ms)"), F("plugin_001_lpmininterval"), round(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][2]), PLUGIN_001_LONGPRESS_MIN_INTERVAL, PLUGIN_001_LONGPRESS_MAX_INTERVAL);
 
         //TO-DO: add Extra-Long Press event
@@ -158,10 +185,10 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
 
         Settings.TaskDevicePluginConfigFloat[event->TaskIndex][0] = getFormItemInt(F("plugin_001_debounce"));
 
-        Settings.TaskDevicePluginConfig[event->TaskIndex][4] = isFormItemChecked(F("plugin_001_dc"));
+        Settings.TaskDevicePluginConfig[event->TaskIndex][4] = getFormItemInt(F("plugin_001_dc"));
         Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1] = getFormItemInt(F("plugin_001_dcmaxinterval"));
 
-        Settings.TaskDevicePluginConfig[event->TaskIndex][5] = isFormItemChecked(F("plugin_001_lp"));
+        Settings.TaskDevicePluginConfig[event->TaskIndex][5] = getFormItemInt(F("plugin_001_lp"));
         Settings.TaskDevicePluginConfigFloat[event->TaskIndex][2] = getFormItemInt(F("plugin_001_lpmininterval"));
 
         //TO-DO: add Extra-Long Press event
@@ -184,12 +211,15 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
         else
           pinMode(Settings.TaskDevicePin1[event->TaskIndex], INPUT);
 
+        // @giig1967g-20181022: if it is in the device list we assume it's an input pin
         setPinState(PLUGIN_ID_001, Settings.TaskDevicePin1[event->TaskIndex], PIN_MODE_INPUT, 0);
 
+        // read and store current state to prevent switching at boot time
         switchstate[event->TaskIndex] = Plugin_001_read_switch_state(event);
         outputstate[event->TaskIndex] = switchstate[event->TaskIndex];
 
         // if boot state must be send, inverse default state
+        // this is done to force the trigger in PLUGIN_TEN_PER_SECOND
         if (Settings.TaskDevicePluginConfig[event->TaskIndex][3])
         {
           switchstate[event->TaskIndex] = !switchstate[event->TaskIndex];
@@ -214,11 +244,11 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
         Settings.TaskDevicePluginConfigLong[event->TaskIndex][1]=millis(); //doubleclick timer
         Settings.TaskDevicePluginConfigLong[event->TaskIndex][2]=millis(); //longpress timer
 
-        //set minimum value for doubleclick MIN max speed
+        //set minimum value for doubleclick MIN interval speed
         if (Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1] < PLUGIN_001_DOUBLECLICK_MIN_INTERVAL)
           Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1] = PLUGIN_001_DOUBLECLICK_MIN_INTERVAL;
 
-        //set minimum value for longpress MIN max speed
+        //set minimum value for longpress MIN interval speed
         if (Settings.TaskDevicePluginConfigFloat[event->TaskIndex][2] < PLUGIN_001_LONGPRESS_MIN_INTERVAL)
           Settings.TaskDevicePluginConfigFloat[event->TaskIndex][2] = PLUGIN_001_LONGPRESS_MIN_INTERVAL;
 
@@ -291,13 +321,23 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
           if (debounceTime >= (unsigned long)lround(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][0])) //de-bounce check
           {
             const unsigned long deltaDC = timePassedSince(Settings.TaskDevicePluginConfigLong[event->TaskIndex][1]);
-            if (deltaDC >= (unsigned long)lround(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1]))
+            if ((deltaDC >= (unsigned long)lround(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1])) ||
+                 Settings.TaskDevicePluginConfig[event->TaskIndex][7]==3)
             {
               //reset timer for doubleclick
               Settings.TaskDevicePluginConfig[event->TaskIndex][7]=0;
               Settings.TaskDevicePluginConfigLong[event->TaskIndex][1]=millis();
             }
-            Settings.TaskDevicePluginConfig[event->TaskIndex][7]++;
+
+//just to simplify the reading of the code
+#define COUNTER Settings.TaskDevicePluginConfig[event->TaskIndex][7]
+#define DC Settings.TaskDevicePluginConfig[event->TaskIndex][4]
+
+              //check settings for doubleclick according to the settings
+              if ( COUNTER!=0 || ( COUNTER==0 && (DC==3 || (DC==1 && state==0) || (DC==2 && state==1))) )
+                Settings.TaskDevicePluginConfig[event->TaskIndex][7]++;
+#undef DC
+#undef COUNTER
 
             switchstate[event->TaskIndex] = state;
             const boolean currentOutputState = outputstate[event->TaskIndex];
@@ -324,7 +364,10 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
               outputstate[event->TaskIndex] = new_outputState;
               boolean sendState = new_outputState;
 
-              if (Settings.TaskDevicePluginConfig[event->TaskIndex][7]==3 && Settings.TaskDevicePluginConfig[event->TaskIndex][4])
+              if (Settings.TaskDevicePin1Inversed[event->TaskIndex])
+                sendState = !sendState;
+
+              if (Settings.TaskDevicePluginConfig[event->TaskIndex][7]==3 && Settings.TaskDevicePluginConfig[event->TaskIndex][4]>0)
               {
                 output_value = 3; //double click
               } else {
@@ -339,9 +382,12 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
                 }
               }
               UserVar[event->BaseVarIndex] = output_value;
-              String log = F("SW   : Switch state ");
+
+              String log = F("SW  : GPIO=");
+              log += Settings.TaskDevicePin1[event->TaskIndex];
+              log += F(" State=");
               log += state ? '1' : '0';
-              log += output_value<=1 ? F(" Output value=") : F(" Doubleclick=");
+              log += output_value==3 ? F(" Doubleclick=") : F(" Output value=");
               log += output_value;
               addLog(LOG_LEVEL_INFO, log);
               sendData(event);
@@ -352,8 +398,17 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
             Settings.TaskDevicePluginConfigLong[event->TaskIndex][0] = millis();
           }
         }
+
+//just to simplify the reading of the code
+#define LP Settings.TaskDevicePluginConfig[event->TaskIndex][5]
+#define FIRED Settings.TaskDevicePluginConfig[event->TaskIndex][6]
+
         //check if LP is enabled and if LP has not fired yet
-        else if (Settings.TaskDevicePluginConfig[event->TaskIndex][5] && !Settings.TaskDevicePluginConfig[event->TaskIndex][6]) {
+        else if (!FIRED && (LP==3 ||(LP==1 && state==0)||(LP==2 && state==1) ) ) {
+
+#undef LP
+#undef FIRED
+
           /**************************************************************************\
           20181009 - @giig1967g: new longpress logic is:
           if there is no 'state' change, check if longpress interval reached
@@ -398,9 +453,11 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
               output_value = output_value + 10;
 
               UserVar[event->BaseVarIndex] = output_value;
-              String log = F("SW   : LongPress: Switch state ");
+              String log = F("SW  : LongPress: GPIO= ");
+              log += Settings.TaskDevicePin1[event->TaskIndex];
+              log += F(" State=");
               log += state ? '1' : '0';
-              log += F(" Output value ");
+              log += F(" Output value=");
               log += output_value;
               addLog(LOG_LEVEL_INFO, log);
               sendData(event);

--- a/src/_P009_MCP.ino
+++ b/src/_P009_MCP.ino
@@ -40,7 +40,7 @@ TaskDevicePluginConfigLong settings:
 boolean Plugin_009(byte function, struct EventStruct *event, String& string)
 {
   boolean success = false;
-  static int8_t switchstate[TASKS_MAX];
+  static int switchstate[TASKS_MAX];
 
   switch (function)
   {
@@ -124,7 +124,7 @@ boolean Plugin_009(byte function, struct EventStruct *event, String& string)
         Plugin_009_Config(Settings.TaskDevicePort[event->TaskIndex], 1);
 
         // read and store current state to prevent switching at boot time
-        switchstate[event->TaskIndex] = Plugin_009_Read(Settings.TaskDevicePort[event->TaskIndex]);
+        switchstate[event->TaskIndex] = (int) Plugin_009_Read(Settings.TaskDevicePort[event->TaskIndex]);
 
         // @giig1967g-20181022: set initial UserVar of the switch
         if (Settings.TaskDevicePin1Inversed[event->TaskIndex]){

--- a/src/_P009_MCP.ino
+++ b/src/_P009_MCP.ino
@@ -40,7 +40,7 @@ TaskDevicePluginConfigLong settings:
 boolean Plugin_009(byte function, struct EventStruct *event, String& string)
 {
   boolean success = false;
-  static byte switchstate[TASKS_MAX];
+  static int8_t switchstate[TASKS_MAX];
 
   switch (function)
   {

--- a/src/_P009_MCP.ino
+++ b/src/_P009_MCP.ino
@@ -3,10 +3,39 @@
 //#################################### Plugin 009: MCP23017 input #######################################
 //#######################################################################################################
 
+/**************************************************\
+CONFIG
+TaskDevicePluginConfig settings:
+0: send boot state (true,false)
+1:
+2:
+3:
+4: use doubleclick (true,false)
+5: use longpress (true,false)
+6: LP fired (true,false)
+7: doubleclick counter (=0,1,2,3)
+
+TaskDevicePluginConfigFloat settings:
+0: debounce interval ms
+1: doubleclick interval ms
+2: longpress interval ms
+3:
+
+TaskDevicePluginConfigLong settings:
+0: clickTime debounce ms
+1: clickTime doubleclick ms
+2: clickTime longpress ms
+3:
+\**************************************************/
+
 #define PLUGIN_009
 #define PLUGIN_ID_009         9
 #define PLUGIN_NAME_009       "Switch input - MCP23017"
 #define PLUGIN_VALUENAME1_009 "Switch"
+#define PLUGIN_009_DOUBLECLICK_MIN_INTERVAL 1000
+#define PLUGIN_009_DOUBLECLICK_MAX_INTERVAL 3000
+#define PLUGIN_009_LONGPRESS_MIN_INTERVAL 1000
+#define PLUGIN_009_LONGPRESS_MAX_INTERVAL 5000
 
 boolean Plugin_009(byte function, struct EventStruct *event, String& string)
 {
@@ -23,7 +52,7 @@ boolean Plugin_009(byte function, struct EventStruct *event, String& string)
         Device[deviceCount].VType = SENSOR_TYPE_SWITCH;
         Device[deviceCount].Ports = 16;
         Device[deviceCount].PullUpOption = false;
-        Device[deviceCount].InverseLogicOption = false;
+        Device[deviceCount].InverseLogicOption = true;
         Device[deviceCount].FormulaOption = false;
         Device[deviceCount].ValueCount = 1;
         Device[deviceCount].SendDataOption = true;
@@ -49,6 +78,25 @@ boolean Plugin_009(byte function, struct EventStruct *event, String& string)
       {
         addFormCheckBox(F("Send Boot state") ,F("plugin_009_boot"), Settings.TaskDevicePluginConfig[event->TaskIndex][0]);
 
+        //@giig1967-20181022
+        addFormSubHeader(F("Advanced event management"));
+
+        addFormNumericBox(F("De-bounce (ms)"), F("plugin_019_debounce"), round(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][0]), 0, 250);
+
+        //set minimum value for doubleclick MIN max speed
+        if (Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1] < PLUGIN_009_DOUBLECLICK_MIN_INTERVAL)
+          Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1] = PLUGIN_009_DOUBLECLICK_MIN_INTERVAL;
+
+        addFormCheckBox(F("Doubleclick event (3)"), F("plugin_019_dc"), Settings.TaskDevicePluginConfig[event->TaskIndex][4]);
+        addFormNumericBox(F("Doubleclick max. interval (ms)"), F("plugin_019_dcmaxinterval"), round(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1]), PLUGIN_009_DOUBLECLICK_MIN_INTERVAL, PLUGIN_009_DOUBLECLICK_MAX_INTERVAL);
+
+        //set minimum value for longpress MIN max speed
+        if (Settings.TaskDevicePluginConfigFloat[event->TaskIndex][2] < PLUGIN_009_LONGPRESS_MIN_INTERVAL)
+          Settings.TaskDevicePluginConfigFloat[event->TaskIndex][2] = PLUGIN_009_LONGPRESS_MIN_INTERVAL;
+
+        addFormCheckBox(F("Longpress event (10 & 11)"), F("plugin_019_lp"), Settings.TaskDevicePluginConfig[event->TaskIndex][5]);
+        addFormNumericBox(F("Longpress min. interval (ms)"), F("plugin_019_lpmininterval"), round(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][2]), PLUGIN_009_LONGPRESS_MIN_INTERVAL, PLUGIN_009_LONGPRESS_MAX_INTERVAL);
+
         success = true;
         break;
       }
@@ -56,6 +104,15 @@ boolean Plugin_009(byte function, struct EventStruct *event, String& string)
     case PLUGIN_WEBFORM_SAVE:
       {
         Settings.TaskDevicePluginConfig[event->TaskIndex][0] = isFormItemChecked(F("plugin_009_boot"));
+
+        //@giig1967-20181022
+        Settings.TaskDevicePluginConfigFloat[event->TaskIndex][0] = getFormItemInt(F("plugin_009_debounce"));
+
+        Settings.TaskDevicePluginConfig[event->TaskIndex][4] = isFormItemChecked(F("plugin_009_dc"));
+        Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1] = getFormItemInt(F("plugin_009_dcmaxinterval"));
+
+        Settings.TaskDevicePluginConfig[event->TaskIndex][5] = isFormItemChecked(F("plugin_009_lp"));
+        Settings.TaskDevicePluginConfigFloat[event->TaskIndex][2] = getFormItemInt(F("plugin_009_lpmininterval"));
 
         success = true;
         break;
@@ -69,29 +126,149 @@ boolean Plugin_009(byte function, struct EventStruct *event, String& string)
         // read and store current state to prevent switching at boot time
         switchstate[event->TaskIndex] = Plugin_009_Read(Settings.TaskDevicePort[event->TaskIndex]);
 
+        // @giig1967g-20181022: set initial UserVar of the switch
+        if (Settings.TaskDevicePin1Inversed[event->TaskIndex]){
+          UserVar[event->BaseVarIndex] = !switchstate[event->TaskIndex];
+        } else {
+          UserVar[event->BaseVarIndex] = switchstate[event->TaskIndex];
+        }
+
         // if boot state must be send, inverse default state
         if (Settings.TaskDevicePluginConfig[event->TaskIndex][0])
           switchstate[event->TaskIndex] = !switchstate[event->TaskIndex];
 
+        // @giig1967g-20181022: doubleclick counter = 0
+        Settings.TaskDevicePluginConfig[event->TaskIndex][7]=0;
+
+        // @giig1967g-20181022: used to track if LP has fired
+        Settings.TaskDevicePluginConfig[event->TaskIndex][6]=false;
+
+        // @giig1967g-20181022: store millis for debounce, doubleclick and long press
+        Settings.TaskDevicePluginConfigLong[event->TaskIndex][0]=millis(); //debounce timer
+        Settings.TaskDevicePluginConfigLong[event->TaskIndex][1]=millis(); //doubleclick timer
+        Settings.TaskDevicePluginConfigLong[event->TaskIndex][2]=millis(); //longpress timer
+
+        // @giig1967g-20181022: set minimum value for doubleclick MIN max speed
+        if (Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1] < PLUGIN_009_DOUBLECLICK_MIN_INTERVAL)
+          Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1] = PLUGIN_009_DOUBLECLICK_MIN_INTERVAL;
+
+        // @giig1967g-20181022: set minimum value for longpress MIN max speed
+        if (Settings.TaskDevicePluginConfigFloat[event->TaskIndex][2] < PLUGIN_009_LONGPRESS_MIN_INTERVAL)
+          Settings.TaskDevicePluginConfigFloat[event->TaskIndex][2] = PLUGIN_009_LONGPRESS_MIN_INTERVAL;
+
+        // @giig1967g-20181022: set initial UserVar of the switch
+        UserVar[event->BaseVarIndex] = switchstate[event->TaskIndex];
+
         setPinState(PLUGIN_ID_009, Settings.TaskDevicePort[event->TaskIndex], PIN_MODE_INPUT, 0);
+
         success = true;
         break;
       }
 
     case PLUGIN_TEN_PER_SECOND:
       {
-        int state = Plugin_009_Read(Settings.TaskDevicePort[event->TaskIndex]);
-        if (state != -1)
+        const boolean state = Plugin_009_Read(Settings.TaskDevicePort[event->TaskIndex]);
+        /**************************************************************************\
+        20181022 - @giig1967g: new doubleclick logic is:
+        if there is a 'state' change, check debounce period.
+        Then if doubleclick interval exceeded, reset Settings.TaskDevicePluginConfig[event->TaskIndex][7] to 0
+        Settings.TaskDevicePluginConfig[event->TaskIndex][7] contains the current status for doubleclick:
+        0: start counting
+        1: 1st click
+        2: 2nd click
+        3: 3rd click = doubleclick event if inside interval (calculated as: '3rd click time' minus '1st click time')
+
+        Returned EVENT value is = 3 always for doubleclick
+        In rules this can be checked:
+        on Button#Switch=3 do //will fire if doubleclick
+        \**************************************************************************/
+        if (state != -1 && state != switchstate[event->TaskIndex])
         {
-          if (state != switchstate[event->TaskIndex])
+          Settings.TaskDevicePluginConfigLong[event->TaskIndex][2]=millis();
+          Settings.TaskDevicePluginConfig[event->TaskIndex][6] = false;
+
+          const unsigned long debounceTime = timePassedSince(Settings.TaskDevicePluginConfigLong[event->TaskIndex][0]);
+          if (debounceTime >= (unsigned long)lround(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][0])) //de-bounce check
           {
+            const unsigned long deltaDC = timePassedSince(Settings.TaskDevicePluginConfigLong[event->TaskIndex][1]);
+            if (deltaDC >= (unsigned long)lround(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1]))
+            {
+              //reset timer for doubleclick
+              Settings.TaskDevicePluginConfig[event->TaskIndex][7]=0;
+              Settings.TaskDevicePluginConfigLong[event->TaskIndex][1]=millis();
+            }
+            Settings.TaskDevicePluginConfig[event->TaskIndex][7]++;
+
+            switchstate[event->TaskIndex] = state;
+
+            byte output_value;
+            boolean sendState = switchstate[event->TaskIndex];
+
+            if (Settings.TaskDevicePin1Inversed[event->TaskIndex])
+              sendState = !sendState;
+
+            if (Settings.TaskDevicePluginConfig[event->TaskIndex][7]==3 && Settings.TaskDevicePluginConfig[event->TaskIndex][4])
+            {
+              output_value = 3; //double click
+            } else {
+              output_value = state ? 1 : 0; //single click
+            }
+
+            UserVar[event->BaseVarIndex] = output_value;
+
             String log = F("MCP  : State ");
             log += state;
+            log += output_value<=1 ? F(" Output value=") : F(" Doubleclick=");
+            log += output_value;
             addLog(LOG_LEVEL_INFO, log);
-            switchstate[event->TaskIndex] = state;
-            UserVar[event->BaseVarIndex] = state;
+
             event->sensorType = SENSOR_TYPE_SWITCH;
             sendData(event);
+
+            //reset Userdata so it displays the correct state value in the web page
+            UserVar[event->BaseVarIndex] = sendState ? 1 : 0;
+
+            Settings.TaskDevicePluginConfigLong[event->TaskIndex][0] = millis();
+          }
+        }
+        //check if LP is enabled and if LP has not fired yet
+        else if (Settings.TaskDevicePluginConfig[event->TaskIndex][5] && !Settings.TaskDevicePluginConfig[event->TaskIndex][6]) {
+          /**************************************************************************\
+          20181022 - @giig1967g: new longpress logic is:
+          if there is no 'state' change, check if longpress interval reached
+          When reached send longpress event.
+          Returned Event value = state + 10
+          So if state = 0 => EVENT longpress = 10
+          if state = 1 => EVENT longpress = 11
+          So we can trigger longpress for high or low contact
+
+          In rules this can be checked:
+          on Button#Switch=10 do //will fire if longpress when state = 0
+          on Button#Switch=11 do //will fire if longpress when state = 1
+          \**************************************************************************/
+          const unsigned long deltaLP = timePassedSince(Settings.TaskDevicePluginConfigLong[event->TaskIndex][2]);
+          if (deltaLP >= (unsigned long)lround(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][2]))
+          {
+            byte output_value;
+            Settings.TaskDevicePluginConfig[event->TaskIndex][6] = true;
+
+            boolean sendState = state;
+            if (Settings.TaskDevicePin1Inversed[event->TaskIndex])
+              sendState = !sendState;
+
+            output_value = sendState ? 1 : 0;
+            output_value = output_value + 10;
+
+            UserVar[event->BaseVarIndex] = output_value;
+            String log = F("MCP  : LongPress: Switch state ");
+            log += state ? '1' : '0';
+            log += F(" Output value ");
+            log += output_value;
+            addLog(LOG_LEVEL_INFO, log);
+            sendData(event);
+
+            //reset Userdata so it displays the correct state value in the web page
+            UserVar[event->BaseVarIndex] = sendState ? 1 : 0;
           }
         }
         success = true;

--- a/src/_P019_PCF8574.ino
+++ b/src/_P019_PCF8574.ino
@@ -40,7 +40,7 @@ TaskDevicePluginConfigLong settings:
 boolean Plugin_019(byte function, struct EventStruct *event, String& string)
 {
   boolean success = false;
-  static boolean switchstate[TASKS_MAX];
+  static int8_t switchstate[TASKS_MAX];
 
   switch (function)
   {

--- a/src/_P019_PCF8574.ino
+++ b/src/_P019_PCF8574.ino
@@ -3,10 +3,39 @@
 //#################################### Plugin 019: PCF8574 ##############################################
 //#######################################################################################################
 
+/**************************************************\
+CONFIG
+TaskDevicePluginConfig settings:
+0: send boot state (true,false)
+1:
+2:
+3:
+4: use doubleclick (true,false)
+5: use longpress (true,false)
+6: LP fired (true,false)
+7: doubleclick counter (=0,1,2,3)
+
+TaskDevicePluginConfigFloat settings:
+0: debounce interval ms
+1: doubleclick interval ms
+2: longpress interval ms
+3:
+
+TaskDevicePluginConfigLong settings:
+0: clickTime debounce ms
+1: clickTime doubleclick ms
+2: clickTime longpress ms
+3:
+\**************************************************/
+
 #define PLUGIN_019
 #define PLUGIN_ID_019         19
 #define PLUGIN_NAME_019       "Switch input - PCF8574"
 #define PLUGIN_VALUENAME1_019 "Switch"
+#define PLUGIN_019_DOUBLECLICK_MIN_INTERVAL 1000
+#define PLUGIN_019_DOUBLECLICK_MAX_INTERVAL 3000
+#define PLUGIN_019_LONGPRESS_MIN_INTERVAL 1000
+#define PLUGIN_019_LONGPRESS_MAX_INTERVAL 5000
 
 boolean Plugin_019(byte function, struct EventStruct *event, String& string)
 {
@@ -49,6 +78,25 @@ boolean Plugin_019(byte function, struct EventStruct *event, String& string)
       {
         addFormCheckBox(F("Send Boot state"), F("plugin_019_boot"), Settings.TaskDevicePluginConfig[event->TaskIndex][0]);
 
+        //@giig1967-20181022
+        addFormSubHeader(F("Advanced event management"));
+
+        addFormNumericBox(F("De-bounce (ms)"), F("plugin_019_debounce"), round(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][0]), 0, 250);
+
+        //set minimum value for doubleclick MIN max speed
+        if (Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1] < PLUGIN_019_DOUBLECLICK_MIN_INTERVAL)
+          Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1] = PLUGIN_019_DOUBLECLICK_MIN_INTERVAL;
+
+        addFormCheckBox(F("Doubleclick event (3)"), F("plugin_019_dc"), Settings.TaskDevicePluginConfig[event->TaskIndex][4]);
+        addFormNumericBox(F("Doubleclick max. interval (ms)"), F("plugin_019_dcmaxinterval"), round(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1]), PLUGIN_019_DOUBLECLICK_MIN_INTERVAL, PLUGIN_019_DOUBLECLICK_MAX_INTERVAL);
+
+        //set minimum value for longpress MIN max speed
+        if (Settings.TaskDevicePluginConfigFloat[event->TaskIndex][2] < PLUGIN_019_LONGPRESS_MIN_INTERVAL)
+          Settings.TaskDevicePluginConfigFloat[event->TaskIndex][2] = PLUGIN_019_LONGPRESS_MIN_INTERVAL;
+
+        addFormCheckBox(F("Longpress event (10 & 11)"), F("plugin_019_lp"), Settings.TaskDevicePluginConfig[event->TaskIndex][5]);
+        addFormNumericBox(F("Longpress min. interval (ms)"), F("plugin_019_lpmininterval"), round(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][2]), PLUGIN_019_LONGPRESS_MIN_INTERVAL, PLUGIN_019_LONGPRESS_MAX_INTERVAL);
+
         success = true;
         break;
       }
@@ -56,6 +104,15 @@ boolean Plugin_019(byte function, struct EventStruct *event, String& string)
     case PLUGIN_WEBFORM_SAVE:
       {
         Settings.TaskDevicePluginConfig[event->TaskIndex][0] = isFormItemChecked(F("plugin_019_boot"));
+
+        //@giig1967-20181022
+        Settings.TaskDevicePluginConfigFloat[event->TaskIndex][0] = getFormItemInt(F("plugin_019_debounce"));
+
+        Settings.TaskDevicePluginConfig[event->TaskIndex][4] = isFormItemChecked(F("plugin_019_dc"));
+        Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1] = getFormItemInt(F("plugin_019_dcmaxinterval"));
+
+        Settings.TaskDevicePluginConfig[event->TaskIndex][5] = isFormItemChecked(F("plugin_019_lp"));
+        Settings.TaskDevicePluginConfigFloat[event->TaskIndex][2] = getFormItemInt(F("plugin_019_lpmininterval"));
 
         success = true;
         break;
@@ -66,6 +123,7 @@ boolean Plugin_019(byte function, struct EventStruct *event, String& string)
         // read and store current state to prevent switching at boot time
         switchstate[event->TaskIndex] = Plugin_019_Read(Settings.TaskDevicePort[event->TaskIndex]);
 
+        // @giig1967g-20181022: set initial UserVar of the switch
         if (Settings.TaskDevicePin1Inversed[event->TaskIndex]){
           UserVar[event->BaseVarIndex] = !switchstate[event->TaskIndex];
         } else {
@@ -77,32 +135,141 @@ boolean Plugin_019(byte function, struct EventStruct *event, String& string)
         if (Settings.TaskDevicePluginConfig[event->TaskIndex][0]) {
           switchstate[event->TaskIndex] = !switchstate[event->TaskIndex];
         }
+
+        // @giig1967g-20181022: doubleclick counter = 0
+        Settings.TaskDevicePluginConfig[event->TaskIndex][7]=0;
+
+        // @giig1967g-20181022: used to track if LP has fired
+        Settings.TaskDevicePluginConfig[event->TaskIndex][6]=false;
+
+        // @giig1967g-20181022: store millis for debounce, doubleclick and long press
+        Settings.TaskDevicePluginConfigLong[event->TaskIndex][0]=millis(); //debounce timer
+        Settings.TaskDevicePluginConfigLong[event->TaskIndex][1]=millis(); //doubleclick timer
+        Settings.TaskDevicePluginConfigLong[event->TaskIndex][2]=millis(); //longpress timer
+
+        // @giig1967g-20181022: set minimum value for doubleclick MIN max speed
+        if (Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1] < PLUGIN_019_DOUBLECLICK_MIN_INTERVAL)
+          Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1] = PLUGIN_019_DOUBLECLICK_MIN_INTERVAL;
+
+        // @giig1967g-20181022: set minimum value for longpress MIN max speed
+        if (Settings.TaskDevicePluginConfigFloat[event->TaskIndex][2] < PLUGIN_019_LONGPRESS_MIN_INTERVAL)
+          Settings.TaskDevicePluginConfigFloat[event->TaskIndex][2] = PLUGIN_019_LONGPRESS_MIN_INTERVAL;
+
+        // @giig1967g-20181022: if it is in the device list we assume it's an input pin
+        setPinState(PLUGIN_ID_019, Settings.TaskDevicePort[event->TaskIndex], PIN_MODE_INPUT, 0);
+
         success = true;
         break;
       }
 
     case PLUGIN_TEN_PER_SECOND:
+
       {
-        int state = Plugin_019_Read(Settings.TaskDevicePort[event->TaskIndex]);
-        if (state != -1)
+        const boolean state = Plugin_019_Read(Settings.TaskDevicePort[event->TaskIndex]);
+        /**************************************************************************\
+        20181022 - @giig1967g: new doubleclick logic is:
+        if there is a 'state' change, check debounce period.
+        Then if doubleclick interval exceeded, reset Settings.TaskDevicePluginConfig[event->TaskIndex][7] to 0
+        Settings.TaskDevicePluginConfig[event->TaskIndex][7] contains the current status for doubleclick:
+        0: start counting
+        1: 1st click
+        2: 2nd click
+        3: 3rd click = doubleclick event if inside interval (calculated as: '3rd click time' minus '1st click time')
+
+        Returned EVENT value is = 3 always for doubleclick
+        In rules this can be checked:
+        on Button#Switch=3 do //will fire if doubleclick
+        \**************************************************************************/
+        if (state != -1 && state != switchstate[event->TaskIndex])
         {
-          if (state != switchstate[event->TaskIndex])
+          //@giig1967g20181022: reset timer for long press
+          Settings.TaskDevicePluginConfigLong[event->TaskIndex][2]=millis();
+          Settings.TaskDevicePluginConfig[event->TaskIndex][6] = false;
+
+          const unsigned long debounceTime = timePassedSince(Settings.TaskDevicePluginConfigLong[event->TaskIndex][0]);
+          if (debounceTime >= (unsigned long)lround(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][0])) //de-bounce check
           {
-            String log = F("PCF  : State ");
-            log += state;
-            addLog(LOG_LEVEL_INFO, log);
+            const unsigned long deltaDC = timePassedSince(Settings.TaskDevicePluginConfigLong[event->TaskIndex][1]);
+            if (deltaDC >= (unsigned long)lround(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1]))
+            {
+              //reset timer for doubleclick
+              Settings.TaskDevicePluginConfig[event->TaskIndex][7]=0;
+              Settings.TaskDevicePluginConfigLong[event->TaskIndex][1]=millis();
+            }
+            Settings.TaskDevicePluginConfig[event->TaskIndex][7]++;
+
             switchstate[event->TaskIndex] = state;
 
-            if (Settings.TaskDevicePin1Inversed[event->TaskIndex]){
-              UserVar[event->BaseVarIndex] = !switchstate[event->TaskIndex];
+            byte output_value;
+            boolean sendState = switchstate[event->TaskIndex];
+
+            if (Settings.TaskDevicePin1Inversed[event->TaskIndex])
+              sendState = !sendState;
+
+            if (Settings.TaskDevicePluginConfig[event->TaskIndex][7]==3 && Settings.TaskDevicePluginConfig[event->TaskIndex][4])
+            {
+              output_value = 3; //double click
             } else {
-              UserVar[event->BaseVarIndex] = switchstate[event->TaskIndex];
+              output_value = state ? 1 : 0; //single click
             }
+
+            UserVar[event->BaseVarIndex] = output_value;
+
+            String log = F("PCF  : State ");
+            log += state;
+            log += output_value<=1 ? F(" Output value=") : F(" Doubleclick=");
+            log += output_value;
+            addLog(LOG_LEVEL_INFO, log);
 
             event->sensorType = SENSOR_TYPE_SWITCH;
             sendData(event);
+
+            //reset Userdata so it displays the correct state value in the web page
+            UserVar[event->BaseVarIndex] = sendState ? 1 : 0;
+
+            Settings.TaskDevicePluginConfigLong[event->TaskIndex][0] = millis();
           }
         }
+        //check if LP is enabled and if LP has not fired yet
+        else if (Settings.TaskDevicePluginConfig[event->TaskIndex][5] && !Settings.TaskDevicePluginConfig[event->TaskIndex][6]) {
+          /**************************************************************************\
+          20181022 - @giig1967g: new longpress logic is:
+          if there is no 'state' change, check if longpress interval reached
+          When reached send longpress event.
+          Returned Event value = state + 10
+          So if state = 0 => EVENT longpress = 10
+          if state = 1 => EVENT longpress = 11
+          So we can trigger longpress for high or low contact
+
+          In rules this can be checked:
+          on Button#Switch=10 do //will fire if longpress when state = 0
+          on Button#Switch=11 do //will fire if longpress when state = 1
+          \**************************************************************************/
+          const unsigned long deltaLP = timePassedSince(Settings.TaskDevicePluginConfigLong[event->TaskIndex][2]);
+          if (deltaLP >= (unsigned long)lround(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][2]))
+          {
+            byte output_value;
+            Settings.TaskDevicePluginConfig[event->TaskIndex][6] = true;
+
+            boolean sendState = state;
+            if (Settings.TaskDevicePin1Inversed[event->TaskIndex])
+              sendState = !sendState;
+            output_value = sendState ? 1 : 0;
+            output_value = output_value + 10;
+
+            UserVar[event->BaseVarIndex] = output_value;
+            String log = F("PCF  : LongPress: Switch state ");
+            log += state ? '1' : '0';
+            log += F(" Output value ");
+            log += output_value;
+            addLog(LOG_LEVEL_INFO, log);
+            sendData(event);
+
+            //reset Userdata so it displays the correct state value in the web page
+            UserVar[event->BaseVarIndex] = sendState ? 1 : 0;
+          }
+        }
+
         success = true;
         break;
       }

--- a/src/_P019_PCF8574.ino
+++ b/src/_P019_PCF8574.ino
@@ -40,7 +40,7 @@ TaskDevicePluginConfigLong settings:
 boolean Plugin_019(byte function, struct EventStruct *event, String& string)
 {
   boolean success = false;
-  static int8_t switchstate[TASKS_MAX];
+  static int switchstate[TASKS_MAX];
 
   switch (function)
   {
@@ -121,7 +121,7 @@ boolean Plugin_019(byte function, struct EventStruct *event, String& string)
     case PLUGIN_INIT:
       {
         // read and store current state to prevent switching at boot time
-        switchstate[event->TaskIndex] = Plugin_019_Read(Settings.TaskDevicePort[event->TaskIndex]);
+        switchstate[event->TaskIndex] = (int) Plugin_019_Read(Settings.TaskDevicePort[event->TaskIndex]);
 
         // @giig1967g-20181022: set initial UserVar of the switch
         if (Settings.TaskDevicePin1Inversed[event->TaskIndex]){


### PR DESCRIPTION
Added doubleclick and longpress events for PCF (P019) and MCP (P009).
Same logic as #1880.
