### PR TITLE
Dallas: use reset timming from OneWire lib

### DIFF
--- a/src/_P004_Dallas.ino
+++ b/src/_P004_Dallas.ino
@@ -414,11 +414,11 @@ uint8_t Plugin_004_DS_reset()
     while (!digitalRead(Plugin_004_DallasPin));
 
     pinMode(Plugin_004_DallasPin, OUTPUT); digitalWrite(Plugin_004_DallasPin, LOW);
-    delayMicroseconds(492);               // Dallas spec. = Min. 480uSec. Arduino 500uSec.
+    delayMicroseconds(480);               // Dallas spec. = Min. 480uSec. Arduino 500uSec.
     pinMode(Plugin_004_DallasPin, INPUT); // Float
-    delayMicroseconds(40);
+    delayMicroseconds(70);
     r = !digitalRead(Plugin_004_DallasPin);
-    delayMicroseconds(420);
+    delayMicroseconds(410);
     #if defined(ESP32)
       ESP32interrupts();
     #endif


### PR DESCRIPTION
Even if delays are ok with documentation of 1 wire, One Wire lib somewhat works. 

@TD-er absolutely not tested, before merge check if communication still work propperly.

Why we block interrupts only on ESP32? 1wire is time critical, it may be root couse

related to #1973 #1723