### PR TITLE
[Core 2.4.2] Set core 2.4.2 as default platform

### DIFF
--- a/before_deploy
+++ b/before_deploy
@@ -11,6 +11,8 @@ for ENV in \
   normal_ESP8266_4096 \
   normal_ESP8285_1024 \
   normal_IR_ESP8266_4096 \
+  normal_core_241_ESP8266_1024 \
+  normal_core_241_ESP8266_4096 \
   test_ESP8266_1024\
   test_ESP8266_4096\
   test_ESP8266_4096_VCC\

--- a/dist/README.txt
+++ b/dist/README.txt
@@ -22,6 +22,7 @@ Build type can be:  (differ in included plugins)
 There is also a number of special builds:
 - normal_IR => "Normal" + IR receiver/transmitter plugins and library
 - hard_xxxxx => Special builds for some off-the-shelf hardware.
+- normal_core_241 => "Normal" using core 2.4.1, since 2.4.2 has issues with PWM
 
 Chip can be:
 - ESP8266      => Most likely option

--- a/platformio.ini
+++ b/platformio.ini
@@ -117,7 +117,7 @@ build_unflags             =
 build_flags               = -D BUILD_GIT='"${sysenv.TRAVIS_TAG}"'
                    -D NDEBUG
                    -lstdc++ -lsupc++
-                   -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
+                   -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
                    -DVTABLES_IN_FLASH
 
 
@@ -128,7 +128,7 @@ lib_archive               = false
 upload_speed              = 460800
 framework                 = arduino
 board                     = esp12e
-platform                  = ${core_2_4_1.platform}
+platform                  = ${core_2_4_2.platform}
 monitor_speed             = 115200
 
 [normal]
@@ -136,11 +136,11 @@ platform                  = ${common.platform}
 build_flags               =
 
 [testing]
-platform                  = ${core_2_4_1.platform}
+platform                  = ${core_2_4_2.platform}
 build_flags               = -DPLUGIN_BUILD_TESTING
 
 [dev]
-platform                  = ${core_2_4_1.platform}
+platform                  = ${core_2_4_2.platform}
 build_flags               = -DPLUGIN_BUILD_DEV
 
 [ir]
@@ -285,6 +285,22 @@ board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
 build_unflags             = ${esp8266_1M.build_unflags}
 build_flags               = ${esp8266_1M.build_flags} ${normal.build_flags}
 
+[env:normal_core_241_ESP8266_1024]
+platform                  = ${core_2_4_1.platform}
+lib_deps                  = ${common.lib_deps}
+lib_ignore                = ${common.lib_ignore}
+lib_ldf_mode              = ${common.lib_ldf_mode}
+lib_archive               = ${common.lib_archive}
+framework                 = ${common.framework}
+upload_speed              = ${common.upload_speed}
+monitor_speed             = ${common.monitor_speed}
+board                     = ${common.board}
+board_upload.maximum_size = ${esp8266_1M.board_upload.maximum_size}
+board_build.f_cpu         = ${esp8266_1M.board_build.f_cpu}
+board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
+build_unflags             = ${esp8266_1M.build_unflags}
+build_flags               = ${esp8266_1M.build_flags} ${normal.build_flags}
+
 ; NORMAL: 1024k for esp8285 ----------------------
 [env:normal_ESP8285_1024]
 platform                  = ${common.platform}
@@ -321,6 +337,21 @@ build_flags               = ${espWroom2M.build_flags} ${normal.build_flags}
 ; NORMAL: 4096k version --------------------------
 [env:normal_ESP8266_4096]
 platform                  = ${common.platform}
+lib_deps                  = ${common.lib_deps}
+lib_ignore                = ${common.lib_ignore}
+lib_ldf_mode              = ${common.lib_ldf_mode}
+lib_archive               = ${common.lib_archive}
+framework                 = ${common.framework}
+upload_speed              = ${common.upload_speed}
+monitor_speed             = ${common.monitor_speed}
+board                     = ${common.board}
+board_build.f_cpu         = ${esp8266_4M.board_build.f_cpu}
+board_build.flash_mode    = ${esp8266_4M.board_build.flash_mode}
+build_unflags             = ${esp8266_4M.build_unflags}
+build_flags               = ${esp8266_4M.build_flags} ${normal.build_flags}
+
+[env:normal_core_241_ESP8266_4096]
+platform                  = ${core_2_4_1.platform}
 lib_deps                  = ${common.lib_deps}
 lib_ignore                = ${common.lib_ignore}
 lib_ldf_mode              = ${common.lib_ldf_mode}

--- a/src/define_plugin_sets.h
+++ b/src/define_plugin_sets.h
@@ -140,6 +140,7 @@ To create/register a plugin, you have to :
     #define PLUGIN_SET_ONLY_SWITCH
     // Needs CSE7766 Energy sensor, via Serial RXD 4800 baud 8E1 (GPIO1), TXD (GPIO3)
     #define USES_P077	// CSE7766
+    #define USES_P081   // Cron
 
     // Pre-defined setup parameters
     #define GPIO_KEY1     0              // Button


### PR DESCRIPTION
Also added separate build using core 2.4.1 for those with PWM issues.
See discussion: https://github.com/letscontrolit/ESPEasy/issues/1931#issuecomment-434111161