### PR TITLE
Fixed some bugs and added the possibility to read the user variables with parameter

### DIFF
--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -1681,8 +1681,10 @@ String parseTemplate(String &tmpString, byte lineSize)
           }
           else if (deviceName.equalsIgnoreCase(F("Var"))) {
             String tmpString = tmpStringMid.substring(4);
-            if (tmpString.length()>0 && isDigit(tmpString[0]) && tmpString.toInt()>0 && tmpString.toInt()<=CUSTOM_VARS_MAX){
-              newString += String(customFloatVar[tmpString.toInt()-1]);
+            if (tmpString.length()>0 && isDigit(tmpString[0])) {
+              const int varNum = tmpString.toInt();
+              if (varNum > 0 && varNum <= CUSTOM_VARS_MAX)
+                newString += String(customFloatVar[varNum-1]);
             }
           }
           else


### PR DESCRIPTION
- Fixed a bug where `%eventvalue1,2,3 and 4%` were not parsed correctly
Now this syntax is correctly working: `[Plugin#Pcfgpio#pinstate#%eventvalue1%]`

- Fixed a bug where system variables were parsed too late:
Now this syntax is correctly working: `[Plugin#Pcfgpio#pinstate#%v1%]`

- Added an enhancement so that using `[VAR#%eventvalue1%]` you can get the value of the user variable %vx% inside rules. 
(As per @Grovkillen request: https://github.com/letscontrolit/ESPEasy/pull/1884#issuecomment-429607801)

- Small optimizations in addLog along the code
 