### PR TITLE
[Memanalyzer] Fix memanalyzer.py

### DIFF
--- a/memanalyzer.py
+++ b/memanalyzer.py
@@ -135,17 +135,17 @@ try:
     libs.sort()
 
     #which plugins to test?
-    # if len(sys.argv)>2:
-    #     test_plugins=sys.argv[2:]
-    # else:
-    #     test_plugins=plugins
-    # test_plugins.sort()
+    if len(sys.argv)>2:
+        plugins=sys.argv[2:]
+    else:
+        plugins=plugins
+    plugins.sort()
 
     print("Analysing ESPEasy memory usage for env {} ...\n".format(env))
 
     #### disable all plugins and to get base size
-     for plugin in plugins:
-         disable_plugin(plugin)
+    for plugin in plugins:
+        disable_plugin(plugin)
 
 
     # for lib in libs:

--- a/memanalyzer.py
+++ b/memanalyzer.py
@@ -135,17 +135,17 @@ try:
     libs.sort()
 
     #which plugins to test?
-    if len(sys.argv)>2:
-        test_plugins=sys.argv[2:]
-    else:
-        test_plugins=plugins
-    test_plugins.sort()
+    # if len(sys.argv)>2:
+    #     test_plugins=sys.argv[2:]
+    # else:
+    #     test_plugins=plugins
+    # test_plugins.sort()
 
     print("Analysing ESPEasy memory usage for env {} ...\n".format(env))
 
     #### disable all plugins and to get base size
-    for plugin in test_plugins:
-        disable_plugin(plugin)
+     for plugin in plugins:
+         disable_plugin(plugin)
 
 
     # for lib in libs:
@@ -204,7 +204,7 @@ try:
 
     ##### test per plugin
     results={}
-    for plugin in test_plugins:
+    for plugin in plugins:
         enable_plugin(plugin)
         subprocess.check_call("platformio run --silent --environment "+env, shell=True)
         results[plugin]=analyse_memory(".pioenvs/"+env+"/firmware.elf")
@@ -222,7 +222,7 @@ try:
 
 
     ##### test with all test_plugins at once
-    for plugin in test_plugins:
+    for plugin in plugins:
         enable_plugin(plugin)
 
     subprocess.check_call("platformio run --silent --environment "+env, shell=True)


### PR DESCRIPTION
I hope this will fix the problem with the memanalyzer.py not analyzing more than 49 plugins. This was probably due to the fact that the `test_plugins` was only analyzing the NUMBER of test plugins + normal plugins. That sum was 77. It didn't consider the number of controller (plugins) 13 or notification (plugins) 2.

It then just analyzed the first 62 rows in the snooped array. 77-13-12=62. I have now changed the `test_` and hopefully we get all 77+13+2 plugins analyzed.