### PR TITLE
Amend nosleep command to accept awake time

### DIFF
--- a/src/Commands/System.h
+++ b/src/Commands/System.h
@@ -4,7 +4,9 @@
 
 String Command_System_NoSleep(struct EventStruct *event, const char* Line)
 {
-	Settings.deepSleep = 0;
+	if (event->Par1 > 0)
+		Settings.deepSleep = event->Par1; // set deep Sleep awake time
+	else Settings.deepSleep = 0;
 	return return_command_success();
 }
 

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -248,6 +248,12 @@ void setup()
 
   timermqtt_interval = 250; // Interval for checking MQTT
   timerAwakeFromDeepSleep = millis();
+  if (Settings.UseRules && isDeepSleepEnabled())
+  {
+    String event = F("System#NoSleep=");
+    event += Settings.deepSleep;
+    rulesProcessing(event);
+  }
 
   PluginInit();
   CPluginInit();
@@ -499,6 +505,13 @@ void loop()
      firstLoop = false;
      timerAwakeFromDeepSleep = millis(); // Allow to run for "awake" number of seconds, now we have wifi.
      // schedule_all_task_device_timers(); Disabled for now, since we are now using queues for controllers.
+     if (Settings.UseRules && isDeepSleepEnabled())
+     {
+        String event = F("System#NoSleep=");
+        event += Settings.deepSleep;
+        rulesProcessing(event);
+     }
+
 
      RTC.bootFailedCount = 0;
      saveToRTC();

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -144,6 +144,11 @@ void deepSleep(int delay)
   if (lastBootCause!=BOOT_CAUSE_DEEP_SLEEP)
   {
     addLog(LOG_LEVEL_INFO, F("SLEEP: Entering deep sleep in 30 seconds."));
+    if (Settings.UseRules && isDeepSleepEnabled())
+      {
+        String event = F("System#NoSleep=30");
+        rulesProcessing(event);
+      }
     delayBackground(30000);
     //disabled?
     if (!isDeepSleepEnabled())


### PR DESCRIPTION
Amend system command "nosleep" to accept a parameter that sets the awake time (eg. nosleep for <time>).
like this it's possible to send a "nosleep" command to the unit immediately after it awakes, do whatever needed and then reset the awake time with "nosleep,<time>" instead of having to go via web-page.