### PR TITLE
[WiFi] Improve disconnect detection and run delay(1) when not connected

### DIFF
--- a/src/Commands/HTTP.h
+++ b/src/Commands/HTTP.h
@@ -4,7 +4,7 @@
 
 String Command_HTTP_SendToHTTP(struct EventStruct *event, const char* Line)
 {
-	if (wifiStatus == ESPEASY_WIFI_SERVICES_INITIALIZED) {
+	if (WiFiConnected()) {
 		String strLine = Line;
 		String host = parseString(strLine, 2);
 		String port = parseString(strLine, 3);

--- a/src/Commands/MQTT.h
+++ b/src/Commands/MQTT.h
@@ -36,7 +36,7 @@ String Command_MQTT_messageDelay(struct EventStruct *event, const char* Line)
 
 String Command_MQTT_Publish(struct EventStruct *event, const char* Line)
 {
-  if (wifiStatus == ESPEASY_WIFI_SERVICES_INITIALIZED) {
+  if (WiFiConnected()) {
     // ToDo TD-er: Not sure about this function, but at least it sends to an existing MQTTclient
     int enabledMqttController = firstEnabledMQTTController();
     if (enabledMqttController >= 0) {

--- a/src/Commands/UPD.h
+++ b/src/Commands/UPD.h
@@ -37,7 +37,7 @@ String Command_UPD_SendTo(struct EventStruct *event, const char* Line)
 
 String Command_UDP_SendToUPD(struct EventStruct *event, const char* Line)
 {
-  if (wifiStatus == ESPEASY_WIFI_SERVICES_INITIALIZED) {
+  if (WiFiConnected()) {
     String strLine = Line;
     String ip = parseString(strLine, 2);
     String port = parseString(strLine, 3);

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -1636,16 +1636,7 @@ Ticker connectionCheck;
 #endif
 
 bool reconnectChecker = false;
-void connectionCheckHandler()
-{
-  if (reconnectChecker == false && !WiFiConnected()){
-    reconnectChecker = true;
-    WiFi.reconnect();
-  }
-  else if (WiFiConnected() && reconnectChecker == true){
-    reconnectChecker = false;
-  }
-}
+void connectionCheckHandler();
 
 bool useStaticIP();
 

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -481,6 +481,9 @@ void loop()
     wifiSetupConnect = false;
   }
   if (wifiStatus != ESPEASY_WIFI_SERVICES_INITIALIZED) {
+    // WiFi connection is not yet available, so introduce some extra delays to
+    // help the background tasks managing wifi connections
+    delay(1);
     if (wifiStatus >= ESPEASY_WIFI_CONNECTED) processConnect();
     if (wifiStatus >= ESPEASY_WIFI_GOT_IP) processGotIP();
     if (wifiStatus == ESPEASY_WIFI_DISCONNECTED) processDisconnect();

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -388,7 +388,7 @@ void statusLED(boolean traffic)
   else
   {
 
-    if (wifiStatus == ESPEASY_WIFI_SERVICES_INITIALIZED)
+    if (WiFiConnected())
     {
       long int delta = timePassedSince(gnLastUpdate);
       if (delta>0 || delta<0 )

--- a/src/Networking.ino
+++ b/src/Networking.ino
@@ -11,7 +11,7 @@
   \*********************************************************************************************/
 void syslog(byte logLevel, const char *message)
 {
-  if (Settings.Syslog_IP[0] != 0 && wifiStatus == ESPEASY_WIFI_SERVICES_INITIALIZED)
+  if (Settings.Syslog_IP[0] != 0 && WiFiConnected())
   {
     IPAddress broadcastIP(Settings.Syslog_IP[0], Settings.Syslog_IP[1], Settings.Syslog_IP[2], Settings.Syslog_IP[3]);
     portUDP.beginPacket(broadcastIP, 514);

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -898,7 +898,7 @@ void handle_root() {
     TXBuffer += formatIP(ip);
 
     addRowLabel(F("Wifi RSSI"));
-    if (wifiStatus == ESPEASY_WIFI_SERVICES_INITIALIZED)
+    if (WiFiConnected())
     {
       TXBuffer += String(WiFi.RSSI());
       TXBuffer += F(" dB (");
@@ -5312,7 +5312,7 @@ void handle_setup() {
 
   addHeader(false,TXBuffer.buf);
 
-  if (wifiStatus == ESPEASY_WIFI_SERVICES_INITIALIZED)
+  if (WiFiConnected())
   {
     addHtmlError(SaveSettings());
     const IPAddress ip = WiFi.localIP();
@@ -5688,7 +5688,7 @@ void handle_sysinfo() {
 
    addTableSeparator(F("Network"), 2, 3, F("Wifi"));
 
-  if (wifiStatus == ESPEASY_WIFI_SERVICES_INITIALIZED)
+  if (WiFiConnected())
   {
      addRowLabel(F("Wifi"));
     #if defined(ESP8266)

--- a/src/_P036_FrameOLED.ino
+++ b/src/_P036_FrameOLED.ino
@@ -472,7 +472,7 @@ String P36_parseTemplate(String &tmpString, byte lineSize) {
 
 void display_header() {
   static boolean showWiFiName = true;
-  if (showWiFiName && (wifiStatus == ESPEASY_WIFI_SERVICES_INITIALIZED) ) {
+  if (showWiFiName && (WiFiConnected()) ) {
     String newString = WiFi.SSID();
     newString.trim();
     display_title(newString);
@@ -635,7 +635,7 @@ void display_scroll(String outString[], String inString[], int nlines, int scrol
 
 //Draw Signal Strength Bars, return true when there was an update.
 bool display_wifibars() {
-  const bool connected = wifiStatus == ESPEASY_WIFI_SERVICES_INITIALIZED;
+  const bool connected = WiFiConnected();
   const int nbars_filled = (WiFi.RSSI() + 100) / 8;
   const int newState = connected ? nbars_filled : P36_WIFI_STATE_UNSET;
   if (newState == lastWiFiState)
@@ -657,7 +657,7 @@ bool display_wifibars() {
   display->setColor(BLACK);
   display->fillRect(x , y, size_x, size_y);
   display->setColor(WHITE);
-  if (wifiStatus == ESPEASY_WIFI_SERVICES_INITIALIZED) {
+  if (WiFiConnected()) {
     for (byte ibar = 0; ibar < nbars; ibar++) {
       int16_t height = size_y * (ibar + 1) / nbars;
       int16_t xpos = x + ibar * width;


### PR DESCRIPTION
Make sure disconnects will not be missed.
Give background tasks more time when not connected to WiFi.
This may help lowering power consumption and improve chance of getting connected.

See also discussion here: #2008