### PR TITLE
Bugfix/uniform gpio labels

### DIFF
--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -1490,6 +1490,12 @@ struct systemTimerStruct
 };
 std::map<unsigned long, systemTimerStruct> systemTimers;
 
+enum gpio_direction {
+  gpio_input,
+  gpio_output,
+  gpio_bidirectional
+};
+
 /*********************************************************************************************\
  * pinStatesStruct
 \*********************************************************************************************/

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -272,12 +272,22 @@ String formatGpioName_output_optional(const String& label) {
   return formatGpioName(label, gpio_output, true);
 }
 
+// RX/TX are the only signals which are crossed, so they must be labelled like this:
+// "GPIO <-- RX" and "GPIO <-- TX"
 String formatGpioName_TX(bool optional) {
-  return formatGpioName("TX", gpio_output, optional);
+  return formatGpioName("RX", gpio_output, optional);
 }
 
 String formatGpioName_RX(bool optional) {
-  return formatGpioName("RX", gpio_input, optional);
+  return formatGpioName("TX", gpio_input, optional);
+}
+
+String formatGpioName_TX_HW(bool optional) {
+  return formatGpioName("RX (HW)", gpio_output, optional);
+}
+
+String formatGpioName_RX_HW(bool optional) {
+  return formatGpioName("TX (HW)", gpio_input, optional);
 }
 
 /*********************************************************************************************\

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -226,7 +226,59 @@ int8_t getTaskIndexByName(String TaskNameSearch)
   return -1;
 }
 
+/*********************************************************************************************\
+   Device GPIO name functions to share flash strings
+  \*********************************************************************************************/
+String formatGpioName(const String& label, gpio_direction direction, bool optional) {
+  int reserveLength = 5 /* "GPIO " */ + 8 /* "&#8644; " */ + label.length();
+  if (optional) {
+    reserveLength += 11;
+  }
+  String result;
+  result.reserve(reserveLength);
+  result += F("GPIO ");
+  switch (direction) {
+    case gpio_input:         result += F("&larr; "); break;
+    case gpio_output:        result += F("&rarr; "); break;
+    case gpio_bidirectional: result += F("&#8644; "); break;
+  }
+  result += label;
+  if (optional)
+    result += F("(optional)");
+  return result;
+}
 
+String formatGpioName(const String& label, gpio_direction direction) {
+  return formatGpioName(label, direction, false);
+}
+
+String formatGpioName_input(const String& label) {
+  return formatGpioName(label, gpio_input, false);
+}
+
+String formatGpioName_output(const String& label) {
+  return formatGpioName(label, gpio_output, false);
+}
+
+String formatGpioName_bidirectional(const String& label) {
+  return formatGpioName(label, gpio_bidirectional, false);
+}
+
+String formatGpioName_input_optional(const String& label) {
+  return formatGpioName(label, gpio_input, true);
+}
+
+String formatGpioName_output_optional(const String& label) {
+  return formatGpioName(label, gpio_output, true);
+}
+
+String formatGpioName_TX(bool optional) {
+  return formatGpioName("TX", gpio_output, optional);
+}
+
+String formatGpioName_RX(bool optional) {
+  return formatGpioName("RX", gpio_input, optional);
+}
 
 /*********************************************************************************************\
    set pin mode & state (info table)

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -2280,7 +2280,7 @@ void handle_devices() {
           if (Device[DeviceIndex].Type >= DEVICE_TYPE_SINGLE)
             addFormPinSelect(TempEvent.String1, F("taskdevicepin1"), Settings.TaskDevicePin1[taskIndex]);
           if (Device[DeviceIndex].Type >= DEVICE_TYPE_DUAL)
-            addFormPinSelect( TempEvent.String2, F("taskdevicepin2"), Settings.TaskDevicePin2[taskIndex]);
+            addFormPinSelect(TempEvent.String2, F("taskdevicepin2"), Settings.TaskDevicePin2[taskIndex]);
           if (Device[DeviceIndex].Type == DEVICE_TYPE_TRIPLE)
             addFormPinSelect(TempEvent.String3, F("taskdevicepin3"), Settings.TaskDevicePin3[taskIndex]);
         }

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -1728,17 +1728,17 @@ void handle_hardware() {
   addHelpButton(F("ESPEasy#Hardware_page"));
 
   addFormSubHeader(F("Wifi Status LED"));
-  addFormPinSelect(F("GPIO &rarr; LED"), "pled", Settings.Pin_status_led);
+  addFormPinSelect(formatGpioName_output("LED"), "pled", Settings.Pin_status_led);
   addFormCheckBox(F("Inversed LED"), F("pledi"), Settings.Pin_status_led_Inversed);
   addFormNote(F("Use &rsquo;GPIO-2 (D4)&rsquo; with &rsquo;Inversed&rsquo; checked for onboard LED"));
 
   addFormSubHeader(F("Reset Pin"));
-  addFormPinSelect(F("GPIO &larr; Switch"), "pres", Settings.Pin_Reset);
+  addFormPinSelect(formatGpioName_input(F("Switch")), "pres", Settings.Pin_Reset);
   addFormNote(F("Press about 10s for factory reset"));
 
   addFormSubHeader(F("I2C Interface"));
-  addFormPinSelectI2C(F("GPIO &#8703; SDA"), F("psda"), Settings.Pin_i2c_sda);
-  addFormPinSelectI2C(F("GPIO &#8702; SCL"), F("pscl"), Settings.Pin_i2c_scl);
+  addFormPinSelectI2C(formatGpioName_bidirectional("SDA"), F("psda"), Settings.Pin_i2c_sda);
+  addFormPinSelectI2C(formatGpioName_output("SCL"), F("pscl"), Settings.Pin_i2c_scl);
 
   // SPI Init
   addFormSubHeader(F("SPI Interface"));
@@ -1746,7 +1746,7 @@ void handle_hardware() {
   addFormNote(F("CLK=GPIO-14 (D5), MISO=GPIO-12 (D6), MOSI=GPIO-13 (D7)"));
   addFormNote(F("Chip Select (CS) config must be done in the plugin"));
 #ifdef FEATURE_SD
-  addFormPinSelect(F("GPIO &rarr; SD Card CS"), "sd", Settings.Pin_sd_cs);
+  addFormPinSelect(formatGpioName_output("SD Card CS"), "sd", Settings.Pin_sd_cs);
 #endif
 
   addFormSubHeader(F("GPIO boot states"));
@@ -3186,6 +3186,10 @@ void html_copyText_TD() {
 // Add some recognizable token to show which parts will be copied.
 void html_copyText_marker() {
   TXBuffer += F("&#x022C4;"); //   &diam; &diamond; &Diamond; &#x022C4; &#8900;
+}
+
+void html_add_estimate_symbol() {
+  TXBuffer += F(" &#8793; "); //   &#8793;  &#x2259;  &wedgeq;
 }
 
 void html_table_class_normal() {

--- a/src/_P001_Switch.ino
+++ b/src/_P001_Switch.ino
@@ -99,6 +99,19 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case PLUGIN_GET_DEVICEGPIONAMES:
+      {
+        // FIXME TD-er: This plugin is handling too much.
+        // - switch/dimmer input
+        // - PWM output
+        // - switch output (relays)
+        // - servo output
+        // - sending pulses
+        // - playing tunes
+        event->String1 = formatGpioName_bidirectional("");
+        break;
+      }
+
     case PLUGIN_WEBFORM_LOAD:
       {
         String options[2];

--- a/src/_P002_ADC.ino
+++ b/src/_P002_ADC.ino
@@ -60,11 +60,11 @@ boolean Plugin_002(byte function, struct EventStruct *event, String& string)
         addFormCheckBox(F("Calibration Enabled"), F("p002_cal"), Settings.TaskDevicePluginConfig[event->TaskIndex][3]);
 
         addFormNumericBox(F("Point 1"), F("p002_adc1"), Settings.TaskDevicePluginConfigLong[event->TaskIndex][0], 0, 1023);
-        addHtml(F(" &#8793; "));
+        html_add_estimate_symbol();
         addTextBox(F("p002_out1"), String(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][0], 3), 10);
 
         addFormNumericBox(F("Point 2"), F("p002_adc2"), Settings.TaskDevicePluginConfigLong[event->TaskIndex][1], 0, 1023);
-        addHtml(F(" &#8793; "));
+        html_add_estimate_symbol();
         addTextBox(F("p002_out2"), String(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1], 3), 10);
 
         success = true;

--- a/src/_P003_Pulse.ino
+++ b/src/_P003_Pulse.ino
@@ -63,6 +63,12 @@ boolean Plugin_003(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case PLUGIN_GET_DEVICEGPIONAMES:
+      {
+        event->String1 = formatGpioName_input(F("Pulse"));
+        break;
+      }
+
     case PLUGIN_WEBFORM_LOAD:
       {
       	addFormNumericBox(F("Debounce Time (mSec)"), F("p003")

--- a/src/_P004_Dallas.ino
+++ b/src/_P004_Dallas.ino
@@ -51,6 +51,12 @@ boolean Plugin_004(byte function, struct EventStruct * event, String& string)
             break;
         }
 
+        case PLUGIN_GET_DEVICEGPIONAMES:
+          {
+            event->String1 = formatGpioName_bidirectional(F("1-Wire"));
+            break;
+          }
+
         case PLUGIN_WEBFORM_LOAD:
         {
             uint8_t savedAddress[8];
@@ -111,7 +117,7 @@ boolean Plugin_004(byte function, struct EventStruct * event, String& string)
                   ExtraTaskSettings.TaskDevicePluginConfigLong[x] = addr[x];
 
               Plugin_004_DS_setResolution(addr, getFormItemInt(F("p004_res")));
-              Plugin_004_DS_startConvertion(addr);
+              Plugin_004_DS_startConversion(addr);
             }
             success = true;
             break;
@@ -135,7 +141,7 @@ boolean Plugin_004(byte function, struct EventStruct * event, String& string)
             if (Plugin_004_DallasPin != -1){
               uint8_t addr[8];
               Plugin_004_get_addr(addr, event->TaskIndex);
-              Plugin_004_DS_startConvertion(addr);
+              Plugin_004_DS_startConversion(addr);
               delay(800); //give it time to do intial conversion
             }
             success = true;
@@ -163,7 +169,7 @@ boolean Plugin_004(byte function, struct EventStruct * event, String& string)
                     UserVar[event->BaseVarIndex] = NAN;
                     log += F("Error!");
                 }
-                Plugin_004_DS_startConvertion(addr);
+                Plugin_004_DS_startConversion(addr);
 
                 log += (" (");
                 for (byte x = 0; x < 8; x++)
@@ -218,7 +224,7 @@ byte Plugin_004_DS_scan(byte getDeviceROM, uint8_t* ROM)
 *   11 bits resolution -> 375 ms
 *   12 bits resolution -> 750 ms
 \*********************************************************************************************/
-void Plugin_004_DS_startConvertion(uint8_t ROM[8])
+void Plugin_004_DS_startConversion(uint8_t ROM[8])
 {
     Plugin_004_DS_reset();
     Plugin_004_DS_write(0x55); // Choose ROM

--- a/src/_P005_DHT.ino
+++ b/src/_P005_DHT.ino
@@ -59,6 +59,12 @@ boolean Plugin_005(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case PLUGIN_GET_DEVICEGPIONAMES:
+      {
+        event->String1 = formatGpioName_bidirectional(F("Data"));
+        break;
+      }
+
     case PLUGIN_WEBFORM_LOAD:
       {
         const String options[] = { F("DHT 11"), F("DHT 22"), F("DHT 12"), F("Sonoff am2301"), F("Sonoff si7021") };

--- a/src/_P008_RFID.ino
+++ b/src/_P008_RFID.ino
@@ -52,6 +52,13 @@ boolean Plugin_008(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case PLUGIN_GET_DEVICEGPIONAMES:
+      {
+        event->String1 = formatGpioName_input(F("D0 (Green, 5V)"));
+        event->String2 = formatGpioName_input(F("D1 (White, 5V)"));
+        break;
+      }
+
     case PLUGIN_INIT:
       {
         Plugin_008_init = true;

--- a/src/_P013_HCSR04.ino
+++ b/src/_P013_HCSR04.ino
@@ -64,6 +64,12 @@ boolean Plugin_013(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case PLUGIN_GET_DEVICEGPIONAMES:
+      {
+        event->String1 = formatGpioName_output(F("Trigger"));
+        event->String2 = formatGpioName_input(F("Echo, 5V"));
+        break;
+      }
 
     case PLUGIN_WEBFORM_LOAD:
       {

--- a/src/_P016_IR.ino
+++ b/src/_P016_IR.ino
@@ -133,6 +133,12 @@ boolean Plugin_016(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case PLUGIN_GET_DEVICEGPIONAMES:
+      {
+        event->String1 = formatGpioName_input(F("IR"));
+        break;
+      }
+
     case PLUGIN_INIT:
       {
         int irPin = Settings.TaskDevicePin1[event->TaskIndex];
@@ -251,9 +257,9 @@ boolean Plugin_016(byte function, struct EventStruct *event, String& string)
 // an IRSEND HTTP/MQTT command. It analyzes the timings, and searches for a common denominator which can be
 // used to compress the values. If found, it then produces a string consisting of B32 Hex digit for each
 // timing value, appended by the denominators for Pulse and Blank. This string can then be used in an
-// IRSEND command. An important advantage of this string over the current IRSEND RAW B32 format implemented 
+// IRSEND command. An important advantage of this string over the current IRSEND RAW B32 format implemented
 // by GusPS is that it allows easy inspections and modifications after the code is constructed.
-//     
+//
 // Author: Gilad Raz (jazzgil)  23sep2018
 
 void displayRawToReadableB32Hex() {
@@ -265,7 +271,7 @@ void displayRawToReadableB32Hex() {
         line += uint64ToString(results.rawbuf[i] * RAWTICK, 10) + ",";
     addLog(LOG_LEVEL_DEBUG, line);
 
-    // Find a common denominator divisor for odd indexes (pulses) and then even indexes (blanks). 
+    // Find a common denominator divisor for odd indexes (pulses) and then even indexes (blanks).
     for (uint16_t p = 0; p < 2; p++) {
         uint16_t cd = 0xFFFFU;      // current divisor
         // find the lowest value to start the divisor with.
@@ -273,7 +279,7 @@ void displayRawToReadableB32Hex() {
             uint16_t val = results.rawbuf[i] * RAWTICK;
             if (cd > val) cd = val;
         }
-        
+
         uint16_t bstDiv = -1, bstAvg = 0xFFFFU;
         float bstMul = 5000;
         cd += get_tolerance(cd) + 1;

--- a/src/_P017_PN532.ino
+++ b/src/_P017_PN532.ino
@@ -68,6 +68,7 @@ boolean Plugin_017(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_WEBFORM_LOAD:
       {
+        // FIXME TD-er: Why is this using pin3 and not pin1? And why isn't this using the normal pin selection functions?
       	addFormPinSelect(F("Reset Pin"), F("taskdevicepin3"), Settings.TaskDevicePin3[event->TaskIndex]);
         success = true;
         break;

--- a/src/_P018_Dust.ino
+++ b/src/_P018_Dust.ino
@@ -45,6 +45,12 @@ boolean Plugin_018(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case PLUGIN_GET_DEVICEGPIONAMES:
+      {
+        event->String1 = formatGpioName_output(F("LED"));
+        break;
+      }
+
     case PLUGIN_INIT:
       {
         Plugin_018_init = true;

--- a/src/_P020_Ser2Net.ino
+++ b/src/_P020_Ser2Net.ino
@@ -44,6 +44,12 @@ boolean Plugin_020(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case PLUGIN_GET_DEVICEGPIONAMES:
+      {
+        event->String1 = formatGpioName_bidirectional(F("Reset"));
+        break;
+      }
+
     case PLUGIN_WEBFORM_LOAD:
       {
       	addFormNumericBox(F("TCP Port"), F("p020_port"), ExtraTaskSettings.TaskDevicePluginConfigLong[0]);

--- a/src/_P021_Level.ino
+++ b/src/_P021_Level.ino
@@ -43,6 +43,12 @@ boolean Plugin_021(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case PLUGIN_GET_DEVICEGPIONAMES:
+      {
+        event->String1 = formatGpioName_output(F("Level low"));
+        break;
+      }
+
     case PLUGIN_WEBFORM_LOAD:
       {
         // char tmpString[128];

--- a/src/_P023_OLED.ino
+++ b/src/_P023_OLED.ino
@@ -104,6 +104,7 @@ boolean Plugin_023(byte function, struct EventStruct *event, String& string)
           addFormTextBox(String(F("Line ")) + (varNr + 1), String(F("p023_template")) + (varNr + 1), deviceTemplate[varNr], 64);
         }
 
+        // FIXME TD-er: Why is this using pin3 and not pin1? And why isn't this using the normal pin selection functions?
         addFormPinSelect(F("Display button"), F("taskdevicepin3"), Settings.TaskDevicePin3[event->TaskIndex]);
 
         addFormNumericBox(F("Display Timeout"), F("plugin_23_timer"), Settings.TaskDevicePluginConfig[event->TaskIndex][2]);

--- a/src/_P025_ADS1115.ino
+++ b/src/_P025_ADS1115.ino
@@ -102,11 +102,11 @@ boolean Plugin_025(byte function, struct EventStruct *event, String& string)
         addFormCheckBox(F("Calibration Enabled"), F("p025_cal"), Settings.TaskDevicePluginConfig[event->TaskIndex][3]);
 
         addFormNumericBox(F("Point 1"), F("p025_adc1"), Settings.TaskDevicePluginConfigLong[event->TaskIndex][0], -32768, 32767);
-        addHtml(F(" &#8793; "));
+        html_add_estimate_symbol();
         addTextBox(F("p025_out1"), String(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][0], 3), 10);
 
         addFormNumericBox(F("Point 2"), F("p025_adc2"), Settings.TaskDevicePluginConfigLong[event->TaskIndex][1], -32768, 32767);
-        addHtml(F(" &#8793; "));
+        html_add_estimate_symbol();
         addTextBox(F("p025_out2"), String(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1], 3), 10);
 
         success = true;

--- a/src/_P029_Output.ino
+++ b/src/_P029_Output.ino
@@ -17,7 +17,7 @@ boolean Plugin_029(byte function, struct EventStruct *event, String& string)
     case PLUGIN_DEVICE_ADD:
       {
         Device[++deviceCount].Number = PLUGIN_ID_029;
-        Device[deviceCount].Type = DEVICE_TYPE_SINGLE;
+        Device[deviceCount].Type = DEVICE_TYPE_SINGLE; // FIXME TD-er: Does this need a pin? Seems not to be used
         Device[deviceCount].VType = SENSOR_TYPE_SWITCH;
         Device[deviceCount].Ports = 0;
         Device[deviceCount].PullUpOption = false;

--- a/src/_P031_SHT1X.ino
+++ b/src/_P031_SHT1X.ino
@@ -56,6 +56,13 @@ boolean Plugin_031(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case PLUGIN_GET_DEVICEGPIONAMES:
+      {
+        event->String1 = formatGpioName_bidirectional(F("Data"));
+        event->String2 = formatGpioName_output(F("SCK"));
+        break;
+      }
+
     case PLUGIN_INIT:
       {
         Plugin_031_init = true;

--- a/src/_P035_IRTX.ino
+++ b/src/_P035_IRTX.ino
@@ -7,7 +7,7 @@
 #include <IRremoteESP8266.h>
 #endif
 #include <IRsend.h>
-#include <IRutils.h>    
+#include <IRutils.h>
 
 IRsend *Plugin_035_irSender;
 
@@ -42,6 +42,12 @@ boolean Plugin_035(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_GET_DEVICEVALUENAMES:
       {
+        break;
+      }
+
+    case PLUGIN_GET_DEVICEGPIONAMES:
+      {
+        event->String1 = formatGpioName_TX();
         break;
       }
 
@@ -92,7 +98,7 @@ boolean Plugin_035(byte function, struct EventStruct *event, String& string)
 
           if (IrType.equalsIgnoreCase(F("RAW")) || IrType.equalsIgnoreCase(F("RAW2"))) {
             String IrRaw;
-            uint16_t IrHz=0; 
+            uint16_t IrHz=0;
             unsigned int IrPLen=0;
             unsigned int IrBLen=0;
 
@@ -117,7 +123,7 @@ boolean Plugin_035(byte function, struct EventStruct *event, String& string)
             printWebString += IrBLen;
             printWebString += F("<BR>");
 
-            uint16_t buf[200]; 
+            uint16_t buf[200];
             uint16_t idx = 0;
             if (IrType.equalsIgnoreCase(F("RAW"))) {
                 unsigned int c0 = 0; //count consecutives 0s
@@ -247,16 +253,16 @@ boolean Plugin_035(byte function, struct EventStruct *event, String& string)
                                                           memcpy(ircodestr, TmpStr1, sizeof(TmpStr1[0])*100);
                                                         }
             //if (GetArgv(command, TmpStr1, 100, 4)) IrBits = str2int(TmpStr1); //not needed any more... leave it for reverce compatibility or remove it and break existing instalations?
-            //if (GetArgv(command, TmpStr1, 100, 5)) IrRepeat = str2int(TmpStr1); // Ir repeat is usfull in some circonstances, have to see how to add it and have it be revese compatible as well. 
+            //if (GetArgv(command, TmpStr1, 100, 5)) IrRepeat = str2int(TmpStr1); // Ir repeat is usfull in some circonstances, have to see how to add it and have it be revese compatible as well.
             //if (GetArgv(command, TmpStr1, 100, 6)) IrSecondCode = strtoul(TmpStr1, NULL, 16);
-            
+
             //Comented out need char[] for input Needs fixing
             if (IrType.equalsIgnoreCase(F("NEC"))) Plugin_035_irSender->sendNEC(IrCode);
             if (IrType.equalsIgnoreCase(F("SONY"))) Plugin_035_irSender->sendSony(IrCode);
             if (IrType.equalsIgnoreCase(F("Sherwood"))) Plugin_035_irSender->sendSherwood(IrCode);
             if (IrType.equalsIgnoreCase(F("SAMSUNG"))) Plugin_035_irSender->sendSAMSUNG(IrCode);
-            if (IrType.equalsIgnoreCase(F("LG"))) Plugin_035_irSender->sendLG(IrCode); 
-            if (IrType.equalsIgnoreCase(F("SharpRaw"))) Plugin_035_irSender->sendSharpRaw(IrBits);                         
+            if (IrType.equalsIgnoreCase(F("LG"))) Plugin_035_irSender->sendLG(IrCode);
+            if (IrType.equalsIgnoreCase(F("SharpRaw"))) Plugin_035_irSender->sendSharpRaw(IrBits);
             if (IrType.equalsIgnoreCase(F("JVC"))) Plugin_035_irSender->sendJVC(IrCode);
             if (IrType.equalsIgnoreCase(F("Denon"))) Plugin_035_irSender->sendDenon(IrCode);
             if (IrType.equalsIgnoreCase(F("SanyoLC7461"))) Plugin_035_irSender->sendSanyoLC7461(IrCode);
@@ -485,7 +491,7 @@ void parseStringAndSendAirCon(const uint16_t irType, const String str) {
       break;
 #endif
   }
-  
+
 }
 
 #if SEND_PRONTO

--- a/src/_P035_IRTX.ino
+++ b/src/_P035_IRTX.ino
@@ -47,7 +47,7 @@ boolean Plugin_035(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_GET_DEVICEGPIONAMES:
       {
-        event->String1 = formatGpioName_TX();
+        event->String1 = formatGpioName_output("LED");
         break;
       }
 

--- a/src/_P036_FrameOLED.ino
+++ b/src/_P036_FrameOLED.ino
@@ -145,6 +145,7 @@ boolean Plugin_036(byte function, struct EventStruct *event, String& string)
           addFormTextBox(String(F("Line ")) + (varNr + 1), String(F("p036_template")) + (varNr + 1), P036_deviceTemplate[varNr], P36_Nchars);
         }
 
+        // FIXME TD-er: Why is this using pin3 and not pin1? And why isn't this using the normal pin selection functions?
         addFormPinSelect(F("Display button"), F("taskdevicepin3"), Settings.TaskDevicePin3[event->TaskIndex]);
 
         addFormNumericBox(F("Display Timeout"), F("p036_timer"), Settings.TaskDevicePluginConfig[event->TaskIndex][4]);

--- a/src/_P038_NeoPixel.ino
+++ b/src/_P038_NeoPixel.ino
@@ -66,6 +66,8 @@ boolean Plugin_038(byte function, struct EventStruct *event, String& string)
         int indices[] = { 1, 2 };
 
       	addFormNumericBox(F("Led Count"), F("p038_leds"), Settings.TaskDevicePluginConfig[event->TaskIndex][0],1,999);
+
+        // FIXME TD-er: Why isn't this using the normal pin selection functions?
       	addFormPinSelect(F("GPIO"), F("taskdevicepin1"), Settings.TaskDevicePin1[event->TaskIndex]);
         addFormSelector(F("Strip Type"), F("p038_strip"), 2, options, indices, Settings.TaskDevicePluginConfig[event->TaskIndex][1] );
 

--- a/src/_P039_Thermocouple.ino
+++ b/src/_P039_Thermocouple.ino
@@ -80,6 +80,12 @@ boolean Plugin_039(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case PLUGIN_GET_DEVICEGPIONAMES:
+      {
+        event->String1 = formatGpioName_output(F("CS"));
+        break;
+      }
+
     case PLUGIN_INIT:
       {
         // Get CS Pin

--- a/src/_P041_NeoClock.ino
+++ b/src/_P041_NeoClock.ino
@@ -49,6 +49,12 @@ boolean Plugin_041(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case PLUGIN_GET_DEVICEGPIONAMES:
+      {
+        event->String1 = formatGpioName_output(F("Data"));
+        break;
+      }
+
     case PLUGIN_WEBFORM_LOAD:
       {
       	addFormNumericBox(F("Red"), F("p041_red"), Settings.TaskDevicePluginConfig[event->TaskIndex][0], 0, 255);

--- a/src/_P042_Candle.ino
+++ b/src/_P042_Candle.ino
@@ -133,6 +133,12 @@ boolean Plugin_042(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case PLUGIN_GET_DEVICEGPIONAMES:
+      {
+        event->String1 = formatGpioName_output(F("Data"));
+        break;
+      }
+      
     case PLUGIN_WEBFORM_LOAD:
       {
         addHtml(F("<script src=\"jscolor.min.js\"></script>\n"));

--- a/src/_P043_ClkOutput.ino
+++ b/src/_P043_ClkOutput.ino
@@ -41,6 +41,12 @@ boolean Plugin_043(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case PLUGIN_GET_DEVICEGPIONAMES:
+      {
+        event->String1 = formatGpioName_output(F("Clock Event"));
+        break;
+      }
+
     case PLUGIN_WEBFORM_LOAD:
       {
         String options[3];

--- a/src/_P044_P1WifiGateway.ino
+++ b/src/_P044_P1WifiGateway.ino
@@ -80,6 +80,7 @@ boolean Plugin_044(byte function, struct EventStruct *event, String& string)
 
       	addFormNumericBox(F("Stop bits"), F("p044_stop"), ExtraTaskSettings.TaskDevicePluginConfigLong[4]);
 
+        // FIXME TD-er: Why isn't this using the normal pin selection functions?
       	addFormPinSelect(F("Reset target after boot"), F("taskdevicepin1"), Settings.TaskDevicePin1[event->TaskIndex]);
 
       	addFormNumericBox(F("RX Receive Timeout (mSec)"), F("p044_rxwait"), Settings.TaskDevicePluginConfig[event->TaskIndex][0]);

--- a/src/_P049_MHZ19.ino
+++ b/src/_P049_MHZ19.ino
@@ -198,6 +198,13 @@ boolean Plugin_049(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case PLUGIN_GET_DEVICEGPIONAMES:
+      {
+        event->String1 = formatGpioName_RX(false);
+        event->String2 = formatGpioName_TX(false);
+        break;
+      }
+
     case PLUGIN_WEBFORM_LOAD:
       {
         byte choice = Settings.TaskDevicePluginConfig[event->TaskIndex][0];

--- a/src/_P052_SenseAir.ino
+++ b/src/_P052_SenseAir.ino
@@ -63,6 +63,13 @@ boolean Plugin_052(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case PLUGIN_GET_DEVICEGPIONAMES:
+      {
+        event->String1 = formatGpioName_RX(false);
+        event->String2 = formatGpioName_TX(false);
+        break;
+      }
+
       case PLUGIN_WRITE:
           {
       			String cmd = parseString(string, 1);

--- a/src/_P053_PMSx003.ino
+++ b/src/_P053_PMSx003.ino
@@ -212,9 +212,9 @@ boolean Plugin_053(byte function, struct EventStruct *event, String& string)
 
       case PLUGIN_GET_DEVICEGPIONAMES:
         {
-          event->String1 = F("GPIO &larr; TX");
-          event->String2 = F("GPIO &rarr; RX");
-          event->String3 = F("GPIO &rarr; Reset");
+          event->String1 = formatGpioName_RX(false);
+          event->String2 = formatGpioName_TX(false);
+          event->String3 = formatGpioName_output(F("Reset");
           break;
         }
 

--- a/src/_P053_PMSx003.ino
+++ b/src/_P053_PMSx003.ino
@@ -214,7 +214,7 @@ boolean Plugin_053(byte function, struct EventStruct *event, String& string)
         {
           event->String1 = formatGpioName_RX(false);
           event->String2 = formatGpioName_TX(false);
-          event->String3 = formatGpioName_output(F("Reset");
+          event->String3 = formatGpioName_output(F("Reset"));
           break;
         }
 

--- a/src/_P055_Chiming.ino
+++ b/src/_P055_Chiming.ino
@@ -121,9 +121,9 @@ boolean Plugin_055(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_GET_DEVICEGPIONAMES:
       {
-        event->String1 = F("GPIO &rarr; Driver#1");
-        event->String2 = F("GPIO &rarr; Driver#2");
-        event->String3 = F("GPIO &rarr; Driver#4");
+        event->String1 = formatGpioName_output(F("Driver#1"));
+        event->String2 = formatGpioName_output(F("Driver#2"));
+        event->String3 = formatGpioName_output(F("Driver#4"));
         break;
       }
 
@@ -135,7 +135,7 @@ boolean Plugin_055(byte function, struct EventStruct *event, String& string)
         if (Settings.TaskDevicePluginConfig[event->TaskIndex][1] <= 0)   //Plugin_055_millisPauseTime
           Settings.TaskDevicePluginConfig[event->TaskIndex][1] = 400;
 
-        addFormPinSelect(F("GPIO &rarr; Driver#8"), F("TDP4"), (int)(Settings.TaskDevicePin[3][event->TaskIndex]));
+        addFormPinSelect(formatGpioName_output(F("Driver#8")), F("TDP4"), (int)(Settings.TaskDevicePin[3][event->TaskIndex]));
 
 
         addFormSubHeader(F("Timing"));

--- a/src/_P055_Chiming.ino
+++ b/src/_P055_Chiming.ino
@@ -135,8 +135,8 @@ boolean Plugin_055(byte function, struct EventStruct *event, String& string)
         if (Settings.TaskDevicePluginConfig[event->TaskIndex][1] <= 0)   //Plugin_055_millisPauseTime
           Settings.TaskDevicePluginConfig[event->TaskIndex][1] = 400;
 
+        // FIXME TD-er: Should we add support for 4 pin definitions?
         addFormPinSelect(formatGpioName_output(F("Driver#8")), F("TDP4"), (int)(Settings.TaskDevicePin[3][event->TaskIndex]));
-
 
         addFormSubHeader(F("Timing"));
 

--- a/src/_P056_SDS011-Dust.ino
+++ b/src/_P056_SDS011-Dust.ino
@@ -59,6 +59,14 @@ boolean Plugin_056(byte function, struct EventStruct *event, String& string)
         strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[1], PSTR(PLUGIN_VALUENAME2_056));
         break;
       }
+
+    case PLUGIN_GET_DEVICEGPIONAMES:
+      {
+        event->String1 = formatGpioName_RX(false);
+        event->String2 = formatGpioName_TX(true); // optional
+        break;
+      }
+
     case PLUGIN_WEBFORM_LOAD:
       {
         if (Plugin_056_hasTxPin(event)) {
@@ -83,12 +91,6 @@ boolean Plugin_056(byte function, struct EventStruct *event, String& string)
           success = true;
           break;
         }
-    case PLUGIN_GET_DEVICEGPIONAMES:
-      {
-        event->String1 = formatGpioName_RX(false);
-        event->String2 = formatGpioName_TX(true);
-        break;
-      }
 
     case PLUGIN_INIT:
       {

--- a/src/_P056_SDS011-Dust.ino
+++ b/src/_P056_SDS011-Dust.ino
@@ -85,8 +85,8 @@ boolean Plugin_056(byte function, struct EventStruct *event, String& string)
         }
     case PLUGIN_GET_DEVICEGPIONAMES:
       {
-        event->String1 = F("GPIO &larr; TX");
-        event->String2 = F("GPIO &#8674; RX (optional)");
+        event->String1 = formatGpioName_RX(false);
+        event->String2 = formatGpioName_TX(true);
         break;
       }
 

--- a/src/_P059_Encoder.ino
+++ b/src/_P059_Encoder.ino
@@ -72,9 +72,9 @@ boolean Plugin_059(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_GET_DEVICEGPIONAMES:
       {
-        event->String1 = F("GPIO &larr; A");
-        event->String2 = F("GPIO &larr; B");
-        event->String3 = F("GPIO &#8672; I (optional)");
+        event->String1 = formatGpioName_input(F("A (CLK)"));
+        event->String2 = formatGpioName_input(F("B (DT)"));
+        event->String3 = formatGpioName_input_optional(F("I (Z)"));
         break;
       }
 

--- a/src/_P060_MCP3221.ino
+++ b/src/_P060_MCP3221.ino
@@ -82,11 +82,11 @@ boolean Plugin_060(byte function, struct EventStruct *event, String& string)
         addFormCheckBox(F("Calibration Enabled"), F("p060_cal"), CONFIG(3));
 
         addFormNumericBox(F("Point 1"), F("p060_adc1"), Settings.TaskDevicePluginConfigLong[event->TaskIndex][0], 0, 4095);
-        addHtml(F(" &#8793; "));
+        html_add_estimate_symbol();
         addTextBox(F("p060_out1"), String(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][0], 3), 10);
 
         addFormNumericBox(F("Point 2"), F("p060_adc2"), Settings.TaskDevicePluginConfigLong[event->TaskIndex][1], 0, 4095);
-        addHtml(F(" &#8793; "));
+        html_add_estimate_symbol();
         addTextBox(F("p060_out2"), String(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1], 3), 10);
 
         success = true;

--- a/src/_P063_TTP229_KeyPad.ino
+++ b/src/_P063_TTP229_KeyPad.ino
@@ -103,8 +103,8 @@ boolean Plugin_063(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_GET_DEVICEGPIONAMES:
       {
-        event->String1 = F("GPIO &rarr; SCL");
-        event->String2 = F("GPIO &#8644; SDO");
+        event->String1 = formatGpioName_output("SCL");
+        event->String2 = formatGpioName_bidirectional("SDO");
         break;
       }
 

--- a/src/_P065_DRF0299_MP3.ino
+++ b/src/_P065_DRF0299_MP3.ino
@@ -76,7 +76,7 @@ boolean Plugin_065(byte function, struct EventStruct *event, String& string)
 
       case PLUGIN_GET_DEVICEGPIONAMES:
         {
-          event->String1 = F("GPIO &rarr; RX");
+          event->String1 = formatGpioName_TX(false);
           break;
         }
 

--- a/src/_P067_HX711_Load_Cell.ino
+++ b/src/_P067_HX711_Load_Cell.ino
@@ -114,8 +114,8 @@ boolean Plugin_067(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_GET_DEVICEGPIONAMES:
       {
-        event->String1 = F("GPIO &rarr; SCL");
-        event->String2 = F("GPIO &larr; DOUT");
+        event->String1 = formatGpioName_output("SCL");
+        event->String2 = formatGpioName_input("DOUT");
         break;
       }
 
@@ -137,11 +137,11 @@ boolean Plugin_067(byte function, struct EventStruct *event, String& string)
         addFormCheckBox(F("Calibration Enabled"), F("p067_cal"), Settings.TaskDevicePluginConfig[event->TaskIndex][3]);
 
         addFormNumericBox(F("Point 1"), F("p067_adc1"), Settings.TaskDevicePluginConfigLong[event->TaskIndex][0]);
-        addHtml(F(" &#8793; "));
+        html_add_estimate_symbol();
         addTextBox(F("p067_out1"), String(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][0], 3), 10);
 
         addFormNumericBox(F("Point 2"), F("p067_adc2"), Settings.TaskDevicePluginConfigLong[event->TaskIndex][1]);
-        addHtml(F(" &#8793; "));
+        html_add_estimate_symbol();
         addTextBox(F("p067_out2"), String(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][1], 3), 10);
 
         success = true;

--- a/src/_P070_NeoPixel_Clock.ino
+++ b/src/_P070_NeoPixel_Clock.ino
@@ -75,7 +75,7 @@ boolean Plugin_070(byte function, struct EventStruct *event, String& string)
 
 	case PLUGIN_GET_DEVICEGPIONAMES:
 	  {
-		    event->String1 = F("GPIO &rarr; LED");
+		    event->String1 = formatGpioName_output("LED");
         break;
 	  }
 

--- a/src/_P071_Kamstrup401.ino
+++ b/src/_P071_Kamstrup401.ino
@@ -57,6 +57,13 @@ boolean Plugin_071(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case PLUGIN_GET_DEVICEGPIONAMES:
+      {
+        event->String1 = formatGpioName_RX(false);
+        event->String2 = formatGpioName_TX(false);
+        break;
+      }
+
     case PLUGIN_INIT:
       {
         Plugin_071_init = true;

--- a/src/_P073_7DGT.ino
+++ b/src/_P073_7DGT.ino
@@ -92,6 +92,12 @@ boolean Plugin_073(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case PLUGIN_GET_DEVICEGPIONAMES:
+      {
+        // Do not name the pins, since they are swapped between types.
+        break;
+      }
+
     case PLUGIN_WEBFORM_LOAD:
       {
         addFormNote(F("TM1637:  1st=CLK-Pin, 2nd=DIO-Pin"));

--- a/src/_P075_Nextion.ino
+++ b/src/_P075_Nextion.ino
@@ -114,13 +114,13 @@ boolean Plugin_075(byte function, struct EventStruct *event, String& string)
       rxPin = Settings.TaskDevicePin1[event->TaskIndex];
       txPin = Settings.TaskDevicePin2[event->TaskIndex];
 
-      event->String1 = formatGpioName_input(F("SS RX");
-      event->String2 = formatGpioName_output(F("SS TX");
+      event->String1 = formatGpioName_RX(false);
+      event->String2 = formatGpioName_TX(false);
 
       if(AdvHwSerial == true) {
         if ((rxPin == 3 && txPin == 1) || (rxPin == 13 && txPin == 15)) {
-          event->String1 = formatGpioName_input(F("HW RX");
-          event->String2 = formatGpioName_output(F("HW TX");
+          event->String1 = formatGpioName_RX_HW(false);
+          event->String2 = formatGpioName_TX_HW(false);
         }
       }
       break;

--- a/src/_P075_Nextion.ino
+++ b/src/_P075_Nextion.ino
@@ -114,13 +114,13 @@ boolean Plugin_075(byte function, struct EventStruct *event, String& string)
       rxPin = Settings.TaskDevicePin1[event->TaskIndex];
       txPin = Settings.TaskDevicePin2[event->TaskIndex];
 
-      event->String1 = F("GPIO SS RX &larr; ");
-      event->String2 = F("GPIO SS TX &rarr; ");
+      event->String1 = formatGpioName_input(F("SS RX");
+      event->String2 = formatGpioName_output(F("SS TX");
 
       if(AdvHwSerial == true) {
         if ((rxPin == 3 && txPin == 1) || (rxPin == 13 && txPin == 15)) {
-            event->String1 = F("GPIO HW RX &larr; ");
-            event->String2 = F("GPIO HW TX &rarr; ");
+          event->String1 = formatGpioName_input(F("HW RX");
+          event->String2 = formatGpioName_output(F("HW TX");
         }
       }
       break;

--- a/src/_P076_HLW8012.ino
+++ b/src/_P076_HLW8012.ino
@@ -77,6 +77,14 @@ boolean Plugin_076(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case PLUGIN_GET_DEVICEGPIONAMES:
+      {
+        event->String1 = formatGpioName_output("SEL");
+        event->String2 = formatGpioName_input("CF1");
+        event->String3 = formatGpioName_input("CF");
+        break;
+      }
+
     case PLUGIN_WEBFORM_LOAD:
       {
         addFormNote(F("Sonoff POW: 1st(SEL)=GPIO-5, 2nd(CF1)=GPIO-13, 3rd(CF)=GPIO-14"));

--- a/src/_P077_CSE7766.ino
+++ b/src/_P077_CSE7766.ino
@@ -84,6 +84,12 @@ boolean Plugin_077(byte function, struct EventStruct *event, String& string)
         break;
       }
 
+    case PLUGIN_GET_DEVICEGPIONAMES:
+      {
+        // No pins selectable, all hard coded
+        break;
+      }
+
     case PLUGIN_WEBFORM_LOAD:
       {
         addFormNumericBox(F("U Ref"), F("p077_URef"), Settings.TaskDevicePluginConfig[event->TaskIndex][0]);

--- a/src/_P078_Eastron.ino
+++ b/src/_P078_Eastron.ino
@@ -92,9 +92,9 @@ boolean Plugin_078(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_GET_DEVICEGPIONAMES:
       {
-        event->String1 = F("GPIO RX");
-        event->String2 = F("GPIO TX");
-        event->String3 = F("GPIO DE (optional)");
+        event->String1 = formatGpioName_RX(false);
+        event->String2 = formatGpioName_TX(false);
+        event->String3 = formatGpioName_output_optional("DE");
         break;
       }
 

--- a/src/_P080_DallasIButton.ino
+++ b/src/_P080_DallasIButton.ino
@@ -51,6 +51,12 @@ boolean Plugin_080(byte function, struct EventStruct * event, String& string)
             break;
         }
 
+        case PLUGIN_GET_DEVICEGPIONAMES:
+          {
+            event->String1 = formatGpioName_bidirectional(F("1-Wire"));
+            break;
+          }
+
         case PLUGIN_WEBFORM_LOAD:
         {
             uint8_t savedAddress[8];


### PR DESCRIPTION
All custom GPIO labels (set using `PLUGIN_GET_DEVICEGPIONAMES` ) now use the same format.

Special note about the RX/TX labels. since these are the only ones to be crossed.
"GPIO <-- TX" is rather descriptive. The GPIO is on the ESP side, TX is on the sensor side.

So the function to format the label is called `formatGpioName_RX` and it will write "GPIO <- TX"
At least it is clear where it is going to be used, it is the RX channel on the ESP side. (for example SoftwareSerial describes the pins with function on ESP side)

For a few plugins also "5V" is displayed to warn users to use a level converter.
