### PR TITLE
[WIFI] Fix mDNS startup for log levels below LOG_LEVEL_INFO

### DIFF
--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -602,9 +602,6 @@ const byte DNS_PORT = 53;
 IPAddress apIP(DEFAULT_AP_IP);
 DNSServer dnsServer;
 bool dnsServerActive = false;
-#ifdef FEATURE_MDNS
-MDNSResponder mdns;
-#endif
 
 // MQTT client
 WiFiClient mqtt;

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -128,7 +128,7 @@ void setup()
 #endif
   WiFi.persistent(false); // Do not use SDK storage of SSID/WPA parameters
   WiFi.setAutoReconnect(false);
-  setWifiMode(WIFI_OFF);
+  WiFi.mode(WIFI_OFF);
   lowestFreeStack = getFreeStackWatermark();
   lowestRAM = FreeMem();
 

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -943,6 +943,11 @@ void backgroundtasks()
 
   #endif
 
+  #ifdef FEATURE_MDNS
+  // Allow MDNS processing
+  MDNS.update();
+  #endif
+
   delay(0);
 
   statusLED(false);

--- a/src/ESPEasyWifi.ino
+++ b/src/ESPEasyWifi.ino
@@ -119,20 +119,20 @@ void processGotIP() {
   }
 
   #ifdef FEATURE_MDNS
-
-    if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-      String log = F("WIFI : ");
-      if (MDNS.begin(WifiGetHostname().c_str(), WiFi.localIP())) {
-
-        log += F("mDNS started, with name: ");
-        log += WifiGetHostname();
-        log += F(".local");
-      }
-      else{
-        log += F("mDNS failed");
-      }
-      addLog(LOG_LEVEL_INFO, log);
+  addLog(LOG_LEVEL_INFO, F("WIFI : Starting mDNS..."));
+  bool mdns_started = MDNS.begin(WifiGetHostname().c_str());
+  if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+    String log = F("WIFI : ");
+    if (mdns_started) {
+      log += F("mDNS started, with name: ");
+      log += WifiGetHostname();
+      log += F(".local");
     }
+    else{
+      log += F("mDNS failed");
+    }
+    addLog(LOG_LEVEL_INFO, log);
+  }
   #endif
 
   // First try to get the time, since that may be used in logs
@@ -152,6 +152,11 @@ void processGotIP() {
 //  WiFi.scanDelete();
   wifiStatus = ESPEASY_WIFI_SERVICES_INITIALIZED;
   setWebserverRunning(true);
+  #ifdef FEATURE_MDNS
+  if (mdns_started) {
+    MDNS.addService("http", "tcp", 80);
+  }
+  #endif
   wifi_connect_attempt = 0;
   if (wifiSetup) {
     // Wifi setup was active, Apparently these settings work.


### PR DESCRIPTION
Please note this is a follow-up to #1980.

I've managed to fix wdt reset with mDNS enabled when ESPEasy is compiled with SDK 2.4.2, and it seem [this change](https://github.com/letscontrolit/ESPEasy/compare/mega...3cky:mdns-fix?expand=1#diff-8a3b628d805ef06cd106c798ae52516fL114) is crucial. By some reason, calling `setWifiMode(WIFI_OFF)` at startup causes crash just like described in esp8266/Arduino#4028, so I replaced it with bare `WiFi.mode(WIFI_OFF)` which seems to work fine.

Also I cleaned up some unused mDNS-related stuff and fixed formatting.