### PR TITLE
[C++11] Use nullptr instead of NULL

### DIFF
--- a/src/Commands/Diagnostic.h
+++ b/src/Commands/Diagnostic.h
@@ -15,7 +15,7 @@ String Command_Malloc(struct EventStruct *event, const char* Line)
 {
 	char* ramtest;
 	ramtest = (char*)malloc(event->Par1);
-	if (ramtest == NULL) return F("failed");
+	if (ramtest == nullptr) return F("failed");
 	free(ramtest);
 	return return_command_success();
 }

--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -297,7 +297,7 @@ void scheduleNextMQTTdelayQueue() {
 void processMQTTdelayQueue() {
   START_TIMER;
   MQTT_queue_element* element(MQTTDelayHandler.getNext());
-  if (element == NULL) return;
+  if (element == nullptr) return;
   if (MQTTclient.publish(element->_topic.c_str(), element->_payload.c_str(), element->_retained)) {
     setIntervalTimerOverride(TIMER_MQTT, 10); // Make sure the MQTT is being processed as soon as possible.
     MQTTDelayHandler.markProcessed(true);

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -648,7 +648,7 @@ String to_json_object_value(const String& object, const String& value);
 
 bool I2C_read_bytes(uint8_t i2caddr, I2Cdata_bytes& data);
 bool I2C_write8_reg(uint8_t i2caddr, byte reg, byte value);
-uint8_t I2C_read8_reg(uint8_t i2caddr, byte reg, bool * is_ok = NULL);
+uint8_t I2C_read8_reg(uint8_t i2caddr, byte reg, bool * is_ok = nullptr);
 uint16_t I2C_read16_reg(uint8_t i2caddr, byte reg);
 int32_t I2C_read24_reg(uint8_t i2caddr, byte reg);
 uint16_t I2C_read16_LE_reg(uint8_t i2caddr, byte reg);
@@ -1212,7 +1212,7 @@ struct ExtraTaskSettingsStruct
 struct EventStruct
 {
   EventStruct() :
-    Data(NULL), idx(0), Par1(0), Par2(0), Par3(0), Par4(0), Par5(0),
+    Data(nullptr), idx(0), Par1(0), Par2(0), Par3(0), Par4(0), Par5(0),
     Source(0), TaskIndex(TASKS_MAX), ControllerIndex(0), ProtocolIndex(0), NotificationIndex(0),
     BaseVarIndex(0), sensorType(0), OriginTaskIndex(0) {}
   EventStruct(const struct EventStruct& event):

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -87,7 +87,7 @@
 #include "_CPlugin_Helper.h"
 
 // Blynk_get prototype
-boolean Blynk_get(const String& command, byte controllerIndex,float *data = NULL );
+boolean Blynk_get(const String& command, byte controllerIndex,float *data = nullptr );
 
 int firstEnabledBlynkController() {
   for (byte i = 0; i < CONTROLLER_MAX; ++i) {
@@ -323,16 +323,16 @@ void setup()
     if(UseRTOSMultitasking){
       log = F("RTOS : Launching tasks");
       addLog(LOG_LEVEL_INFO, log);
-      xTaskCreatePinnedToCore(RTOS_TaskServers, "RTOS_TaskServers", 16384, NULL, 1, NULL, 1);
-      xTaskCreatePinnedToCore(RTOS_TaskSerial, "RTOS_TaskSerial", 8192, NULL, 1, NULL, 1);
-      xTaskCreatePinnedToCore(RTOS_Task10ps, "RTOS_Task10ps", 8192, NULL, 1, NULL, 1);
+      xTaskCreatePinnedToCore(RTOS_TaskServers, "RTOS_TaskServers", 16384, nullptr, 1, nullptr, 1);
+      xTaskCreatePinnedToCore(RTOS_TaskSerial, "RTOS_TaskSerial", 8192, nullptr, 1, nullptr, 1);
+      xTaskCreatePinnedToCore(RTOS_Task10ps, "RTOS_Task10ps", 8192, nullptr, 1, nullptr, 1);
       xTaskCreatePinnedToCore(
                     RTOS_HandleSchedule,   /* Function to implement the task */
                     "RTOS_HandleSchedule", /* Name of the task */
                     16384,      /* Stack size in words */
-                    NULL,       /* Task input parameter */
+                    nullptr,       /* Task input parameter */
                     1,          /* Priority of the task */
-                    NULL,       /* Task handle. */
+                    nullptr,       /* Task handle. */
                     1);         /* Core where the task should run */
     }
   #endif

--- a/src/ESPEasyStatistics.ino
+++ b/src/ESPEasyStatistics.ino
@@ -7,7 +7,7 @@ void logStatistics(byte loglevel, bool clearStats) {
         if (!x.second.isEmpty()) {
             const int pluginId = x.first/32;
             String P_name = "";
-            Plugin_ptr[pluginId](PLUGIN_GET_DEVICENAME, NULL, P_name);
+            Plugin_ptr[pluginId](PLUGIN_GET_DEVICENAME, nullptr, P_name);
             log = F("PluginStats P_");
             log += pluginId + 1;
             log += '_';

--- a/src/ESPEasyStorage.ino
+++ b/src/ESPEasyStorage.ino
@@ -832,7 +832,7 @@ String getPartitionTable(byte pType, const String& itemSep, const String& lineEn
   esp_partition_type_t partitionType = static_cast<esp_partition_type_t>(pType);
   String result;
   const esp_partition_t * _mypart;
-  esp_partition_iterator_t _mypartiterator = esp_partition_find(partitionType, ESP_PARTITION_SUBTYPE_ANY, NULL);
+  esp_partition_iterator_t _mypartiterator = esp_partition_find(partitionType, ESP_PARTITION_SUBTYPE_ANY, nullptr);
   if (_mypartiterator) {
     do {
       _mypart = esp_partition_get(_mypartiterator);
@@ -846,7 +846,7 @@ String getPartitionTable(byte pType, const String& itemSep, const String& lineEn
       result += itemSep;
       result += (_mypart->encrypted ? F("Yes") : F("-"));
       result += lineEnd;
-    } while ((_mypartiterator = esp_partition_next(_mypartiterator)) != NULL);
+    } while ((_mypartiterator = esp_partition_next(_mypartiterator)) != nullptr);
   }
   esp_partition_iterator_release(_mypartiterator);
   return result;

--- a/src/I2C.ino
+++ b/src/I2C.ino
@@ -74,7 +74,7 @@ uint8_t I2C_read8_reg(uint8_t i2caddr, byte reg, bool * is_ok) {
   Wire.write((uint8_t)reg);
   Wire.endTransmission(END_TRANSMISSION_FLAG);
   byte count = Wire.requestFrom(i2caddr, (byte)1);
-  if (is_ok != NULL) {
+  if (is_ok != nullptr) {
     *is_ok = (count == 1);
   }
   value = Wire.read();

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -15,7 +15,7 @@ extern "C" void tcp_abort (struct tcp_pcb* pcb);
 void tcpCleanup()
 {
 
-     while(tcp_tw_pcbs!=NULL)
+     while(tcp_tw_pcbs!=nullptr)
     {
       tcp_abort(tcp_tw_pcbs);
     }
@@ -29,14 +29,14 @@ void tcpCleanup()
 //      https://github.com/esp8266/Arduino/issues/5148#issuecomment-424329183
 //      https://github.com/letscontrolit/ESPEasy/issues/1824
 #ifdef ESP32
-// FIXME TD-er: For ESP32 you need to provide the task number, or NULL to get from the calling task.
+// FIXME TD-er: For ESP32 you need to provide the task number, or nullptr to get from the calling task.
 uint32_t getCurrentFreeStack() {
   register uint8_t *sp asm("a1");
-  return (sp - pxTaskGetStackStart(NULL));
+  return (sp - pxTaskGetStackStart(nullptr));
 }
 
 uint32_t getFreeStackWatermark() {
-  return uxTaskGetStackHighWaterMark(NULL);
+  return uxTaskGetStackHighWaterMark(nullptr);
 }
 
 // FIXME TD-er: Must check if these functions are also needed for ESP32.

--- a/src/StringConverter.ino
+++ b/src/StringConverter.ino
@@ -294,8 +294,8 @@ bool safe_strncpy(char* dest, const String& source, size_t max_size) {
 
 bool safe_strncpy(char* dest, const char* source, size_t max_size) {
   if (max_size < 1) return false;
-  if (dest == NULL) return false;
-  if (source == NULL) return false;
+  if (dest == nullptr) return false;
+  if (source == nullptr) return false;
   bool result = true;
   memset(dest, 0, max_size);
   size_t str_length = strlen(source);

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -1388,7 +1388,7 @@ void handle_controllers() {
       if (!Protocol[ProtocolIndex].Custom)
       {
 
-        addFormSelector(F("Locate Controller"), F("usedns"), 2, options, NULL, NULL, choice, true);
+        addFormSelector(F("Locate Controller"), F("usedns"), 2, options, nullptr, nullptr, choice, true);
         if (ControllerSettings.UseDNS)
         {
           addFormTextBox( F("Controller Hostname"), F("controllerhostname"), ControllerSettings.HostName, sizeof(ControllerSettings.HostName)-1);
@@ -1403,9 +1403,9 @@ void handle_controllers() {
         addUnit(F("ms"));
         addFormNumericBox( F("Max Queue Depth"), F("maxqueuedepth"), ControllerSettings.MaxQueueDepth, 1, CONTROLLER_DELAY_QUEUE_DEPTH_MAX);
         addFormNumericBox( F("Max Retries"), F("maxretry"), ControllerSettings.MaxRetry, 1, CONTROLLER_DELAY_QUEUE_RETRY_MAX);
-        addFormSelector(F("Full Queue Action"), F("deleteoldest"), 2, options_delete_oldest, NULL, NULL, choice_delete_oldest, true);
+        addFormSelector(F("Full Queue Action"), F("deleteoldest"), 2, options_delete_oldest, nullptr, nullptr, choice_delete_oldest, true);
 
-        addFormSelector(F("Check Reply"), F("mustcheckreply"), 2, options_mustcheckreply, NULL, NULL, choice_mustcheckreply, true);
+        addFormSelector(F("Check Reply"), F("mustcheckreply"), 2, options_mustcheckreply, nullptr, nullptr, choice_mustcheckreply, true);
         addFormNumericBox( F("Client Timeout"), F("clienttimeout"), ControllerSettings.ClientTimeout, 10, CONTROLLER_CLIENTTIMEOUT_MAX);
         addUnit(F("ms"));
 
@@ -1796,7 +1796,7 @@ void addFormPinStateSelect(const String& label, const String& id, int choice, bo
 void addPinStateSelect(String name, int choice, bool enabled)
 {
   String options[4] = { F("Default"), F("Output Low"), F("Output High"), F("Input") };
-  addSelector(name, 4, options, NULL, NULL, choice, false, enabled);
+  addSelector(name, 4, options, nullptr, nullptr, choice, false, enabled);
 }
 
 //********************************************************************************
@@ -1811,7 +1811,7 @@ void addFormIPaccessControlSelect(const String& label, const String& id, int cho
 void addIPaccessControlSelect(String name, int choice)
 {
   String options[3] = { F("Allow All"), F("Allow Local Subnet"), F("Allow IP range") };
-  addSelector(name, 3, options, NULL, NULL, choice, false);
+  addSelector(name, 3, options, nullptr, nullptr, choice, false);
 }
 
 
@@ -2714,12 +2714,12 @@ void addFormSelectorI2C(const String& id, int addressCount, const int addresses[
     if (x == 0)
       options[x] += F(" - (default)");
   }
-  addFormSelector(F("I2C Address"), id, addressCount, options, addresses, NULL, selectedIndex, false);
+  addFormSelector(F("I2C Address"), id, addressCount, options, addresses, nullptr, selectedIndex, false);
 }
 
 void addFormSelector(const String& label, const String& id, int optionCount, const String options[], const int indices[], int selectedIndex)
 {
-  addFormSelector(label, id, optionCount, options, indices, NULL, selectedIndex, false);
+  addFormSelector(label, id, optionCount, options, indices, nullptr, selectedIndex, false);
 }
 
 void addFormSelector(const String& label, const String& id, int optionCount, const String options[], const int indices[], const String attr[], int selectedIndex, boolean reloadonchange)
@@ -4203,7 +4203,7 @@ void stream_plugin_function_timing_stats_json(
 
 void stream_plugin_timing_stats_json(int pluginId) {
   String P_name = "";
-  Plugin_ptr[pluginId](PLUGIN_GET_DEVICENAME, NULL, P_name);
+  Plugin_ptr[pluginId](PLUGIN_GET_DEVICENAME, nullptr, P_name);
   TXBuffer += '{';
   stream_next_json_object_value(F("name"), P_name);
   stream_next_json_object_value(F("id"), String(pluginId));
@@ -4278,7 +4278,7 @@ void stream_timing_statistics(bool clearStats) {
       if (!x.second.isEmpty()) {
           const int pluginId = x.first/32;
           String P_name = "";
-          Plugin_ptr[pluginId](PLUGIN_GET_DEVICENAME, NULL, P_name);
+          Plugin_ptr[pluginId](PLUGIN_GET_DEVICENAME, nullptr, P_name);
           if (x.second.thresholdExceeded(TIMING_STATS_THRESHOLD)) {
             html_TR_TD_highlight();
           } else {
@@ -4504,11 +4504,11 @@ void addFormDstSelect(bool isStart, uint16_t choice) {
   }
   TimeChangeRule rule(isStart ? tmpstart : tmpend, 0);
   addRowLabel(weeklabel);
-  addSelector(weekid, 5, week, weekValues, NULL, rule.week, false);
+  addSelector(weekid, 5, week, weekValues, nullptr, rule.week, false);
   TXBuffer += F("<BR>");
-  addSelector(dowid, 7, dow, dowValues, NULL, rule.dow, false);
+  addSelector(dowid, 7, dow, dowValues, nullptr, rule.dow, false);
   TXBuffer += F("<BR>");
-  addSelector(monthid, 12, month, monthValues, NULL, rule.month, false);
+  addSelector(monthid, 12, month, monthValues, nullptr, rule.month, false);
 
   addFormNumericBox(hourlabel, hourid, rule.hour, 0, 23);
   addUnit(isStart ? F("hour &#x21b7;") : F("hour &#x21b6;"));
@@ -4529,7 +4529,7 @@ void addLogLevelSelect(String name, int choice)
   for (int i = 0; i < LOG_LEVEL_NRELEMENTS; ++i) {
     options[i + 1] = getLogLevelDisplayStringFromIndex(i, optionValues[i + 1]);
   }
-  addSelector(name, LOG_LEVEL_NRELEMENTS + 1, options, optionValues, NULL, choice, false);
+  addSelector(name, LOG_LEVEL_NRELEMENTS + 1, options, optionValues, nullptr, choice, false);
 }
 
 void addFormLogFacilitySelect(const String& label, const String& id, int choice)
@@ -4542,7 +4542,7 @@ void addLogFacilitySelect(String name, int choice)
 {
   String options[12] = { F("Kernel"), F("User"), F("Daemon"), F("Message"), F("Local0"), F("Local1"), F("Local2"), F("Local3"), F("Local4"), F("Local5"), F("Local6"), F("Local7")};
   int optionValues[12] = { 0, 1, 3, 5, 16, 17, 18, 19, 20, 21, 22, 23 };
-  addSelector(name, 12, options, optionValues, NULL, choice, false);
+  addSelector(name, 12, options, optionValues, nullptr, choice, false);
 }
 
 
@@ -5576,7 +5576,7 @@ void handle_rules() {
   }
 
    html_TR_TD();
-  addSelector(F("set"), RULESETS_MAX, options, optionValues, NULL, choice, true);
+  addSelector(F("set"), RULESETS_MAX, options, optionValues, nullptr, choice, true);
   addHelpButton(F("Tutorial_Rules"));
 
   // load form data from flash
@@ -6378,12 +6378,12 @@ void getStorageTableSVG(SettingsType settingsType) {
 
 int getPartionCount(byte pType) {
   esp_partition_type_t partitionType = static_cast<esp_partition_type_t>(pType);
-  esp_partition_iterator_t _mypartiterator = esp_partition_find(partitionType, ESP_PARTITION_SUBTYPE_ANY, NULL);
+  esp_partition_iterator_t _mypartiterator = esp_partition_find(partitionType, ESP_PARTITION_SUBTYPE_ANY, nullptr);
   int nrPartitions = 0;
   if (_mypartiterator) {
     do {
       ++nrPartitions;
-    } while ((_mypartiterator = esp_partition_next(_mypartiterator)) != NULL);
+    } while ((_mypartiterator = esp_partition_next(_mypartiterator)) != nullptr);
   }
   esp_partition_iterator_release(_mypartiterator);
   return nrPartitions;
@@ -6397,7 +6397,7 @@ void getPartitionTableSVG(byte pType, unsigned int partitionColor) {
   uint32_t realSize = getFlashRealSizeInBytes();
   esp_partition_type_t partitionType = static_cast<esp_partition_type_t>(pType);
   const esp_partition_t * _mypart;
-  esp_partition_iterator_t _mypartiterator = esp_partition_find(partitionType, ESP_PARTITION_SUBTYPE_ANY, NULL);
+  esp_partition_iterator_t _mypartiterator = esp_partition_find(partitionType, ESP_PARTITION_SUBTYPE_ANY, nullptr);
   write_SVG_image_header(SVG_BAR_WIDTH + 250, nrPartitions * SVG_BAR_HEIGHT + shiftY);
   float yOffset = shiftY;
   if (_mypartiterator) {
@@ -6413,7 +6413,7 @@ void getPartitionTableSVG(byte pType, unsigned int partitionColor) {
       textXoffset = SVG_BAR_WIDTH + 130;
       createSvgTextElement(getPartitionType(_mypart->type, _mypart->subtype), textXoffset, textYoffset);
       yOffset += SVG_BAR_HEIGHT;
-    } while ((_mypartiterator = esp_partition_next(_mypartiterator)) != NULL);
+    } while ((_mypartiterator = esp_partition_next(_mypartiterator)) != nullptr);
   }
   TXBuffer += F("</svg>\n");
   esp_partition_iterator_release(_mypartiterator);

--- a/src/_C012.ino
+++ b/src/_C012.ino
@@ -64,7 +64,7 @@ boolean CPlugin_012(byte function, struct EventStruct *event, String& string)
 }
 
 //********************************************************************************
-// Process Queued Blynk request, with data set to NULL
+// Process Queued Blynk request, with data set to nullptr
 //********************************************************************************
 bool do_process_c012_delay_queue(int controller_number, const C012_queue_element& element, ControllerSettingsStruct& ControllerSettings) {
   while (element.txt[element.valuesSent] == "") {

--- a/src/_CPlugin_Helper.h
+++ b/src/_CPlugin_Helper.h
@@ -264,11 +264,11 @@ struct ControllerDelayHandlerStruct {
   // Get the next element.
   // Remove front element when max_retries is reached.
   T* getNext() {
-    if (sendQueue.empty()) return NULL;
+    if (sendQueue.empty()) return nullptr;
     if (attempt > max_retries) {
       sendQueue.pop_front();
       attempt = 0;
-      if (sendQueue.empty()) return NULL;
+      if (sendQueue.empty()) return nullptr;
     }
     return &sendQueue.front();
   }
@@ -334,7 +334,7 @@ ControllerDelayHandlerStruct<MQTT_queue_element> MQTTDelayHandler;
                 bool do_process_c##NNN##_delay_queue(int controller_number, const C##NNN##_queue_element& element, ControllerSettingsStruct& ControllerSettings); \
                 void process_c##NNN##_delay_queue() { \
                   C##NNN##_queue_element* element(C##NNN##_DelayHandler.getNext()); \
-                  if (element == NULL) return; \
+                  if (element == nullptr) return; \
                   MakeControllerSettings(ControllerSettings); \
                   LoadControllerSettings(element->controller_idx, ControllerSettings); \
                   C##NNN##_DelayHandler.configureControllerSettings(ControllerSettings); \

--- a/src/_P003_Pulse.ino
+++ b/src/_P003_Pulse.ino
@@ -77,7 +77,7 @@ boolean Plugin_003(byte function, struct EventStruct *event, String& string)
         byte choice = Settings.TaskDevicePluginConfig[event->TaskIndex][1];
         byte choice2 = Settings.TaskDevicePluginConfig[event->TaskIndex][2];
         String options[4] = { F("Delta"), F("Delta/Total/Time"), F("Total"), F("Delta/Total") };
-        addFormSelector(F("Counter Type"), F("p003_countertype"), 4, options, NULL, choice );
+        addFormSelector(F("Counter Type"), F("p003_countertype"), 4, options, nullptr, choice );
 
         if (choice !=0)
           addHtml(F("<span style=\"color:red\">Total count is not persistent!</span>"));

--- a/src/_P011_PME.ino
+++ b/src/_P011_PME.ino
@@ -48,7 +48,7 @@ boolean Plugin_011(byte function, struct EventStruct *event, String& string)
       {
         byte choice = Settings.TaskDevicePluginConfig[event->TaskIndex][0];
         String options[2] = { F("Digital"), F("Analog") };
-        addFormSelector(F("Port Type"), F("p011"), 2, options, NULL, choice);
+        addFormSelector(F("Port Type"), F("p011"), 2, options, nullptr, choice);
 
         success = true;
         break;

--- a/src/_P012_LCD.ino
+++ b/src/_P012_LCD.ino
@@ -11,7 +11,7 @@
 //  Pump:[Pump#on#O] -> ON/OFF
 #include <LiquidCrystal_I2C.h>
 
-LiquidCrystal_I2C *lcd=NULL;
+LiquidCrystal_I2C *lcd=nullptr;
 int Plugin_012_cols = 16;
 int Plugin_012_rows = 2;
 int Plugin_012_mode = 1;

--- a/src/_P016_IR.ino
+++ b/src/_P016_IR.ino
@@ -90,7 +90,7 @@ const uint16_t kMinUnknownSize = 12;
 // ==================== end of TUNEABLE PARAMETERS ====================
 
 
-IRrecv *irReceiver = NULL;
+IRrecv *irReceiver = nullptr;
 decode_results results;
 
 boolean Plugin_016(byte function, struct EventStruct *event, String& string)

--- a/src/_P020_Ser2Net.ino
+++ b/src/_P020_Ser2Net.ino
@@ -79,7 +79,7 @@ boolean Plugin_020(byte function, struct EventStruct *event, String& string)
         options2[0] = F("None");
         options2[1] = F("Generic");
         options2[2] = F("RFLink");
-        addFormSelector(F("Event processing"), F("p020_events"), 3, options2, NULL, choice2);
+        addFormSelector(F("Event processing"), F("p020_events"), 3, options2, nullptr, choice2);
 
         success = true;
         break;

--- a/src/_P022_PCA9685.ino
+++ b/src/_P022_PCA9685.ino
@@ -38,7 +38,7 @@ boolean Plugin_022(byte function, struct EventStruct *event, String& string)
   int mode2 = 0x10;
   uint16_t freq = PCA9685_MAX_FREQUENCY;
   uint16_t range = PCA9685_MAX_PWM;
-  if(event != NULL && event->TaskIndex >- 1)
+  if(event != nullptr && event->TaskIndex >- 1)
   {
     address = Settings.TaskDevicePort[event->TaskIndex];
     mode2 = Settings.TaskDevicePluginConfig[event->TaskIndex][0];

--- a/src/_P025_ADS1115.ino
+++ b/src/_P025_ADS1115.ino
@@ -81,7 +81,7 @@ boolean Plugin_025(byte function, struct EventStruct *event, String& string)
           F("8x gain (FS=0.512V)"),
           F("16x gain (FS=0.256V)")
         };
-        addFormSelector(F("Gain"), F("p025_gain"), ADS1115_PGA_OPTION, pgaOptions, NULL, pga);
+        addFormSelector(F("Gain"), F("p025_gain"), ADS1115_PGA_OPTION, pgaOptions, nullptr, pga);
 
         #define ADS1115_MUX_OPTION 8
         byte mux = Settings.TaskDevicePluginConfig[event->TaskIndex][2];
@@ -95,7 +95,7 @@ boolean Plugin_025(byte function, struct EventStruct *event, String& string)
           F("AIN2 - GND (Single-Ended)"),
           F("AIN3 - GND (Single-Ended)"),
         };
-        addFormSelector(F("Input Multiplexer"), F("p025_mode"), ADS1115_MUX_OPTION, muxOptions, NULL, mux);
+        addFormSelector(F("Input Multiplexer"), F("p025_mode"), ADS1115_MUX_OPTION, muxOptions, nullptr, mux);
 
         addFormSubHeader(F("Two Point Calibration"));
 

--- a/src/_P026_Sysinfo.ino
+++ b/src/_P026_Sysinfo.ino
@@ -59,13 +59,13 @@ boolean Plugin_026(byte function, struct EventStruct *event, String& string)
         options[11] = F("None");
 
         choice = Settings.TaskDevicePluginConfig[event->TaskIndex][0];
-        addFormSelector(F("Indicator"), F("p026a"), 12, options, NULL, choice);
+        addFormSelector(F("Indicator"), F("p026a"), 12, options, nullptr, choice);
         choice = Settings.TaskDevicePluginConfig[event->TaskIndex][1];
-        addFormSelector(F("Indicator"), F("p026b"), 12, options, NULL, choice);
+        addFormSelector(F("Indicator"), F("p026b"), 12, options, nullptr, choice);
         choice = Settings.TaskDevicePluginConfig[event->TaskIndex][2];
-        addFormSelector(F("Indicator"), F("p026c"), 12, options, NULL, choice);
+        addFormSelector(F("Indicator"), F("p026c"), 12, options, nullptr, choice);
         choice = Settings.TaskDevicePluginConfig[event->TaskIndex][3];
-        addFormSelector(F("Indicator"), F("p026d"), 12, options, NULL, choice);
+        addFormSelector(F("Indicator"), F("p026d"), 12, options, nullptr, choice);
 
         success = true;
         break;

--- a/src/_P027_INA219.ino
+++ b/src/_P027_INA219.ino
@@ -144,7 +144,7 @@ boolean Plugin_027(byte function, struct EventStruct *event, String& string)
 
         byte choiceMeasureType = Settings.TaskDevicePluginConfig[event->TaskIndex][2];
         String options[4] = { F("Voltage"), F("Current"), F("Power"), F("Voltage/Current/Power") };
-        addFormSelector(F("Measurement Type"), F("p027_measuretype"), 4, options, NULL, choiceMeasureType );
+        addFormSelector(F("Measurement Type"), F("p027_measuretype"), 4, options, nullptr, choiceMeasureType );
 
         success = true;
         break;

--- a/src/_P035_IRTX.ino
+++ b/src/_P035_IRTX.ino
@@ -249,12 +249,12 @@ boolean Plugin_035(byte function, struct EventStruct *event, String& string)
           //  unsigned long IrSecondCode=0UL;
             char ircodestr[200];
             if (GetArgv(command, TmpStr1,200, 2)) IrType = TmpStr1;
-                       if (GetArgv(command, TmpStr1, 200, 3)){ IrCode = strtoull(TmpStr1, NULL, 16);
+                       if (GetArgv(command, TmpStr1, 200, 3)){ IrCode = strtoull(TmpStr1, nullptr, 16);
                                                           memcpy(ircodestr, TmpStr1, sizeof(TmpStr1[0])*200);
                                                         }
             //if (GetArgv(command, TmpStr1, 200, 4)) IrBits = str2int(TmpStr1); //not needed any more... leave it for reverce compatibility or remove it and break existing instalations?
             //if (GetArgv(command, TmpStr1, 200, 5)) IrRepeat = str2int(TmpStr1); // Ir repeat is usfull in some circonstances, have to see how to add it and have it be revese compatible as well. 
-            //if (GetArgv(command, TmpStr1, 200, 6)) IrSecondCode = strtoul(TmpStr1, NULL, 16);
+            //if (GetArgv(command, TmpStr1, 200, 6)) IrSecondCode = strtoul(TmpStr1, nullptr, 16);
 
             //Comented out need char[] for input Needs fixing
             if (IrType.equalsIgnoreCase(F("NEC"))) Plugin_035_irSender->sendNEC(IrCode);
@@ -621,7 +621,7 @@ void parseStringAndSendPronto(const String str, uint16_t repeats) {
     index = str.indexOf(',', start_from);
     // Convert the hexadecimal value string to an unsigned integer.
     code_array[count] = strtoul(str.substring(start_from, index).c_str(),
-                                NULL, 16);
+                                nullptr, 16);
     start_from = index + 1;
     count++;
   } while (index != -1);
@@ -738,7 +738,7 @@ uint16_t countValuesInStr(const String str, char sep) {
 //
 //  result = reinterpret_cast<uint16_t*>(malloc(size * sizeof(uint16_t)));
 //  // Check we malloc'ed successfully.
-//  if (result == NULL) {  // malloc failed, so give up.
+//  if (result == nullptr) {  // malloc failed, so give up.
 //    Serial.printf("\nCan't allocate %d bytes. (%d bytes free)\n",
 //                  size * sizeof(uint16_t), ESP.getFreeHeap());
 //    Serial.println("Giving up & forcing a reboot.");

--- a/src/_P036_FrameOLED.ino
+++ b/src/_P036_FrameOLED.ino
@@ -38,7 +38,7 @@ static int8_t lastWiFiState = P36_WIFI_STATE_UNSET;
 
 // Instantiate display here - does not work to do this within the INIT call
 
-OLEDDisplay *display=NULL;
+OLEDDisplay *display=nullptr;
 
 String P036_displayLines[P36_Nlines];
 
@@ -268,7 +268,7 @@ boolean Plugin_036(byte function, struct EventStruct *event, String& string)
           {
             display->end();
             delete display;
-            display=NULL;
+            display=nullptr;
           }
           for (byte varNr = 0; varNr < P36_Nlines; varNr++) {
             P036_displayLines[varNr] = "";

--- a/src/_P037_MQTTImport.ino
+++ b/src/_P037_MQTTImport.ino
@@ -22,7 +22,7 @@
 
 // TODO TD-er: These must be kept in some vector to allow multiple instances of MQTT import.
 WiFiClient espclient_037;
-PubSubClient *MQTTclient_037 = NULL;
+PubSubClient *MQTTclient_037 = nullptr;
 bool MQTTclient_037_connected = false;
 int reconnectCount = 0;
 
@@ -43,7 +43,7 @@ void Plugin_037_try_connect() {
   espclient_037 = WiFiClient();
   espclient_037.setTimeout(CONTROLLER_CLIENTTIMEOUT_DFLT);
 
-  if (MQTTclient_037 == NULL) {
+  if (MQTTclient_037 == nullptr) {
     MQTTclient_037 = new PubSubClient(espclient_037);
   }
   if (MQTTConnect_037())
@@ -58,7 +58,7 @@ void Plugin_037_try_connect() {
 
 void Plugin_037_update_connect_status() {
   bool connected = false;
-  if (MQTTclient_037 != NULL) {
+  if (MQTTclient_037 != nullptr) {
     connected = MQTTclient_037->connected();
   }
   if (MQTTclient_037_connected != connected) {
@@ -158,7 +158,7 @@ boolean Plugin_037(byte function, struct EventStruct *event, String& string)
         success = false;
         //    When we edit the subscription data from the webserver, the plugin is called again with init.
         //    In order to resubscribe we have to disconnect and reconnect in order to get rid of any obsolete subscriptions
-        if (MQTTclient_037 != NULL) {
+        if (MQTTclient_037 != nullptr) {
           MQTTclient_037->disconnect();
           if (MQTTConnect_037())
           {
@@ -171,7 +171,7 @@ boolean Plugin_037(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_TEN_PER_SECOND:
       {
-        if (MQTTclient_037 != NULL && !MQTTclient_037->loop()) {		// Listen out for callbacks
+        if (MQTTclient_037 != nullptr && !MQTTclient_037->loop()) {		// Listen out for callbacks
           Plugin_037_update_connect_status();
         }
         success = true;
@@ -182,7 +182,7 @@ boolean Plugin_037(byte function, struct EventStruct *event, String& string)
       {
         //  Here we check that the MQTT client is alive.
         Plugin_037_try_connect();
-        if (MQTTclient_037 != NULL) {
+        if (MQTTclient_037 != nullptr) {
           if (!MQTTclient_037->connected() || MQTTclient_should_reconnect) {
             if (MQTTclient_should_reconnect) {
               addLog(LOG_LEVEL_ERROR, F("IMPT : MQTT 037 Intentional reconnect"));
@@ -312,7 +312,7 @@ boolean MQTTSubscribe_037()
         if (subscribeTo.length() > 0)
         {
           parseSystemVariables(subscribeTo, false);
-          if (MQTTclient_037 != NULL && MQTTclient_037->subscribe(subscribeTo.c_str()))
+          if (MQTTclient_037 != nullptr && MQTTclient_037->subscribe(subscribeTo.c_str()))
           {
             String log = F("IMPT : [");
             LoadTaskSettings(y);
@@ -382,7 +382,7 @@ void mqttcallback_037(char* c_topic, byte* b_payload, unsigned int length)
 boolean MQTTConnect_037()
 {
   boolean result = false;
-  if (MQTTclient_037 == NULL) return false;
+  if (MQTTclient_037 == nullptr) return false;
   String clientid = getClientName();
   // @ToDo TD-er: Plugin allows for more than one MQTT controller, but we're now using only the first enabled one.
   int enabledMqttController = firstEnabledMQTTController();

--- a/src/_P042_Candle.ino
+++ b/src/_P042_Candle.ino
@@ -163,7 +163,7 @@ boolean Plugin_042(byte function, struct EventStruct *event, String& string)
         }
 
         // Candle Type Selection
-        addFormSelector(F("Flame Type"), F("web_Candle_Type"), 8, options, NULL, choice);
+        addFormSelector(F("Flame Type"), F("web_Candle_Type"), 8, options, nullptr, choice);
 
         // Advanced Color options
         Candle_color = (ColorType)Settings.TaskDevicePluginConfig[event->TaskIndex][5];
@@ -419,7 +419,7 @@ boolean Plugin_042(byte function, struct EventStruct *event, String& string)
           }
 
           if (val_Color != "") {
-            long number = strtol( &val_Color[0], NULL, 16);
+            long number = strtol( &val_Color[0], nullptr, 16);
             // Split RGB to r, g, b values
             byte r = number >> 16;
             byte g = number >> 8 & 0xFF;

--- a/src/_P043_ClkOutput.ino
+++ b/src/_P043_ClkOutput.ino
@@ -67,7 +67,7 @@ boolean Plugin_043(byte function, struct EventStruct *event, String& string)
 
           addHtml(" ");
           byte choice = ExtraTaskSettings.TaskDevicePluginConfig[x];
-          addSelector(String(F("p043_state")) + (x), 3, options, NULL, NULL, choice, false);
+          addSelector(String(F("p043_state")) + (x), 3, options, nullptr, nullptr, choice, false);
         }
         success = true;
         break;

--- a/src/_P044_P1WifiGateway.ino
+++ b/src/_P044_P1WifiGateway.ino
@@ -170,7 +170,7 @@ boolean Plugin_044(byte function, struct EventStruct *event, String& string)
         if (P1GatewayServer) {
           P1GatewayServer->close();
           delete P1GatewayServer;
-          P1GatewayServer = NULL;
+          P1GatewayServer = nullptr;
         }
         success = true;
         break;
@@ -434,7 +434,7 @@ bool checkDatagram(int len) {
         Serial.print(Plugin_044_serial_buf[cnt]);
     }
 
-    validCRCFound = (strtoul(messageCRC, NULL, 16) == currCRC);
+    validCRCFound = (strtoul(messageCRC, nullptr, 16) == currCRC);
     if (!validCRCFound) {
       addLog(LOG_LEVEL_DEBUG, F("P1   : Error: invalid CRC found"));
     }

--- a/src/_P045_MPU6050.ino
+++ b/src/_P045_MPU6050.ino
@@ -137,7 +137,7 @@ boolean Plugin_045(byte function, struct EventStruct *event, String& string)
         options[7] = F("G-force X");
         options[8] = F("G-force Y");
         options[9] = F("G-force Z");
-        addFormSelector(F("Function"), F("p045_function"), 10, options, NULL, choice);
+        addFormSelector(F("Function"), F("p045_function"), 10, options, nullptr, choice);
 
         if (choice == 0) {
           // If this is instance function 0, setup webform for additional vars

--- a/src/_P046_VentusW266.ino
+++ b/src/_P046_VentusW266.ino
@@ -154,7 +154,7 @@ boolean Plugin_046(byte function, struct EventStruct *event, String& string)
         options[7] = F("Unknown 2, byte 16");
         options[8] = F("Unknown 3, byte 19");
 
-        addFormSelector(F("Plugin function"), F("p046"), nrchoices, options, NULL, choice);
+        addFormSelector(F("Plugin function"), F("p046"), nrchoices, options, nullptr, choice);
 
         if (choice==0) {
           addHtml(F("<TR><TD>1st GPIO (5-MOSI):<TD>"));

--- a/src/_P052_SenseAir.ino
+++ b/src/_P052_SenseAir.ino
@@ -108,14 +108,14 @@ boolean Plugin_052(byte function, struct EventStruct *event, String& string)
           byte choiceSensor = Settings.TaskDevicePluginConfig[event->TaskIndex][0];
 
           String optionsSensor[7] = { F("Error Status"), F("Carbon Dioxide"), F("Temperature"), F("Humidity"), F("Relay Status"), F("Temperature Adjustment"), F("ABC period") };
-          addFormSelector(F("Sensor"), F("p052_sensor"), 7, optionsSensor, NULL, choiceSensor);
+          addFormSelector(F("Sensor"), F("p052_sensor"), 7, optionsSensor, nullptr, choiceSensor);
 
           /*
           // ABC functionality disabled for now, due to a bug in the firmware.
           // See https://github.com/letscontrolit/ESPEasy/issues/759
           byte choiceABCperiod = Settings.TaskDevicePluginConfig[event->TaskIndex][1];
           String optionsABCperiod[9] = { F("disable"), F("1 h"), F("12 h"), F("1 day"), F("2 days"), F("4 days"), F("7 days"), F("14 days"), F("30 days") };
-          addFormSelector(F("ABC period"), F("p052_ABC_period"), 9, optionsABCperiod, NULL, choiceABCperiod);
+          addFormSelector(F("ABC period"), F("p052_ABC_period"), 9, optionsABCperiod, nullptr, choiceABCperiod);
           */
 
           success = true;

--- a/src/_P053_PMSx003.ino
+++ b/src/_P053_PMSx003.ino
@@ -22,7 +22,7 @@
 #define PMSx003_SIG2 0X4d
 #define PMSx003_SIZE 32
 
-ESPeasySoftwareSerial *swSerial = NULL;
+ESPeasySoftwareSerial *swSerial = nullptr;
 boolean Plugin_053_init = false;
 boolean values_received = false;
 
@@ -34,7 +34,7 @@ void SerialRead16(uint16_t* value, uint16_t* checksum)
   uint8_t data_high, data_low;
 
   // If swSerial is initialized, we are using soft serial
-  if (swSerial != NULL)
+  if (swSerial != nullptr)
   {
     data_high = swSerial->read();
     data_low = swSerial->read();
@@ -48,7 +48,7 @@ void SerialRead16(uint16_t* value, uint16_t* checksum)
   *value = data_low;
   *value |= (data_high << 8);
 
-  if (checksum != NULL)
+  if (checksum != nullptr)
   {
     *checksum += data_high;
     *checksum += data_low;
@@ -67,7 +67,7 @@ void SerialRead16(uint16_t* value, uint16_t* checksum)
 }
 
 void SerialFlush() {
-  if (swSerial != NULL) {
+  if (swSerial != nullptr) {
     swSerial->flush();
   } else {
     Serial.flush();
@@ -76,7 +76,7 @@ void SerialFlush() {
 
 boolean PacketAvailable(void)
 {
-  if (swSerial != NULL) // Software serial
+  if (swSerial != nullptr) // Software serial
   {
     // When there is enough data in the buffer, search through the buffer to
     // find header (buffer may be out of sync)
@@ -157,7 +157,7 @@ boolean Plugin_053_process_data(struct EventStruct *event) {
   }
 
   // Compare checksums
-  SerialRead16(&checksum2, NULL);
+  SerialRead16(&checksum2, nullptr);
   SerialFlush(); // Make sure no data is lost due to full buffer.
   if (checksum == checksum2)
   {
@@ -230,10 +230,10 @@ boolean Plugin_053(byte function, struct EventStruct *event, String& string)
         log += resetPin;
         addLog(LOG_LEVEL_DEBUG, log);
 
-        if (swSerial != NULL) {
+        if (swSerial != nullptr) {
           // Regardless the set pins, the software serial must be deleted.
           delete swSerial;
-          swSerial = NULL;
+          swSerial = nullptr;
         }
 
         // Hardware serial is RX on 3 and TX on 1
@@ -275,7 +275,7 @@ boolean Plugin_053(byte function, struct EventStruct *event, String& string)
           if (swSerial)
           {
             delete swSerial;
-            swSerial=NULL;
+            swSerial=nullptr;
           }
           break;
       }

--- a/src/_P055_Chiming.ino
+++ b/src/_P055_Chiming.ino
@@ -87,7 +87,7 @@ public:
   }
 };
 
-static CPlugin_055_Data* Plugin_055_Data = NULL;
+static CPlugin_055_Data* Plugin_055_Data = nullptr;
 
 
 boolean Plugin_055(byte function, struct EventStruct *event, String& string)

--- a/src/_P056_SDS011-Dust.ino
+++ b/src/_P056_SDS011-Dust.ino
@@ -20,7 +20,7 @@
 #include <jkSDS011.h>
 
 
-CjkSDS011 *Plugin_056_SDS = NULL;
+CjkSDS011 *Plugin_056_SDS = nullptr;
 
 
 boolean Plugin_056(byte function, struct EventStruct *event, String& string)

--- a/src/_P057_HT16K33_LED.ino
+++ b/src/_P057_HT16K33_LED.ino
@@ -69,7 +69,7 @@
 
 #include <HT16K33.h>
 
-CHT16K33* Plugin_057_M = NULL;
+CHT16K33* Plugin_057_M = nullptr;
 
 #ifndef CONFIG
 #define CONFIG(n) (Settings.TaskDevicePluginConfig[event->TaskIndex][n])
@@ -117,7 +117,7 @@ boolean Plugin_057(byte function, struct EventStruct *event, String& string)
 
         int16_t choice = CONFIG(1);
         String options[3] = {F("none"), F("7-Seg. HH:MM (24 hour)"), F("7-Seg. HH:MM (12 hour)")};
-        addFormSelector(F("Clock Type"), F("clocktype"), 3, options, NULL, choice);
+        addFormSelector(F("Clock Type"), F("clocktype"), 3, options, nullptr, choice);
 
         addFormNumericBox(F("Seg. for <b>X</b>x:xx"), F("clocksegh10"), CONFIG(2), 0, 7);
         addFormNumericBox(F("Seg. for x<b>X</b>:xx"), F("clocksegh1"), CONFIG(3), 0, 7);

--- a/src/_P058_HT16K33_KeyPad.ino
+++ b/src/_P058_HT16K33_KeyPad.ino
@@ -35,7 +35,7 @@
 
 #include <HT16K33.h>
 
-CHT16K33* Plugin_058_K = NULL;
+CHT16K33* Plugin_058_K = nullptr;
 
 #ifndef CONFIG
 #define CONFIG(n) (Settings.TaskDevicePluginConfig[event->TaskIndex][n])

--- a/src/_P061_KeyPad.ino
+++ b/src/_P061_KeyPad.ino
@@ -110,7 +110,7 @@ boolean Plugin_061(byte function, struct EventStruct *event, String& string)
           addFormNote(F("PCF8574 uses address 0x20+; PCF8574<b>A</b> uses address 0x38+"));
 
         String options[3] = { F("MCP23017 (Matrix 9x8)"), F("PCF8574 (Matrix 5x4)"), F("PCF8574 (Direct 8)") };
-        addFormSelector(F("Chip (Mode)"), F("chip"), 3, options, NULL, CONFIG(1));
+        addFormSelector(F("Chip (Mode)"), F("chip"), 3, options, nullptr, CONFIG(1));
 
         success = true;
         break;

--- a/src/_P062_MPR121_KeyPad.ino
+++ b/src/_P062_MPR121_KeyPad.ino
@@ -23,7 +23,7 @@
 
 #include <Adafruit_MPR121.h>
 
-Adafruit_MPR121* Plugin_062_K = NULL;
+Adafruit_MPR121* Plugin_062_K = nullptr;
 
 #ifndef CONFIG
 #define CONFIG(n) (Settings.TaskDevicePluginConfig[event->TaskIndex][n])

--- a/src/_P064_APDS9960.ino
+++ b/src/_P064_APDS9960.ino
@@ -34,7 +34,7 @@
 #define CONFIG(n) (Settings.TaskDevicePluginConfig[event->TaskIndex][n])
 #endif
 
-SparkFun_APDS9960* PLUGIN_064_pds = NULL;
+SparkFun_APDS9960* PLUGIN_064_pds = nullptr;
 
 
 boolean Plugin_064(byte function, struct EventStruct *event, String& string)

--- a/src/_P065_DRF0299_MP3.ino
+++ b/src/_P065_DRF0299_MP3.ino
@@ -42,7 +42,7 @@
 #define PIN(n) (Settings.TaskDevicePin[n][event->TaskIndex])
 #endif
 
-ESPeasySoftwareSerial* Plugin_065_SoftSerial = NULL;
+ESPeasySoftwareSerial* Plugin_065_SoftSerial = nullptr;
 
 
 boolean Plugin_065(byte function, struct EventStruct *event, String& string)

--- a/src/_P066_VEML6040.ino
+++ b/src/_P066_VEML6040.ino
@@ -73,7 +73,7 @@ boolean Plugin_066(byte function, struct EventStruct *event, String& string)
         addFormSelectorI2C(F("i2c_addr"), 1, optionValues, VEML6040_ADDR);   //Only for display I2C address
 
         String optionsMode[6] = { F("40ms (16496)"), F("80ms (8248)"), F("160ms (4124)"), F("320ms (2062)"), F("640ms (1031)"), F("1280ms (515)") };
-        addFormSelector(F("Integration Time (Max Lux)"), F("itime"), 6, optionsMode, NULL, CONFIG(1));
+        addFormSelector(F("Integration Time (Max Lux)"), F("itime"), 6, optionsMode, nullptr, CONFIG(1));
 
         String optionsVarMap[6] = {
           F("R, G, B, W"),
@@ -82,7 +82,7 @@ boolean Plugin_066(byte function, struct EventStruct *event, String& string)
           F("R, G, B, Color Temperature [K]"),
           F("R, G, B, Ambient Light [Lux]"),
           F("Color Temperature [K], Ambient Light [Lux], Y, W") };
-        addFormSelector(F("Value Mapping"), F("map"), 6, optionsVarMap, NULL, CONFIG(2));
+        addFormSelector(F("Value Mapping"), F("map"), 6, optionsVarMap, nullptr, CONFIG(2));
 
         success = true;
         break;

--- a/src/_P067_HX711_Load_Cell.ino
+++ b/src/_P067_HX711_Load_Cell.ino
@@ -126,7 +126,7 @@ boolean Plugin_067(byte function, struct EventStruct *event, String& string)
         addFormCheckBox(F("Oversampling"), F("oversampling"), CONFIG(0));
 
         String optionsMode[3] = { F("Channel A, Gain 128"), F("Channel B, Gain 32"), F("Channel A, Gain 64") };
-        addFormSelector(F("Mode"), F("mode"), 3, optionsMode, NULL, CONFIG(1));
+        addFormSelector(F("Mode"), F("mode"), 3, optionsMode, nullptr, CONFIG(1));
 
         addFormTextBox(F("Offset"), F("p067_offset"), String(Settings.TaskDevicePluginConfigFloat[event->TaskIndex][3], 3), 25);
         addHtml(F(" &nbsp; &nbsp; &#8617; Tare: "));

--- a/src/_P068_SHT3x.ino
+++ b/src/_P068_SHT3x.ino
@@ -87,7 +87,7 @@ void SHT3X::get()
 #define CONFIG(n) (Settings.TaskDevicePluginConfig[event->TaskIndex][n])
 #endif
 
-SHT3X*  Plugin_068_SHT3x[TASKS_MAX] = { NULL, };
+SHT3X*  Plugin_068_SHT3x[TASKS_MAX] = { nullptr, };
 
 
 //==============================================

--- a/src/_P069_LM75A.ino
+++ b/src/_P069_LM75A.ino
@@ -110,7 +110,7 @@ private:
 #define CONFIG(n) (Settings.TaskDevicePluginConfig[event->TaskIndex][n])
 #endif
 
-LM75A* PLUGIN_069_LM75A = NULL;
+LM75A* PLUGIN_069_LM75A = nullptr;
 
 
 boolean Plugin_069(byte function, struct EventStruct *event, String& string)

--- a/src/_P071_Kamstrup401.ino
+++ b/src/_P071_Kamstrup401.ino
@@ -152,43 +152,43 @@ boolean Plugin_071(byte function, struct EventStruct *event, String& string)
               else
                m_energy = 0;
 
-              tmpstr = strtok(NULL, " ");
+              tmpstr = strtok(nullptr, " ");
               if (tmpstr)
                m_volume = atol(tmpstr);
               else
                m_volume = 0;
 
-              tmpstr = strtok(NULL, " ");
+              tmpstr = strtok(nullptr, " ");
               if (tmpstr)
                m_hours = atol(tmpstr);
               else
                m_hours = 0;
 
-              tmpstr = strtok(NULL, " ");
+              tmpstr = strtok(nullptr, " ");
               if (tmpstr)
                m_tempin = atol(tmpstr)/100.0;
               else
                m_tempin = 0;
 
-              tmpstr = strtok(NULL, " ");
+              tmpstr = strtok(nullptr, " ");
               if (tmpstr)
                m_tempout = atol(tmpstr)/100.0;
               else
                m_tempout = 0;
 
-              tmpstr = strtok(NULL, " ");
+              tmpstr = strtok(nullptr, " ");
               if (tmpstr)
                m_tempdiff = atol(tmpstr)/100.0;
               else
                m_tempdiff = 0;
 
-              tmpstr = strtok(NULL, " ");
+              tmpstr = strtok(nullptr, " ");
               if (tmpstr)
                m_power = atol(tmpstr)/10.0;
               else
                m_power = 0;
 
-              tmpstr = strtok(NULL, " ");
+              tmpstr = strtok(nullptr, " ");
               if (tmpstr)
                m_flow = atol(tmpstr);
               else

--- a/src/_P073_7DGT.ino
+++ b/src/_P073_7DGT.ino
@@ -41,7 +41,7 @@ class p073_7dgt
     byte brightness;
     boolean timesep;
 };
-p073_7dgt *Plugin_073_7dgt = NULL;
+p073_7dgt *Plugin_073_7dgt = nullptr;
 //---------------------------------------------------
 
 uint8_t p073_showbuffer[8];
@@ -103,9 +103,9 @@ boolean Plugin_073(byte function, struct EventStruct *event, String& string)
         addFormNote(F("TM1637:  1st=CLK-Pin, 2nd=DIO-Pin"));
         addFormNote(F("MAX7219: 1st=DIN-Pin, 2nd=CLK-Pin, 3rd=CS-Pin"));
         String displtype[5] = { F("TM1637 - 4 digit (colon)"), F("TM1637 - 4 digit (dots)"), F("TM1637 - 6 digit"), F("MAX7219 - 8 digit")};
-        addFormSelector(F("Display Type"), F("p073_displtype"), 4, displtype, NULL, Settings.TaskDevicePluginConfig[event->TaskIndex][0]);
+        addFormSelector(F("Display Type"), F("p073_displtype"), 4, displtype, nullptr, Settings.TaskDevicePluginConfig[event->TaskIndex][0]);
         String displout[4] = { F("Manual"), F("Clock - Blink"), F("Clock - No Blink"), F("Date")  };
-        addFormSelector(F("Display Output"), F("p073_displout"), 4, displout, NULL, Settings.TaskDevicePluginConfig[event->TaskIndex][1]);
+        addFormSelector(F("Display Output"), F("p073_displout"), 4, displout, nullptr, Settings.TaskDevicePluginConfig[event->TaskIndex][1]);
         addFormNumericBox(F("Brightness"), F("p073_brightness"), Settings.TaskDevicePluginConfig[event->TaskIndex][2], 0, 15);
         success = true;
         break;

--- a/src/_P074_TSL2591.ino
+++ b/src/_P074_TSL2591.ino
@@ -82,7 +82,7 @@ boolean Plugin_074(byte function, struct EventStruct *event, String& string)
         // tsl.setTiming(TSL2591_INTEGRATIONTIME_600MS);  // longest integration time (dim light)
 
         String optionsMode[6] = { F("100ms"), F("200ms"), F("300ms"), F("400ms"), F("500ms"), F("600ms") };
-        addFormSelector(F("Integration Time"), F("p074_itime"), 6, optionsMode, NULL, CONFIG(1));
+        addFormSelector(F("Integration Time"), F("p074_itime"), 6, optionsMode, nullptr, CONFIG(1));
 
 
 //        TSL2591_GAIN_LOW                  = 0x00,    // low gain (1x)
@@ -95,7 +95,7 @@ boolean Plugin_074(byte function, struct EventStruct *event, String& string)
           F("medium gain (25x)"),
           F("medium gain (428x)"),
           F("max gain (9876x)") };
-        addFormSelector(F("Value Mapping"), F("p074_gain"), 4, optionsGain, NULL, CONFIG(2));
+        addFormSelector(F("Value Mapping"), F("p074_gain"), 4, optionsGain, nullptr, CONFIG(2));
 
         success = true;
         break;

--- a/src/_P075_Nextion.ino
+++ b/src/_P075_Nextion.ino
@@ -57,7 +57,7 @@
 
 
 // Global vars
-ESPeasySoftwareSerial *SoftSerial = NULL;
+ESPeasySoftwareSerial *SoftSerial = nullptr;
 int rxPin = -1;
 int txPin = -1;
 
@@ -170,7 +170,7 @@ boolean Plugin_075(byte function, struct EventStruct *event, String& string)
       options[2] = F("57600");
       options[3] = F("115200");
 
-      addFormSelector(F("Baud Rate"), F("p075_baud"), 4, options, NULL, choice);
+      addFormSelector(F("Baud Rate"), F("p075_baud"), 4, options, nullptr, choice);
       addFormNote(F("Un-check box for Soft Serial communication (low performance mode, 9600 Baud)."));
       addFormNote(F("Hardware Serial is available when the GPIO pins are RX=D7 and TX=D8."));
       addFormNote(F("D8 (GPIO-15) requires a Buffer Circuit (PNP transistor) or ESP boot may fail."));
@@ -252,9 +252,9 @@ boolean Plugin_075(byte function, struct EventStruct *event, String& string)
         txPin = Settings.TaskDevicePin2[event->TaskIndex];
       }
 
-      if (SoftSerial != NULL) {
+      if (SoftSerial != nullptr) {
         delete SoftSerial;
-        SoftSerial = NULL;
+        SoftSerial = nullptr;
       }
 
       String log;
@@ -299,7 +299,7 @@ boolean Plugin_075(byte function, struct EventStruct *event, String& string)
             log = F("NEXTION075 : Using software serial");
             addLog(LOG_LEVEL_INFO, log);
             HwSerial = SOFTSERIAL;
-            if (SoftSerial == NULL) {
+            if (SoftSerial == nullptr) {
                 SoftSerial = new ESPeasySoftwareSerial(rxPin, txPin, false, RXBUFFSZ);
             }
             SoftSerial->begin(9600);
@@ -443,7 +443,7 @@ boolean Plugin_075(byte function, struct EventStruct *event, String& string)
     case PLUGIN_EXIT: {
         if (SoftSerial) {
             delete SoftSerial;
-            SoftSerial=NULL;
+            SoftSerial=nullptr;
         }
 
         if(HwSerial == UARTSERIAL) {
@@ -494,7 +494,7 @@ boolean Plugin_075(byte function, struct EventStruct *event, String& string)
         }
       }
       else {
-        if(SoftSerial == NULL) break;                   // SoftSerial missing, exit.
+        if(SoftSerial == nullptr) break;                   // SoftSerial missing, exit.
         charCount = SoftSerial->available();            // Prime the Soft Serial engine.
         if(charCount >= RXBUFFWARN) {
             String log;
@@ -653,7 +653,7 @@ void sendCommand(const char *cmd, boolean SerialMode)
         Serial.write(0xff);
     }
     else {                                              // Send command using bit-bang soft serial.
-        if(SoftSerial != NULL){
+        if(SoftSerial != nullptr){
             SoftSerial->print(cmd);
             SoftSerial->write(0xff);
             SoftSerial->write(0xff);

--- a/src/_P076_HLW8012.ino
+++ b/src/_P076_HLW8012.ino
@@ -14,7 +14,7 @@
 //
 
 #include <HLW8012.h>
-HLW8012 *Plugin_076_hlw = NULL;
+HLW8012 *Plugin_076_hlw = nullptr;
 
 #define PLUGIN_076
 #define PLUGIN_ID_076        76

--- a/src/_P078_Eastron.ino
+++ b/src/_P078_Eastron.ino
@@ -38,8 +38,8 @@
 
 // These pointers may be used among multiple instances of the same plugin,
 // as long as the same serial settings are used.
-ESPeasySoftwareSerial* Plugin_078_SoftSerial = NULL;
-SDM* Plugin_078_SDM = NULL;
+ESPeasySoftwareSerial* Plugin_078_SoftSerial = nullptr;
+SDM* Plugin_078_SDM = nullptr;
 boolean Plugin_078_init = false;
 
 boolean Plugin_078(byte function, struct EventStruct *event, String& string)
@@ -113,13 +113,13 @@ boolean Plugin_078(byte function, struct EventStruct *event, String& string)
         addFormNumericBox(F("Modbus Address"), F("p078_dev_id"), P078_DEV_ID, 1, 247);
 
         String options_model[4] = { F("SDM120C"), F("SDM220T"), F("SDM230"), F("SDM630") };
-        addFormSelector(F("Model Type"), F("p078_model"), 4, options_model, NULL, P078_MODEL );
+        addFormSelector(F("Model Type"), F("p078_model"), 4, options_model, nullptr, P078_MODEL );
 
         String options_baudrate[6];
         for (int i = 0; i < 6; ++i) {
           options_baudrate[i] = String(p078_storageValueToBaudrate(i));
         }
-        addFormSelector(F("Baud Rate"), F("p078_baudrate"), 6, options_baudrate, NULL, P078_BAUDRATE );
+        addFormSelector(F("Baud Rate"), F("p078_baudrate"), 6, options_baudrate, nullptr, P078_BAUDRATE );
 
         if (P078_MODEL == 0 && P078_BAUDRATE > 3)
           addFormNote(F("<span style=\"color:red\"> SDM120 only allows up to 9600 baud with default 2400!</span>"));
@@ -131,10 +131,10 @@ boolean Plugin_078(byte function, struct EventStruct *event, String& string)
         for (int i = 0; i < 10; ++i) {
           options_query[i] = p078_getQueryString(i);
         }
-        addFormSelector(F("Variable 1"), F("p078_query1"), 10, options_query, NULL, P078_QUERY1);
-        addFormSelector(F("Variable 2"), F("p078_query2"), 10, options_query, NULL, P078_QUERY2);
-        addFormSelector(F("Variable 3"), F("p078_query3"), 10, options_query, NULL, P078_QUERY3);
-        addFormSelector(F("Variable 4"), F("p078_query4"), 10, options_query, NULL, P078_QUERY4);
+        addFormSelector(F("Variable 1"), F("p078_query1"), 10, options_query, nullptr, P078_QUERY1);
+        addFormSelector(F("Variable 2"), F("p078_query2"), 10, options_query, nullptr, P078_QUERY2);
+        addFormSelector(F("Variable 3"), F("p078_query3"), 10, options_query, nullptr, P078_QUERY3);
+        addFormSelector(F("Variable 4"), F("p078_query4"), 10, options_query, nullptr, P078_QUERY4);
 
         success = true;
         break;
@@ -158,17 +158,17 @@ boolean Plugin_078(byte function, struct EventStruct *event, String& string)
     case PLUGIN_INIT:
       {
         Plugin_078_init = true;
-        if (Plugin_078_SoftSerial != NULL) {
+        if (Plugin_078_SoftSerial != nullptr) {
           delete Plugin_078_SoftSerial;
-          Plugin_078_SoftSerial=NULL;
+          Plugin_078_SoftSerial=nullptr;
         }
         Plugin_078_SoftSerial = new ESPeasySoftwareSerial(Settings.TaskDevicePin1[event->TaskIndex], Settings.TaskDevicePin2[event->TaskIndex]);
         unsigned int baudrate = p078_storageValueToBaudrate(P078_BAUDRATE);
         Plugin_078_SoftSerial->begin(baudrate);
 
-        if (Plugin_078_SDM != NULL) {
+        if (Plugin_078_SDM != nullptr) {
           delete Plugin_078_SDM;
-          Plugin_078_SDM=NULL;
+          Plugin_078_SDM=nullptr;
         }
         Plugin_078_SDM = new SDM(*Plugin_078_SoftSerial, baudrate, P078_DEPIN);
         Plugin_078_SDM->begin();
@@ -179,13 +179,13 @@ boolean Plugin_078(byte function, struct EventStruct *event, String& string)
     case PLUGIN_EXIT:
     {
       Plugin_078_init = false;
-      if (Plugin_078_SoftSerial != NULL) {
+      if (Plugin_078_SoftSerial != nullptr) {
         delete Plugin_078_SoftSerial;
-        Plugin_078_SoftSerial=NULL;
+        Plugin_078_SoftSerial=nullptr;
       }
-      if (Plugin_078_SDM != NULL) {
+      if (Plugin_078_SDM != nullptr) {
         delete Plugin_078_SDM;
-        Plugin_078_SDM=NULL;
+        Plugin_078_SDM=nullptr;
       }
       break;
     }
@@ -210,7 +210,7 @@ boolean Plugin_078(byte function, struct EventStruct *event, String& string)
 }
 
 float p078_readVal(byte query, byte node, unsigned int model) {
-  if (Plugin_078_SDM == NULL) return 0.0;
+  if (Plugin_078_SDM == nullptr) return 0.0;
   const float _tempvar = Plugin_078_SDM->readVal(p078_getRegister(query, model), node);
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
     String log = F("EASTRON: (");

--- a/src/_P081_Cron.ino
+++ b/src/_P081_Cron.ino
@@ -99,7 +99,7 @@ boolean Plugin_081(byte function, struct EventStruct *event, String& string)
       if(/*strcmp(expression, state.Expression)*/1 != 0)
       {
         cron_expr expr;
-        const char* err = NULL;
+        const char* err = nullptr;
         memset(&expr, 0, sizeof(expr));
         cron_parse_expr(expression, &expr, &err);
         if (!err)

--- a/src/_Pxxx_PluginTemplate.ino
+++ b/src/_Pxxx_PluginTemplate.ino
@@ -135,7 +135,7 @@ boolean Plugin_xxx(byte function, struct EventStruct *event, String& string)
       For strings, always use the F() macro, which stores the string in flash, not in memory.
 
       //String dropdown[5] = { F("option1"), F("option2"), F("option3"), F("option4")};
-      //addFormSelector(string, F("drop-down menu"), F("plugin_xxx_displtype"), 4, dropdown, NULL, Settings.TaskDevicePluginConfig[event->TaskIndex][0]);
+      //addFormSelector(string, F("drop-down menu"), F("plugin_xxx_displtype"), 4, dropdown, nullptr, Settings.TaskDevicePluginConfig[event->TaskIndex][0]);
 
       //number selection (min-value - max-value)
       addFormNumericBox(string, F("description"), F("plugin_xxx_description"), Settings.TaskDevicePluginConfig[event->TaskIndex][1], min-value, max-value);


### PR DESCRIPTION
Just to make sure the compiler will warn when an overloaded (or changed) function is being called with the wrong parameter type.