### PR TITLE
[WiFi] Reduce CPU power on wifi connection issues

### DIFF
--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -533,8 +533,13 @@ void loop()
   //normal mode, run each task when its time
   else
   {
-    if (!UseRTOSMultitasking) {
-      // On ESP32 the schedule is executed on the 2nd core.
+    if (!firstLoopConnectionsEstablished && !WiFiConnected()
+        && wifi_connect_attempt >= 4 && (wifi_connect_attempt / 2) % 2 == 0) {
+      // Some emergency work-around to make the node connect to wifi by stop executing
+      // scheduled tasks for 2 attempts and run the loop faster plus give time to run background tasks.
+      WifiCheck();
+    } else if (!UseRTOSMultitasking) {
+      // On ESP32 the schedule is executed in a separate task.
       handle_schedule();
     }
   }


### PR DESCRIPTION
See this extensive test list: https://github.com/letscontrolit/ESPEasy/issues/2008#issuecomment-437661851

This patch will stop executing the scheduler for 2 connection attempts starting the 4th attempt.
So on attempt 4, 5, 8, 9, 12, 13, .... etc. will it stop executing the scheduler.
This will in the end result in undesired behavior, like not executing rules or acting on triggers when wifi connection is lost.
But that's for later concerns.