### PR TITLE
[Serial] Redirect all Serial.print/println to a buffer

### DIFF
--- a/src/Command.ino
+++ b/src/Command.ino
@@ -195,7 +195,7 @@ String return_not_connected()
 
 String return_result(struct EventStruct *event, const String& result)
 {
-	Serial.println(result);
+	serialPrintln(result);
 	if (event->Source == VALUE_SOURCE_SERIAL) {
 		return return_command_success();
 	}
@@ -250,16 +250,16 @@ void printDirectory(File dir, int numTabs)
 			break;
 		}
 		for (uint8_t i = 0; i < numTabs; i++) {
-			Serial.print('\t');
+			serialPrint('\t');
 		}
-		Serial.print(entry.name());
+		serialPrint(entry.name());
 		if (entry.isDirectory()) {
-			Serial.println("/");
+			serialPrintln("/");
 			printDirectory(entry, numTabs + 1);
 		} else {
 			// files have sizes, directories do not
-			Serial.print("\t\t");
-			Serial.println(entry.size(), DEC);
+			serialPrint("\t\t");
+			serialPrintln(entry.size(), DEC);
 		}
 		entry.close();
 	}

--- a/src/Command.ino
+++ b/src/Command.ino
@@ -25,19 +25,17 @@
 \*********************************************************************************************/
 String doExecuteCommand(const char * cmd, struct EventStruct *event, const char* line)
 {
-	// Simple macro to match command to function call.
-  #define COMMAND_CASE(S, C) if (strcmp_P(cmd_lc, PSTR(S)) == 0) return (C(event, line));
-
-	String tmpcmd;
-	tmpcmd = cmd;
-	tmpcmd.toLowerCase();
+  String cmd_lc;
+	cmd_lc = cmd;
+	cmd_lc.toLowerCase();
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
   	String log = F("Command: ");
-  	log += tmpcmd;
+  	log += cmd_lc;
   	addLog(LOG_LEVEL_INFO, log);
   }
-	char cmd_lc[INPUT_COMMAND_SIZE];
-	tmpcmd.toCharArray(cmd_lc, tmpcmd.length() + 1);
+  // Simple macro to match command to function call.
+  #define COMMAND_CASE(S, C) if (strcmp_P(cmd_lc.c_str(), PSTR(S)) == 0) { return (C(event, line)); }
+
   switch (cmd_lc[0]) {
     case 'a': {
 	  COMMAND_CASE("accessinfo"             , Command_AccessInfo_Ls);              // Network Command
@@ -213,31 +211,35 @@ String return_see_serial(struct EventStruct *event)
 void ExecuteCommand(byte source, const char *Line)
 {
 	checkRAM(F("ExecuteCommand"));
-	char TmpStr1[INPUT_COMMAND_SIZE];
-	TmpStr1[0] = 0;
-	char cmd[INPUT_COMMAND_SIZE];
-	cmd[0] = 0;
+  String cmd;
+  if (!GetArgv(Line, cmd, 1)) {
+    return;
+  }
 	struct EventStruct TempEvent;
 	// FIXME TD-er: Not sure what happens now, but TaskIndex cannot be set here
 	// since commands can originate from anywhere.
 	TempEvent.Source = source;
-	GetArgv(Line, cmd, 1);
-  if (GetArgv(Line, TmpStr1, 2)) TempEvent.Par1 = CalculateParam(TmpStr1);
-	if (GetArgv(Line, TmpStr1, 3)) TempEvent.Par2 = CalculateParam(TmpStr1);
-	if (GetArgv(Line, TmpStr1, 4)) TempEvent.Par3 = CalculateParam(TmpStr1);
-	if (GetArgv(Line, TmpStr1, 5)) TempEvent.Par4 = CalculateParam(TmpStr1);
-	if (GetArgv(Line, TmpStr1, 6)) TempEvent.Par5 = CalculateParam(TmpStr1);
+  {
+    // Use extra scope to delete the TmpStr1 before executing command.
+    char TmpStr1[INPUT_COMMAND_SIZE];
+  	TmpStr1[0] = 0;
+    if (GetArgv(Line, TmpStr1, 2)) TempEvent.Par1 = CalculateParam(TmpStr1);
+  	if (GetArgv(Line, TmpStr1, 3)) TempEvent.Par2 = CalculateParam(TmpStr1);
+  	if (GetArgv(Line, TmpStr1, 4)) TempEvent.Par3 = CalculateParam(TmpStr1);
+  	if (GetArgv(Line, TmpStr1, 5)) TempEvent.Par4 = CalculateParam(TmpStr1);
+  	if (GetArgv(Line, TmpStr1, 6)) TempEvent.Par5 = CalculateParam(TmpStr1);
+  }
 
-  if (source == VALUE_SOURCE_WEB_FRONTEND) {
-    // Must run immediately, to see result in web frontend
-    String status = doExecuteCommand((char*)&cmd[0], &TempEvent, Line);
-    delay(0);
-    SendStatus(source, status);
-    delay(0);
+  String status = doExecuteCommand(cmd.c_str(), &TempEvent, Line);
+  delay(0);
+  SendStatus(source, status);
+  delay(0);
+/*
   } else {
     // Schedule to run async
-    schedule_command_timer((char*)&cmd[0], &TempEvent, Line);
+    schedule_command_timer(cmd.c_str(), &TempEvent, Line);
   }
+*/
 }
 
 #ifdef FEATURE_SD

--- a/src/Commands/Common.h
+++ b/src/Commands/Common.h
@@ -34,7 +34,7 @@ String Command_GetORSetIP(struct EventStruct *event,
 			return return_result(event, result);
 		}
 	} else {
-		Serial.println();
+		serialPrintln();
 		String result = targetDescription;
 		if (useStaticIP()) {
 			result += formatIP(IP);
@@ -61,13 +61,13 @@ String Command_GetORSetString(struct EventStruct *event,
 			String result = targetDescription;
 			result += F(" is too large. max size is ");
 			result += len;
-			Serial.println();
+			serialPrintln();
 			return return_result(event, result);
 		}else  {
 			strcpy(target, TmpStr1);
 		}
 	}else  {
-		Serial.println();
+		serialPrintln();
 		String result = targetDescription;
 		result += target;
 		return return_result(event, result);

--- a/src/Commands/Common.h
+++ b/src/Commands/Common.h
@@ -4,7 +4,7 @@
 #include <ctype.h>
 #include <Arduino.h>
 
-bool IsNumeric(char * source)
+bool IsNumeric(const char * source)
 {
 	bool result = false;
 	if (source) {
@@ -26,19 +26,25 @@ String Command_GetORSetIP(struct EventStruct *event,
 			  IPAddress dhcpIP,
 			  int arg)
 {
-	char TmpStr1[INPUT_COMMAND_SIZE];
-	if (GetArgv(Line, TmpStr1, arg + 1)) {
-		if (!str2ip(TmpStr1, IP)) {
-			String result = F("Invalid parameter: ");
-			result += TmpStr1;
-			return return_result(event, result);
+	bool hasArgument = false;
+	{
+		// Check if command is valid. Leave in separate scope to delete the TmpStr1
+		char TmpStr1[INPUT_COMMAND_SIZE];
+		if (GetArgv(Line, TmpStr1, arg + 1)) {
+			hasArgument = true;
+			if (!str2ip(TmpStr1, IP)) {
+				String result = F("Invalid parameter: ");
+				result += TmpStr1;
+				return return_result(event, result);
+			}
 		}
-	} else {
+	}
+	if (!hasArgument) {
 		serialPrintln();
 		String result = targetDescription;
 		if (useStaticIP()) {
 			result += formatIP(IP);
-		}else  {
+		} else {
 			result += formatIP(dhcpIP);
 			result += F("(DHCP)");
 		}
@@ -55,18 +61,24 @@ String Command_GetORSetString(struct EventStruct *event,
 			      int arg
 			      )
 {
-	char TmpStr1[INPUT_COMMAND_SIZE];
-	if (GetArgv(Line, TmpStr1, arg + 1)) {
-		if (strlen(TmpStr1) > len) {
-			String result = targetDescription;
-			result += F(" is too large. max size is ");
-			result += len;
-			serialPrintln();
-			return return_result(event, result);
-		}else  {
-			strcpy(target, TmpStr1);
+	bool hasArgument = false;
+	{
+		// Check if command is valid. Leave in separate scope to delete the TmpStr1
+		char TmpStr1[INPUT_COMMAND_SIZE];
+		if (GetArgv(Line, TmpStr1, arg + 1)) {
+			hasArgument = true;
+			if (strlen(TmpStr1) > len) {
+				String result = targetDescription;
+				result += F(" is too large. max size is ");
+				result += len;
+				serialPrintln();
+				return return_result(event, result);
+			} else {
+				strcpy(target, TmpStr1);
+			}
 		}
-	}else  {
+	}
+	if (hasArgument) {
 		serialPrintln();
 		String result = targetDescription;
 		result += target;
@@ -81,16 +93,23 @@ String Command_GetORSetBool(struct EventStruct *event,
 			    bool *value,
 			    int arg)
 {
-	char TmpStr1[INPUT_COMMAND_SIZE];
-	if (GetArgv(Line, TmpStr1, arg + 1)) {
-		if (IsNumeric(TmpStr1)) {
-			*value = atoi(TmpStr1) > 0;
+	bool hasArgument = false;
+	{
+		// Check if command is valid. Leave in separate scope to delete the TmpStr1
+		String TmpStr1;
+		if (GetArgv(Line, TmpStr1, arg + 1)) {
+			hasArgument = true;
+			TmpStr1.toLowerCase();
+			if (IsNumeric(TmpStr1.c_str())) {
+				*value = atoi(TmpStr1.c_str()) > 0;
+			}
+	    else if (strcmp_P(PSTR("on"), TmpStr1.c_str()) == 0) *value = true;
+			else if (strcmp_P(PSTR("true"), TmpStr1.c_str()) == 0) *value = true;
+			else if (strcmp_P(PSTR("off"), TmpStr1.c_str()) == 0) *value = false;
+			else if (strcmp_P(PSTR("false"), TmpStr1.c_str()) == 0) *value = false;
 		}
-    else if (strcmp_P(PSTR("on"), TmpStr1) == 0) *value = true;
-		else if (strcmp_P(PSTR("true"), TmpStr1) == 0) *value = true;
-		else if (strcmp_P(PSTR("off"), TmpStr1) == 0) *value = false;
-		else if (strcmp_P(PSTR("false"), TmpStr1) == 0) *value = false;
-	}else  {
+	}
+	if (hasArgument) {
 		String result = targetDescription;
 		result += toString(*value);
 		return return_result(event, result);

--- a/src/Commands/Diagnostic.h
+++ b/src/Commands/Diagnostic.h
@@ -91,8 +91,7 @@ String Command_Background(struct EventStruct *event, const char* Line)
 
 String Command_Debug(struct EventStruct *event, const char* Line)
 {
-	char TmpStr1[INPUT_COMMAND_SIZE];
-	if (GetArgv(Line, TmpStr1, 2)) {
+	if (HasArgv(Line, 2)) {
 		setLogLevelFor(LOG_TO_SERIAL, event->Par1);
 	}else  {
 		serialPrintln();

--- a/src/Commands/Diagnostic.h
+++ b/src/Commands/Diagnostic.h
@@ -39,14 +39,14 @@ String Command_SerialFloat(struct EventStruct *event, const char* Line)
 
 String Command_MemInfo(struct EventStruct *event, const char* Line)
 {
-	Serial.print(F("SecurityStruct         | "));
-	Serial.println(sizeof(SecuritySettings));
-	Serial.print(F("SettingsStruct         | "));
-	Serial.println(sizeof(Settings));
-	Serial.print(F("ExtraTaskSettingsStruct| "));
-	Serial.println(sizeof(ExtraTaskSettings));
-	Serial.print(F("DeviceStruct           | "));
-	Serial.println(sizeof(Device));
+	serialPrint(F("SecurityStruct         | "));
+	serialPrintln(String(sizeof(SecuritySettings)));
+	serialPrint(F("SettingsStruct         | "));
+	serialPrintln(String(sizeof(Settings)));
+	serialPrint(F("ExtraTaskSettingsStruct| "));
+	serialPrintln(String(sizeof(ExtraTaskSettings)));
+	serialPrint(F("DeviceStruct           | "));
+	serialPrintln(String(sizeof(Device)));
 	return return_see_serial(event);
 }
 
@@ -58,22 +58,22 @@ String Command_MemInfo_detail(struct EventStruct *event, const char* Line)
 		SettingsType settingsType = static_cast<SettingsType>(st);
 		int max_index, offset, max_size;
 		int struct_size = 0;
-		Serial.println();
-		Serial.print(getSettingsTypeString(settingsType));
-		Serial.println(F(" | start | end | max_size | struct_size"));
-		Serial.println(F("--- | --- | --- | --- | ---"));
+		serialPrintln();
+		serialPrint(getSettingsTypeString(settingsType));
+		serialPrintln(F(" | start | end | max_size | struct_size"));
+		serialPrintln(F("--- | --- | --- | --- | ---"));
 		getSettingsParameters(settingsType, 0, max_index, offset, max_size, struct_size);
 		for (int i = 0; i < max_index; ++i) {
 			getSettingsParameters(settingsType, i, offset, max_size);
-			Serial.print(i);
-			Serial.print('|');
-			Serial.print(offset);
-			Serial.print('|');
-			Serial.print(offset + max_size - 1);
-			Serial.print('|');
-			Serial.print(max_size);
-			Serial.print('|');
-			Serial.println(struct_size);
+			serialPrint(String(i));
+			serialPrint("|");
+			serialPrint(String(offset));
+			serialPrint("|");
+			serialPrint(String(offset + max_size - 1));
+			serialPrint("|");
+			serialPrint(String(max_size));
+			serialPrint("|");
+			serialPrintln(String(struct_size));
 		}
 	}
 	return return_see_serial(event);
@@ -82,10 +82,10 @@ String Command_MemInfo_detail(struct EventStruct *event, const char* Line)
 String Command_Background(struct EventStruct *event, const char* Line)
 {
 	unsigned long timer = millis() + event->Par1;
-	Serial.println(F("start"));
+	serialPrintln(F("start"));
 	while (!timeOutReached(timer))
 		backgroundtasks();
-	Serial.println(F("end"));
+	serialPrintln(F("end"));
 	return return_see_serial(event);
 }
 
@@ -95,9 +95,9 @@ String Command_Debug(struct EventStruct *event, const char* Line)
 	if (GetArgv(Line, TmpStr1, 2)) {
 		setLogLevelFor(LOG_TO_SERIAL, event->Par1);
 	}else  {
-		Serial.println();
-		Serial.print(F("Serial debug level: "));
-		Serial.println(Settings.SerialLogLevel);
+		serialPrintln();
+		serialPrint(F("Serial debug level: "));
+		serialPrintln(String(Settings.SerialLogLevel));
 	}
 	return return_see_serial(event);
 }

--- a/src/Commands/MQTT.h
+++ b/src/Commands/MQTT.h
@@ -27,8 +27,8 @@ String Command_MQTT_messageDelay(struct EventStruct *event, const char* Line)
   else{
     String result = F("MQTT message delay:");
     result += Settings.MessageDelay;
-    Serial.println();
-    Serial.println(result);
+    serialPrintln();
+    serialPrintln(result);
     return result;
   }
   return return_command_success();

--- a/src/Commands/MQTT.h
+++ b/src/Commands/MQTT.h
@@ -20,8 +20,7 @@ String Command_MQTT_UseUnitNameAsClientId(struct EventStruct *event, const char*
 
 String Command_MQTT_messageDelay(struct EventStruct *event, const char* Line)
 {
-  char TmpStr1[INPUT_COMMAND_SIZE];
-  if (GetArgv(Line, TmpStr1, 2)) {
+  if (HasArgv(Line, 2)) {
     Settings.MessageDelay = event->Par1;
   }
   else{

--- a/src/Commands/Notifications.h
+++ b/src/Commands/Notifications.h
@@ -4,10 +4,8 @@
 
 String Command_Notifications_Notify(struct EventStruct *event, const char* Line)
 {
-	char TmpStr1[INPUT_COMMAND_SIZE];
 	String message = "";
-	if (GetArgv(Line, TmpStr1, 3))
-		message = TmpStr1;
+	GetArgv(Line, message, 3);
 
 	if (event->Par1 > 0) {
 		int index = event->Par1 - 1;

--- a/src/Commands/Rules.h
+++ b/src/Commands/Rules.h
@@ -6,11 +6,10 @@
 
 String Command_Rules_Execute(struct EventStruct *event, const char* Line)
 {
-	char TmpStr1[INPUT_COMMAND_SIZE];
-	if (GetArgv(Line, TmpStr1, 2)) {
-		String fileName = TmpStr1;
-		String event = "";
-		rulesProcessingFile(fileName, event);
+	String filename;
+	if (GetArgv(Line, filename, 2)) {
+		String event;
+		rulesProcessingFile(filename, event);
 	}
 	return return_command_success();
 }
@@ -36,10 +35,10 @@ String Command_Rules_Events(struct EventStruct *event, const char* Line)
 
 String Command_Rules_Let(struct EventStruct *event, const char* Line)
 {
-	char TmpStr1[INPUT_COMMAND_SIZE];
+	String TmpStr1;
 	if (GetArgv(Line, TmpStr1, 3)) {
-		float result = 0;
-		Calculate(TmpStr1, &result);
+		float result = 0.0;
+		Calculate(TmpStr1.c_str(), &result);
 		customFloatVar[event->Par1-1] = result;
 	}
 	return return_command_success();

--- a/src/Commands/Settings.h
+++ b/src/Commands/Settings.h
@@ -8,7 +8,7 @@ String Command_Settings_Build(struct EventStruct *event, const char* Line)
 	if (GetArgv(Line, TmpStr1, 2)) {
 		Settings.Build = event->Par1;
 	}else  {
-		Serial.println();
+		serialPrintln();
 		String result = F("Build:");
 		result += Settings.Build;
     return return_result(event, result);
@@ -22,7 +22,7 @@ String Command_Settings_Unit(struct EventStruct *event, const char* Line)
 	if (GetArgv(Line, TmpStr1, 2)) {
 		Settings.Unit = event->Par1;
 	}else  {
-		Serial.println();
+		serialPrintln();
 		String result = F("Unit:");
 		result += Settings.Unit;
     return return_result(event, result);
@@ -64,20 +64,20 @@ String Command_Settings_Load(struct EventStruct *event, const char* Line)
 String Command_Settings_Print(struct EventStruct *event, const char* Line)
 {
 	char str[20];
-	Serial.println();
+	serialPrintln();
 
-	Serial.println(F("System Info"));
+	serialPrintln(F("System Info"));
 	IPAddress ip = WiFi.localIP();
 	sprintf_P(str, PSTR("%u.%u.%u.%u"), ip[0], ip[1], ip[2], ip[3]);
-	Serial.print(F("  IP Address    : ")); Serial.println(str);
-	Serial.print(F("  Build         : ")); Serial.println((int)BUILD);
-	Serial.print(F("  Name          : ")); Serial.println(Settings.Name);
-	Serial.print(F("  Unit          : ")); Serial.println((int)Settings.Unit);
-	Serial.print(F("  WifiSSID      : ")); Serial.println(SecuritySettings.WifiSSID);
-	Serial.print(F("  WifiKey       : ")); Serial.println(SecuritySettings.WifiKey);
-	Serial.print(F("  WifiSSID2     : ")); Serial.println(SecuritySettings.WifiSSID2);
-	Serial.print(F("  WifiKey2      : ")); Serial.println(SecuritySettings.WifiKey2);
-	Serial.print(F("  Free mem      : ")); Serial.println(FreeMem());
+	serialPrint(F("  IP Address    : ")); serialPrintln(str);
+	serialPrint(F("  Build         : ")); serialPrintln(String((int)BUILD));
+	serialPrint(F("  Name          : ")); serialPrintln(Settings.Name);
+	serialPrint(F("  Unit          : ")); serialPrintln(String((int)Settings.Unit));
+	serialPrint(F("  WifiSSID      : ")); serialPrintln(SecuritySettings.WifiSSID);
+	serialPrint(F("  WifiKey       : ")); serialPrintln(SecuritySettings.WifiKey);
+	serialPrint(F("  WifiSSID2     : ")); serialPrintln(SecuritySettings.WifiSSID2);
+	serialPrint(F("  WifiKey2      : ")); serialPrintln(SecuritySettings.WifiKey2);
+	serialPrint(F("  Free mem      : ")); serialPrintln(String(FreeMem()));
 	return return_see_serial(event);
 }
 

--- a/src/Commands/Settings.h
+++ b/src/Commands/Settings.h
@@ -4,10 +4,9 @@
 
 String Command_Settings_Build(struct EventStruct *event, const char* Line)
 {
-	char TmpStr1[INPUT_COMMAND_SIZE];
-	if (GetArgv(Line, TmpStr1, 2)) {
+	if (HasArgv(Line, 2)) {
 		Settings.Build = event->Par1;
-	}else  {
+	} else {
 		serialPrintln();
 		String result = F("Build:");
 		result += Settings.Build;
@@ -18,8 +17,7 @@ String Command_Settings_Build(struct EventStruct *event, const char* Line)
 
 String Command_Settings_Unit(struct EventStruct *event, const char* Line)
 {
-	char TmpStr1[INPUT_COMMAND_SIZE];
-	if (GetArgv(Line, TmpStr1, 2)) {
+	if (HasArgv(Line, 2)) {
 		Settings.Unit = event->Par1;
 	}else  {
 		serialPrintln();
@@ -84,12 +82,7 @@ String Command_Settings_Print(struct EventStruct *event, const char* Line)
 String Command_Settings_Reset(struct EventStruct *event, const char* Line)
 {
 	ResetFactory();
-  #if defined(ESP8266)
-	ESP.reset();
-  #endif
-  #if defined(ESP32)
-	ESP.restart();
-  #endif
+	reboot();
 	return return_command_success();
 }
 

--- a/src/Commands/System.h
+++ b/src/Commands/System.h
@@ -22,12 +22,7 @@ String Command_System_Reboot(struct EventStruct *event, const char* Line)
 	pinMode(0, INPUT);
 	pinMode(2, INPUT);
 	pinMode(15, INPUT);
-#if defined(ESP8266)
-	ESP.reset();
-#endif
-#if defined(ESP32)
-	ESP.restart();
-#endif
+	reboot();
 	return return_command_success();
 }
 

--- a/src/Commands/Tasks.h
+++ b/src/Commands/Tasks.h
@@ -25,7 +25,7 @@ String Command_Task_ValueSet(struct EventStruct *event, const char* Line)
 		UserVar[(VARS_PER_TASK * (event->Par1 - 1)) + event->Par2 - 1] = result;
 	}else  {
 		//TODO: Get Task description and var name
-		Serial.println(UserVar[(VARS_PER_TASK * (event->Par1 - 1)) + event->Par2 - 1]);
+		serialPrintln(String(UserVar[(VARS_PER_TASK * (event->Par1 - 1)) + event->Par2 - 1]));
 	}
 	return return_command_success();
 }

--- a/src/Commands/Tasks.h
+++ b/src/Commands/Tasks.h
@@ -18,10 +18,10 @@ String Command_Task_ClearAll(struct EventStruct *event, const char* Line)
 
 String Command_Task_ValueSet(struct EventStruct *event, const char* Line)
 {
-	char TmpStr1[INPUT_COMMAND_SIZE];
+	String TmpStr1;
 	if (GetArgv(Line, TmpStr1, 4)) {
 		float result = 0;
-		Calculate(TmpStr1, &result);
+		Calculate(TmpStr1.c_str(), &result);
 		UserVar[(VARS_PER_TASK * (event->Par1 - 1)) + event->Par2 - 1] = result;
 	}else  {
 		//TODO: Get Task description and var name
@@ -41,10 +41,10 @@ String Command_Task_ValueToggle(struct EventStruct *event, const char* Line)
 
 String Command_Task_ValueSetAndRun(struct EventStruct *event, const char* Line)
 {
-	char TmpStr1[INPUT_COMMAND_SIZE];
+	String TmpStr1;
 	if (GetArgv(Line, TmpStr1, 4)) {
 		float result = 0;
-		Calculate(TmpStr1, &result);
+		Calculate(TmpStr1.c_str(), &result);
 		UserVar[(VARS_PER_TASK * (event->Par1 - 1)) + event->Par2 - 1] = result;
 		SensorSendTask(event->Par1 - 1);
 	}

--- a/src/Commands/Time.h
+++ b/src/Commands/Time.h
@@ -13,10 +13,9 @@ String Command_NTPHost(struct EventStruct *event, const char* Line)
 
 String Command_useNTP(struct EventStruct *event, const char* Line)
 {
-	char TmpStr1[INPUT_COMMAND_SIZE];
-	if (GetArgv(Line, TmpStr1, 2)) {
+	if (HasArgv(Line, 2)) {
 		Settings.UseNTP = event->Par1;
-	}else  {
+	} else {
 		serialPrintln();
 		String result = F("UseNTP:");
 		result += toString(Settings.UseNTP);
@@ -27,10 +26,9 @@ String Command_useNTP(struct EventStruct *event, const char* Line)
 
 String Command_TimeZone(struct EventStruct *event, const char* Line)
 {
-	char TmpStr1[INPUT_COMMAND_SIZE];
-	if (GetArgv(Line, TmpStr1, 2)) {
+	if (HasArgv(Line, 2)) {
 		Settings.TimeZone = event->Par1;
-	}else  {
+	} else {
 		serialPrintln();
 		String result = F("TimeZone:");
 		result += Settings.TimeZone;
@@ -41,8 +39,7 @@ String Command_TimeZone(struct EventStruct *event, const char* Line)
 
 String Command_DST(struct EventStruct *event, const char* Line)
 {
-	char TmpStr1[INPUT_COMMAND_SIZE];
-	if (GetArgv(Line, TmpStr1, 2)) {
+	if (HasArgv(Line, 2)) {
 		Settings.DST = event->Par1;
 	}else  {
 		serialPrintln();

--- a/src/Commands/Time.h
+++ b/src/Commands/Time.h
@@ -17,7 +17,7 @@ String Command_useNTP(struct EventStruct *event, const char* Line)
 	if (GetArgv(Line, TmpStr1, 2)) {
 		Settings.UseNTP = event->Par1;
 	}else  {
-		Serial.println();
+		serialPrintln();
 		String result = F("UseNTP:");
 		result += toString(Settings.UseNTP);
 		return return_result(event, result);
@@ -31,7 +31,7 @@ String Command_TimeZone(struct EventStruct *event, const char* Line)
 	if (GetArgv(Line, TmpStr1, 2)) {
 		Settings.TimeZone = event->Par1;
 	}else  {
-		Serial.println();
+		serialPrintln();
 		String result = F("TimeZone:");
 		result += Settings.TimeZone;
 		return return_result(event, result);
@@ -45,7 +45,7 @@ String Command_DST(struct EventStruct *event, const char* Line)
 	if (GetArgv(Line, TmpStr1, 2)) {
 		Settings.DST = event->Par1;
 	}else  {
-		Serial.println();
+		serialPrintln();
 		String result = F("DST:");
 		result += toString(Settings.DST);
 		return return_result(event, result);

--- a/src/Commands/WiFi.h
+++ b/src/Commands/WiFi.h
@@ -72,25 +72,26 @@ String Command_Wifi_STAMode(struct EventStruct *event, const char* Line)
 
 String Command_Wifi_Mode(struct EventStruct *event, const char* Line)
 {
-	char TmpStr1[INPUT_COMMAND_SIZE];
+	String TmpStr1;
 	if (GetArgv(Line, TmpStr1, 2)) {
 		WiFiMode_t mode = WIFI_MODE_MAX;
 		if (event->Par1 > 0) {
 			mode = (WiFiMode_t)(event->Par1 - 1);
-		}else  {
-			if (strcmp_P(TmpStr1, PSTR("off")) == 0) mode = WIFI_OFF;
-			else if (strcmp_P(TmpStr1, PSTR("sta")) == 0) mode = WIFI_STA;
-			else if (strcmp_P(TmpStr1, PSTR("ap")) == 0) mode = WIFI_AP;
-			else if (strcmp_P(TmpStr1, PSTR("ap+sta")) == 0) mode = WIFI_AP_STA;
+		} else {
+			TmpStr1.toLowerCase();
+			if (strcmp_P(TmpStr1.c_str(), PSTR("off")) == 0) mode = WIFI_OFF;
+			else if (strcmp_P(TmpStr1.c_str(), PSTR("sta")) == 0) mode = WIFI_STA;
+			else if (strcmp_P(TmpStr1.c_str(), PSTR("ap")) == 0) mode = WIFI_AP;
+			else if (strcmp_P(TmpStr1.c_str(), PSTR("ap+sta")) == 0) mode = WIFI_AP_STA;
 		}
 		if (mode >= WIFI_OFF && mode < WIFI_MODE_MAX) {
 			setWifiMode(mode);
 			setAPinternal(WifiIsAP(mode));
-		}else  {
+		} else {
 			serialPrintln();
 			return return_result(event, F("Wifi Mode: invalid arguments"));
 		}
-	}else  {
+	} else {
 		serialPrintln();
 		String result = F("WiFi Mode:");
 		result += toString(WiFi.getMode());

--- a/src/Commands/WiFi.h
+++ b/src/Commands/WiFi.h
@@ -87,11 +87,11 @@ String Command_Wifi_Mode(struct EventStruct *event, const char* Line)
 			setWifiMode(mode);
 			setAPinternal(WifiIsAP(mode));
 		}else  {
-			Serial.println();
+			serialPrintln();
 			return return_result(event, F("Wifi Mode: invalid arguments"));
 		}
 	}else  {
-		Serial.println();
+		serialPrintln();
 		String result = F("WiFi Mode:");
 		result += toString(WiFi.getMode());
 		return return_result(event, result);

--- a/src/Commands/i2c.h
+++ b/src/Commands/i2c.h
@@ -9,11 +9,11 @@ String Command_i2c_Scanner(struct EventStruct *event, const char* Line)
 		Wire.beginTransmission(address);
 		error = Wire.endTransmission();
 		if (error == 0) {
-			Serial.print(F("I2C  : Found 0x"));
-			Serial.println(String(address, HEX));
+			serialPrint(F("I2C  : Found 0x"));
+			serialPrintln(String(address, HEX));
 		}else if (error == 4) {
-			Serial.print(F("I2C  : Error at 0x"));
-			Serial.println(String(address, HEX));
+			serialPrint(F("I2C  : Error at 0x"));
+			serialPrintln(String(address, HEX));
 		}
 	}
 	return return_see_serial(event);

--- a/src/Commands/wd.h
+++ b/src/Commands/wd.h
@@ -20,7 +20,7 @@ String Command_WD_Read(struct EventStruct *event, const char* Line)
   if ( Wire.requestFrom((uint8_t)event->Par1, (uint8_t)1) == 1 )
   {
     byte value = Wire.read();
-    Serial.println();
+    serialPrintln();
     String result = F("I2C Read address ");
     result += formatToHex(event->Par1);
     result += F(" Value ");

--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -278,7 +278,7 @@ void SendStatus(byte source, String status)
       MQTTStatus(status);
       break;
     case VALUE_SOURCE_SERIAL:
-      Serial.println(status);
+      serialPrintln(status);
       break;
   }
 }

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -1411,11 +1411,9 @@ struct LogStruct {
 } Logging;
 
 std::deque<char> serialWriteBuffer;
-unsigned long last_serial_writebuffer_read = 0;
 
 byte highest_active_log_level = 0;
 bool log_to_serial_disabled = false;
-bool log_to_serial_disabled_temporary = false;
 // Do this in a template to prevent casting to String when not needed.
 #define addLog(L,S) if (loglevelActiveFor(L)) { addToLog(L,S); }
 

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -1410,8 +1410,8 @@ struct LogStruct {
 
 } Logging;
 
-std::deque<char> serialLogBuffer;
-unsigned long last_serial_log_read = 0;
+std::deque<char> serialWriteBuffer;
+unsigned long last_serial_writebuffer_read = 0;
 
 byte highest_active_log_level = 0;
 bool log_to_serial_disabled = false;

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -125,7 +125,7 @@ void setup()
   #endif
 
   Serial.begin(115200);
-  // Serial.print("\n\n\nBOOOTTT\n\n\n");
+  // serialPrint("\n\n\nBOOOTTT\n\n\n");
 
   initLog();
 
@@ -142,7 +142,7 @@ void setup()
 
   if (SpiffsSectors() < 32)
   {
-    Serial.println(F("\nNo (or too small) SPIFFS area..\nSystem Halted\nPlease reflash with 128k SPIFFS minimum!"));
+    serialPrintln(F("\nNo (or too small) SPIFFS area..\nSystem Halted\nPlease reflash with 128k SPIFFS minimum!"));
     while (true)
       delay(1);
   }
@@ -215,11 +215,11 @@ void setup()
   if (Settings.Version != VERSION || Settings.PID != ESP_PROJECT_PID)
   {
     // Direct Serial is allowed here, since this is only an emergency task.
-    Serial.print(F("\nPID:"));
-    Serial.println(Settings.PID);
-    Serial.print(F("Version:"));
-    Serial.println(Settings.Version);
-    Serial.println(F("INIT : Incorrect PID or version!"));
+    serialPrint(F("\nPID:"));
+    serialPrintln(String(Settings.PID));
+    serialPrint(F("Version:"));
+    serialPrintln(String(Settings.Version));
+    serialPrintln(F("INIT : Incorrect PID or version!"));
     delay(1000);
     ResetFactory();
   }
@@ -750,15 +750,15 @@ void runOncePerSecond()
 /*
   if (Settings.SerialLogLevel == LOG_LEVEL_DEBUG_DEV)
   {
-    Serial.print(F("Plugin calls: 50 ps:"));
-    Serial.print(elapsed50ps);
-    Serial.print(F(" uS, 10 ps:"));
-    Serial.print(elapsed10ps);
-    Serial.print(F(" uS, 10 psU:"));
-    Serial.print(elapsed10psU);
-    Serial.print(F(" uS, 1 ps:"));
-    Serial.print(elapsed);
-    Serial.println(F(" uS"));
+    serialPrint(F("Plugin calls: 50 ps:"));
+    serialPrint(elapsed50ps);
+    serialPrint(F(" uS, 10 ps:"));
+    serialPrint(elapsed10ps);
+    serialPrint(F(" uS, 10 psU:"));
+    serialPrint(elapsed10psU);
+    serialPrint(F(" uS, 1 ps:"));
+    serialPrint(elapsed);
+    serialPrintln(F(" uS"));
     elapsed50ps=0;
     elapsed10ps=0;
     elapsed10psU=0;
@@ -910,7 +910,7 @@ void backgroundtasks()
   #if defined(ESP8266)
     tcpCleanup();
   #endif
-  process_serialLogBuffer();
+  process_serialWriteBuffer();
   if(!UseRTOSMultitasking){
     if (Settings.UseSerial)
       if (Serial.available())

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -706,12 +706,7 @@ void runOncePerSecond()
         }
       case CMD_REBOOT:
         {
-          #if defined(ESP8266)
-            ESP.reset();
-          #endif
-          #if defined(ESP32)
-            ESP.restart();
-          #endif
+          reboot();
           break;
         }
     }

--- a/src/ESPEasyStorage.ino
+++ b/src/ESPEasyStorage.ino
@@ -60,7 +60,7 @@ String appendLineToFile(const String& fname, const String& line) {
 String BuildFixes()
 {
   checkRAM(F("BuildFixes"));
-  Serial.println(F("\nBuild changed!"));
+  serialPrintln(F("\nBuild changed!"));
 
   if (Settings.Build < 145)
   {
@@ -80,13 +80,13 @@ String BuildFixes()
 
   if (Settings.Build < 20101)
   {
-    Serial.println(F("Fix reset Pin"));
+    serialPrintln(F("Fix reset Pin"));
     Settings.Pin_Reset = -1;
   }
   if (Settings.Build < 20102) {
     // Settings were 'mangled' by using older version
     // Have to patch settings to make sure no bogus data is being used.
-    Serial.println(F("Fix settings with uninitalized data or corrupted by switching between versions"));
+    serialPrintln(F("Fix settings with uninitalized data or corrupted by switching between versions"));
     Settings.UseRTOSMultitasking = false;
     Settings.Pin_Reset = -1;
     Settings.SyslogFacility = DEFAULT_SYSLOG_FACILITY;
@@ -134,7 +134,7 @@ void fileSystemCheck()
   else
   {
     String log = F("FS   : Mount failed");
-    Serial.println(log);
+    serialPrintln(log);
     addLog(LOG_LEVEL_ERROR, log);
     ResetFactory();
   }

--- a/src/ESPEasyWifi.ino
+++ b/src/ESPEasyWifi.ino
@@ -683,26 +683,26 @@ void WifiDisconnect()
 void WifiScan()
 {
   // Direct Serial is allowed here, since this function will only be called from serial input.
-  Serial.println(F("WIFI : SSID Scan start"));
+  serialPrintln(F("WIFI : SSID Scan start"));
   int n = WiFi.scanNetworks(false, true);
   if (n == 0)
-    Serial.println(F("WIFI : No networks found"));
+    serialPrintln(F("WIFI : No networks found"));
   else
   {
-    Serial.print(F("WIFI : "));
-    Serial.print(n);
-    Serial.println(F(" networks found"));
+    serialPrint(F("WIFI : "));
+    serialPrint(String(n));
+    serialPrintln(F(" networks found"));
     for (int i = 0; i < n; ++i)
     {
       // Print SSID and RSSI for each network found
-      Serial.print(F("WIFI : "));
-      Serial.print(i + 1);
-      Serial.print(": ");
-      Serial.println(formatScanResult(i, " "));
+      serialPrint(F("WIFI : "));
+      serialPrint(String(i + 1));
+      serialPrint(": ");
+      serialPrintln(formatScanResult(i, " "));
       delay(10);
     }
   }
-  Serial.println("");
+  serialPrintln("");
 }
 
 String formatScanResult(int i, const String& separator) {

--- a/src/Hardware.ino
+++ b/src/Hardware.ino
@@ -112,16 +112,14 @@ void checkResetFactoryPin(){
   }
   else
   { // reset pin released
-    if (factoryResetCounter > 9) // factory reset and reboot
+    if (factoryResetCounter > 9) {
+      // factory reset and reboot
       ResetFactory();
-    if (factoryResetCounter > 3) // normal reboot
-    #if defined(ESP8266)
-      ESP.reset();
-    #endif
-    #if defined(ESP32)
-      ESP.restart();
-    #endif
-
+    }
+    if (factoryResetCounter > 3) {
+      // normal reboot
+      reboot();
+    }
     factoryResetCounter = 0; // count was < 3, reset counter
   }
 }

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -717,14 +717,14 @@ boolean GetArgv(const char *string, char *argv, unsigned int argv_size, unsigned
   \*********************************************************************************************/
 #if defined(ARDUINO_ESP8266_RELEASE_2_3_0)
 void dump (uint32_t addr) { //Seems already included in core 2.4 ...
-  Serial.print (addr, HEX);
-  Serial.print(": ");
+  serialPrint (addr, HEX);
+  serialPrint(": ");
   for (uint32_t a = addr; a < addr + 16; a++)
   {
-    Serial.print ( pgm_read_byte(a), HEX);
-    Serial.print (" ");
+    serialPrint ( pgm_read_byte(a), HEX);
+    serialPrint (" ");
   }
-  Serial.println("");
+  serialPrintln("");
 }
 #endif
 
@@ -774,29 +774,29 @@ String getTaskDeviceName(byte TaskIndex) {
 /********************************************************************************************\
   Reset all settings to factory defaults
   \*********************************************************************************************/
-void ResetFactory(void)
+void ResetFactory()
 {
   const GpioFactorySettingsStruct gpio_settings(ResetFactoryDefaultPreference.getDeviceModel());
 
   checkRAM(F("ResetFactory"));
   // Direct Serial is allowed here, since this is only an emergency task.
-  Serial.print(F("RESET: Resetting factory defaults... using "));
-  Serial.print(getDeviceModelString(ResetFactoryDefaultPreference.getDeviceModel()));
-  Serial.println(F(" settings"));
+  serialPrint(F("RESET: Resetting factory defaults... using "));
+  serialPrint(getDeviceModelString(ResetFactoryDefaultPreference.getDeviceModel()));
+  serialPrintln(F(" settings"));
   delay(1000);
   if (readFromRTC())
   {
-    Serial.print(F("RESET: Warm boot, reset count: "));
-    Serial.println(RTC.factoryResetCounter);
+    serialPrint(F("RESET: Warm boot, reset count: "));
+    serialPrintln(String(RTC.factoryResetCounter));
     if (RTC.factoryResetCounter >= 3)
     {
-      Serial.println(F("RESET: Too many resets, protecting your flash memory (powercycle to solve this)"));
+      serialPrintln(F("RESET: Too many resets, protecting your flash memory (powercycle to solve this)"));
       return;
     }
   }
   else
   {
-    Serial.println(F("RESET: Cold boot"));
+    serialPrintln(F("RESET: Cold boot"));
     initRTC();
     // TODO TD-er: Store set device model in RTC.
   }
@@ -807,12 +807,12 @@ void ResetFactory(void)
 
   //always format on factory reset, in case of corrupt SPIFFS
   SPIFFS.end();
-  Serial.println(F("RESET: formatting..."));
+  serialPrintln(F("RESET: formatting..."));
   SPIFFS.format();
-  Serial.println(F("RESET: formatting done..."));
+  serialPrintln(F("RESET: formatting done..."));
   if (!SPIFFS.begin())
   {
-    Serial.println(F("RESET: FORMAT SPIFFS FAILED!"));
+    serialPrintln(F("RESET: FORMAT SPIFFS FAILED!"));
     return;
   }
 
@@ -960,7 +960,7 @@ void ResetFactory(void)
   SaveControllerSettings(0, ControllerSettings);
 #endif
   checkRAM(F("ResetFactory2"));
-  Serial.println(F("RESET: Succesful, rebooting. (you might need to press the reset button if you've justed flashed the firmware)"));
+  serialPrintln(F("RESET: Succesful, rebooting. (you might need to press the reset button if you've justed flashed the firmware)"));
   //NOTE: this is a known ESP8266 bug, not our fault. :)
   delay(1000);
   WiFi.persistent(true); // use SDK storage of SSID/WPA parameters
@@ -985,7 +985,7 @@ void emergencyReset()
   if (Serial.available() == 2)
     if (Serial.read() == 0xAA && Serial.read() == 0x55)
     {
-      Serial.println(F("\n\n\rSystem will reset to factory defaults in 10 seconds..."));
+      serialPrintln(F("\n\n\rSystem will reset to factory defaults in 10 seconds..."));
       delay(10000);
       ResetFactory();
     }
@@ -1321,7 +1321,7 @@ void setLogLevelFor(byte destination, byte logLevel) {
 
 void updateLogLevelCache() {
   byte max_lvl = 0;
-  if (!log_to_serial_disabled && serialLogActiveRead()) {
+  if (!log_to_serial_disabled && serialWriteBufferActiveRead()) {
     max_lvl = _max(max_lvl, Settings.SerialLogLevel);
     if (Settings.SerialLogLevel >= LOG_LEVEL_DEBUG_MORE)
       Serial.setDebugOutput(true);
@@ -1351,7 +1351,7 @@ byte getSerialLogLevel() {
     logLevelSettings = 2;
   }
 /*
-  if (!serialLogActiveRead()) {
+  if (!serialWriteBufferActiveRead()) {
     if (logLevelSettings != 0) {
       updateLogLevelCache();
     }
@@ -1407,23 +1407,11 @@ boolean loglevelActive(byte logLevel, byte logLevelSettings) {
 
 void addToLog(byte logLevel, const char *line)
 {
-  const size_t line_length = strlen(line);
   if (loglevelActiveFor(LOG_TO_SERIAL, logLevel)) {
-    int roomLeft = ESP.getFreeHeap() - 5000;
-    if (roomLeft > 0) {
-      String timestamp_log(millis());
-      timestamp_log += F(" : ");
-      for (size_t i = 0; i < timestamp_log.length(); ++i) {
-        serialLogBuffer.push_back(timestamp_log[i]);
-      }
-      size_t pos = 0;
-      while (pos < line_length && pos < static_cast<size_t>(roomLeft)) {
-        serialLogBuffer.push_back(line[pos]);
-        ++pos;
-      }
-      serialLogBuffer.push_back('\r');
-      serialLogBuffer.push_back('\n');
-    }
+    addToSerialBuffer(String(millis()).c_str());
+    addToSerialBuffer(" : ");
+    addToSerialBuffer(line);
+    addNewlineToSerialBuffer();
   }
   if (loglevelActiveFor(LOG_TO_SYSLOG, logLevel)) {
     syslog(logLevel, line);
@@ -1442,22 +1430,6 @@ void addToLog(byte logLevel, const char *line)
 #endif
 }
 
-void process_serialLogBuffer() {
-  if (serialLogBuffer.size() == 0) return;
-  size_t snip = 128; // Some default, ESP32 doesn't have the availableForWrite function yet.
-#if defined(ESP8266)
-  snip = Serial.availableForWrite();
-#endif
-  if (snip > 0) {
-    last_serial_log_read = millis();
-    size_t bytes_to_write = serialLogBuffer.size();
-    if (snip < bytes_to_write) bytes_to_write = snip;
-    for (size_t i = 0; i < bytes_to_write; ++i) {
-      Serial.write(serialLogBuffer.front());
-      serialLogBuffer.pop_front();
-    }
-  }
-}
 
 void tempDisableSerialLog(bool setToDisabled) {
   if (log_to_serial_disabled_temporary == setToDisabled) return;
@@ -1467,34 +1439,6 @@ void tempDisableSerialLog(bool setToDisabled) {
   //  updateLogLevelCache();
 }
 
-bool serialLogActiveRead() {
-  if (!Settings.UseSerial) return false;
-  // Some default, ESP32 doesn't have the availableForWrite function yet.
-  // Not sure how to detect read activity on an ESP32.
-  size_t tx_free = 128;
-#if defined(ESP8266)
-  tx_free = Serial.availableForWrite();
-#endif
-  static size_t prev_tx_free = 0;
-  if (tx_free < prev_tx_free) {
-    prev_tx_free = tx_free;
-    tempDisableSerialLog(false);
-    return true;
-  }
-  // Must always set it or else it will never recover from prev_tx_free == 0
-  prev_tx_free = tx_free;
-  if (timePassedSince(last_serial_log_read) > LOG_BUFFER_EXPIRE) {
-    serialLogBuffer.clear();
-    // Just add some marker to get it going again when the serial buffer is
-    // read again and the serial log level was temporary set to 0 since nothing was read.
-    if (Settings.SerialLogLevel > 0) {
-      serialLogBuffer.push_back('\n');
-    }
-    tempDisableSerialLog(true);
-    return false;
-  }
-  return true;
-}
 
 /********************************************************************************************\
   Delayed reboot, in case of issues, do not reboot with high frequency as it might not help...
@@ -1504,8 +1448,8 @@ void delayedReboot(int rebootDelay)
   // Direct Serial is allowed here, since this is only an emergency task.
   while (rebootDelay != 0 )
   {
-    Serial.print(F("Delayed Reset "));
-    Serial.println(rebootDelay);
+    serialPrint(F("Delayed Reset "));
+    serialPrintln(String(rebootDelay));
     rebootDelay--;
     delay(1000);
   }
@@ -2357,9 +2301,9 @@ for (byte x=0; x < RULESETS_MAX; x++){
     activeRuleSets[x] = false;
 
   if (Settings.SerialLogLevel == LOG_LEVEL_DEBUG_DEV){
-    Serial.print(fileName);
-    Serial.print(" ");
-    Serial.println(activeRuleSets[x]);
+    serialPrint(fileName);
+    serialPrint(" ");
+    serialPrintln(String(activeRuleSets[x]));
     }
   }
 }
@@ -2413,9 +2357,9 @@ String rulesProcessingFile(const String& fileName, String& event)
   if (!Settings.UseRules) return "";
   checkRAM(F("rulesProcessingFile"));
   if (Settings.SerialLogLevel == LOG_LEVEL_DEBUG_DEV){
-    Serial.print(F("RuleDebug Processing:"));
-    Serial.println(fileName);
-    Serial.println(F("     flags CMI  parse output:"));
+    serialPrint(F("RuleDebug Processing:"));
+    serialPrintln(fileName);
+    serialPrintln(F("     flags CMI  parse output:"));
   }
 
   static byte nestingLevel = 0;
@@ -2587,13 +2531,14 @@ void parseCompleteNonCommentLine(
     fakeIfBlock = 0;
   }
 
-  if (Settings.SerialLogLevel == LOG_LEVEL_DEBUG_DEV){
-    Serial.print(F("RuleDebug: "));
-    Serial.print(codeBlock);
-    Serial.print(match);
-    Serial.print(isCommand);
-    Serial.print(F(": "));
-    Serial.println(line);
+  if (loglevelActiveFor(LOG_LEVEL_DEBUG_DEV)) {
+    String log = F("RuleDebug: ");
+    log += codeBlock;
+    log += match;
+    log += isCommand;
+    log += ": ";
+    log += line;
+    addLog(LOG_LEVEL_DEBUG_DEV, log);
   }
 
   if (match) // rule matched for one action or a block of actions
@@ -3142,7 +3087,7 @@ class RamTracker{
             lowestMemoryInTraceIndex=i;
             }
           }
-      //Serial.println(lowestMemoryInTraceIndex);
+      //serialPrintln(lowestMemoryInTraceIndex);
       return lowestMemoryInTraceIndex;
       }
 
@@ -3454,30 +3399,30 @@ void ArduinoOTAInit()
     ArduinoOTA.setPassword(SecuritySettings.Password);
 
   ArduinoOTA.onStart([]() {
-      Serial.println(F("OTA  : Start upload"));
+      serialPrintln(F("OTA  : Start upload"));
       SPIFFS.end(); //important, otherwise it fails
   });
 
   ArduinoOTA.onEnd([]() {
-      Serial.println(F("\nOTA  : End"));
+      serialPrintln(F("\nOTA  : End"));
       //"dangerous": if you reset during flash you have to reflash via serial
       //so dont touch device until restart is complete
-      Serial.println(F("\nOTA  : DO NOT RESET OR POWER OFF UNTIL BOOT+FLASH IS COMPLETE."));
+      serialPrintln(F("\nOTA  : DO NOT RESET OR POWER OFF UNTIL BOOT+FLASH IS COMPLETE."));
       delay(100);
       reboot();
   });
   ArduinoOTA.onProgress([](unsigned int progress, unsigned int total) {
 
-      Serial.printf("OTA  : Progress %u%%\r", (progress / (total / 100)));
+      serialPrintf("OTA  : Progress %u%%\r", (progress / (total / 100)));
   });
 
   ArduinoOTA.onError([](ota_error_t error) {
-      Serial.print(F("\nOTA  : Error (will reboot): "));
-      if (error == OTA_AUTH_ERROR) Serial.println(F("Auth Failed"));
-      else if (error == OTA_BEGIN_ERROR) Serial.println(F("Begin Failed"));
-      else if (error == OTA_CONNECT_ERROR) Serial.println(F("Connect Failed"));
-      else if (error == OTA_RECEIVE_ERROR) Serial.println(F("Receive Failed"));
-      else if (error == OTA_END_ERROR) Serial.println(F("End Failed"));
+      serialPrint(F("\nOTA  : Error (will reboot): "));
+      if (error == OTA_AUTH_ERROR) serialPrintln(F("Auth Failed"));
+      else if (error == OTA_BEGIN_ERROR) serialPrintln(F("Begin Failed"));
+      else if (error == OTA_CONNECT_ERROR) serialPrintln(F("Connect Failed"));
+      else if (error == OTA_RECEIVE_ERROR) serialPrintln(F("Receive Failed"));
+      else if (error == OTA_END_ERROR) serialPrintln(F("End Failed"));
 
       delay(100);
       reboot();

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -3412,8 +3412,7 @@ void ArduinoOTAInit()
       reboot();
   });
   ArduinoOTA.onProgress([](unsigned int progress, unsigned int total) {
-
-      serialPrintf("OTA  : Progress %u%%\r", (progress / (total / 100)));
+      Serial.printf("OTA  : Progress %u%%\r", (progress / (total / 100)));
   });
 
   ArduinoOTA.onError([](ota_error_t error) {

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -629,6 +629,21 @@ byte getNotificationProtocolIndex(byte Number)
 /********************************************************************************************\
   Find positional parameter in a char string
   \*********************************************************************************************/
+
+bool HasArgv(const char *string, unsigned int argc) {
+  char TmpStr1[INPUT_COMMAND_SIZE];
+  return GetArgv(string, TmpStr1, INPUT_COMMAND_SIZE, argc);
+}
+
+bool GetArgv(const char *string, String& argvString, unsigned int argc) {
+  char TmpStr1[INPUT_COMMAND_SIZE];
+  bool hasArgument = GetArgv(string, TmpStr1, INPUT_COMMAND_SIZE, argc);
+  if (hasArgument) {
+    argvString = TmpStr1;
+  }
+  return hasArgument;
+}
+
 boolean GetArgv(const char *string, char *argv, unsigned int argc) {
   return GetArgv(string, argv, INPUT_COMMAND_SIZE, argc);
 }
@@ -1457,6 +1472,8 @@ void delayedReboot(int rebootDelay)
 }
 
 void reboot() {
+  // FIXME TD-er: Should network connections be actively closed or does this introduce new issues?
+  flushAndDisconnectAllClients();
   #if defined(ESP32)
     ESP.restart();
   #else

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -1336,12 +1336,13 @@ void setLogLevelFor(byte destination, byte logLevel) {
 
 void updateLogLevelCache() {
   byte max_lvl = 0;
-  if (!log_to_serial_disabled && serialWriteBufferActiveRead()) {
-    max_lvl = _max(max_lvl, Settings.SerialLogLevel);
-    if (Settings.SerialLogLevel >= LOG_LEVEL_DEBUG_MORE)
-      Serial.setDebugOutput(true);
-  } else {
+  if (log_to_serial_disabled) {
     Serial.setDebugOutput(false);
+  } else {
+    max_lvl = _max(max_lvl, Settings.SerialLogLevel);
+    if (Settings.SerialLogLevel >= LOG_LEVEL_DEBUG_MORE) {
+      Serial.setDebugOutput(true);
+    }
   }
   max_lvl = _max(max_lvl, Settings.SyslogLevel);
   if (Logging.logActiveRead()) {
@@ -1358,22 +1359,13 @@ bool loglevelActiveFor(byte logLevel) {
 }
 
 byte getSerialLogLevel() {
-  byte logLevelSettings = 0;
-  if (!Settings.UseSerial) return 0;
-  if (log_to_serial_disabled || log_to_serial_disabled_temporary) return 0;
-  logLevelSettings = Settings.SerialLogLevel;
+  if (log_to_serial_disabled || !Settings.UseSerial) return 0;
   if (wifiStatus != ESPEASY_WIFI_SERVICES_INITIALIZED){
-    logLevelSettings = 2;
-  }
-/*
-  if (!serialWriteBufferActiveRead()) {
-    if (logLevelSettings != 0) {
-      updateLogLevelCache();
+    if (Settings.SerialLogLevel < LOG_LEVEL_INFO) {
+      return LOG_LEVEL_INFO;
     }
-    logLevelSettings = 0;
   }
-*/
-  return logLevelSettings;
+  return Settings.SerialLogLevel;
 }
 
 byte getWebLogLevel() {
@@ -1443,15 +1435,6 @@ void addToLog(byte logLevel, const char *line)
     logFile.close();
   }
 #endif
-}
-
-
-void tempDisableSerialLog(bool setToDisabled) {
-  if (log_to_serial_disabled_temporary == setToDisabled) return;
-
-  // FIXME TD-er: For some reason disabling serial log will not enable it again.
-  //  log_to_serial_disabled_temporary = setToDisabled;
-  //  updateLogLevelCache();
 }
 
 

--- a/src/Serial.ino
+++ b/src/Serial.ino
@@ -74,7 +74,11 @@ void process_serialWriteBuffer() {
     size_t bytes_to_write = serialWriteBuffer.size();
     if (snip < bytes_to_write) bytes_to_write = snip;
     for (size_t i = 0; i < bytes_to_write; ++i) {
-      Serial.write(serialWriteBuffer.front());
+      const char c = serialWriteBuffer.front();
+      if (c != static_cast<char>(1))  // special marker
+      {
+        Serial.write(c);
+      }
       serialWriteBuffer.pop_front();
     }
   }
@@ -101,7 +105,7 @@ bool serialWriteBufferActiveRead() {
     // Just add some marker to get it going again when the serial buffer is
     // read again and the serial log level was temporary set to 0 since nothing was read.
     if (Settings.SerialLogLevel > 0) {
-      serialWriteBuffer.push_back('\n');
+      serialWriteBuffer.push_back(static_cast<char>(1));
     }
     tempDisableSerialLog(true);
     return false;

--- a/src/Serial.ino
+++ b/src/Serial.ino
@@ -31,7 +31,7 @@ void serial()
         break;
       InputBuffer_Serial[SerialInByteCounter] = 0; // serial data completed
       Serial.write('>');
-      Serial.println(InputBuffer_Serial);
+      serialPrintln(InputBuffer_Serial);
       String action = InputBuffer_Serial;
       struct EventStruct TempEvent;
       action=parseTemplate(action,action.length());  //@giig1967g: parseTemplate before executing the command bug#1977
@@ -44,3 +44,108 @@ void serial()
     }
   }
 }
+
+
+void addToSerialBuffer(const char *line) {
+  const size_t line_length = strlen(line);
+  int roomLeft = ESP.getFreeHeap() - 5000;
+  if (roomLeft > 0) {
+    size_t pos = 0;
+    while (pos < line_length && pos < static_cast<size_t>(roomLeft)) {
+      serialWriteBuffer.push_back(line[pos]);
+      ++pos;
+    }
+  }
+}
+
+void addNewlineToSerialBuffer() {
+  serialWriteBuffer.push_back('\r');
+  serialWriteBuffer.push_back('\n');
+}
+
+void process_serialWriteBuffer() {
+  if (serialWriteBuffer.size() == 0) return;
+  size_t snip = 128; // Some default, ESP32 doesn't have the availableForWrite function yet.
+#if defined(ESP8266)
+  snip = Serial.availableForWrite();
+#endif
+  if (snip > 0) {
+    last_serial_writebuffer_read = millis();
+    size_t bytes_to_write = serialWriteBuffer.size();
+    if (snip < bytes_to_write) bytes_to_write = snip;
+    for (size_t i = 0; i < bytes_to_write; ++i) {
+      Serial.write(serialWriteBuffer.front());
+      serialWriteBuffer.pop_front();
+    }
+  }
+}
+
+bool serialWriteBufferActiveRead() {
+  if (!Settings.UseSerial) return false;
+  // Some default, ESP32 doesn't have the availableForWrite function yet.
+  // Not sure how to detect read activity on an ESP32.
+  size_t tx_free = 128;
+#if defined(ESP8266)
+  tx_free = Serial.availableForWrite();
+#endif
+  static size_t prev_tx_free = 0;
+  if (tx_free < prev_tx_free) {
+    prev_tx_free = tx_free;
+    tempDisableSerialLog(false);
+    return true;
+  }
+  // Must always set it or else it will never recover from prev_tx_free == 0
+  prev_tx_free = tx_free;
+  if (timePassedSince(last_serial_writebuffer_read) > LOG_BUFFER_EXPIRE) {
+    serialWriteBuffer.clear();
+    // Just add some marker to get it going again when the serial buffer is
+    // read again and the serial log level was temporary set to 0 since nothing was read.
+    if (Settings.SerialLogLevel > 0) {
+      serialWriteBuffer.push_back('\n');
+    }
+    tempDisableSerialLog(true);
+    return false;
+  }
+  return true;
+}
+
+// For now, only send it to the serial buffer and try to process it.
+// Later we may want to wrap it into a log.
+void serialPrint(const String& text) {
+  addToSerialBuffer(text.c_str());
+  process_serialWriteBuffer();
+}
+
+void serialPrintln(const String& text) {
+  addToSerialBuffer(text.c_str());
+  addNewlineToSerialBuffer();
+  process_serialWriteBuffer();
+}
+
+void serialPrintln() {
+  addNewlineToSerialBuffer();
+  process_serialWriteBuffer();
+}
+
+
+
+// Do not add helper functions for other types, since those types can only be
+// explicit matched at a constructor, not a function declaration.
+/*
+void serialPrint(char c) {
+  serialPrint(String(c));
+}
+
+
+void serialPrint(unsigned long value) {
+  serialPrint(String(value));
+}
+
+void serialPrint(long value) {
+  serialPrint(String(value));
+}
+
+void serialPrintln(unsigned long value) {
+  serialPrintln(String(value));
+}
+*/

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -4447,12 +4447,16 @@ void handle_timingstats() {
   html_end_table();
 
   html_table_class_normal();
+  const float timespan = timeSinceLastReset / 1000.0;
   addFormHeader(F("Statistics"));
-  addRowLabel(F("Time span"));
-  TXBuffer += String(timeSinceLastReset / 1000.0);
-  TXBuffer += " sec";
+  addRowLabel(F("Start Period"));
+  struct tm startPeriod = addSeconds(tm, -1.0 * timespan, false);
+  TXBuffer += getDateTimeString(startPeriod, '-', ':', ' ', false);
   addRowLabel(F("Local Time"));
   TXBuffer += getDateTimeString('-', ':', ' ');
+  addRowLabel(F("Time span"));
+  TXBuffer += String(timespan);
+  TXBuffer += " sec";
   html_end_table();
 
   sendHeadandTail_stdtemplate(_TAIL);

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -673,7 +673,7 @@ static byte navMenuIndex = MENU_INDEX_MAIN;
 
 void getWebPageTemplateVar(const String& varName )
 {
- // Serial.print(varName); Serial.print(" : free: "); Serial.print(ESP.getFreeHeap());   Serial.print("var len before:  "); Serial.print (varValue.length()) ;Serial.print("after:  ");
+ // serialPrint(varName); serialPrint(" : free: "); serialPrint(ESP.getFreeHeap());   serialPrint("var len before:  "); serialPrint (varValue.length()) ;serialPrint("after:  ");
  //varValue = "";
 
   if (varName == F("name"))

--- a/src/_C007.ino
+++ b/src/_C007.ino
@@ -75,7 +75,7 @@ bool do_process_c007_delay_queue(int controller_number, const C007_queue_element
   url += SecuritySettings.ControllerPassword[element.controller_idx]; // "0UDNN17RW6XAS2E5" // api key
 
   if (Settings.SerialLogLevel >= LOG_LEVEL_DEBUG_MORE)
-    Serial.println(url);
+    serialPrintln(url);
 
   return send_via_http(controller_number, client,
     create_http_get_request(controller_number, ControllerSettings, url),

--- a/src/_P016_IR.ino
+++ b/src/_P016_IR.ino
@@ -138,7 +138,7 @@ boolean Plugin_016(byte function, struct EventStruct *event, String& string)
         int irPin = Settings.TaskDevicePin1[event->TaskIndex];
         if (irReceiver == 0 && irPin != -1)
         {
-          Serial.println(F("IR Init"));
+          serialPrintln(F("IR Init"));
           irReceiver = new IRrecv(irPin, kCaptureBufferSize, P016_TIMEOUT, true);
           irReceiver->setUnknownThreshold(kMinUnknownSize); // Ignore messages with less than minimum on or off pulses.
           irReceiver->enableIRIn(); // Start the receiver
@@ -326,7 +326,7 @@ void displayRawToReadableB32Hex() {
         uint16_t bstDiv = -1, bstAvg = 0xFFFFU;
         float bstMul = 5000;
         cd += get_tolerance(cd) + 1;
-        //Serial.println(String("p="+ uint64ToString(p, 10) + " start cd=" + uint64ToString(cd, 10)).c_str());
+        //serialPrintln(String("p="+ uint64ToString(p, 10) + " start cd=" + uint64ToString(cd, 10)).c_str());
         // find the best divisor based on lowest avg err, within allowed tolerance.
         while (--cd >= MIN_VIABLE_DIV) {
             uint32_t avg = 0;
@@ -346,7 +346,7 @@ void displayRawToReadableB32Hex() {
                 bstMul = avgTms;
                 bstAvg = avg;
                 bstDiv = cd;
-                //Serial.println(String("p="+ uint64ToString(p, 10) + " cd=" + uint64ToString(cd, 10) +"  avgErr=" + uint64ToString(avg, 10) + " totTms="+ uint64ToString(totTms, 10) + " avgTms="+ uint64ToString((uint16_t)(avgTms*10), 10) ).c_str());
+                //serialPrintln(String("p="+ uint64ToString(p, 10) + " cd=" + uint64ToString(cd, 10) +"  avgErr=" + uint64ToString(avg, 10) + " totTms="+ uint64ToString(totTms, 10) + " avgTms="+ uint64ToString((uint16_t)(avgTms*10), 10) ).c_str());
             }
         }
         if (bstDiv == 0xFFFFU) {
@@ -372,7 +372,7 @@ void displayRawToReadableB32Hex() {
         tmOut[i] = tm;
         //line += uint64ToString(tm, 10) + ",";
     }
-    //Serial.println(line);
+    //serialPrintln(line);
 
     char out[total];
     unsigned int iOut = 0, s = 2, d = 0;

--- a/src/_P020_Ser2Net.ino
+++ b/src/_P020_Ser2Net.ino
@@ -296,7 +296,7 @@ boolean Plugin_020(byte function, struct EventStruct *event, String& string)
         {
           success = true;
           String tmpString = string.substring(11);
-          Serial.println(tmpString);
+          Serial.println(tmpString); // FIXME TD-er: Should this also use the serial write buffer?
         }
         break;
       }

--- a/src/_P024_MLX90614.ino
+++ b/src/_P024_MLX90614.ino
@@ -98,8 +98,8 @@ boolean Plugin_024(byte function, struct EventStruct *event, String& string)
 //        if (!msgTemp024) // Mysensors
 //          msgTemp024 = new MyMessage(event->BaseVarIndex, V_TEMP); //Mysensors
 //        present(event->BaseVarIndex, S_TEMP); //Mysensors
-//        Serial.print("Present MLX90614: "); //Mysensors
-//        Serial.println(event->BaseVarIndex); //Mysensors
+//        serialPrint("Present MLX90614: "); //Mysensors
+//        serialPrintln(event->BaseVarIndex); //Mysensors
         success = true;
         break;
       }

--- a/src/_P035_IRTX.ino
+++ b/src/_P035_IRTX.ino
@@ -253,7 +253,7 @@ boolean Plugin_035(byte function, struct EventStruct *event, String& string)
                                                           memcpy(ircodestr, TmpStr1, sizeof(TmpStr1[0])*200);
                                                         }
             //if (GetArgv(command, TmpStr1, 200, 4)) IrBits = str2int(TmpStr1); //not needed any more... leave it for reverce compatibility or remove it and break existing instalations?
-            //if (GetArgv(command, TmpStr1, 200, 5)) IrRepeat = str2int(TmpStr1); // Ir repeat is usfull in some circonstances, have to see how to add it and have it be revese compatible as well. 
+            //if (GetArgv(command, TmpStr1, 200, 5)) IrRepeat = str2int(TmpStr1); // Ir repeat is usfull in some circonstances, have to see how to add it and have it be revese compatible as well.
             //if (GetArgv(command, TmpStr1, 200, 6)) IrSecondCode = strtoul(TmpStr1, NULL, 16);
 
             //Comented out need char[] for input Needs fixing
@@ -261,9 +261,9 @@ boolean Plugin_035(byte function, struct EventStruct *event, String& string)
             if (IrType.equalsIgnoreCase(F("SONY"))) Plugin_035_irSender->sendSony(IrCode);
             if (IrType.equalsIgnoreCase(F("Sherwood"))) Plugin_035_irSender->sendSherwood(IrCode);
             if (IrType.equalsIgnoreCase(F("SAMSUNG"))) Plugin_035_irSender->sendSAMSUNG(IrCode);
-            if (IrType.equalsIgnoreCase(F("LG"))) Plugin_035_irSender->sendLG(IrCode); 
-            if (IrType.equalsIgnoreCase(F("LG2"))) Plugin_035_irSender->sendLG2(IrCode); 
-            if (IrType.equalsIgnoreCase(F("SharpRaw"))) Plugin_035_irSender->sendSharpRaw(IrBits);                         
+            if (IrType.equalsIgnoreCase(F("LG"))) Plugin_035_irSender->sendLG(IrCode);
+            if (IrType.equalsIgnoreCase(F("LG2"))) Plugin_035_irSender->sendLG2(IrCode);
+            if (IrType.equalsIgnoreCase(F("SharpRaw"))) Plugin_035_irSender->sendSharpRaw(IrBits);
             if (IrType.equalsIgnoreCase(F("JVC"))) Plugin_035_irSender->sendJVC(IrCode);
             if (IrType.equalsIgnoreCase(F("Denon"))) Plugin_035_irSender->sendDenon(IrCode);
             if (IrType.equalsIgnoreCase(F("SanyoLC7461"))) Plugin_035_irSender->sendSanyoLC7461(IrCode);
@@ -289,7 +289,7 @@ boolean Plugin_035(byte function, struct EventStruct *event, String& string)
             if (IrType.equalsIgnoreCase(F("GICable"))) Plugin_035_irSender->sendGICable(IrCode);
 			      if (IrType.equalsIgnoreCase(F("Pioneer"))) Plugin_035_irSender->sendPioneer(IrCode);
             if (IrType.equalsIgnoreCase(F("LUTRON"))) Plugin_035_irSender->sendLutron(IrCode);
-            
+
             if (IrType.equalsIgnoreCase(F("MITSUBISHI_AC"))) parseStringAndSendAirCon(MITSUBISHI_AC, ircodestr);
             if (IrType.equalsIgnoreCase(F("FUJITSU_AC"))) parseStringAndSendAirCon(FUJITSU_AC, ircodestr);
             if (IrType.equalsIgnoreCase(F("Kelvinator"))) parseStringAndSendAirCon(KELVINATOR, ircodestr);
@@ -307,7 +307,7 @@ boolean Plugin_035(byte function, struct EventStruct *event, String& string)
             if (IrType.equalsIgnoreCase(F("HAIER_AC_YRW02"))) parseStringAndSendAirCon(HAIER_AC_YRW02, ircodestr);
             if (IrType.equalsIgnoreCase(F("SAMSUNG_AC"))) parseStringAndSendAirCon(SAMSUNG_AC, ircodestr);
             if (IrType.equalsIgnoreCase(F("WHIRLPOOL_AC"))) parseStringAndSendAirCon(WHIRLPOOL_AC, ircodestr);
-            if (IrType.equalsIgnoreCase(F("MWM"))) parseStringAndSendAirCon(MWM, ircodestr);    
+            if (IrType.equalsIgnoreCase(F("MWM"))) parseStringAndSendAirCon(MWM, ircodestr);
            // NEC (non-strict)?
           }
 
@@ -739,7 +739,7 @@ uint16_t countValuesInStr(const String str, char sep) {
 //  result = reinterpret_cast<uint16_t*>(malloc(size * sizeof(uint16_t)));
 //  // Check we malloc'ed successfully.
 //  if (result == NULL) {  // malloc failed, so give up.
-//    serialPrintf("\nCan't allocate %d bytes. (%d bytes free)\n",
+//    Serial.printf("\nCan't allocate %d bytes. (%d bytes free)\n",
 //                  size * sizeof(uint16_t), ESP.getFreeHeap());
 //    serialPrintln("Giving up & forcing a reboot.");
 //    ESP.restart();  // Reboot.

--- a/src/_P035_IRTX.ino
+++ b/src/_P035_IRTX.ino
@@ -238,7 +238,7 @@ boolean Plugin_035(byte function, struct EventStruct *event, String& string)
             //String line = "";
             //for (int i = 0; i < idx; i++)
             //    line += uint64ToString(buf[i], 10) + ",";
-            //Serial.println(line);
+            //serialPrintln(line);
 
             //sprintf_P(log, PSTR("IR Params1: Hz:%u - PLen: %u - BLen: %u"), IrHz, IrPLen, IrBLen);
             //addLog(LOG_LEVEL_INFO, log);
@@ -739,9 +739,9 @@ uint16_t countValuesInStr(const String str, char sep) {
 //  result = reinterpret_cast<uint16_t*>(malloc(size * sizeof(uint16_t)));
 //  // Check we malloc'ed successfully.
 //  if (result == NULL) {  // malloc failed, so give up.
-//    Serial.printf("\nCan't allocate %d bytes. (%d bytes free)\n",
+//    serialPrintf("\nCan't allocate %d bytes. (%d bytes free)\n",
 //                  size * sizeof(uint16_t), ESP.getFreeHeap());
-//    Serial.println("Giving up & forcing a reboot.");
+//    serialPrintln("Giving up & forcing a reboot.");
 //    ESP.restart();  // Reboot.
 //    delay(500);  // Wait for the restart to happen.
 //    return result;  // Should never get here, but just in case.

--- a/src/_P041_NeoClock.ino
+++ b/src/_P041_NeoClock.ino
@@ -100,8 +100,8 @@ boolean Plugin_041(byte function, struct EventStruct *event, String& string)
     case PLUGIN_ONCE_A_SECOND:
       {
         //int ldrVal = map(analogRead(A0), 0, 1023, 15, 245);
-        //Serial.print("LDR value: ");
-        //Serial.println(ldrVal);
+        //serialPrint("LDR value: ");
+        //serialPrintln(ldrVal);
         //Plugin_041_pixels->setBrightness(255-ldrVal);
         //Plugin_041_pixels->show(); // This sends the updated pixel color to the hardware.
         success = true;

--- a/src/_P044_P1WifiGateway.ino
+++ b/src/_P044_P1WifiGateway.ino
@@ -359,9 +359,9 @@ bool validP1char(char ch) {
   } else {
     addLog(LOG_LEVEL_DEBUG, F("P1   : Error: invalid char read from P1"));
     if (serialdebug) {
-      Serial.print(F("faulty char>"));
-      Serial.print(ch);
-      Serial.println("<");
+      serialPrint(F("faulty char>"));
+      serialPrint(String(ch));
+      serialPrintln("<");
     }
     return false;
   }
@@ -414,12 +414,12 @@ bool checkDatagram(int len) {
   if (!CRCcheck) return true;
 
   if (serialdebug) {
-    Serial.print(F("input length: "));
-    Serial.println(len);
-    Serial.print("Start char \\ : ");
-    Serial.println(startChar);
-    Serial.print(F("End char ! : "));
-    Serial.println(endChar);
+    serialPrint(F("input length: "));
+    serialPrintln(String(len));
+    serialPrint("Start char \\ : ");
+    serialPrintln(String(startChar));
+    serialPrint(F("End char ! : "));
+    serialPrintln(String(endChar));
   }
 
   if (endChar >= 0)
@@ -431,7 +431,7 @@ bool checkDatagram(int len) {
     messageCRC[4] = 0;
     if (serialdebug) {
       for (int cnt = 0; cnt < len; cnt++)
-        Serial.print(Plugin_044_serial_buf[cnt]);
+        serialPrint(String(Plugin_044_serial_buf[cnt]));
     }
 
     validCRCFound = (strtoul(messageCRC, NULL, 16) == currCRC);

--- a/src/_P064_APDS9960.ino
+++ b/src/_P064_APDS9960.ino
@@ -141,9 +141,9 @@ boolean Plugin_064(byte function, struct EventStruct *event, String& string)
 
         //int gesture = PLUGIN_064_pds->readGestureNonBlocking();
 
-        //if (gesture == -1) Serial.print(".");
-        //if (gesture == -2) Serial.print(":");
-        //if (gesture == -3) Serial.print("|");
+        //if (gesture == -1) serialPrint(".");
+        //if (gesture == -2) serialPrint(":");
+        //if (gesture == -3) serialPrint("|");
 
         //if ( 0 && PLUGIN_064_pds->isGestureAvailable() )
         if (gesture >= 0)

--- a/src/_P071_Kamstrup401.ino
+++ b/src/_P071_Kamstrup401.ino
@@ -122,7 +122,7 @@ boolean Plugin_071(byte function, struct EventStruct *event, String& string)
           {
             // receive byte
             r = kamSer.read();
-            //Serial.println(r);
+            //serialPrintln(r);
             if (parity_check(r))
             {
                parityerrors += 1;
@@ -141,8 +141,8 @@ boolean Plugin_071(byte function, struct EventStruct *event, String& string)
           {
             if ( parityerrors == 0 )
             {
-//              Serial.print("OK: " );
-//              Serial.println(message);
+//              serialPrint("OK: " );
+//              serialPrintln(message);
               message[i] = 0;
 
               tmpstr = strtok(message, " ");
@@ -229,7 +229,7 @@ boolean Plugin_071(byte function, struct EventStruct *event, String& string)
             {
               message[i] = 0;
               String log = F("ERR(PARITY):" );
-              Serial.print("par");
+              serialPrint("par");
               log += message;
               addLog(LOG_LEVEL_INFO, log);
               //UserVar[event->BaseVarIndex] = NAN;

--- a/src/_P081_Cron.ino
+++ b/src/_P081_Cron.ino
@@ -113,14 +113,14 @@ boolean Plugin_081(byte function, struct EventStruct *event, String& string)
           NEXTEXECUTION = converter.value;
 
 #if PLUGIN_081_DEBUG
-          Serial.println(last);
+          serialPrintln(last);
           converter.value = LASTEXECUTION;
-          Serial.println(converter.time);
-          Serial.println(getDateTimeString(*gmtime(&last)));
-          Serial.println(next);
+          serialPrintln(converter.time);
+          serialPrintln(getDateTimeString(*gmtime(&last)));
+          serialPrintln(next);
           converter.value = NEXTEXECUTION;
-          Serial.println(converter.time);
-          Serial.println(getDateTimeString(*gmtime(&next)));
+          serialPrintln(converter.time);
+          serialPrintln(getDateTimeString(*gmtime(&next)));
           PrintCronExp(expr);
 #endif
         }
@@ -202,13 +202,13 @@ boolean Plugin_081(byte function, struct EventStruct *event, String& string)
       struct tm current = tm;
       time_t  current_t = mktime((struct tm *)&current);
       #if PLUGIN_081_DEBUG
-        Serial.println(F("CRON Debug info:"));
-        Serial.print(F("Next execution:"));
-        Serial.println(getDateTimeString(*gmtime(&next)));
-        Serial.print(F("Current Time:"));
-        Serial.println(getDateTimeString(current));
-        Serial.print(F("Triggered:"));
-        Serial.println(next <=  current_t);
+        serialPrintln(F("CRON Debug info:"));
+        serialPrint(F("Next execution:"));
+        serialPrintln(getDateTimeString(*gmtime(&next)));
+        serialPrint(F("Current Time:"));
+        serialPrintln(getDateTimeString(current));
+        serialPrint(F("Triggered:"));
+        serialPrintln(next <=  current_t);
       #endif
       if(function == PLUGIN_TIME_CHANGE || next <=  current_t)
       {
@@ -220,15 +220,15 @@ boolean Plugin_081(byte function, struct EventStruct *event, String& string)
 
 #if PLUGIN_081_DEBUG
         PrintCronExp(expr);
-        Serial.print(F("Expression:"));
-        Serial.println(expression);
+        serialPrint(F("Expression:"));
+        serialPrintln(expression);
 #endif
         if(error)
         {
           //TODO: Notify at ui de error
 #if PLUGIN_081_DEBUG
-          Serial.print(F("Errors:"));
-          Serial.println(String(error));
+          serialPrint(F("Errors:"));
+          serialPrintln(String(error));
 #endif
           addLog(LOG_LEVEL_ERROR, String(F("CRON Expression:")) + String(error));
         }
@@ -239,10 +239,10 @@ boolean Plugin_081(byte function, struct EventStruct *event, String& string)
           if(next != CRON_INVALID_INSTANT)
           {
 #if PLUGIN_081_DEBUG
-            Serial.print(F("LastExecution:"));
-            Serial.println(getDateTimeString(*gmtime(&last)));
-            Serial.print(F("NextExecution:"));
-            Serial.println(getDateTimeString(*gmtime(&next)));
+            serialPrint(F("LastExecution:"));
+            serialPrintln(getDateTimeString(*gmtime(&last)));
+            serialPrint(F("NextExecution:"));
+            serialPrintln(getDateTimeString(*gmtime(&next)));
 #endif
 
             converter.time = last;
@@ -250,13 +250,13 @@ boolean Plugin_081(byte function, struct EventStruct *event, String& string)
             converter.time = next;
             NEXTEXECUTION = converter.value;
 #if PLUGIN_081_DEBUG
-            Serial.println(F("Check Conversion"));
-            Serial.println(last);
+            serialPrintln(F("Check Conversion"));
+            serialPrintln(last);
             converter.value = LASTEXECUTION;
-            Serial.println(converter.time);
-            Serial.println(next);
+            serialPrintln(converter.time);
+            serialPrintln(next);
             converter.value = NEXTEXECUTION;
-            Serial.println(converter.time);
+            serialPrintln(converter.time);
 #endif
             addLog(LOG_LEVEL_DEBUG, String(F("Next execution:")) + getDateTimeString(*gmtime(&next)));
             LoadTaskSettings(event->TaskIndex);
@@ -290,50 +290,50 @@ boolean Plugin_081(byte function, struct EventStruct *event, String& string)
 
 #if PLUGIN_081_DEBUG
 void PrintCronExp(struct cron_expr_t e) {
-  Serial.println(F("===DUMP Cron Expression==="));
-  Serial.print(F("Seconds:"));
+  serialPrintln(F("===DUMP Cron Expression==="));
+  serialPrint(F("Seconds:"));
   for (int i = 0; i < 8; i++)
   {
-    Serial.print(e.seconds[i]);
-    Serial.print(",");
+    serialPrint(e.seconds[i]);
+    serialPrint(",");
   }
-  Serial.println();
-  Serial.print(F("Minutes:"));
+  serialPrintln();
+  serialPrint(F("Minutes:"));
   for (int i = 0; i < 8; i++)
   {
-    Serial.print(e.minutes[i]);
-    Serial.print(",");
+    serialPrint(e.minutes[i]);
+    serialPrint(",");
   }
-  Serial.println();
-  Serial.print(F("hours:"));
+  serialPrintln();
+  serialPrint(F("hours:"));
   for (int i = 0; i < 3; i++)
   {
-    Serial.print(e.hours[i]);
-    Serial.print(",");
+    serialPrint(e.hours[i]);
+    serialPrint(",");
   }
-  Serial.println();
-  Serial.print(F("months:"));
+  serialPrintln();
+  serialPrint(F("months:"));
   for (int i = 0; i < 2; i++)
   {
-    Serial.print(e.months[i]);
-    Serial.print(",");
+    serialPrint(e.months[i]);
+    serialPrint(",");
   }
-  Serial.println();
-  Serial.print(F("days_of_week:"));
+  serialPrintln();
+  serialPrint(F("days_of_week:"));
   for (int i = 0; i < 1; i++)
   {
-    Serial.print(e.days_of_week[i]);
-    Serial.print(",");
+    serialPrint(e.days_of_week[i]);
+    serialPrint(",");
   }
-  Serial.println();
-  Serial.print(F("days_of_month:"));
+  serialPrintln();
+  serialPrint(F("days_of_month:"));
   for (int i = 0; i < 4; i++)
   {
-    Serial.print(e.days_of_month[i]);
-    Serial.print(",");
+    serialPrint(e.days_of_month[i]);
+    serialPrint(",");
   }
-  Serial.println();
-  Serial.println(F("END=DUMP Cron Expression==="));
+  serialPrintln();
+  serialPrintln(F("END=DUMP Cron Expression==="));
 
 }
 #endif

--- a/src/_Reporting.ino
+++ b/src/_Reporting.ino
@@ -48,7 +48,7 @@ void ReportStatus()
   payload += F("\r\n\r\n");
   payload += body;
 
-  Serial.println(payload);
+  serialPrintln(payload);
   client.print(payload);
 
 


### PR DESCRIPTION
Writing data to the serial port while it is not being read may cause all kinds of issues and maybe even Watchdog Resets.
All `Serial.print` and `Serial.println` calls in our own code is now sent to a dynamic buffer.
This buffer will try to only send data to the serial port when its buffer permits it.
After a while, unread data will be dropped.