### PR TITLE
[Sonoff POW] Merge POW r1/r2 in the same build

### DIFF
--- a/before_deploy
+++ b/before_deploy
@@ -37,8 +37,7 @@ for ENV in \
   dev_ESP8266_1024\
   dev_ESP8266_4096\
   dev_ESP8285_1024\
-  hard_SONOFF_POW\
-  hard_SONOFF_POW_R2_4M\
+  hard_SONOFF_POW_4M\
   minimal_ESP8266_1024_OTA\
   minimal_ESP8285_1024_OTA\
   esp32dev\

--- a/platformio.ini
+++ b/platformio.ini
@@ -640,7 +640,7 @@ build_flags               = ${esp8266_4M.build_flags} ${dev.build_flags}
 ;build_unflags             = ${Sonoff.build_unflags}
 ;build_flags               = ${Sonoff.build_flags} -D PLUGIN_SET_SONOFF_TH1x
 
-; ITEAD / SONOFF POW version --------------------
+; ITEAD / SONOFF POW & POW R2 version --------------------
 ; Sonoff Pow (ESP8266 - HLW8012)
 ; GPIO00 Button
 ; GPIO05 HLW8012 Sel output
@@ -648,20 +648,6 @@ build_flags               = ${esp8266_4M.build_flags} ${dev.build_flags}
 ; GPIO13 HLW8012 CF1 voltage / current
 ; GPIO14 HLW8012 CF power
 ; GPIO15 Blue Led (0 = On, 1 = Off)
-[env:hard_SONOFF_POW]
-upload_speed              = ${common.upload_speed}
-monitor_speed             = ${common.monitor_speed}
-framework                 = ${common.framework}
-platform                  = ${Sonoff.platform}
-lib_deps                  = ${common.lib_deps}
-lib_ignore                = ${common.lib_ignore}
-lib_ldf_mode              = ${common.lib_ldf_mode}
-lib_archive               = ${common.lib_archive}
-board_build.f_cpu         = ${Sonoff.board_build.f_cpu}
-board_build.flash_mode    = ${Sonoff.board_build.flash_mode}
-board                     = ${Sonoff.board}
-build_unflags             = ${Sonoff.build_unflags}
-build_flags               = ${Sonoff.build_flags} -D PLUGIN_SET_SONOFF_POW
 
 ; Sonoff Pow R2 (ESP8266 4M flash - CSE7766)
 ; GPIO00 Button
@@ -669,7 +655,7 @@ build_flags               = ${Sonoff.build_flags} -D PLUGIN_SET_SONOFF_POW
 ; GPIO03 Serial TXD
 ; GPIO12 Red Led and Relay (0 = Off, 1 = On)
 ; GPIO13 Blue Led (0 = On, 1 = Off)
-[env:hard_SONOFF_POW_R2_4M]
+[env:hard_SONOFF_POW_4M]
 upload_speed              = ${common.upload_speed}
 monitor_speed             = ${common.monitor_speed}
 framework                 = ${common.framework}
@@ -682,7 +668,7 @@ board_build.f_cpu         = ${Sonoff_4M.board_build.f_cpu}
 board_build.flash_mode    = ${Sonoff_4M.board_build.flash_mode}
 board                     = ${Sonoff_4M.board}
 build_unflags             = ${Sonoff_4M.build_unflags}
-build_flags               = ${Sonoff_4M.build_flags} -D PLUGIN_SET_SONOFF_POW_R2
+build_flags               = ${Sonoff_4M.build_flags} -D PLUGIN_SET_SONOFF_POW
 
 ; ITEAD / SONOFF S20 version --------------------
 ;[env:hard_SONOFF_S20]

--- a/src/_P076_HLW8012.ino
+++ b/src/_P076_HLW8012.ino
@@ -19,7 +19,11 @@ HLW8012 *Plugin_076_hlw = NULL;
 #define PLUGIN_076
 #define PLUGIN_ID_076        76
 #define PLUGIN_076_DEBUG     true    //activate extra log info in the debug
-#define PLUGIN_NAME_076       "Energy (AC) - HLW8012 [TESTING]"
+#ifdef PLUGIN_SET_SONOFF_POW
+  #define PLUGIN_NAME_076       "Energy (AC) - HLW8012 (POW r1) [TESTING]"
+#else
+  #define PLUGIN_NAME_076       "Energy (AC) - HLW8012 [TESTING]"
+#endif
 #define PLUGIN_VALUENAME1_076 "Voltage (V)"
 #define PLUGIN_VALUENAME2_076 "Current (A)"
 #define PLUGIN_VALUENAME3_076 "Active Power (W)"

--- a/src/_P077_CSE7766.ino
+++ b/src/_P077_CSE7766.ino
@@ -7,7 +7,11 @@
 
 #define PLUGIN_077
 #define PLUGIN_ID_077         77
-#define PLUGIN_NAME_077       "Energy (AC) - CSE7766 [TESTING]"
+#ifdef PLUGIN_SET_SONOFF_POW
+  #define PLUGIN_NAME_077       "Energy (AC) - CSE7766 (POW r2) [TESTING]"
+#else
+  #define PLUGIN_NAME_077       "Energy (AC) - CSE7766 [TESTING]"
+#endif
 #define PLUGIN_VALUENAME1_077 "Voltage"
 #define PLUGIN_VALUENAME2_077 "Power"
 #define PLUGIN_VALUENAME3_077 "Current"

--- a/src/define_plugin_sets.h
+++ b/src/define_plugin_sets.h
@@ -132,88 +132,36 @@ To create/register a plugin, you have to :
 // Itead ----------------------------
 #ifdef PLUGIN_SET_SONOFF_BASIC
     #define PLUGIN_DESCR  "Sonoff Basic"
-    #define PLUGIN_SET_ONLY_SWITCH
 
-    // Pre-defined setup parameters
-    #define GPIO_KEY1     0              // Button
-    #define GPIO_REL1     12             // Red Led and Relay (0 = Off, 1 = On)
-    #define DEFAULT_PIN_STATUS_LED 13    // Green Led (0 = On, 1 = Off)
+    #define PLUGIN_SET_ONLY_SWITCH
 #endif
 
 #ifdef PLUGIN_SET_SONOFF_TH1x
     #define PLUGIN_DESCR  "Sonoff TH10/TH16"
+
     #define PLUGIN_SET_ONLY_SWITCH
     #define PLUGIN_SET_ONLY_TEMP_HUM
-
-    // Pre-defined setup parameters
-    #define GPIO_KEY1     0              // Button
-    #define GPIO_REL1     12             // Red Led and Relay (0 = Off, 1 = On)
-    #define DEFAULT_PIN_STATUS_LED 13    // Green Led (0 = On, 1 = Off)
 #endif
 
 #ifdef PLUGIN_SET_SONOFF_POW
-    #define PLUGIN_DESCR  "Sonoff POW R1"
-
-    // Undef first to prevent compiler warnings
-    #undef DEFAULT_PIN_I2C_SDA
-    #undef DEFAULT_PIN_I2C_SCL
-    #undef DEFAULT_PIN_STATUS_LED
+    #define PLUGIN_DESCR  "Sonoff POW R1/R2"
 
     #define PLUGIN_SET_ONLY_SWITCH
-    #define USES_P076
-    #define DEFAULT_PIN_I2C_SDA    4
-    #define DEFAULT_PIN_I2C_SCL    2  // GPIO5 conflicts with HLW8012 Sel output
-
-    // Pre-defined setup parameters
-    #define GPIO_KEY1     0           // Button
-    #define GPIO_REL1     12          // Red Led and Relay (0 = Off, 1 = On)
-    #define DEFAULT_PIN_STATUS_LED 15 // Blue Led (0 = On, 1 = Off)
-#endif
-
-#ifdef PLUGIN_SET_SONOFF_POW_R2
-    #define PLUGIN_DESCR  "Sonoff POW R2"
-
-    // Undef first to prevent compiler warnings
-    #undef DEFAULT_PIN_STATUS_LED
-
-    #define PLUGIN_SET_ONLY_SWITCH
+    #define USES_P076   // HWL8012   in POW r1
     // Needs CSE7766 Energy sensor, via Serial RXD 4800 baud 8E1 (GPIO1), TXD (GPIO3)
-    #define USES_P077	// CSE7766
+    #define USES_P077	  // CSE7766   in POW R2
     #define USES_P081   // Cron
-
-    // Pre-defined setup parameters
-    #define GPIO_KEY1     0              // Button
-    #define GPIO_REL1     12             // Red Led and Relay (0 = Off, 1 = On)
-    #define DEFAULT_PIN_STATUS_LED 13    // Blue Led (0 = On, 1 = Off)
 #endif
 
 #ifdef PLUGIN_SET_SONOFF_S2x
     #define PLUGIN_DESCR  "Sonoff S20/22/26"
-    #define PLUGIN_SET_ONLY_SWITCH
 
-    // Pre-defined setup parameters
-    #define GPIO_KEY1     0              // Button
-    #define GPIO_REL1     12             // Red Led and Relay (0 = Off, 1 = On)
-    #define DEFAULT_PIN_STATUS_LED 13    // Green Led (0 = On, 1 = Off)
+    #define PLUGIN_SET_ONLY_SWITCH
 #endif
 
 #ifdef PLUGIN_SET_SONOFF_4CH
     #define PLUGIN_DESCR  "Sonoff 4CH"
     #define PLUGIN_SET_ONLY_SWITCH
-
-    #define DEFAULT_PIN_I2C_SDA    3  // GPIO4 conflicts with GPIO_REL3
-    #define DEFAULT_PIN_I2C_SCL    2  // GPIO5 conflicts with GPIO_REL2
-
-    // Pre-defined setup parameters
-    #define GPIO_KEY1     0           // Button 1
-    #define GPIO_KEY2     9           // Button 2
-    #define GPIO_KEY3     10          // Button 3
-    #define GPIO_KEY4     14          // Button 4
-    #define GPIO_REL1     12          // Red Led and Relay1 (0 = Off, 1 = On)
-    #define GPIO_REL2     5           // Red Led and Relay2 (0 = Off, 1 = On)
-    #define GPIO_REL3     4           // Red Led and Relay3 (0 = Off, 1 = On)
-    #define GPIO_REL4     15          // Red Led and Relay4 (0 = Off, 1 = On)
-    #define DEFAULT_PIN_STATUS_LED 13 // Blue Led (0 = On, 1 = Off)
 #endif
 
 #ifdef PLUGIN_SET_SONOFF_TOUCH
@@ -228,11 +176,6 @@ To create/register a plugin, you have to :
     #define PLUGIN_SET_ONLY_SWITCH
     #define CONTROLLER_SET_STABLE
     #define NOTIFIER_SET_STABLE
-
-    #undef DEFAULT_PIN_I2C_SDA
-    #undef DEFAULT_PIN_I2C_SCL
-    #define DEFAULT_PIN_I2C_SDA    6  // GPIO4 conflicts with relay control.
-    #define DEFAULT_PIN_I2C_SCL    7  // GPIO5 conflicts with SW input
 #endif
 
 // Easy ----------------------------


### PR DESCRIPTION
Sonoff POW build now is usable for both POW and POW r2.
Use the Reset Factory default to select proper pre-defined setup for keys and relay.
Both power sensors are included as plugin.