### PR TITLE
Allow for duplicate task names again

### DIFF
--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -565,13 +565,13 @@ String checkTaskSettings(byte taskIndex) {
         if (strcasecmp(ExtraTaskSettings.TaskDeviceName, deviceName.c_str()) == 0) {
           err = F("Task Device Name is not unique, conflicts with task ID #");
           err += (i+1);
-          return err;
+//          return err;
         }
       }
     }
   }
 
-  err = LoadTaskSettings(taskIndex);
+  err += LoadTaskSettings(taskIndex);
   return err;
 }
 


### PR DESCRIPTION
Only warn if a task name is duplicate but allow it to be saved without clearing the value-names of that task.