### PR TITLE
 [#1970] Fix: HTTP Header broken in 'Generic HTTP Advanced' controller

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 recommonmark==0.4.0
-Sphinx==1.8.1
+Sphinx==1.8.2
 sphinx-bootstrap-theme==0.6.5

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -3059,7 +3059,7 @@ void SendValueLogger(byte TaskIndex)
       logger += ExtraTaskSettings.TaskDeviceValueNames[varNr];
       logger += ',';
       logger += formatUserVarNoCheck(TaskIndex, varNr);
-      logger += F("\r\n");
+      logger += "\r\n";
     }
 
     addLog(LOG_LEVEL_DEBUG, logger);

--- a/src/_C011.ino
+++ b/src/_C011.ino
@@ -165,20 +165,27 @@ boolean Create_schedule_HTTP_C011(struct EventStruct *event)
     controller_number, event->ControllerIndex, ControllerSettings,
     String(customConfig.HttpMethod), customConfig.HttpUri);
 
-  if (strlen(customConfig.HttpHeader) > 0)
+
+  if (strlen(customConfig.HttpHeader) > 0) {
+    if (payload.endsWith("\r\n\r\n")) {
+      // Remove extra newline, see https://github.com/letscontrolit/ESPEasy/issues/1970
+      payload.remove(payload.length()-2);
+    }
     payload += customConfig.HttpHeader;
+  }
   ReplaceTokenByValue(payload, event);
 
   if (strlen(customConfig.HttpBody) > 0)
   {
     String body = String(customConfig.HttpBody);
     ReplaceTokenByValue(body, event);
-    payload += F("\r\nContent-Length: ");
+    payload += "\r\n";
+    payload += F("Content-Length: ");
     payload += String(body.length());
-    payload += F("\r\n\r\n");
+    payload += "\r\n\r\n";
     payload += body;
   }
-  payload += F("\r\n");
+  payload += "\r\n";
 
   bool success = C011_DelayHandler.addToQueue(C011_queue_element(event->ControllerIndex, payload));
   scheduleNextDelayQueue(TIMER_C011_DELAY_QUEUE, C011_DelayHandler.getNextScheduleTime());

--- a/src/_CPlugin_Helper.h
+++ b/src/_CPlugin_Helper.h
@@ -480,7 +480,7 @@ String get_user_agent_request_header_field() {
   request += String(CRCValues.compileDate);
   request += ' ';
   request += String(CRCValues.compileTime);
-  request += F("\r\n");
+  request += "\r\n";
   agent_size = request.length();
   return request;
 }
@@ -501,20 +501,21 @@ String do_create_http_request(
   request += ' ';
   if (!uri.startsWith("/")) request += '/';
   request += uri;
-  request += F(" HTTP/1.1\r\n");
+  request += F(" HTTP/1.1");
+  request += "\r\n";
   if (content_length >= 0) {
     request += F("Content-Length: ");
     request += content_length;
-    request += F("\r\n");
+    request += "\r\n";
   }
   request += F("Host: ");
   request += hostportString;
-  request += F("\r\n");
+  request += "\r\n";
   request += auth_header;
   request += additional_options;
   request += get_user_agent_request_header_field();
   request += F("Connection: close\r\n");
-  request += F("\r\n");
+  request += "\r\n";
   addLog(LOG_LEVEL_DEBUG, request);
   return request;
 }

--- a/src/_P020_Ser2Net.ino
+++ b/src/_P020_Ser2Net.ino
@@ -246,7 +246,7 @@ boolean Plugin_020(byte function, struct EventStruct *event, String& string)
         if (Settings.UseRules)
         {
           String message = (char*)serial_buf;
-          int NewLinePos = message.indexOf(F("\r\n"));
+          int NewLinePos = message.indexOf("\r\n");
           if (NewLinePos > 0)
             message = message.substring(0, NewLinePos);
           String eventString = "";

--- a/src/_Reporting.ino
+++ b/src/_Reporting.ino
@@ -41,11 +41,11 @@ void ReportStatus()
   String payload = F("POST /report.php HTTP/1.1\r\n");
   payload += F("Host: ");
   payload += host;
-  payload += F("\r\n");
+  payload += "\r\n";
   payload += F("Connection: close\r\n");
   payload += F("Content-Length: ");
   payload += String(body.length());
-  payload += F("\r\n\r\n");
+  payload += "\r\n\r\n";
   payload += body;
 
   serialPrintln(payload);


### PR DESCRIPTION
Also replaced a number of short strings not to use F() macro to reduce binary footprint.