### PR TITLE
Fix P029 - MQTT Helper: device status not updated when GPIO is (#1708)

### DIFF
--- a/src/_C002.ino
+++ b/src/_C002.ino
@@ -99,6 +99,7 @@ boolean CPlugin_002(byte function, struct EventStruct *event, String& string)
                       {
                         case 0:
                           pwmValue = 0;
+                          UserVar[baseVar] = pwmValue;
                           break;
                         case 1:
                           pwmValue = UserVar[baseVar];


### PR DESCRIPTION
Fix for #1708 