### PR TITLE
[Build] Remove dev builds for 1MB modules

### DIFF
--- a/before_deploy
+++ b/before_deploy
@@ -34,9 +34,7 @@ for ENV in \
   test_ESP8266_4096_VCC\
   test_ESP8266_1024_VCC\
   test_ESP8285_1024\
-  dev_ESP8266_1024\
   dev_ESP8266_4096\
-  dev_ESP8285_1024\
   hard_SONOFF_POW_4M\
   minimal_ESP8266_1024_OTA\
   minimal_ESP8285_1024_OTA\


### PR DESCRIPTION
The dev builds have become too large for 1MB nodes.
Disabled for now.

```
Error: The program size (893752 bytes) is greater than maximum allowed (892912 bytes)
*** [checkprogsize] Explicit exit, status 1
DATA:    [======    ]  60.9% (used 49912 bytes from 81920 bytes)
PROGRAM: [==========]  100.1% (used 893752 bytes from 892912 bytes)
```