### PR TITLE
[#2162] Restore PlatformIO config for WROOM02 + new 2M128 flash layout

### DIFF
--- a/before_deploy
+++ b/before_deploy
@@ -32,29 +32,31 @@ fi
 
 
 for ENV in \
+  dev_ESP8266_4096\
   esp-wrover-kit_test_1M8_partition\
   esp32dev\
   esp32test_1M8_partition\
-  normal_ESP8266_1024\
-  normal_ESP8266_1024_VCC\
+  hard_SONOFF_POW_4M\
+  hard_core_250_beta_SONOFF_POW_4M\
+  hard_core_250_beta_Shelly_1_2M128\
   minimal_ESP8266_1024_OTA\
   minimal_ESP8285_1024_OTA\
-  normal_ESP8285_1024\
+  normal_ESP8266_1024\
+  normal_ESP8266_1024_VCC\
   normal_ESP8266_4096\
+  normal_ESP8285_1024\
   normal_IR_ESP8266_4096\
+  normal_WROOM02_2048\
+  normal_core_241_ESP8266_1024\
+  normal_core_241_ESP8266_4096\
+  normal_core_250_beta_ESP8266_1024\
+  normal_core_250_beta_ESP8266_4096\
+  normal_core_250_beta_IR_ESP8266_4096\
+  normal_core_250_beta_WROOM02_2M128\
   test_ESP8266_4096\
   test_ESP8266_4096_VCC\
-  dev_ESP8266_4096\
-  hard_SONOFF_POW_4M\
-  normal_core_241_ESP8266_4096\
-  normal_core_241_ESP8266_1024\
-  normal_core_250_beta_ESP8266_4096\
-  normal_core_250_beta_ESP8266_1024\
-  normal_core_250_beta_IR_ESP8266_4096\
   test_core_250_beta_ESP8266_4096\
-  test_core_250_beta_ESP8266_4096_VCC\
-  hard_core_250_beta_SONOFF_POW_4M\
-  hard_core_250_beta_Shelly_1;\
+  test_core_250_beta_ESP8266_4096_VCC;\
 do
   MAX_FILESIZE=1044464
   if [[ ${ENV} == *"1024"* ]]; then

--- a/platformio.ini
+++ b/platformio.ini
@@ -223,17 +223,33 @@ board_build.f_cpu         = ${esp8266_1M.board_build.f_cpu}
 build_unflags             = ${esp8266_1M.build_unflags}
 build_flags               = ${esp8266_1M.build_flags} -DESP8285
 
-[esp8266_2M]
+[esp8266_2M128]
 board                     = esp12e
 board_build.flash_mode    = dio
 board_build.f_cpu         = ${common.board_build.f_cpu}
 build_unflags             = ${regular_platform.build_unflags}
 build_flags               = -Wl,-Tesp8266.flash.2m128.ld
 
+[espWroom2M]
+board_build.flash_mode    = dout
+board_build.f_cpu         = ${common.board_build.f_cpu}
+board_upload.maximum_size = 1044464
+board                     = esp_wroom_02
+build_unflags             = ${common.build_unflags}
+build_flags               = -Wl,-Tesp8266.flash.2m.ld
+
+[espWroom2M128]
+board_build.flash_mode    = dout
+board_build.f_cpu         = ${common.board_build.f_cpu}
+board_upload.maximum_size = 1044464
+board                     = esp_wroom_02
+build_unflags             = ${common.build_unflags}
+build_flags               = -Wl,-Tesp8266.flash.2m128.ld
+
 [esp8266_4M]
 board                     = esp12e
 board_build.flash_mode    = dio
-board_upload.maximum_size = 900000
+board_upload.maximum_size = 1044464
 board_build.f_cpu         = ${common.board_build.f_cpu}
 build_unflags             = ${regular_platform.build_unflags}
 build_flags               = -Wl,-Tesp8266.flash.4m1m.ld
@@ -410,6 +426,41 @@ board_build.f_cpu         = ${esp8285_1M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8285_1M.board_build.flash_mode}
 build_unflags             = ${esp8285_1M.build_unflags}
 build_flags               = ${esp8285_1M.build_flags} ${normal.build_flags}
+
+; NORMAL: 2048k WROOM02 version --------------------------
+[env:normal_WROOM02_2048]
+platform                  = ${normal.platform}
+lib_deps                  = ${common.lib_deps}
+lib_ignore                = ${common.lib_ignore}
+lib_ldf_mode              = ${common.lib_ldf_mode}
+lib_archive               = ${common.lib_archive}
+framework                 = ${common.framework}
+upload_speed              = ${common.upload_speed}
+monitor_speed             = ${common.monitor_speed}
+board                     = ${espWroom2M.board}
+board_upload.maximum_size = ${espWroom2M.board_upload.maximum_size}
+board_build.f_cpu         = ${espWroom2M.board_build.f_cpu}
+board_build.flash_mode    = ${espWroom2M.board_build.flash_mode}
+build_unflags             = ${espWroom2M.build_unflags}
+build_flags               = ${espWroom2M.build_flags} ${normal.build_flags}
+
+; NORMAL: 2048k WROOM02 version 128k SPIFFS --------------------------
+[env:normal_core_250_beta_WROOM02_2M128]
+platform                  = ${normal_beta.platform}
+lib_deps                  = ${common.lib_deps}
+lib_ignore                = ${common.lib_ignore}
+lib_ldf_mode              = ${common.lib_ldf_mode}
+lib_archive               = ${common.lib_archive}
+framework                 = ${common.framework}
+upload_speed              = ${common.upload_speed}
+monitor_speed             = ${common.monitor_speed}
+board                     = ${espWroom2M128.board}
+board_upload.maximum_size = ${espWroom2M128.board_upload.maximum_size}
+board_build.f_cpu         = ${espWroom2M128.board_build.f_cpu}
+board_build.flash_mode    = ${espWroom2M128.board_build.flash_mode}
+build_unflags             = ${espWroom2M128.build_unflags}
+build_flags               = ${espWroom2M128.build_flags} ${normal_beta.build_flags}
+
 
 ; NORMAL: 4096k version --------------------------
 [env:normal_ESP8266_4096]
@@ -803,7 +854,7 @@ build_flags               = ${normal_beta.build_flags} ${esp8266_4M.build_flags}
 ; https://shelly.cloud/shelly1-open-source/
 ; GPIO04 Relay (non inverted)
 ; GPIO05 Button
-[env:hard_core_250_beta_Shelly_1]
+[env:hard_core_250_beta_Shelly_1_2M128]
 upload_speed              = ${common.upload_speed}
 monitor_speed             = ${common.monitor_speed}
 framework                 = ${common.framework}
@@ -812,11 +863,11 @@ lib_deps                  = ${common.lib_deps}
 lib_ignore                = ${common.lib_ignore}
 lib_ldf_mode              = ${common.lib_ldf_mode}
 lib_archive               = ${common.lib_archive}
-board_build.f_cpu         = ${esp8266_2M.board_build.f_cpu}
-board_build.flash_mode    = ${esp8266_2M.board_build.flash_mode}
-board                     = ${esp8266_2M.board}
-build_unflags             = ${esp8266_2M.build_unflags}
-build_flags               = ${normal_beta.build_flags} ${esp8266_2M.build_flags} -D PLUGIN_SET_SHELLY_1
+board_build.f_cpu         = ${esp8266_2M128.board_build.f_cpu}
+board_build.flash_mode    = ${esp8266_2M128.board_build.flash_mode}
+board                     = ${esp8266_2M128.board}
+build_unflags             = ${esp8266_2M128.build_unflags}
+build_flags               = ${normal_beta.build_flags} ${esp8266_2M128.build_flags} -D PLUGIN_SET_SHELLY_1
 
 
 


### PR DESCRIPTION
See #2162
Also added a WROOM02 core 2.5.0 beta test build using the new 2M128k flash layout. (allowing OTA)
Using the new layout will remove any existing 2M1M layout.