### PR TITLE
[deepSleep] Make deepSleep work again with 2.5.0 and refactor delay var

### DIFF
--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -167,19 +167,19 @@ void deepSleepStart(int dsdelay)
   String event = F("System#Sleep");
   rulesProcessing(event);
 
-
   RTC.deepSleepState = 1;
   saveToRTC();
-
-  if (dsdelay > 4294 || dsdelay < 0)
-    dsdelay = 4294;   //max sleep time ~1.2h
 
   addLog(LOG_LEVEL_INFO, F("SLEEP: Powering down to deepsleep..."));
   delay(100); // give the node time to send above log message before going to sleep
   #if defined(ESP8266)
     #if defined(CORE_2_5_0)
-      ESP.deepSleepInstant((uint32_t)dsdelay * 1000000, WAKE_RF_DEFAULT);
+      if (dsdelay > ESP.deepSleepMax() || dsdelay < 0)
+        dsdelay = ESP.deepSleepMax();   //max sleep time
+        ESP.deepSleepInstant((uint32_t)dsdelay * 1000000, WAKE_RF_DEFAULT);
     #else
+      if (dsdelay > 4294 || dsdelay < 0)
+        dsdelay = 4294;   //max sleep time ~1.2h
       ESP.deepSleep((uint32_t)dsdelay * 1000000, WAKE_RF_DEFAULT);
     #endif
   #endif

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -130,7 +130,7 @@ bool readyForSleep()
   return timeOutReached(timerAwakeFromDeepSleep + 1000 * Settings.deepSleep);
 }
 
-void deepSleep(int delay)
+void deepSleep(int dsdelay)
 {
 
   checkRAM(F("deepSleep"));
@@ -158,10 +158,10 @@ void deepSleep(int delay)
     }
   }
   saveUserVarToRTC();
-  deepSleepStart(delay); // Call deepSleepStart function after these checks
+  deepSleepStart(dsdelay); // Call deepSleepStart function after these checks
 }
 
-void deepSleepStart(int delay)
+void deepSleepStart(int dsdelay)
 {
   // separate function that is called from above function or directly from rules, usign deepSleep as a one-shot
   String event = F("System#Sleep");
@@ -171,15 +171,16 @@ void deepSleepStart(int delay)
   RTC.deepSleepState = 1;
   saveToRTC();
 
-  if (delay > 4294 || delay < 0)
-    delay = 4294;   //max sleep time ~1.2h
+  if (dsdelay > 4294 || dsdelay < 0)
+    dsdelay = 4294;   //max sleep time ~1.2h
 
   addLog(LOG_LEVEL_INFO, F("SLEEP: Powering down to deepsleep..."));
+  delay(100); // give the node time to send above log message before going to sleep
   #if defined(ESP8266)
-    ESP.deepSleep((uint32_t)delay * 1000000, WAKE_RF_DEFAULT);
+    ESP.deepSleepInstant((uint32_t)dsdelay * 1000000, WAKE_RF_DEFAULT);
   #endif
   #if defined(ESP32)
-    esp_sleep_enable_timer_wakeup((uint32_t)delay * 1000000);
+    esp_sleep_enable_timer_wakeup((uint32_t)dsdelay * 1000000);
     esp_deep_sleep_start();
   #endif
 }
@@ -515,9 +516,9 @@ void statusLED(boolean traffic)
 /********************************************************************************************\
   delay in milliseconds with background processing
   \*********************************************************************************************/
-void delayBackground(unsigned long delay)
+void delayBackground(unsigned long dsdelay)
 {
-  unsigned long timer = millis() + delay;
+  unsigned long timer = millis() + dsdelay;
   while (!timeOutReached(timer))
     backgroundtasks();
 }

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -174,16 +174,14 @@ void deepSleepStart(int dsdelay)
   delay(100); // give the node time to send above log message before going to sleep
   #if defined(ESP8266)
     #if defined(CORE_2_5_0)
-      if ((uint64_t)dsdelay > (ESP.deepSleepMax()/1000000ULL) || dsdelay < 0) {
-        if ((ESP.deepSleepMax()/1000000ULL) > (uint64_t)INT_MAX)
-          dsdelay = INT_MAX;
-        else
-          dsdelay = (int)(ESP.deepSleepMax()/1000000ULL);
+      uint64_t deepSleep_usec = dsdelay * 1000000ULL;
+      if ((deepSleep_usec > ESP.deepSleepMax()) || dsdelay < 0) {
+        deepSleep_usec = ESP.deepSleepMax();
       }
-        ESP.deepSleepInstant((uint32_t)dsdelay * 1000000, WAKE_RF_DEFAULT);
+      ESP.deepSleepInstant(deepSleep_usec, WAKE_RF_DEFAULT);
     #else
       if (dsdelay > 4294 || dsdelay < 0)
-        dsdelay = 4294;   //max sleep time ~1.2h
+        dsdelay = 4294;   //max sleep time ~71 minutes
       ESP.deepSleep((uint32_t)dsdelay * 1000000, WAKE_RF_DEFAULT);
     #endif
   #endif

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -174,8 +174,12 @@ void deepSleepStart(int dsdelay)
   delay(100); // give the node time to send above log message before going to sleep
   #if defined(ESP8266)
     #if defined(CORE_2_5_0)
-      if (dsdelay > ESP.deepSleepMax() || dsdelay < 0)
-        dsdelay = ESP.deepSleepMax();   //max sleep time
+      if ((uint64_t)dsdelay > (ESP.deepSleepMax()/1000000ULL) || dsdelay < 0) {
+        if ((ESP.deepSleepMax()/1000000ULL) > (uint64_t)INT_MAX)
+          dsdelay = INT_MAX;
+        else
+          dsdelay = (int)(ESP.deepSleepMax()/1000000ULL);
+      }
         ESP.deepSleepInstant((uint32_t)dsdelay * 1000000, WAKE_RF_DEFAULT);
     #else
       if (dsdelay > 4294 || dsdelay < 0)

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -177,7 +177,11 @@ void deepSleepStart(int dsdelay)
   addLog(LOG_LEVEL_INFO, F("SLEEP: Powering down to deepsleep..."));
   delay(100); // give the node time to send above log message before going to sleep
   #if defined(ESP8266)
-    ESP.deepSleepInstant((uint32_t)dsdelay * 1000000, WAKE_RF_DEFAULT);
+    #if defined(CORE_2_5_0)
+      ESP.deepSleepInstant((uint32_t)dsdelay * 1000000, WAKE_RF_DEFAULT);
+    #else
+      ESP.deepSleep((uint32_t)dsdelay * 1000000, WAKE_RF_DEFAULT);
+    #endif
   #endif
   #if defined(ESP32)
     esp_sleep_enable_timer_wakeup((uint32_t)dsdelay * 1000000);

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -1271,8 +1271,12 @@ void handle_config() {
   addHelpButton(F("SleepMode"));
   addFormNote(F("0 = Sleep Disabled, else time awake from sleep"));
 
-  addFormNumericBox( F("Sleep time"), F("delay"), Settings.Delay, 0, 4294);   //limited by hardware to ~1.2h
-  addUnit(F("sec"));
+  #if defined(CORE_2_5_0)
+    addFormNumericBox( F("Sleep time"), F("delay"), Settings.Delay, 0, ESP.deepSleepMax());   //limited by hardware
+  #else
+    addFormNumericBox( F("Sleep time"), F("delay"), Settings.Delay, 0, 4294);   //limited by hardware to ~1.2h
+  #endif
+    addUnit(F("sec"));
 
   addFormCheckBox(F("Sleep on connection failure"), F("deepsleeponfail"), Settings.deepSleepOnFail);
 

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -1271,15 +1271,19 @@ void handle_config() {
   addHelpButton(F("SleepMode"));
   addFormNote(F("0 = Sleep Disabled, else time awake from sleep"));
 
-  #if defined(CORE_2_5_0)
-    int dsmax = INT_MAX;
-    if ((ESP.deepSleepMax()/1000000ULL) <= (uint64_t)INT_MAX)
-      dsmax = (int)(ESP.deepSleepMax()/1000000ULL);
-    addFormNumericBox( F("Sleep time"), F("delay"), Settings.Delay, 0, dsmax);   //limited by hardware
-  #else
-    addFormNumericBox( F("Sleep time"), F("delay"), Settings.Delay, 0, 4294);   //limited by hardware to ~1.2h
-  #endif
-    addUnit(F("sec"));
+  int dsmax = 4294; // About 71 minutes
+#if defined(CORE_2_5_0)
+  dsmax = INT_MAX;
+  if ((ESP.deepSleepMax()/1000000ULL) <= (uint64_t)INT_MAX)
+    dsmax = (int)(ESP.deepSleepMax()/1000000ULL);
+#endif
+  addFormNumericBox( F("Sleep time"), F("delay"), Settings.Delay, 0, dsmax);   //limited by hardware
+  {
+    String maxSleeptimeUnit = F("sec (max: ");
+    maxSleeptimeUnit += String(dsmax);
+    maxSleeptimeUnit += ')';
+    addUnit(maxSleeptimeUnit);
+  }
 
   addFormCheckBox(F("Sleep on connection failure"), F("deepsleeponfail"), Settings.deepSleepOnFail);
 

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -1272,7 +1272,10 @@ void handle_config() {
   addFormNote(F("0 = Sleep Disabled, else time awake from sleep"));
 
   #if defined(CORE_2_5_0)
-    addFormNumericBox( F("Sleep time"), F("delay"), Settings.Delay, 0, ESP.deepSleepMax());   //limited by hardware
+    int dsmax = INT_MAX;
+    if ((ESP.deepSleepMax()/1000000ULL) <= (uint64_t)INT_MAX)
+      dsmax = (int)(ESP.deepSleepMax()/1000000ULL);
+    addFormNumericBox( F("Sleep time"), F("delay"), Settings.Delay, 0, dsmax);   //limited by hardware
   #else
     addFormNumericBox( F("Sleep time"), F("delay"), Settings.Delay, 0, 4294);   //limited by hardware to ~1.2h
   #endif


### PR DESCRIPTION
Make deepSleep work again with Core 2.5.0. Changed ESP.deepSleep() to ESP.deepSleepInstant().

Refactor delay variable to dsdelay to avoid conflicts with the delay() function.

Added a delay(100) before going to sleep to give the node time to send the last log messages.