### PR TITLE
SHT_3x: Add code to start periodic transmission if not enough data is received

### DIFF
--- a/src/_P068_SHT3x.ino
+++ b/src/_P068_SHT3x.ino
@@ -80,6 +80,12 @@ void SHT3X::get()
 	{
 		tmp = NAN;
 		hum = NAN;
+
+		// Set to periodic mode
+		Wire.beginTransmission(_i2c_device_address);
+		Wire.write(0x20);   // periodic 0.5mps
+		Wire.write(0x32);   // repeatability high
+		Wire.endTransmission();
 	}
 }
 


### PR DESCRIPTION
I'm using an SHT35. Every now and then (about once in 2 month), for some reason the SHT35 resets. With some EMI, i can provoke this faster. If that happens, you have to resend the periodic transmissions command. I added the code.