### PR TITLE
[WiFi] Disable wifi initialization at boot (core 2.5.0-b2)

### DIFF
--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -103,6 +103,19 @@ int firstEnabledBlynkController() {
 
 //void checkRAM( const __FlashStringHelper* flashString);
 
+#ifdef CORE_2_5_0
+/*********************************************************************************************\
+ * Pre-init
+\*********************************************************************************************/
+void preinit() {
+  // Global WiFi constructors are not called yet
+  // (global class instances like WiFi, Serial... are not yet initialized)..
+  // No global object methods or C++ exceptions can be called in here!
+  //The below is a static class method, which is similar to a function, so it's ok.
+  ESP8266WiFiClass::preinitWiFiOff();
+}
+#endif
+
 /*********************************************************************************************\
  * SETUP
 \*********************************************************************************************/


### PR DESCRIPTION
See:
- https://github.com/esp8266/Arduino/issues/2111
- https://github.com/esp8266/Arduino/pull/5395/files

Hopefully it will help for modules which have a hard time to connect to WiFi, which may be caused by weak power supply.
It will also not start unintended DHCP-client services which lead to strange issues when using static IP configuration.
Tests should reveal if it will also help to lessen the chaos which may happen now the 'May deal' is off, so please perform some tests and we'll see the coming days.
At least it will save some peak power at startup.

N.B. this will only work on core 2.5.0 beta 2 and newer.