### PR TITLE
[WiFi] Some minor changes for WiFi stability

### DIFF
--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -502,7 +502,7 @@ void loop()
     WiFiConnectRelaxed();
     wifiSetupConnect = false;
   }
-  if (wifiStatus != ESPEASY_WIFI_SERVICES_INITIALIZED || unprocessedWifiEvents()) {
+  if ((wifiStatus != ESPEASY_WIFI_SERVICES_INITIALIZED) || unprocessedWifiEvents()) {
     // WiFi connection is not yet available, so introduce some extra delays to
     // help the background tasks managing wifi connections
     delay(1);
@@ -792,6 +792,8 @@ void runEach30Seconds()
     log += connectionFailures;
     log += F(" FreeMem ");
     log += FreeMem();
+    log += F(" WiFiStatus ");
+    log += wifiStatus;
     addLog(LOG_LEVEL_INFO, log);
   }
   sendSysInfoUDP(1);

--- a/src/ESPEasyWiFiEvent.h
+++ b/src/ESPEasyWiFiEvent.h
@@ -103,8 +103,9 @@ void onDisconnect(const WiFiEventStationModeDisconnected& event){
   if (timeDiff(lastConnectMoment, last_wifi_connect_attempt_moment) > 0) {
     // There was an unsuccessful connection attempt
     lastConnectedDuration = timeDiff(last_wifi_connect_attempt_moment, lastDisconnectMoment);
-  } else
+  } else {
     lastConnectedDuration = timeDiff(lastConnectMoment, lastDisconnectMoment);
+  }
   lastDisconnectReason = event.reason;
   wifiStatus = ESPEASY_WIFI_DISCONNECTED;
   processedDisconnect = false;

--- a/src/ESPEasyWifi.ino
+++ b/src/ESPEasyWifi.ino
@@ -480,9 +480,11 @@ bool WiFiConnected() {
       return true;
     }
     // else wifiStatus is no longer in sync.
+    addLog(LOG_LEVEL_INFO, F("WIFI  : WiFiConnected() out of sync"));
     resetWiFi();
   }
   delay(1);
+  STOP_TIMER(WIFI_ISCONNECTED_STATS);  // SMY: also count this call when not connected
   return false;
 }
 
@@ -572,10 +574,10 @@ bool wifiConnectTimeoutReached() {
   // wait until it connects + add some device specific random offset to prevent
   // all nodes overloading the accesspoint when turning on at the same time.
   #if defined(ESP8266)
-  const unsigned int randomOffset_in_sec = wifi_connect_attempt == 1 ? 0 : 1000 * ((ESP.getChipId() & 0xF));
+  const unsigned int randomOffset_in_sec = (wifi_connect_attempt == 1) ? 0 : 1000 * ((ESP.getChipId() & 0xF));
   #endif
   #if defined(ESP32)
-  const unsigned int randomOffset_in_sec = wifi_connect_attempt == 1 ? 0 : 1000 * ((ESP.getEfuseMac() & 0xF));
+  const unsigned int randomOffset_in_sec = (wifi_connect_attempt == 1) ? 0 : 1000 * ((ESP.getEfuseMac() & 0xF));
   #endif
   return timeOutReached(last_wifi_connect_attempt_moment + DEFAULT_WIFI_CONNECTION_TIMEOUT + randomOffset_in_sec);
 }
@@ -615,8 +617,10 @@ bool tryConnectWiFi() {
       return(true);   //already connected, need to disconnect first
     }
   }
-  if (!wifiConnectTimeoutReached())
+  if (!wifiConnectTimeoutReached()) {
+    delay(0); // SMY: give some time to handle WiFi
     return true;    // timeout not reached yet, thus no need to retry again.
+  }
   if (!selectValidWiFiSettings()) {
     addLog(LOG_LEVEL_ERROR, F("WIFI : No valid WiFi settings!"));
     return false;
@@ -637,6 +641,7 @@ bool tryConnectWiFi() {
     addLog(LOG_LEVEL_INFO, log);
   }
   setupStaticIPconfig();
+//  WiFi.setPhyMode(WIFI_PHY_MODE_11G); // SMY: uncomment to force 802.11g for use with MikroTik AP's.
   last_wifi_connect_attempt_moment = millis();
   switch (wifi_connect_attempt) {
     case 0:
@@ -657,7 +662,7 @@ bool tryConnectWiFi() {
         log += ssid;
         addLog(LOG_LEVEL_INFO, log);
       }
-      return false;
+      break;
     }
     case WL_CONNECT_FAILED: {
       if (loglevelActiveFor(LOG_LEVEL_INFO)) {
@@ -665,7 +670,23 @@ bool tryConnectWiFi() {
         log += ssid;
         addLog(LOG_LEVEL_INFO, log);
       }
-      return false;
+      break;
+    }
+    case WL_DISCONNECTED: {
+      if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+        String log = F("WIFI : Not configured in Station Mode!!: ");
+        log += ssid;
+        addLog(LOG_LEVEL_INFO, log);
+      }
+      break;
+    }
+    case WL_IDLE_STATUS: {
+      if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+        String log = F("WIFI : Connection in IDLE state: ");
+        log += ssid;
+        addLog(LOG_LEVEL_INFO, log);
+      }
+      break;
     }
     case WL_CONNECTED: {
       return true;
@@ -834,12 +855,18 @@ void WifiCheck()
 
   processDisableAPmode();
   IPAddress ip = WiFi.localIP();
-  if (!useStaticIP()) {
-    if (ip[0] == 0 && ip[1] == 0 && ip[2] == 0 && ip[3] == 0) {
-      if (WiFiConnected()) {
+  if (WiFiConnected()) { // let's just check for wifi, no matter if we have an IP or not...
+    if (!useStaticIP()) {
+      if (ip[0] == 0 && ip[1] == 0 && ip[2] == 0 && ip[3] == 0) {
         // Some strange situation where the DHCP renew probably has failed and erased the config.
+        addLog(LOG_LEVEL_ERROR, F("WIFI : DHCP renew probably failed"));
         resetWiFi();
       }
+    }
+  } else {
+    if (wifiStatus == ESPEASY_WIFI_SERVICES_INITIALIZED) { // SMY: WiFi seems to be disconnected and out of sync with internal state... strange... we should never get here!!
+      addLog(LOG_LEVEL_ERROR, F("WIFI : WiFiCheck out of sync"));
+      resetWiFi();
     }
   }
 

--- a/src/_CPlugin_Helper.h
+++ b/src/_CPlugin_Helper.h
@@ -582,7 +582,11 @@ void log_connecting_fail(const String& prefix, int controller_number, Controller
   if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
     String log = prefix;
     log += get_formatted_Controller_number(controller_number);
-    log += F(" connection failed");
+    log += F(" connection failed (");
+    log += connectionFailures;
+    log += F("/");
+    log += Settings.ConnectionFailuresThreshold;
+    log += F(")");
     addLog(LOG_LEVEL_ERROR, log);
   }
 }

--- a/src/__Plugin.ino
+++ b/src/__Plugin.ino
@@ -1134,7 +1134,7 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
             }
           }
           START_TIMER;
-          bool retval = Plugin_ptr[x](Function, event, str);
+          Plugin_ptr[x](Function, event, str);
           STOP_TIMER_TASK(x,Function);
           delay(0); // SMY: call delay(0) unconditionally
         }
@@ -1264,7 +1264,7 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
                   schedule_task_device_timer_at_init(TempEvent.TaskIndex);
                 }
                 START_TIMER;
-                bool retval = Plugin_ptr[x](Function, &TempEvent, str);
+                Plugin_ptr[x](Function, &TempEvent, str);
                 STOP_TIMER_TASK(x,Function);
                 delay(0); // SMY: call delay(0) unconditionally
               }

--- a/src/__Plugin.ino
+++ b/src/__Plugin.ino
@@ -1136,7 +1136,7 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
           START_TIMER;
           bool retval = Plugin_ptr[x](Function, event, str);
           STOP_TIMER_TASK(x,Function);
-          if (retval) delay(0);
+          delay(0); // SMY: call delay(0) unconditionally
         }
       }
       return true;
@@ -1183,8 +1183,8 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
                 START_TIMER;
                 bool retval = (Plugin_ptr[x](Function, &TempEvent, str));
                 STOP_TIMER_TASK(x,Function);
+                delay(0); // SMY: call delay(0) unconditionally
                 if (retval) {
-                  delay(0);
                   return true;
                 }
               }
@@ -1195,7 +1195,7 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
         for (byte x = 0; x < PLUGIN_MAX; x++) {
           if (Plugin_id[x] != 0) {
             if (Plugin_ptr[x](Function, event, str)) {
-              delay(0);
+              delay(0); // SMY: call delay(0) unconditionally
               return true;
             }
           }
@@ -1221,9 +1221,9 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
               START_TIMER;
               bool retval =  (Plugin_ptr[x](Function, &TempEvent, str));
               STOP_TIMER_TASK(x,Function);
+              delay(0); // SMY: call delay(0) unconditionally
               if (retval){
                 checkRAM(F("PluginCallUDP"),x);
-                delay(0);
                 return true;
               }
             }
@@ -1266,7 +1266,7 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
                 START_TIMER;
                 bool retval = Plugin_ptr[x](Function, &TempEvent, str);
                 STOP_TIMER_TASK(x,Function);
-                if (retval) delay(0);
+                delay(0); // SMY: call delay(0) unconditionally
               }
             }
           }
@@ -1307,7 +1307,7 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
             ExtraTaskSettings.TaskIndex = event->TaskIndex;
           }
           STOP_TIMER_TASK(x,Function);
-          if (retval) delay(0);
+          delay(0); // SMY: call delay(0) unconditionally
           return retval;
         }
       }


### PR DESCRIPTION
- Call delay(0) unconditionally after plugin calls as they can take quie some time, even if they fail
- add some more log output in various places for WiFi info
- add some ()/{} to make groupings clear
- add all possible statuses in case statement after WiFi.begin() call
- test for layer 2 availability independent of valid IP (can happen that IP is still valid, but layer 2 is lost)

See also Issue #1987 and #2203