### PR TITLE
[Plugin Sets] Decouple PLUGIN_BUILD_MINIMAL_OTA

### DIFF
--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -2955,7 +2955,7 @@ void addSaveButton(const String &url, const String &label)
 
 void addSaveButton(class StreamingBuffer &buffer, const String &url, const String &label)
 {
-#ifdef PLUGIN_BUILD_MINIMAL_OTA
+#ifdef BUILD_MINIMAL_OTA
   addButtonWithSvg(buffer, url, label
      , ""
      , false);
@@ -2973,7 +2973,7 @@ void addDeleteButton(const String &url, const String &label)
 
 void addDeleteButton(class StreamingBuffer &buffer, const String &url, const String &label)
 {
-#ifdef PLUGIN_BUILD_MINIMAL_OTA
+#ifdef BUILD_MINIMAL_OTA
   addButtonWithSvg(buffer, url, label
      , ""
      , true);

--- a/src/define_plugin_sets.h
+++ b/src/define_plugin_sets.h
@@ -80,6 +80,8 @@ To create/register a plugin, you have to :
 
     #define CONTROLLER_SET_NONE
 
+    #define BUILD_MINIMAL_OTA
+
     #define USES_C001   // Domoticz HTTP
     #define USES_C002   // Domoticz MQTT
     #define USES_C005   // OpenHAB MQTT


### PR DESCRIPTION
Decouple PLUGN_BUILD_MINIMAL_OTA in define_plugin_sets.h from other #defines in source code, otherwise either plugin set from Custom.h gets overriden by PLUGN_BUILD_MINIMAL_OTA from define_plugin_sets.h or #define's in code (eg. WebServer.ino) are not included.
Also name is misleading, as eg. WebServer is not a plugin..