### PR TITLE
fix reset bug for esp32 by casting explicitly, should fix #2242

### DIFF
--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -2822,9 +2822,9 @@ void addSelector_Head(const String& id, boolean reloadonchange) {
 void addSelector_Head(const String& id, boolean reloadonchange, bool disabled)
 {
   if (reloadonchange) {
-    addSelector_Head(id, F("return dept_onchange(frmselect)"), disabled);
+    addSelector_Head(id, (const String) F("return dept_onchange(frmselect)"), disabled);
   } else {
-    addSelector_Head(id, "", disabled);
+    addSelector_Head(id, (const String) "", disabled);
   }
 }
 


### PR DESCRIPTION
This fixes the reset bug described in #2242 for me. When not casting explicitly, the the function addSelector_Head seems to run in a loop. It interprets the the strings as a bool.

If there is a better fix for this please point me to it.