### PR TITLE
Fixed compile errors that occurred when FEATURE_SD is defined.

### DIFF
--- a/src/Command.ino
+++ b/src/Command.ino
@@ -122,7 +122,7 @@ String doExecuteCommand(const char * cmd, struct EventStruct *event, const char*
     }
     case 's': {
 	  COMMAND_CASE("save"                   , Command_Settings_Save);              // Settings.h
-	#if FEATURE_SD
+	#ifdef FEATURE_SD
 	  COMMAND_CASE("sdcard"                 , Command_SD_LS);                      // SDCARDS.h
 	  COMMAND_CASE("sdremove"               , Command_SD_Remove);                  // SDCARDS.h
 	#endif
@@ -258,7 +258,7 @@ void printDirectory(File dir, int numTabs)
 			break;
 		}
 		for (uint8_t i = 0; i < numTabs; i++) {
-			serialPrint('\t');
+			serialPrint("\t");
 		}
 		serialPrint(entry.name());
 		if (entry.isDirectory()) {
@@ -267,7 +267,7 @@ void printDirectory(File dir, int numTabs)
 		} else {
 			// files have sizes, directories do not
 			serialPrint("\t\t");
-			serialPrintln(entry.size(), DEC);
+			serialPrintln(String(entry.size(), DEC));
 		}
 		entry.close();
 	}

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -168,7 +168,7 @@
 //#define PLUGIN_BUILD_DEV
 
 //add this if you want SD support (add 10k flash)
-//#define FEATURE_SD
+#define FEATURE_SD
 
 // ********************************************************************************
 //   DO NOT CHANGE ANYTHING BELOW THIS LINE

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -168,7 +168,7 @@
 //#define PLUGIN_BUILD_DEV
 
 //add this if you want SD support (add 10k flash)
-#define FEATURE_SD
+//#define FEATURE_SD
 
 // ********************************************************************************
 //   DO NOT CHANGE ANYTHING BELOW THIS LINE


### PR DESCRIPTION
I got the following errors while compiling with activated sd card feature (#define FEATURE_SD):
(1) #if with no expression
(2) converting to 'const String' from initializer list would use explicit constructor 'String::String(char)'
(3) no matching function for call to 'serialPrintln(uint32_t, int)'