### PR TITLE
MQTT Import : A bad clientId is build in case of a reconnect #2298

### DIFF
--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -159,6 +159,7 @@ bool MQTTConnect(int controller_idx)
     clientid = F("ESPClient_");
     clientid += WiFi.macAddress();
   }
+  clientid.replace(' ', '_'); // Make sure no spaces are present in the client ID
   if (wifi_reconnects >= 1 && Settings.uniqueMQTTclientIdReconnect()) {
     // Work-around for 'lost connections' to the MQTT broker.
     // If the broker thinks the connection is still alive, a reconnect from the

--- a/src/_P037_MQTTImport.ino
+++ b/src/_P037_MQTTImport.ino
@@ -32,6 +32,8 @@ String getClientName() {
   //
   String tmpClientName = F("%sysname%-Import");
   String ClientName = parseTemplate(tmpClientName, 20);
+  ClientName.trim(); // Avoid spaced in the name.
+  ClientName.replace(' ', '_');
   if (reconnectCount != 0) ClientName += reconnectCount;
   return ClientName;
 }


### PR DESCRIPTION
Fix is to trim spaces before adding connection count and replace existing spaces into `_`
See #2298 