### PR TITLE
[ESP32dev] Disable ESP32dev build due to space constraints

### DIFF
--- a/before_deploy
+++ b/before_deploy
@@ -34,7 +34,6 @@ fi
 for ENV in \
   dev_ESP8266_4096\
   esp-wrover-kit_test_1M8_partition\
-  esp32dev\
   esp32test_1M8_partition\
   hard_SONOFF_POW_4M\
   hard_Ventus_W266\

--- a/platformio.ini
+++ b/platformio.ini
@@ -320,18 +320,20 @@ board_upload.maximum_size = 1900544
 debug_extra_cmds          = break Misc.ino:3011
 
 
-[env:esp32dev]
-platform                  = ${core_esp32_1_5_0.platform}
-board                     = esp32dev
-build_unflags             = ${core_esp32.build_unflags}
-build_flags               = ${core_esp32.build_flags}  -DPLUGIN_SET_GENERIC_ESP32
-lib_deps                  = ${core_esp32.lib_deps}
-lib_ignore                = ${core_esp32.lib_ignore}
-lib_ldf_mode              = ${common.lib_ldf_mode}
-lib_archive               = ${common.lib_archive}
-framework                 = ${common.framework}
-upload_speed              = ${common.upload_speed}
-monitor_speed             = ${common.monitor_speed}
+; 2018-02-17 TD-er
+; Disabled for now, since it does no longer fit in the default sketch partition size
+;[env:esp32dev]
+;platform                  = ${core_esp32_1_5_0.platform}
+;board                     = esp32dev
+;build_unflags             = ${core_esp32.build_unflags}
+;build_flags               = ${core_esp32.build_flags}  -DPLUGIN_SET_GENERIC_ESP32
+;lib_deps                  = ${core_esp32.lib_deps}
+;lib_ignore                = ${core_esp32.lib_ignore}
+;lib_ldf_mode              = ${common.lib_ldf_mode}
+;lib_archive               = ${common.lib_archive}
+;framework                 = ${common.framework}
+;upload_speed              = ${common.upload_speed}
+;monitor_speed             = ${common.monitor_speed}
 
 [env:esp32test_1M8_partition]
 platform                  = ${core_esp32.platform}


### PR DESCRIPTION
This build was still using the 1.34 MB default sketch partition size, but that no longer fits.
So for now this build is disabled.