### PR TITLE
[Factory Reset] Make default switch/relay rules more intuitive

### DIFF
--- a/docs/source/Plugin/P001.rst
+++ b/docs/source/Plugin/P001.rst
@@ -44,6 +44,8 @@ Change log
 
   |added|
   Major overhaul for 2.0 release.
+  |changed|
+  2019/02/26 Changed default name of value from "Switch" to "State".
 
 .. versionadded:: 1.0
   ...

--- a/docs/source/Rules/Rules.rst
+++ b/docs/source/Rules/Rules.rst
@@ -428,9 +428,9 @@ PIR and LDR
 
 .. code-block:: html
 
- On PIR#Switch do
+ On PIR#State do
    if [LDR#Light]<500
-     gpio,16,[PIR#Switch]
+     gpio,16,[PIR#State]
    endif
  endon
 
@@ -441,9 +441,9 @@ PIR and LDR
 
 .. code-block:: html
 
- on PIR#Switch=1 do
+ on PIR#State=1 do
    if [LDR#Light]<500
-     gpio,16,[PIR#Switch]
+     gpio,16,[PIR#State]
    endif
  endon
 
@@ -626,7 +626,7 @@ to make things happen during certain hours of the day:
 
 .. code-block:: html
 
-  On Pir#Switch=1 do
+  On Pir#State=1 do
    If %systime% < 07:00:00
     Gpio,16,0
    Endif

--- a/src/Hardware.ino
+++ b/src/Hardware.ino
@@ -248,7 +248,7 @@ void addButtonRelayRule(byte buttonNumber, byte relay_gpio) {
     fileName += '/';
   #endif
   fileName += F("rules1.txt");
-  String rule = F("on ButtonBNR#switch do\n  if [RelayBNR#switch]=0\n    gpio,GNR,1\n  else\n    gpio,GNR,0\n  endif\nendon\n");
+  String rule = F("on ButtonBNR#state do\n  if [RelayBNR#state]=0\n    gpio,GNR,1\n  else\n    gpio,GNR,0\n  endif\nendon\n");
   rule.replace(F("BNR"), String(buttonNumber));
   rule.replace(F("GNR"), String(relay_gpio));
   String result = appendLineToFile(fileName, rule);

--- a/src/Hardware.ino
+++ b/src/Hardware.ino
@@ -219,6 +219,7 @@ void addSwitchPlugin(byte taskIndex, byte gpio, const String& name, bool activeL
   Settings.TaskDevicePin1PullUp[taskIndex] = true;
   if (activeLow)
     Settings.TaskDevicePluginConfig[taskIndex][2] = 1; // PLUGIN_001_BUTTON_TYPE_PUSH_ACTIVE_LOW;
+  Settings.TaskDevicePluginConfig[taskIndex][3] = 1; // "Send Boot state" checked.
 }
 
 void addPredefinedPlugins(const GpioFactorySettingsStruct& gpio_settings) {
@@ -247,7 +248,7 @@ void addButtonRelayRule(byte buttonNumber, byte relay_gpio) {
     fileName += '/';
   #endif
   fileName += F("rules1.txt");
-  String rule = F("on ButtonBNR#switch do\n  if [ButtonBNR#switch]=1\n    gpio,GNR,1\n  else\n    gpio,GNR,0\n  endif\nendon\n");
+  String rule = F("on ButtonBNR#switch do\n  if [RelayBNR#switch]=0\n    gpio,GNR,1\n  else\n    gpio,GNR,0\n  endif\nendon\n");
   rule.replace(F("BNR"), String(buttonNumber));
   rule.replace(F("GNR"), String(relay_gpio));
   String result = appendLineToFile(fileName, rule);

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -1562,6 +1562,7 @@ void delayedReboot(int rebootDelay)
 void reboot() {
   // FIXME TD-er: Should network connections be actively closed or does this introduce new issues?
   flushAndDisconnectAllClients();
+  SPIFFS.end();
   #if defined(ESP32)
     ESP.restart();
   #else

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -8,8 +8,6 @@
 #define _TAIL true
 #define CHUNKED_BUFFER_SIZE          400
 
-#include <ESP8266WiFi.h>
-
 void sendContentBlocking(String& data);
 void sendHeaderBlocking(bool json, const String& origin = "");
 

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -8,6 +8,8 @@
 #define _TAIL true
 #define CHUNKED_BUFFER_SIZE          400
 
+#include <ESP8266WiFi.h>
+
 void sendContentBlocking(String& data);
 void sendHeaderBlocking(bool json, const String& origin = "");
 
@@ -6690,6 +6692,14 @@ void handle_sysinfo() {
   TXBuffer += F(" - ");
   TXBuffer += lowestFreeStackfunction;
   TXBuffer += ')';
+#ifdef CORE_2_5_0
+  addRowLabel(F("Heap Max Free Block"));
+  TXBuffer += ESP.getMaxFreeBlockSize();
+  addRowLabel(F("Heap Fragmentation"));
+  TXBuffer += ESP.getHeapFragmentation();
+  TXBuffer += '%';
+#endif
+
 
   addRowLabel(F("Boot"));
   TXBuffer += getLastBootCauseString();

--- a/src/_P001_Switch.ino
+++ b/src/_P001_Switch.ino
@@ -31,7 +31,7 @@ TaskDevicePluginConfigLong settings:
 #define PLUGIN_001
 #define PLUGIN_ID_001         1
 #define PLUGIN_NAME_001       "Switch input - Switch"
-#define PLUGIN_VALUENAME1_001 "Switch"
+#define PLUGIN_VALUENAME1_001 "State"
 #ifdef USE_SERVO
   Servo servo1;
   Servo servo2;
@@ -403,7 +403,7 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
 
         Returned EVENT value is = 3 always for doubleclick
         In rules this can be checked:
-        on Button#Switch=3 do //will fire if doubleclick
+        on Button#State=3 do //will fire if doubleclick
         \**************************************************************************/
 
         //long difftimer1 = 0;
@@ -545,8 +545,8 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
             So we can trigger longpress for high or low contact
 
             In rules this can be checked:
-            on Button#Switch=10 do //will fire if longpress when state = 0
-            on Button#Switch=11 do //will fire if longpress when state = 1
+            on Button#State=10 do //will fire if longpress when state = 0
+            on Button#State=11 do //will fire if longpress when state = 1
             \**************************************************************************/
             // Reset SafeButton counter
             PCONFIG_LONG(3) = 0;

--- a/src/_P009_MCP.ino
+++ b/src/_P009_MCP.ino
@@ -31,7 +31,7 @@ TaskDevicePluginConfigLong settings:
 #define PLUGIN_009
 #define PLUGIN_ID_009         9
 #define PLUGIN_NAME_009       "Switch input - MCP23017"
-#define PLUGIN_VALUENAME1_009 "Switch"
+#define PLUGIN_VALUENAME1_009 "State"
 #define PLUGIN_009_DOUBLECLICK_MIN_INTERVAL 1000
 #define PLUGIN_009_DOUBLECLICK_MAX_INTERVAL 3000
 #define PLUGIN_009_LONGPRESS_MIN_INTERVAL 1000
@@ -284,7 +284,7 @@ boolean Plugin_009(byte function, struct EventStruct *event, String& string)
 
         Returned EVENT value is = 3 always for doubleclick
         In rules this can be checked:
-        on Button#Switch=3 do //will fire if doubleclick
+        on Button#State=3 do //will fire if doubleclick
         \**************************************************************************/
         portStatusStruct currentStatus;
         const uint32_t key = createKey(PLUGIN_ID_009,CONFIG_PORT);
@@ -395,8 +395,8 @@ boolean Plugin_009(byte function, struct EventStruct *event, String& string)
             So we can trigger longpress for high or low contact
 
             In rules this can be checked:
-            on Button#Switch=10 do //will fire if longpress when state = 0
-            on Button#Switch=11 do //will fire if longpress when state = 1
+            on Button#State=10 do //will fire if longpress when state = 0
+            on Button#State=11 do //will fire if longpress when state = 1
             \**************************************************************************/
             // Reset SafeButton counter
             PCONFIG_LONG(3) = 0;

--- a/src/_P019_PCF8574.ino
+++ b/src/_P019_PCF8574.ino
@@ -31,7 +31,7 @@ TaskDevicePluginConfigLong settings:
 #define PLUGIN_019
 #define PLUGIN_ID_019         19
 #define PLUGIN_NAME_019       "Switch input - PCF8574"
-#define PLUGIN_VALUENAME1_019 "Switch"
+#define PLUGIN_VALUENAME1_019 "State"
 #define PLUGIN_019_DOUBLECLICK_MIN_INTERVAL 1000
 #define PLUGIN_019_DOUBLECLICK_MAX_INTERVAL 3000
 #define PLUGIN_019_LONGPRESS_MIN_INTERVAL 1000
@@ -281,7 +281,7 @@ boolean Plugin_019(byte function, struct EventStruct *event, String& string)
 
         Returned EVENT value is = 3 always for doubleclick
         In rules this can be checked:
-        on Button#Switch=3 do //will fire if doubleclick
+        on Button#State=3 do //will fire if doubleclick
         \**************************************************************************/
         portStatusStruct currentStatus;
         const uint32_t key = createKey(PLUGIN_ID_019,CONFIG_PORT);
@@ -392,8 +392,8 @@ boolean Plugin_019(byte function, struct EventStruct *event, String& string)
             So we can trigger longpress for high or low contact
 
             In rules this can be checked:
-            on Button#Switch=10 do //will fire if longpress when state = 0
-            on Button#Switch=11 do //will fire if longpress when state = 1
+            on Button#State=10 do //will fire if longpress when state = 0
+            on Button#State=11 do //will fire if longpress when state = 1
             \**************************************************************************/
             // Reset SafeButton counter
             PCONFIG_LONG(3) = 0;


### PR DESCRIPTION
As suggested on the [forum](https://www.letscontrolit.com/forum/viewtopic.php?p=33065#p35422) by #ShaMAD

The default switch/relay rules now work immediately after boot so no need anymore to press the button twice after boot to get in sync with the relay.