### PR TITLE
[Energy] Call delay from scheduler during idle time

### DIFF
--- a/docs/source/Tools/Tools.rst
+++ b/docs/source/Tools/Tools.rst
@@ -4,8 +4,113 @@ Tools
 Log
 ===
 
-INFO
+Info
 ====
+
+Advanced
+========
+
+Special and Experimental Settings
+---------------------------------
+
+Fixed IP Octet
+^^^^^^^^^^^^^^
+
+Sets the last byte(octet) of the IP address to this value, regardless of what IP is given using DHCP (all other settings received via DHCP will be used)
+
+So if you receive 192.168.1.234 from your DHCP server and this value is set to "10",
+then the used IP in your node is 192.168.1.10.
+But since you're receiving more information from the DHCP server,
+like subnet mask / gateway / DNS, it may still be useful.
+This allows a somewhat static IP in your network (N.B. use it with an 'octet' outside the range of the DHCP IPs) while still having set to DHCP.
+So if you take the node to another network which does use 192.168.52.x then you will know it will be on 192.168.52.10 (when setting this value to "10")
+
+I2C ClockStretchLimit
+^^^^^^^^^^^^^^^^^^^^^
+
+- `I2C-bus.org - Clock Stretching <https://www.i2c-bus.org/clock-stretching/>`_
+- `ESPeasy wiki - Basics: The I2C Bus <https://www.letscontrolit.com/wiki/index.php/Basics:_The_I%C2%B2C_Bus>`_
+
+WD I2C Address
+^^^^^^^^^^^^^^
+
+The Watchdog timer can be accessed via I2C.
+What can be read/set/changed must still be documented.
+
+Use SSDP
+^^^^^^^^
+
+Is disabled for now since it is causing crashes.
+SSDP can be used to help auto discovery of a node.
+For example Windows uses it to find hosts on a network.
+
+Connection Failure Threshold
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Number of failed network connect attempts before issuing a reboot (0 = disabled)
+A side effect is that trying to reach some server which is offline, may also result
+in reboots of the ESP node.
+
+Force WiFi B/G
+^^^^^^^^^^^^^^
+
+Force the WiFi to use only 802.11-B or -G protocol (not -N)
+Since the 802.11 G mode of the ESP is more tolerant to noise, it may improve link
+stability on some nodes.
+
+Restart WiFi on lost conn.
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Force a complete WiFi radio shutdown & restart when connection with access point is lost.
+
+Force WiFi no sleep
+^^^^^^^^^^^^^^^^^^^
+
+This option will set the WiFi sleep mode to no sleep.
+This may cause the node to consume maximum power and should only be used for testing purposes.
+It may even lead to more instability on nodes where the power supply is not
+sufficient or the extra heat cannot be dissipated.
+
+Since changing the mode back to the default setting may lead to crashes in some core versions, this option is only enabled when starting the node.
+To activate a change of this setting, a reboot is required.
+
+Periodical send Gratuitous ARP
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ESP node may sometimes miss ARP broadcast packets and thus not answer them if needed.
+This may lead to the situation where a packet sent to the node cannot be delivered,
+since the switch does not know how to route the packet.
+To overcome this, the ESP node may send a *Gratuitous ARP* packet, which is
+essentially an answer to a request which hasn't been made.
+These gratuitous ARP packets however may help the switch to remember which
+MAC address is connected via what port.
+
+By default the ESP will send out such a gratuitous ARP packet every time it
+receives an IP address and also when it was unable to make a connection to a host.
+It could be the other host was replying, but the packet was not routable to the ESP node.
+
+This *Periodical send Gratuitous ARP* option will send these kind of ARP packets
+continuously with some interval.
+This interval is defined in the source code in ``TIMER_GRATUITOUS_ARP_MAX`` (e.g. 5000 msec)
+
+
+CPU Eco mode
+^^^^^^^^^^^^
+
+Will call delay() from scheduler during idle loops.
+This will result in a significant energy reduction of up-to 0.2 Watt.
+
+However, it is no guarantee the power consumption will be reduced.
+For example when the host is receiving continuous ping requests, it will never activate the power save mode.
+
+If the power save mode is active, the node may miss some broadcast packets.
+For example the ESPeasy p2p packets will be missed every now and then, so do not
+activate this mode when response time  on received packets is important.
+
+If the node is only sending packets (e.g. only a sensor connected and sending to some server),
+then this is a great way to save energy and also reduce heat.
+
+
 
 Show JSON
 =========
@@ -31,10 +136,10 @@ The Factory Reset allows just that, and more.
 Pre-defined module configurations help to setup the following:
 
 - GPIO connected to button => plugin switch configured
-- GPIO connected to relais => plugin switch configured
+- GPIO connected to relay => plugin switch configured
 - If there is a conflict with default I2C pins, then those are set to no pin assigned for I2C
 - Status LED GPIO
-- Added rule to combine button and relais.
+- Added rule to combine button and relay.
 
 .. image:: images/FactoryReset_screenshot.png
 

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -39,9 +39,9 @@
 #define DEFAULT_WIFI_CONNECTION_TIMEOUT  10000  // minimum timeout in ms for WiFi to be connected.
 #define DEFAULT_WIFI_FORCE_BG_MODE       false  // when set, only allow to connect in 802.11B or G mode (not N)
 #define DEFAULT_WIFI_RESTART_WIFI_CONN_LOST  false // Perform wifi off and on when connection was lost.
-#define DEFAULT_ECO_MODE                 true   // When set, make idle calls between executing tasks.
+#define DEFAULT_ECO_MODE                 false   // When set, make idle calls between executing tasks.
 #define DEFAULT_WIFI_NONE_SLEEP          false  // When set, the wifi will be set to no longer sleep (more power used and need reboot to reset mode)
-#define DEFAULT_GRATUITOUS_ARD           true   // When set, the node will send periodical gratuitous ARP packets to announce itself.
+#define DEFAULT_GRATUITOUS_ARD           false  // When set, the node will send periodical gratuitous ARP packets to announce itself.
 
 // --- Default Controller ------------------------------------------------------------------------------
 #define DEFAULT_CONTROLLER   false              // true or false enabled or disabled, set 1st controller defaults
@@ -228,8 +228,8 @@
 #define TIMER_C012_DELAY_QUEUE             17
 #define TIMER_C013_DELAY_QUEUE             18
 
-#define TIMING_STATS_THRESHOLD         100000
-#define TIMER_GRATUITOUS_ARP_MAX       60000L
+#define TIMING_STATS_THRESHOLD             100000
+#define TIMER_GRATUITOUS_ARP_MAX           5000
 
 // Minimum delay between messages for a controller to send in msec.
 #define CONTROLLER_DELAY_QUEUE_DELAY_MAX   3600000
@@ -736,9 +736,8 @@ struct SettingsStruct
   bool WiFiRestart_connection_lost() {  return getBitFromUL(VariousBits1, 5); }
   void WiFiRestart_connection_lost(bool value) {  setBitToUL(VariousBits1, 5, value); }
 
-  // Enable eco mode by default, so invert the values (default = 0)
-  bool EcoPowerMode() {  return !getBitFromUL(VariousBits1, 6); }
-  void EcoPowerMode(bool value) {  setBitToUL(VariousBits1, 6, !value); }
+  bool EcoPowerMode() {  return getBitFromUL(VariousBits1, 6); }
+  void EcoPowerMode(bool value) {  setBitToUL(VariousBits1, 6, value); }
 
   bool WifiNoneSleep() {  return getBitFromUL(VariousBits1, 7); }
   void WifiNoneSleep(bool value) {  setBitToUL(VariousBits1, 7, value); }

--- a/src/ESPEasyStorage.ino
+++ b/src/ESPEasyStorage.ino
@@ -202,6 +202,7 @@ void afterloadSettings() {
   if (modelMatchingFlashSize(model)) {
     ResetFactoryDefaultPreference = Settings.ResetFactoryDefaultPreference;
   }
+  msecTimerHandler.setEcoMode(Settings.EcoPowerMode());
 }
 
 /********************************************************************************************\

--- a/src/ESPEasyWifi.ino
+++ b/src/ESPEasyWifi.ino
@@ -143,6 +143,7 @@ void processGotIP() {
   MQTTclient_should_reconnect = true;
   timermqtt_interval = 100;
   setIntervalTimer(TIMER_MQTT);
+  sendGratuitousARP_now();
   if (Settings.UseRules)
   {
     String event = F("WiFi#Connected");
@@ -530,6 +531,11 @@ bool prepareWiFi() {
   safe_strncpy(hostname, WifiGetHostname().c_str(), sizeof(hostname));
   #if defined(ESP8266)
     wifi_station_set_hostname(hostname);
+    if (Settings.WifiNoneSleep()) {
+      // Only set this mode during setup.
+      // Reset to default power mode requires a reboot since setting it to WIFI_LIGHT_SLEEP will cause a crash.
+      WiFi.setSleepMode(WIFI_NONE_SLEEP);
+    }
   #endif
   #if defined(ESP32)
     WiFi.setHostname(hostname);

--- a/src/Networking.ino
+++ b/src/Networking.ino
@@ -6,6 +6,9 @@
 #define IPADDR2STR(addr) (uint8_t)((uint32_t)addr &  0xFF), (uint8_t)(((uint32_t)addr >> 8) &  0xFF), (uint8_t)(((uint32_t)addr >> 16) &  0xFF), (uint8_t)(((uint32_t)addr >> 24) &  0xFF)
 //  #endif
 
+#include <lwip/netif.h>
+#include <lwip/etharp.h>
+
 /*********************************************************************************************\
    Syslog client
   \*********************************************************************************************/
@@ -227,9 +230,14 @@ void sendUDP(byte unit, byte* data, byte size)
   \*********************************************************************************************/
 void refreshNodeList()
 {
+  bool mustSendGratuitousARP = false;
   for (NodesMap::iterator it = Nodes.begin(); it != Nodes.end(); ) {
     bool mustRemove = true;
     if (it->second.ip[0] != 0) {
+      if (it->second.age > 8) {
+        // Increase frequency sending ARP requests for 2 minutes
+        mustSendGratuitousARP = true;
+      }
       if (it->second.age < 10) {
         it->second.age++;
         mustRemove = false;
@@ -239,6 +247,9 @@ void refreshNodeList()
     if (mustRemove) {
       it = Nodes.erase(it);
     }
+  }
+  if (mustSendGratuitousARP) {
+    sendGratuitousARP_now();
   }
 }
 
@@ -710,6 +721,9 @@ bool connectClient(WiFiClient& client, IPAddress ip, uint16_t port)
     return false;
   }
   bool connected = (client.connect(ip, port) == 1);
+  if (!connected) {
+    sendGratuitousARP_now();
+  }
   STOP_TIMER(CONNECT_CLIENT_STATS);
 #if defined(ESP32) || defined(ARDUINO_ESP8266_RELEASE_2_3_0) || defined(ARDUINO_ESP8266_RELEASE_2_4_0)
 #else
@@ -729,6 +743,9 @@ bool resolveHostByName(const char* aHostname, IPAddress& aResult) {
 #else
   bool resolvedIP = WiFi.hostByName(aHostname, aResult, CONTROLLER_CLIENTTIMEOUT_DFLT) == 1;
 #endif
+  if (!resolvedIP) {
+    sendGratuitousARP_now();
+  }
   STOP_TIMER(HOST_BY_NAME_STATS);
   return resolvedIP;
 }
@@ -758,4 +775,14 @@ bool beginWiFiUDP_randomPort(WiFiUDP& udp) {
       return true;
   }
   return false;
+}
+
+void sendGratuitousARP() {
+  START_TIMER;
+  netif *n = netif_list;
+  while (n) {
+    etharp_gratuitous(n);
+    n = n->next;
+  }
+  STOP_TIMER(GRAT_ARP_STATS);
 }

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -5003,6 +5003,7 @@ void handle_advanced() {
   addFormNote(F("Change WiFi sleep settings requires reboot to activate"));
   addFormCheckBox(F("Periodical send Gratuitous ARP"), F("gratuitous_arp"), Settings.gratuitousARP());
   addFormCheckBox(F("CPU Eco mode"), F("eco_mode"), Settings.EcoPowerMode());
+  addFormNote(F("Node may miss receiving packets with Eco mode enabled"));
 
   addFormNumericBox(F("I2C ClockStretchLimit"), F("wireclockstretchlimit"), Settings.WireClockStretchLimit);   //TODO define limits
   #if defined(FEATURE_ARDUINO_OTA)

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -4906,6 +4906,9 @@ void handle_advanced() {
     Settings.OldRulesEngine(isFormItemChecked(F("oldrulesengine")));
     Settings.ForceWiFi_bg_mode(isFormItemChecked(F("forcewifi_bg")));
     Settings.WiFiRestart_connection_lost(isFormItemChecked(F("wifi_restart_conn_lost")));
+    Settings.EcoPowerMode(isFormItemChecked(F("eco_mode")));
+    Settings.WifiNoneSleep(isFormItemChecked(F("wifi_none_sleep")));
+    Settings.gratuitousARP(isFormItemChecked(F("gratuitous_arp")));
 
     addHtmlError(SaveSettings());
     if (systemTimePresent())
@@ -4994,6 +4997,12 @@ void handle_advanced() {
 #endif
 
   addFormCheckBox(F("Restart WiFi on lost conn."), F("wifi_restart_conn_lost"), Settings.WiFiRestart_connection_lost());
+#ifdef ESP8266
+  addFormCheckBox(F("Force WiFi no sleep"), F("wifi_none_sleep"), Settings.WifiNoneSleep());
+#endif
+  addFormNote(F("Change WiFi sleep settings requires reboot to activate"));
+  addFormCheckBox(F("Periodical send Gratuitous ARP"), F("gratuitous_arp"), Settings.gratuitousARP());
+  addFormCheckBox(F("CPU Eco mode"), F("eco_mode"), Settings.EcoPowerMode());
 
   addFormNumericBox(F("I2C ClockStretchLimit"), F("wireclockstretchlimit"), Settings.WireClockStretchLimit);   //TODO define limits
   #if defined(FEATURE_ARDUINO_OTA)


### PR DESCRIPTION
This will reduce the loop counter and even cause some inverse effect. Higher loop count means the node has more work to do (less scheduled tasks which are not yet due for work)

Initial tests show a significant lower power consumption and thus hopefully a more stable wifi connection.
The average used delay during idle calls can be seen in the timing stats (likely around 2.5 msec per idle loop)
The CPU load (in %) is still the same as before this patch, but the node feels a bit more 'snappy' and the extremes in the timing stats are lower.

See also [this discussion](https://github.com/esp8266/Arduino/issues/5825#issuecomment-468432426)