### PR TITLE
[ADC] Use simple filter for ADC plugin and show value on setup page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
   apt:
     packages:
     - cppcheck
-
+    - binutils
 
 
 install:

--- a/before_deploy
+++ b/before_deploy
@@ -30,6 +30,8 @@ if [ -d "docs/build" ]; then
   cp -r docs/build/* ${TMP_DIST}/docs/
 fi
 
+mkdir -p ${TMP_DIST}/memstats
+
 for ENV in \
   dev_ESP8266_4M\
   esp-wrover-kit_test_1M8_partition\
@@ -94,6 +96,16 @@ do
     mv $BIN "${TMP_DIST}/bin/ESP_Easy_${VERSION}_${ENV}.bin"
   else
     echo "Build too large for $ENV $FILESIZE > $MAX_FILESIZE "
+  fi
+
+  ELFFILE=`echo ".pioenvs/${ENV}/firmware.elf"`
+  if [ -f $ELFFILE ]; then
+    SYMBOLS_STATS=`echo "${TMP_DIST}/memstats/${ENV}_symbols.txt"`
+    STRINGS_STATS=`echo "${TMP_DIST}/memstats/${ENV}_strings.txt"`
+    readelf -a ${ELFFILE} |grep 3ff |sort -n -k 3 > ${SYMBOLS_STATS}
+    objdump  -s -j .rodata ${ELFFILE} > ${STRINGS_STATS}
+    gzip ${SYMBOLS_STATS}
+    gzip ${STRINGS_STATS}
   fi
 done
 

--- a/before_deploy
+++ b/before_deploy
@@ -100,12 +100,10 @@ do
 
   ELFFILE=`echo ".pioenvs/${ENV}/firmware.elf"`
   if [ -f $ELFFILE ]; then
-    SYMBOLS_STATS=`echo "${TMP_DIST}/memstats/${ENV}_symbols.txt"`
-    STRINGS_STATS=`echo "${TMP_DIST}/memstats/${ENV}_strings.txt"`
+    SYMBOLS_STATS=`echo "${TMP_DIST}/memstats/symbols_${ENV}.txt"`
+    STRINGS_STATS=`echo "${TMP_DIST}/memstats/strings_${ENV}.txt"`
     readelf -a ${ELFFILE} |grep 3ff |sort -n -k 3 > ${SYMBOLS_STATS}
     objdump  -s -j .rodata ${ELFFILE} > ${STRINGS_STATS}
-    gzip ${SYMBOLS_STATS}
-    gzip ${STRINGS_STATS}
   fi
 done
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -164,15 +164,17 @@ upload_speed              = 115200
 framework                 = arduino
 board                     = esp12e
 monitor_speed             = 115200
+;targets                   = size, checkprogsize
+targets                   =
 
 [regular_platform]
 build_unflags             =
-build_flags               = ${core_2_4_2.build_flags}
+build_flags               = ${core_2_4_2.build_flags} -DBUILD_NO_DEBUG -DWEBSERVER_RULES_DEBUG=0
 platform                  = ${core_2_4_2.platform}
 
 [beta_platform]
 build_unflags             =
-build_flags               = ${core_stage.build_flags} -DARDUINO_ESP8266_RELEASE='"2.6.0-dev"'
+build_flags               = ${core_stage.build_flags} -DARDUINO_ESP8266_RELEASE='"2.6.0-dev"' -DBUILD_NO_DEBUG -DWEBSERVER_RULES_DEBUG=0
 platform                  = ${core_stage.platform}
 
 
@@ -315,6 +317,7 @@ monitor_speed             = ${common.monitor_speed}
 board_build.partitions    = esp32_partition_app1810k_spiffs316k.csv
 board_upload.maximum_size = 1900544
 debug_extra_cmds          = break Misc.ino:3011
+targets                   = ${common.targets}
 
 
 ; 2018-02-17 TD-er
@@ -346,6 +349,8 @@ upload_speed              = ${common.upload_speed}
 monitor_speed             = ${common.monitor_speed}
 board_build.partitions    = esp32_partition_app1810k_spiffs316k.csv
 board_upload.maximum_size = 1900544
+targets                   = ${common.targets}
+
 
 
 ;;; NORMAL (STABLE) ; ****; ****; ****; ****; ****; ****; ****; ****; ****; ****; ****;;;;
@@ -368,6 +373,8 @@ board_build.f_cpu         = ${esp8266_1M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
 build_unflags             = ${esp8266_1M.build_unflags}
 build_flags               = ${esp8266_1M.build_flags} ${normal.build_flags}
+targets                   = ${common.targets}
+
 
 [env:normal_ESP8266_1M_VCC]
 platform                  = ${normal.platform}
@@ -384,6 +391,8 @@ board_build.f_cpu         = ${esp8266_1M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
 build_unflags             = ${esp8266_1M.build_unflags}
 build_flags               = ${esp8266_1M.build_flags} ${normal.build_flags} -D FEATURE_ADC_VCC=true
+targets                   = ${common.targets}
+
 
 [env:minimal_ESP8266_1M_OTA]
 platform                  = ${normal_ota.platform}
@@ -400,6 +409,8 @@ board_build.f_cpu         = ${esp8266_1M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
 build_unflags             = ${esp8266_1M.build_unflags}
 build_flags               = ${esp8266_1M.build_flags} ${normal_ota.build_flags}
+targets                   = ${common.targets}
+
 
 [env:minimal_ESP8285_1M_OTA]
 platform                  = ${normal_ota.platform}
@@ -416,6 +427,8 @@ board_build.f_cpu         = ${esp8285_1M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8285_1M.board_build.flash_mode}
 build_unflags             = ${esp8285_1M.build_unflags}
 build_flags               = ${esp8285_1M.build_flags} ${normal_ota.build_flags}
+targets                   = ${common.targets}
+
 
 [env:minimal_core_250_ESP8266_1M_OTA]
 platform                  = ${normal_250_ota.platform}
@@ -432,6 +445,8 @@ board_build.f_cpu         = ${esp8266_1M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
 build_unflags             = ${esp8266_1M.build_unflags}
 build_flags               = ${esp8266_1M.build_flags} ${normal_250_ota.build_flags}
+targets                   = ${common.targets}
+
 
 [env:minimal_core_250_ESP8285_1M_OTA]
 platform                  = ${normal_250_ota.platform}
@@ -448,6 +463,8 @@ board_build.f_cpu         = ${esp8285_1M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8285_1M.board_build.flash_mode}
 build_unflags             = ${esp8285_1M.build_unflags}
 build_flags               = ${esp8285_1M.build_flags} ${normal_250_ota.build_flags}
+targets                   = ${common.targets}
+
 
 [env:normal_core_241_ESP8266_1M]
 platform                  = ${normal_241.platform}
@@ -464,6 +481,8 @@ board_build.f_cpu         = ${esp8266_1M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
 build_unflags             = ${esp8266_1M.build_unflags}
 build_flags               = ${normal_241.build_flags} ${esp8266_1M.build_flags}
+targets                   = ${common.targets}
+
 
 [env:normal_core_242_ESP8266_1M]
 platform                  = ${normal_242.platform}
@@ -480,6 +499,8 @@ board_build.f_cpu         = ${esp8266_1M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
 build_unflags             = ${esp8266_1M.build_unflags}
 build_flags               = ${normal_242.build_flags} ${esp8266_1M.build_flags}
+targets                   = ${common.targets}
+
 
 
 [env:normal_core_250_ESP8266_1M]
@@ -497,6 +518,8 @@ board_build.f_cpu         = ${esp8266_1M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
 build_unflags             = ${esp8266_1M.build_unflags}
 build_flags               = ${normal_250.build_flags} ${esp8266_1M.build_flags}
+targets                   = ${common.targets}
+
 
 ; NORMAL: 1024k for esp8285 ----------------------
 [env:normal_ESP8285_1M]
@@ -514,6 +537,8 @@ board_build.f_cpu         = ${esp8285_1M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8285_1M.board_build.flash_mode}
 build_unflags             = ${esp8285_1M.build_unflags}
 build_flags               = ${esp8285_1M.build_flags} ${normal.build_flags}
+targets                   = ${common.targets}
+
 
 ; NORMAL: 2048k WROOM02 version --------------------------
 [env:normal_WROOM02_2M]
@@ -531,6 +556,8 @@ board_build.f_cpu         = ${espWroom2M.board_build.f_cpu}
 board_build.flash_mode    = ${espWroom2M.board_build.flash_mode}
 build_unflags             = ${espWroom2M.build_unflags}
 build_flags               = ${espWroom2M.build_flags} ${normal.build_flags}
+targets                   = ${common.targets}
+
 
 ; NORMAL: 2048k WROOM02 version 256k SPIFFS --------------------------
 [env:normal_core_250_WROOM02_2M256]
@@ -548,6 +575,8 @@ board_build.f_cpu         = ${espWroom2M256.board_build.f_cpu}
 board_build.flash_mode    = ${espWroom2M256.board_build.flash_mode}
 build_unflags             = ${espWroom2M256.build_unflags}
 build_flags               = ${espWroom2M256.build_flags} ${normal_250.build_flags}
+targets                   = ${common.targets}
+
 
 
 ; NORMAL: 4096k version --------------------------
@@ -565,6 +594,8 @@ board_build.f_cpu         = ${esp8266_4M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_4M.board_build.flash_mode}
 build_unflags             = ${esp8266_4M.build_unflags}
 build_flags               = ${esp8266_4M.build_flags} ${normal.build_flags}
+targets                   = ${common.targets}
+
 
 [env:normal_core_241_ESP8266_4M]
 platform                  = ${normal_241.platform}
@@ -580,6 +611,8 @@ board_build.f_cpu         = ${esp8266_4M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_4M.board_build.flash_mode}
 build_unflags             = ${esp8266_4M.build_unflags}
 build_flags               = ${normal_241.build_flags} ${esp8266_4M.build_flags}
+targets                   = ${common.targets}
+
 
 [env:normal_core_250_ESP8266_4M]
 platform                  = ${normal_250.platform}
@@ -595,6 +628,8 @@ board_build.f_cpu         = ${esp8266_4M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_4M.board_build.flash_mode}
 build_unflags             = ${esp8266_4M.build_unflags}
 build_flags               = ${normal_250.build_flags} ${esp8266_4M.build_flags}
+targets                   = ${common.targets}
+
 
 
 ; NORMAL IR: 4096k version --------------------------
@@ -613,6 +648,8 @@ board_build.f_cpu         = ${esp8266_1M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
 build_unflags             = ${esp8266_1M.build_unflags}
 build_flags               = ${normal_ir.build_flags} ${esp8266_1M.build_flags}
+targets                   = ${common.targets}
+
 
 ; NORMAL IR: 4096k version --------------------------
 ; Build including IR libraries
@@ -630,6 +667,8 @@ board_build.f_cpu         = ${esp8266_4M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_4M.board_build.flash_mode}
 build_unflags             = ${esp8266_4M.build_unflags}
 build_flags               = ${normal_ir.build_flags} ${esp8266_4M.build_flags}
+targets                   = ${common.targets}
+
 
 [env:normal_core_250_IR_ESP8266_4M]
 platform                  = ${normal_250_ir.platform}
@@ -645,6 +684,8 @@ board_build.f_cpu         = ${esp8266_4M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_4M.board_build.flash_mode}
 build_unflags             = ${esp8266_4M.build_unflags}
 build_flags               = ${normal_250_ir.build_flags} ${esp8266_4M.build_flags}
+targets                   = ${common.targets}
+
 
 
 ;;; TESTING ; ****; ****; ****; ****; ****; ****; ****; ****; ****; ****; ****; ****; ****
@@ -667,6 +708,8 @@ build_flags               = ${normal_250_ir.build_flags} ${esp8266_4M.build_flag
 ;board_build.f_cpu         = ${esp8266_1M.board_build.f_cpu}
 ;build_unflags             = ${esp8266_1M.build_unflags}
 ;build_flags               = ${esp8266_1M.build_flags} ${testing.build_flags}
+;targets                   = ${common.targets}
+
 
 ; TEST: 1024k for esp8285 ------------------------
 ;[env:test_ESP8285_1M]
@@ -684,6 +727,8 @@ build_flags               = ${normal_250_ir.build_flags} ${esp8266_4M.build_flag
 ;board                     = ${esp8285_1M.board}
 ;build_unflags             = ${esp8285_1M.build_unflags}
 ;build_flags               = ${esp8285_1M.build_flags} ${testing.build_flags}
+;targets                   = ${common.targets}
+
 
 
 ; TEST: 4096k version ----------------------------
@@ -701,6 +746,8 @@ board_build.f_cpu         = ${esp8266_4M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_4M.board_build.flash_mode}
 build_unflags             = ${esp8266_4M.build_unflags}
 build_flags               = ${esp8266_4M.build_flags} ${testing_242.build_flags}
+targets                   = ${common.targets}
+
 
 
 [env:test_core_250_ESP8266_4M]
@@ -717,6 +764,8 @@ board_build.f_cpu         = ${esp8266_4M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_4M.board_build.flash_mode}
 build_unflags             = ${esp8266_4M.build_unflags}
 build_flags               = ${esp8266_4M.build_flags} ${testing_250.build_flags}
+targets                   = ${common.targets}
+
 
 [env:normal_core_260_sdk2_alpha_ESP8266_4M]
 platform                  = ${testing_beta.platform}
@@ -732,6 +781,8 @@ board_build.f_cpu         = ${esp8266_4M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_4M.board_build.flash_mode}
 build_unflags             = ${esp8266_4M.build_unflags}
 build_flags               = ${esp8266_4M.build_flags} ${normal_beta.build_flags}
+targets                   = ${common.targets}
+
 
 [env:test_core_260_sdk2_alpha_ESP8266_4M]
 platform                  = ${testing_beta.platform}
@@ -747,6 +798,8 @@ board_build.f_cpu         = ${esp8266_4M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_4M.board_build.flash_mode}
 build_unflags             = ${esp8266_4M.build_unflags}
 build_flags               = ${esp8266_4M.build_flags} ${testing_beta.build_flags}
+targets                   = ${common.targets}
+
 
 
 [env:test_core_260_sdk3_alpha_ESP8266_4M]
@@ -763,6 +816,8 @@ board_build.f_cpu         = ${esp8266_4M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_4M.board_build.flash_mode}
 build_unflags             = ${esp8266_4M.build_unflags}
 build_flags               = ${esp8266_4M.build_flags} ${testing_beta.build_flags} -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK3
+targets                   = ${common.targets}
+
 
 ; TEST: 1024k version + FEATURE_ADC_VCC ----------
 ;[env:test_ESP8266_1M_VCC]
@@ -779,6 +834,8 @@ build_flags               = ${esp8266_4M.build_flags} ${testing_beta.build_flags
 ;board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
 ;build_unflags             = ${esp8266_1M.build_unflags}
 ;build_flags               = ${esp8266_1M.build_flags} ${testing.build_flags} -D FEATURE_ADC_VCC=true
+;targets                   = ${common.targets}
+
 
 ; TEST: 4096k version + FEATURE_ADC_VCC ----------
 [env:test_ESP8266_4M_VCC]
@@ -795,6 +852,8 @@ board_build.f_cpu         = ${esp8266_4M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_4M.board_build.flash_mode}
 build_unflags             = ${esp8266_4M.build_unflags}
 build_flags               = ${esp8266_4M.build_flags} ${testing.build_flags} -D FEATURE_ADC_VCC=true
+targets                   = ${common.targets}
+
 
 [env:test_core_260_sdk2_alpha_ESP8266_4M_VCC]
 platform                  = ${testing_beta.platform}
@@ -810,6 +869,8 @@ board_build.f_cpu         = ${esp8266_4M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_4M.board_build.flash_mode}
 build_unflags             = ${esp8266_4M.build_unflags}
 build_flags               = ${esp8266_4M.build_flags} ${testing_beta.build_flags} -D FEATURE_ADC_VCC=true
+targets                   = ${common.targets}
+
 
 
 ;;; DEV ; ****; ****; ****; ****; ****; ****; ****; ****; ****; ****; ****; ****; ****;;;;
@@ -832,6 +893,8 @@ build_flags               = ${esp8266_4M.build_flags} ${testing_beta.build_flags
 ;board                     = ${esp8266_1M.board}
 ;build_unflags             = ${esp8266_1M.build_unflags}
 ;build_flags               = ${esp8266_1M.build_flags} ${dev.build_flags}
+;targets                   = ${common.targets}
+
 
 ; DEV: 1024k for esp8285 -------------------------
 ;[env:dev_ESP8285_1M]
@@ -849,6 +912,8 @@ build_flags               = ${esp8266_4M.build_flags} ${testing_beta.build_flags
 ;board                     = ${esp8285_1M.board}
 ;build_unflags             = ${esp8285_1M.build_unflags}
 ;build_flags               = ${esp8285_1M.build_flags} ${dev.build_flags}
+;targets                   = ${common.targets}
+
 
 ; DEV : 4096k version ----------------------------
 [env:dev_ESP8266_4M]
@@ -865,6 +930,8 @@ board_build.f_cpu         = ${esp8266_4M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_4M.board_build.flash_mode}
 build_unflags             = ${esp8266_4M.build_unflags}
 build_flags               = ${esp8266_4M.build_flags} ${dev.build_flags}
+targets                   = ${common.targets}
+
 
 
 ;;; HARDWARE SPECIFIC VERSIONS ; ****; ****; ****; ****; ****; ****; ****; ****; ****;;;;;
@@ -888,6 +955,8 @@ build_flags               = ${esp8266_4M.build_flags} ${dev.build_flags}
 ;board                     = ${esp8266_1M.board}
 ;build_unflags             = ${esp8266_1M.build_unflags}
 ;build_flags               = ${esp8266_1M.build_flags} -D PLUGIN_SET_SONOFF_BASIC
+;targets                   = ${common.targets}
+
 
 
 ; ITEAD / SONOFF TH10/TH16 version -------------------
@@ -905,6 +974,8 @@ build_flags               = ${esp8266_4M.build_flags} ${dev.build_flags}
 ;board                     = ${esp8266_1M.board}
 ;build_unflags             = ${esp8266_1M.build_unflags}
 ;build_flags               = ${esp8266_1M.build_flags} -D PLUGIN_SET_SONOFF_TH1x
+;targets                   = ${common.targets}
+
 
 ; ITEAD / SONOFF POW & POW R2 version --------------------
 ; Sonoff Pow (ESP8266 - HLW8012)
@@ -935,6 +1006,8 @@ board_build.flash_mode    = ${esp8266_4M.board_build.flash_mode}
 board                     = ${esp8266_4M.board}
 build_unflags             = ${esp8266_4M.build_unflags}
 build_flags               = ${normal.build_flags} ${esp8266_4M.build_flags} -D PLUGIN_SET_SONOFF_POW
+targets                   = ${common.targets}
+
 
 [env:hard_core_250_SONOFF_POW_4M]
 upload_speed              = ${common.upload_speed}
@@ -950,6 +1023,8 @@ board_build.flash_mode    = ${esp8266_4M.board_build.flash_mode}
 board                     = ${esp8266_4M.board}
 build_unflags             = ${esp8266_4M.build_unflags}
 build_flags               = ${normal_250.build_flags} ${esp8266_4M.build_flags} -D PLUGIN_SET_SONOFF_POW
+targets                   = ${common.targets}
+
 
 ; ITEAD / SONOFF S20 version --------------------
 ;[env:hard_SONOFF_S20]
@@ -966,6 +1041,8 @@ build_flags               = ${normal_250.build_flags} ${esp8266_4M.build_flags} 
 ;board                     = ${esp8266_1M.board}
 ;build_unflags             = ${esp8266_1M.build_unflags}
 ;build_flags               = ${esp8266_1M.build_flags} -D PLUGIN_SET_SONOFF_S2x
+;targets                   = ${common.targets}
+
 
 ; ITEAD / SONOFF 4CH version --------------------
 ;[env:hard_SONOFF_4CH]
@@ -982,6 +1059,8 @@ build_flags               = ${normal_250.build_flags} ${esp8266_4M.build_flags} 
 ;board                     = ${esp8266_1M.board}
 ;build_unflags             = ${esp8266_1M.build_unflags}
 ;build_flags               = ${esp8266_1M.build_flags} -D PLUGIN_SET_SONOFF_4CH
+;targets                   = ${common.targets}
+
 
 ; ITEAD / SONOFF TOUCH version ------------------
 ;[env:hard_SONOFF_TOUCH]
@@ -998,6 +1077,8 @@ build_flags               = ${normal_250.build_flags} ${esp8266_4M.build_flags} 
 ;board                     = ${esp8266_1M.board}
 ;build_unflags             = ${esp8266_1M.build_unflags}
 ;build_flags               = ${esp8266_1M.build_flags} -D PLUGIN_SET_SONOFF_TOUCH
+;targets                   = ${common.targets}
+
 
 ; Shelly1 Open Source (ESP8266-2MB)
 ; https://shelly.cloud/shelly1-open-source/
@@ -1017,6 +1098,8 @@ board_build.flash_mode    = ${esp8266_2M256.board_build.flash_mode}
 board                     = ${esp8266_2M256.board}
 build_unflags             = ${esp8266_2M256.build_unflags}
 build_flags               = ${normal_250.build_flags} ${esp8266_2M256.build_flags} -D PLUGIN_SET_SHELLY_1
+targets                   = ${common.targets}
+
 
 
 
@@ -1038,3 +1121,4 @@ board_build.flash_mode    = ${esp8266_1M.board_build.flash_mode}
 board                     = ${esp8266_1M.board}
 build_unflags             = ${esp8266_1M.build_unflags}
 build_flags               = ${normal.build_flags} ${esp8266_1M.build_flags} -D PLUGIN_SET_VENTUS_W266
+targets                   = ${common.targets}

--- a/platformio.ini
+++ b/platformio.ini
@@ -151,10 +151,12 @@ lib_ignore                = AS_BH1750, ESP8266WiFi, ESP8266Ping, ESP8266WebServe
 lib_deps                  = https://github.com/TD-er/ESPEasySerial.git
 monitor_speed             = 115200
 
-
+[debug_flags]
+build_flags               = -DBUILD_NO_DEBUG -DWEBSERVER_RULES_DEBUG=0
 
 [common]
 board_build.f_cpu         = 80000000L
+build_flags               = ${debug_flags.build_flags}
 build_unflags             = -DDEBUG_ESP_PORT
 lib_deps                  = ""
 lib_ignore                = ESP32_ping, ESP32WebServer, IRremoteESP8266
@@ -169,12 +171,12 @@ targets                   =
 
 [regular_platform]
 build_unflags             =
-build_flags               = ${core_2_4_2.build_flags} -DBUILD_NO_DEBUG -DWEBSERVER_RULES_DEBUG=0
+build_flags               = ${core_2_4_2.build_flags} ${common.build_flags}
 platform                  = ${core_2_4_2.platform}
 
 [beta_platform]
 build_unflags             =
-build_flags               = ${core_stage.build_flags} -DARDUINO_ESP8266_RELEASE='"2.6.0-dev"' -DBUILD_NO_DEBUG -DWEBSERVER_RULES_DEBUG=0
+build_flags               = ${core_stage.build_flags} ${common.build_flags} -DARDUINO_ESP8266_RELEASE='"2.6.0-dev"'
 platform                  = ${core_stage.platform}
 
 
@@ -185,15 +187,15 @@ build_flags               = ${regular_platform.build_flags}
 
 [normal_241]
 platform                  = ${core_2_4_1.platform}
-build_flags               = ${core_2_4_1.build_flags}  -DFORCE_PRE_2_5_0
+build_flags               = ${core_2_4_1.build_flags} ${common.build_flags} -DFORCE_PRE_2_5_0
 
 [normal_242]
 platform                  = ${core_2_4_2.platform}
-build_flags               = ${core_2_4_2.build_flags}  -DFORCE_PRE_2_5_0
+build_flags               = ${core_2_4_2.build_flags} ${common.build_flags} -DFORCE_PRE_2_5_0
 
 [normal_250]
 platform                  = ${core_2_5_0.platform}
-build_flags               = ${core_2_5_0.build_flags}
+build_flags               = ${core_2_5_0.build_flags} ${common.build_flags}
 
 [normal_beta]
 platform                  = ${beta_platform.platform}
@@ -207,7 +209,7 @@ board_upload.maximum_size = 616448
 
 [normal_250_ota]
 platform                  = ${core_2_5_0.platform}
-build_flags               = ${core_2_5_0.build_flags} -DPLUGIN_BUILD_MINIMAL_OTA
+build_flags               = ${core_2_5_0.build_flags} ${common.build_flags} -DPLUGIN_BUILD_MINIMAL_OTA
 board_upload.maximum_size = ${normal_ota.board_upload.maximum_size}
 
 [normal_beta_ota]
@@ -222,7 +224,7 @@ lib_ignore                = ESP32_ping, ESP32WebServer
 
 [normal_250_ir]
 platform                  = ${core_2_5_0.platform}
-build_flags               = ${core_2_5_0.build_flags} -DPLUGIN_BUILD_NORMAL_IR
+build_flags               = ${core_2_5_0.build_flags} ${common.build_flags} -DPLUGIN_BUILD_NORMAL_IR
 lib_ignore                = ESP32_ping, ESP32WebServer
 
 [testing]
@@ -231,11 +233,11 @@ build_flags               = ${regular_platform.build_flags} -DPLUGIN_BUILD_TESTI
 
 [testing_242]
 platform                  = ${core_2_4_2.platform}
-build_flags               = ${core_2_4_2.build_flags} -DPLUGIN_BUILD_TESTING
+build_flags               = ${core_2_4_2.build_flags} ${common.build_flags} -DPLUGIN_BUILD_TESTING
 
 [testing_250]
 platform                  = ${core_2_5_0.platform}
-build_flags               = ${core_2_5_0.build_flags} -DPLUGIN_BUILD_TESTING
+build_flags               = ${core_2_5_0.build_flags} ${common.build_flags} -DPLUGIN_BUILD_TESTING
 
 [testing_beta]
 platform                  = ${beta_platform.platform}

--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -181,13 +181,13 @@ bool MQTTConnect(int controller_idx)
 
   String LWTMessageConnect = ControllerSettings.LWTMessageConnect;
   if(LWTMessageConnect.length() == 0){
-    LWTMessageConnect = DEFAULT_MQTT_LWT_CONNECT_MESSAGE;
+    LWTMessageConnect = F(DEFAULT_MQTT_LWT_CONNECT_MESSAGE);
   }
   parseSystemVariables(LWTMessageConnect, false);
 
   String LWTMessageDisconnect = ControllerSettings.LWTMessageDisconnect;
   if(LWTMessageDisconnect.length() == 0){
-    LWTMessageDisconnect = DEFAULT_MQTT_LWT_DISCONNECT_MESSAGE;
+    LWTMessageDisconnect = F(DEFAULT_MQTT_LWT_DISCONNECT_MESSAGE);
   }
   parseSystemVariables(LWTMessageDisconnect, false);
 

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -35,6 +35,7 @@
 #define DEFAULT_IPRANGE_LOW  "0.0.0.0"          // Allowed IP range to access webserver
 #define DEFAULT_IPRANGE_HIGH "255.255.255.255"  // Allowed IP range to access webserver
 #define DEFAULT_IP_BLOCK_LEVEL 1                // 0: ALL_ALLOWED  1: LOCAL_SUBNET_ALLOWED  2: ONLY_IP_RANGE_ALLOWED
+#define DEFAULT_ADMIN_USERNAME  "admin"
 
 #define DEFAULT_WIFI_CONNECTION_TIMEOUT  10000  // minimum timeout in ms for WiFi to be connected.
 #define DEFAULT_WIFI_FORCE_BG_MODE       false  // when set, only allow to connect in 802.11B or G mode (not N)

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -168,10 +168,13 @@ void setup()
   emergencyReset();
 
   String log = F("\n\n\rINIT : Booting version: ");
-  log += BUILD_GIT;
+  log += F(BUILD_GIT);
   log += " (";
   log += getSystemLibraryString();
   log += ')';
+  addLog(LOG_LEVEL_INFO, log);
+  log = F("INIT : Free RAM:");
+  log += FreeMem();
   addLog(LOG_LEVEL_INFO, log);
 
 

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -498,6 +498,7 @@ void loop()
   if(MainLoopCall_ptr)
       MainLoopCall_ptr();
   */
+  dummyString = String(); // Fixme TD-er  Make sure this global variable doesn't keep memory allocated.
 
   updateLoopStats();
 

--- a/src/ESPEasyStorage.ino
+++ b/src/ESPEasyStorage.ino
@@ -572,7 +572,9 @@ String InitFile(const char* fname, int datasize)
 
     for (int x = 0; x < datasize ; x++)
     {
-      SPIFFS_CHECK(f.write(0), fname);
+      // See https://github.com/esp8266/Arduino/commit/b1da9eda467cc935307d553692fdde2e670db258#r32622483
+      uint8_t zero_value = 0;
+      SPIFFS_CHECK(f.write(&zero_value, 1), fname);
     }
     f.close();
   }
@@ -676,7 +678,9 @@ String ClearInFile(char* fname, int index, int datasize)
     SPIFFS_CHECK(f.seek(index, fs::SeekSet), fname);
     for (int x = 0; x < datasize ; x++)
     {
-      SPIFFS_CHECK(f.write(0), fname);
+      // See https://github.com/esp8266/Arduino/commit/b1da9eda467cc935307d553692fdde2e670db258#r32622483
+      uint8_t zero_value = 0;
+      SPIFFS_CHECK(f.write(&zero_value, 1), fname);
     }
     f.close();
   } else {

--- a/src/ESPEasyStorage.ino
+++ b/src/ESPEasyStorage.ino
@@ -46,7 +46,9 @@ String appendLineToFile(const String& fname, const String& line) {
   SPIFFS_CHECK(f, fname.c_str());
   const size_t lineLength = line.length();
   for (size_t i = 0; i < lineLength; ++i) {
-    SPIFFS_CHECK(f.write(line[i]), fname.c_str());
+    // See https://github.com/esp8266/Arduino/commit/b1da9eda467cc935307d553692fdde2e670db258#r32622483
+    uint8_t value = static_cast<uint8_t>(line[i]);
+    SPIFFS_CHECK(f.write(&value, 1), fname.c_str());
   }
   f.close();
   return "";
@@ -71,7 +73,9 @@ String BuildFixes()
     {
       for (int x = 0; x < 4096; x++)
       {
-        SPIFFS_CHECK(f.write(0), fname.c_str());
+        // See https://github.com/esp8266/Arduino/commit/b1da9eda467cc935307d553692fdde2e670db258#r32622483
+        uint8_t zero_value = 0;
+        SPIFFS_CHECK(f.write(&zero_value, 1), fname.c_str());
       }
       f.close();
     }
@@ -621,7 +625,9 @@ String SaveToFile(char* fname, int index, byte* memAddress, int datasize)
     byte *pointerToByteToSave = memAddress;
     for (int x = 0; x < datasize ; x++)
     {
-      SPIFFS_CHECK(f.write(*pointerToByteToSave), fname);
+      // See https://github.com/esp8266/Arduino/commit/b1da9eda467cc935307d553692fdde2e670db258#r32622483
+      uint8_t byteToSave = *pointerToByteToSave;
+      SPIFFS_CHECK(f.write(&byteToSave, 1), fname);
       pointerToByteToSave++;
       if (x % 256 == 0) {
         // one page written, do some background tasks

--- a/src/I2C.ino
+++ b/src/I2C.ino
@@ -72,7 +72,20 @@ uint8_t I2C_read8_reg(uint8_t i2caddr, byte reg, bool * is_ok) {
 
   Wire.beginTransmission(i2caddr);
   Wire.write((uint8_t)reg);
-  Wire.endTransmission(END_TRANSMISSION_FLAG);
+
+  if (Wire.endTransmission(END_TRANSMISSION_FLAG) != 0) {
+    /*
+    0:success
+    1:data too long to fit in transmit buffer
+    2:received NACK on transmit of address
+    3:received NACK on transmit of data
+    4:other error
+    See https://www.arduino.cc/en/Reference/WireEndTransmission
+    */
+    if (is_ok != NULL) {
+      *is_ok = false;
+    }
+  }
   byte count = Wire.requestFrom(i2caddr, (byte)1);
   if (is_ok != NULL) {
     *is_ok = (count == 1);

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -1095,8 +1095,8 @@ void ResetFactory()
   if (!ResetFactoryDefaultPreference.keepNetwork()) {
     Settings.clearNetworkSettings();
     // TD-er Reset access control
-    str2ip((char*)DEFAULT_IPRANGE_LOW, SecuritySettings.AllowedIPrangeLow);
-    str2ip((char*)DEFAULT_IPRANGE_HIGH, SecuritySettings.AllowedIPrangeHigh);
+    str2ip(F(DEFAULT_IPRANGE_LOW), SecuritySettings.AllowedIPrangeLow);
+    str2ip(F(DEFAULT_IPRANGE_HIGH), SecuritySettings.AllowedIPrangeHigh);
     SecuritySettings.IPblockLevel = DEFAULT_IP_BLOCK_LEVEL;
 
     #if DEFAULT_USE_STATIC_IP

--- a/src/Modbus_RTU.ino
+++ b/src/Modbus_RTU.ino
@@ -1,0 +1,617 @@
+#include <Arduino.h>
+#include <ESPeasySerial.h>
+
+#define MODBUS_RECEIVE_BUFFER 256
+#define MODBUS_BROADCAST_ADDRESS 0xFE
+
+#define MODBUS_READ_HOLDING_REGISTERS 0x03
+#define MODBUS_READ_INPUT_REGISTERS   0x04
+#define MODBUS_WRITE_SINGLE_REGISTER  0x06
+
+#define MODBUS_CMD_READ_RAM      0x44
+#define MODBUS_CMD_READ_EEPROM   0x46
+#define MODBUS_CMD_WRITE_RAM     0x41
+#define MODBUS_CMD_WRITE_EEPROM  0x43
+
+
+
+#define MODBUS_EXCEPTION_ILLEGAL_FUNCTION        1
+#define MODBUS_EXCEPTION_ILLEGAL_DATA_ADDRESS    2
+#define MODBUS_EXCEPTION_ILLEGAL_DATA_VALUE      3
+#define MODBUS_EXCEPTION_SLAVE_OR_SERVER_FAILURE 4
+#define MODBUS_EXCEPTION_ACKNOWLEDGE             5
+#define MODBUS_EXCEPTION_SLAVE_OR_SERVER_BUSY    6
+#define MODBUS_EXCEPTION_NEGATIVE_ACKNOWLEDGE    7
+#define MODBUS_EXCEPTION_MEMORY_PARITY           8
+#define MODBUS_EXCEPTION_NOT_DEFINED             9
+#define MODBUS_EXCEPTION_GATEWAY_PATH            10
+#define MODBUS_EXCEPTION_GATEWAY_TARGET          11
+
+/* Additional error codes for the processCommand return values */
+#define MODBUS_BADCRC   (MODBUS_EXCEPTION_GATEWAY_TARGET + 1)
+#define MODBUS_BADDATA  (MODBUS_EXCEPTION_GATEWAY_TARGET + 2)
+#define MODBUS_BADEXC   (MODBUS_EXCEPTION_GATEWAY_TARGET + 3)
+#define MODBUS_UNKEXC   (MODBUS_EXCEPTION_GATEWAY_TARGET + 4)
+#define MODBUS_MDATA    (MODBUS_EXCEPTION_GATEWAY_TARGET + 5)
+#define MODBUS_BADSLAVE (MODBUS_EXCEPTION_GATEWAY_TARGET + 6)
+
+
+struct ModbusRTU_struct  {
+  ModbusRTU_struct() : easySerial(nullptr) {}
+
+  ~ModbusRTU_struct() { reset(); }
+
+  void reset() {
+    if (easySerial != nullptr) {
+      delete easySerial;
+      easySerial = nullptr;
+    }
+    detected_device_description = "";
+    for (int i = 0; i < 8; ++i) {
+      _sendframe[i] = 0;
+    }
+    _sendframe_used = 0;
+    for (int i = 0; i < MODBUS_RECEIVE_BUFFER; ++i) {
+      _recv_buf[i] = 0xff;
+    }
+    _recv_buf_used = 0;
+    _modbus_address = MODBUS_BROADCAST_ADDRESS;
+    _reads_pass = 0;
+    _reads_crc_failed = 0;
+  }
+
+  bool init(const int16_t serial_rx, const int16_t serial_tx, int16_t baudrate, byte address) {
+    if (serial_rx < 0 || serial_tx < 0)
+      return false;
+    reset();
+    easySerial = new ESPeasySerial(serial_rx, serial_tx);
+    easySerial->begin(baudrate);
+    if (!isInitialized()) return false;
+    _modbus_address = address;
+
+    detected_device_description = getDevice_description(_modbus_address);
+    if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+      String log; // = F("Modbus detected: ");
+      log += detected_device_description;
+      addLog(LOG_LEVEL_INFO, log);
+      modbus_log_MEI(_modbus_address);
+    }
+    return true;
+  }
+
+  bool isInitialized() const {
+    return easySerial != nullptr;
+  }
+
+  void getStatistics(uint32_t& pass, uint32_t& fail) {
+    pass = _reads_pass;
+    fail = _reads_crc_failed;
+  }
+
+
+  String getDevice_description(byte slaveAddress) {
+    bool more_follows = true;
+    byte next_object_id = 0;
+    byte conformity_level = 0;
+    unsigned int object_value_int;
+    String description;
+    String obj_text;
+    for (byte object_id = 0; object_id < 0x84; ++object_id) {
+      if (object_id == 6) {
+        object_id = 0x82; // Skip to the serialnr/sensor type
+      }
+      int result = modbus_get_MEI(slaveAddress, object_id, obj_text,
+                                         object_value_int, next_object_id,
+                                         more_follows, conformity_level);
+      String label;
+      switch (object_id) {
+      case 0x01:
+        if (result == 0) label = "Pcode";
+        break;
+      case 0x02:
+        if (result == 0) label = "Rev";
+        break;
+      case 0x82:
+      {
+        if (result != 0) {
+          uint32_t sensorId = readSensorId();
+          obj_text = String(sensorId, HEX);
+          result = 0;
+
+        }
+        if (result == 0) label = "S/N";
+        break;
+      }
+      case 0x83:
+      {
+        if (result != 0) {
+          uint32_t sensorId = readTypeId();
+          obj_text = String(sensorId, HEX);
+          result = 0;
+        }
+        if (result == 0) label = "Type";
+        break;
+      }
+      default:
+        break;
+      }
+      if (result == 0) {
+        if (label.length() > 0) {
+          // description += MEI_objectid_to_name(object_id);
+          description += label;
+          description += ": ";
+        }
+        if (obj_text.length() > 0) {
+          description += obj_text;
+          description += " - ";
+        }
+      }
+    }
+    return description;
+  }
+
+/*
+  // Read from RAM or EEPROM
+  void buildRead_RAM_EEPROM(byte slaveAddress, byte functionCode,
+                                       short startAddress, byte number_bytes) {
+    _sendframe[0] = slaveAddress;
+    _sendframe[1] = functionCode;
+    _sendframe[2] = (byte)(startAddress >> 8);
+    _sendframe[3] = (byte)(startAddress & 0xFF);
+    _sendframe[4] = number_bytes;
+    _sendframe_used = 5;
+  }
+  */
+
+  // Write to the Special Control Register (SCR)
+  void buildWriteCommandRegister(byte slaveAddress, byte value) {
+    _sendframe[0] = slaveAddress;
+    _sendframe[1] = MODBUS_CMD_WRITE_RAM;
+    _sendframe[2] = 0;    // Address-Hi SCR  (0x0060)
+    _sendframe[3] = 0x60; // Address-Lo SCR
+    _sendframe[4] = 1;    // Count
+    _sendframe[5] = value;
+    _sendframe_used = 6;
+  }
+
+  void buildFrame(byte slaveAddress, byte functionCode,
+                             short startAddress, short parameter) {
+    _sendframe[0] = slaveAddress;
+    _sendframe[1] = functionCode;
+    _sendframe[2] = (byte)(startAddress >> 8);
+    _sendframe[3] = (byte)(startAddress & 0xFF);
+    _sendframe[4] = (byte)(parameter >> 8);
+    _sendframe[5] = (byte)(parameter & 0xFF);
+    _sendframe_used = 6;
+  }
+
+  void build_modbus_MEI_frame(byte slaveAddress, byte device_id,
+                                         byte object_id) {
+    _sendframe[0] = slaveAddress;
+    _sendframe[1] = 0x2B;
+    _sendframe[2] = 0x0E;
+
+    // The parameter "Read Device ID code" allows to define four access types :
+    // 01: request to get the basic device identification (stream access)
+    // 02: request to get the regular device identification (stream access)
+    // 03: request to get the extended device identification (stream access)
+    // 04: request to get one specific identification object (individual access)
+    _sendframe[3] = device_id;
+    _sendframe[4] = object_id;
+    _sendframe_used = 5;
+  }
+
+  String MEI_objectid_to_name(byte object_id) {
+    String result;
+    switch (object_id) {
+    case 0:    result = "VendorName";          break;
+    case 1:    result = "ProductCode";         break;
+    case 2:    result = "MajorMinorRevision";  break;
+    case 3:    result = "VendorUrl";           break;
+    case 4:    result = "ProductName";         break;
+    case 5:    result = "ModelName";           break;
+    case 6:    result = "UserApplicationName"; break;
+    case 0x80: result = "MemoryMapVersion";    break;
+    case 0x81: result = "Firmware Rev.";       break;
+    case 0x82: result = "Sensor S/N";          break;
+    case 0x83: result = "Sensor type";         break;
+    default:
+      result = "0x";
+      result += String(object_id, HEX);
+    }
+    return result;
+  }
+
+  String parse_modbus_MEI_response(unsigned int &object_value_int,
+                                              byte &next_object_id,
+                                              bool &more_follows,
+                                              byte &conformity_level) {
+    String result;
+    if (_recv_buf_used < 8) {
+      // Too small.
+      addLog(LOG_LEVEL_INFO,
+             String("MEI response too small: ") + _recv_buf_used);
+      next_object_id = 0xFF;
+      more_follows = false;
+      return result;
+    }
+    int pos = 4; // Data skipped: slave_address, FunctionCode, MEI type, ReadDevId
+    // See http://www.modbus.org/docs/Modbus_Application_Protocol_V1_1b.pdf
+    // Page 45
+    conformity_level             = _recv_buf[pos++];
+    more_follows                 = _recv_buf[pos++] != 0;
+    next_object_id               = _recv_buf[pos++];
+    const byte number_objects    = _recv_buf[pos++];
+    byte object_id = 0;
+    for (int i = 0; i < number_objects; ++i) {
+      if ((pos + 3) < _recv_buf_used) {
+        object_id                = _recv_buf[pos++];
+        const byte object_length = _recv_buf[pos++];
+        if ((pos + object_length) < _recv_buf_used) {
+          String object_value;
+          if (object_id < 0x80) {
+            // Parse as type String
+            object_value.reserve(object_length);
+            object_value_int = static_cast<unsigned int>(-1);
+            for (int c = 0; c < object_length; ++c) {
+              object_value += char(_recv_buf[pos++]);
+            }
+          } else {
+            object_value.reserve(2 * object_length + 2);
+            object_value_int = 0;
+            for (int c = 0; c < object_length; ++c) {
+              object_value_int =
+                  object_value_int << 8 | _recv_buf[pos++];
+            }
+            object_value = "0x";
+            String hexvalue(object_value_int, HEX);
+            hexvalue.toUpperCase();
+            object_value += hexvalue;
+          }
+          if (i != 0) {
+            // Append to existing description
+            result += String(", ");
+          }
+          result += object_value;
+        }
+      }
+    }
+    return result;
+  }
+
+
+  void logModbusException(byte value) {
+    if (value == 0)
+      return;
+  /*
+    // Exception Response, see:
+    // http://digital.ni.com/public.nsf/allkb/E40CA0CFA0029B2286256A9900758E06?OpenDocument
+    String log = F("Modbus Exception - ");
+    switch (value) {
+    case MODBUS_EXCEPTION_ILLEGAL_FUNCTION: {
+      // The function code received in the query is not an allowable action for
+      // the slave.
+      // If a Poll Program Complete command was issued, this code indicates that
+      // no program function preceded it.
+      log += F("Illegal Function (not allowed by client)");
+      break;
+    }
+    case MODBUS_EXCEPTION_ILLEGAL_DATA_ADDRESS: {
+      // The data address received in the query is not an allowable address for
+      // the slave.
+      log += F("Illegal Data Address");
+      break;
+    }
+    case MODBUS_EXCEPTION_ILLEGAL_DATA_VALUE: {
+      // A value contained in the query data field is not an allowable value for
+      // the slave
+      log += F("Illegal Data Value");
+      break;
+    }
+    case MODBUS_EXCEPTION_SLAVE_OR_SERVER_FAILURE: {
+      // An unrecoverable error occurred while the slave was attempting to perform
+      // the requested action
+      log += F("Slave Device Failure");
+      break;
+    }
+    case MODBUS_EXCEPTION_ACKNOWLEDGE: {
+      // The slave has accepted the request and is processing it, but a long
+      // duration of time will be
+      // required to do so. This response is returned to prevent a timeout error
+      // from occurring in the master.
+      // The master can next issue a Poll Program Complete message to determine if
+      // processing is completed.
+      log += F("Acknowledge");
+      break; // Is this an error?
+    }
+    case MODBUS_EXCEPTION_SLAVE_OR_SERVER_BUSY: {
+      // The slave is engaged in processing a long-duration program command.
+      // The master should retransmit the message later when the slave is free.
+      log += F("Slave Device Busy");
+      break;
+    }
+    case MODBUS_EXCEPTION_NEGATIVE_ACKNOWLEDGE:
+      log += F("Negative acknowledge");
+      break;
+    case MODBUS_EXCEPTION_MEMORY_PARITY:
+      log += F("Memory parity error");
+      break;
+    case MODBUS_EXCEPTION_GATEWAY_PATH:
+      log += F("Gateway path unavailable");
+      break;
+    case MODBUS_EXCEPTION_GATEWAY_TARGET:
+      log += F("Target device failed to respond");
+      break;
+    case MODBUS_BADCRC:
+      log += F("Invalid CRC");
+      break;
+    case MODBUS_BADDATA:
+      log += F("Invalid data");
+      break;
+    case MODBUS_BADEXC:
+      log += F("Invalid exception code");
+      break;
+    case MODBUS_MDATA:
+      log += F("Too many data");
+      break;
+    case MODBUS_BADSLAVE:
+      log += F("Response not from requested slave");
+      break;
+    default:
+      log += String(F("Unknown Exception code: ")) + value;
+      break;
+    }
+    log += F(" - sent: ");
+    log += log_buffer(_sendframe, _sendframe_used);
+    log += F(" - received: ");
+    log += log_buffer(_recv_buf, _recv_buf_used);
+    addLog(LOG_LEVEL_DEBUG_MORE, log);
+  */
+  }
+  
+/*
+  String log_buffer(byte *buffer, int length) {
+    String log;
+    log.reserve(3 * length + 5);
+    for (int i = 0; i < length; ++i) {
+      String hexvalue(buffer[i], HEX);
+      hexvalue.toUpperCase();
+      log += hexvalue;
+      log += F(" ");
+    }
+    log += F("(");
+    log += length;
+    log += F(")");
+    return log;
+  }
+*/
+
+
+  byte processCommand() {
+    // CRC-calculation
+    unsigned int crc =
+        ModRTU_CRC(_sendframe, _sendframe_used);
+    // Note, this number has low and high bytes swapped, so use it accordingly (or
+    // swap bytes)
+    byte checksumHi = (byte)((crc >> 8) & 0xFF);
+    byte checksumLo = (byte)(crc & 0xFF);
+    _sendframe[_sendframe_used++] = checksumLo;
+    _sendframe[_sendframe_used++] = checksumHi;
+
+    int nrRetriesLeft = 2;
+    byte return_value = 0;
+    while (nrRetriesLeft > 0) {
+      return_value = 0;
+      // Send the byte array
+      easySerial->write(_sendframe, _sendframe_used);
+      delay(50);
+
+      // Read answer from sensor
+      _recv_buf_used = 0;
+      while (easySerial->available() &&
+             _recv_buf_used < MODBUS_RECEIVE_BUFFER) {
+        _recv_buf[_recv_buf_used++] =
+            easySerial->read();
+      }
+
+      // Check for MODBUS exception
+      const byte received_functionCode = _recv_buf[1];
+      if ((received_functionCode & 0x80) != 0) {
+        return_value = _recv_buf[2];
+      }
+      // Check checksum
+      crc = ModRTU_CRC(_recv_buf, _recv_buf_used);
+      if (crc != 0u) {
+        ++_reads_crc_failed;
+        return_value = MODBUS_BADCRC;
+      } else {
+        ++_reads_pass;
+      }
+      switch (return_value) {
+      case MODBUS_EXCEPTION_ACKNOWLEDGE:
+      case MODBUS_EXCEPTION_SLAVE_OR_SERVER_BUSY:
+      case MODBUS_BADCRC:
+        // Bad communication, makes sense to retry.
+        break;
+      default:
+        nrRetriesLeft = 0; // When not supported, does not make sense to retry.
+        break;
+      }
+      --nrRetriesLeft;
+    }
+    return return_value;
+  }
+
+  uint32_t read_32b_InputRegister(short address) {
+    uint32_t result = 0;
+    int idHigh = readInputRegister(address);
+    int idLow = readInputRegister(address + 1);
+    if (idHigh >= 0 && idLow >= 0) {
+      result = idHigh;
+      result = result << 16;
+      result += idLow;
+    }
+    return result;
+  }
+
+  int readInputRegister(short address) {
+    // Only read 1 register
+    return process_16b_register(_modbus_address, MODBUS_READ_INPUT_REGISTERS, address, 1);
+  }
+
+  int readHoldingRegister(short address) {
+    // Only read 1 register
+    return process_16b_register(
+        _modbus_address, MODBUS_READ_HOLDING_REGISTERS, address, 1);
+  }
+
+  // Write to holding register.
+  int writeSingleRegister(short address, short value) {
+    // GN: Untested, will probably not work
+    return process_16b_register(
+        _modbus_address, MODBUS_WRITE_SINGLE_REGISTER, address, value);
+  }
+
+  byte modbus_get_MEI(byte slaveAddress, byte object_id,
+                                 String &result, unsigned int &object_value_int,
+                                 byte &next_object_id, bool &more_follows,
+                                 byte &conformity_level) {
+    // Force device_id to 4 = individual access (reading one ID object per call)
+    build_modbus_MEI_frame(slaveAddress, 4, object_id);
+    const byte process_result = processCommand();
+    if (process_result == 0) {
+      result = parse_modbus_MEI_response(object_value_int,
+                                                    next_object_id, more_follows,
+                                                    conformity_level);
+    } else {
+      more_follows = false;
+    }
+    return process_result;
+  }
+
+  void modbus_log_MEI(byte slaveAddress) {
+    // Iterate over all Device identification items, using
+    // Modbus command (0x2B / 0x0E) Read Device Identification
+    // And add to log.
+    bool more_follows = true;
+    byte conformity_level = 0;
+    byte object_id = 0;
+    byte next_object_id = 0;
+    while (more_follows) {
+      String result;
+      unsigned int object_value_int;
+      const byte process_result = modbus_get_MEI(
+          slaveAddress, object_id, result, object_value_int, next_object_id,
+          more_follows, conformity_level);
+      if (process_result == 0) {
+        if (result.length() > 0) {
+          String log = MEI_objectid_to_name(object_id);
+          log += ": ";
+          log += result;
+          addLog(LOG_LEVEL_INFO, log);
+        }
+      } else {
+        switch (process_result) {
+        case MODBUS_EXCEPTION_ILLEGAL_DATA_ADDRESS:
+          // No need to log this exception when scanning.
+          break;
+        default:
+          logModbusException(process_result);
+          break;
+        }
+      }
+      // If more parts are needed, collect them or iterate over the known list.
+      // For example with "individual access" a new request has to be sent for each single item
+      if (more_follows) {
+        object_id = next_object_id;
+      } else if (object_id < 0x84) {
+        // Allow for scanning only the usual object ID's
+        // This range is vendor specific
+        more_follows = true;
+        object_id++;
+        if (object_id == 7) {
+          // Skip range 0x07...0x7F
+          object_id = 0x80;
+        }
+      }
+    }
+  }
+
+  int process_16b_register(byte slaveAddress, byte functionCode,
+                                      short startAddress, short parameter) {
+    buildFrame(slaveAddress, functionCode, startAddress, parameter);
+    const byte process_result = processCommand();
+    if (process_result == 0) {
+      return (_recv_buf[3] << 8) | (_recv_buf[4]);
+    }
+    logModbusException(process_result);
+    return -1;
+  }
+
+  int writeSpecialCommandRegister(byte command) {
+    buildWriteCommandRegister(_modbus_address, command);
+    const byte process_result = processCommand();
+    if (process_result == 0)
+      return 0;
+    logModbusException(process_result);
+    return -1;
+  }
+
+/*
+  unsigned int read_RAM_EEPROM(byte command, byte startAddress,
+                                          byte nrBytes) {
+    buildRead_RAM_EEPROM(_modbus_address, command,
+                                    startAddress, nrBytes);
+    const byte process_result = processCommand();
+    if (process_result == 0) {
+      unsigned int result = 0;
+      for (int i = 0; i < _recv_buf[2]; ++i) {
+        // Most significant byte at lower address
+        result = (result << 8) | _recv_buf[i + 3];
+      }
+      return result;
+    }
+    logModbusException(process_result);
+    return -1;
+  }
+*/
+
+
+  // Compute the MODBUS RTU CRC
+  unsigned int ModRTU_CRC(byte *buf, int len) {
+    unsigned int crc = 0xFFFF;
+    for (int pos = 0; pos < len; pos++) {
+      crc ^= (unsigned int)buf[pos]; // XOR byte into least sig. byte of crc
+
+      for (int i = 8; i != 0; i--) { // Loop over each bit
+        if ((crc & 0x0001) != 0) {   // If the LSB is set
+          crc >>= 1;                 // Shift right and XOR 0xA001
+          crc ^= 0xA001;
+        } else       // Else LSB is not set
+          crc >>= 1; // Just shift right
+      }
+    }
+    return crc;
+  }
+
+  uint32_t readTypeId() {
+    return read_32b_InputRegister(25);
+  }
+
+  uint32_t readSensorId() {
+    return read_32b_InputRegister(29);
+  }
+
+  String detected_device_description;
+
+private:
+  byte _sendframe[8] = {0};
+  byte _sendframe_used = 0;
+  byte _recv_buf[MODBUS_RECEIVE_BUFFER] = {0xff};
+  byte _recv_buf_used = 0;
+  byte _modbus_address = MODBUS_BROADCAST_ADDRESS;
+  uint32_t _reads_pass = 0;
+  uint32_t _reads_crc_failed = 0;
+
+  ESPeasySerial *easySerial;
+};

--- a/src/Networking.ino
+++ b/src/Networking.ino
@@ -359,7 +359,7 @@ void SSDP_schema(WiFiClient &client) {
   ssdp_schema += F("</serialNumber>"
                    "<modelName>ESP Easy</modelName>"
                    "<modelNumber>");
-  ssdp_schema += BUILD_GIT;
+  ssdp_schema += F(BUILD_GIT);
   ssdp_schema += F("</modelNumber>"
                    "<modelURL>http://www.letscontrolit.com</modelURL>"
                    "<manufacturer>http://www.letscontrolit.com</manufacturer>"

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -123,7 +123,7 @@ private:
     buf = "";
     if (beforeTXRam < 3000) {
       lowMemorySkip = true;
-      WebServer.send(200, F("text/plain"), "Low memory. Cannot display webpage :-(");
+      WebServer.send(200, "text/plain", "Low memory. Cannot display webpage :-(");
        #if defined(ESP8266)
          tcpCleanup();
        #endif

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -3861,8 +3861,8 @@ void handle_tools() {
     SPIFFS.info(fs_info);
     if ((fs_info.totalBytes - fs_info.usedBytes) / 1024 > 50) {
       TXBuffer += F("<TR><TD>");
-      TXBuffer += "<script>function downloadUI() { fetch('https://raw.githubusercontent.com/ppisljar/espeasy_new_ui/master/build/index.htm.gz').then(r=>r.arrayBuffer()).then(r => {var f=new FormData();f.append('file', new File([new Blob([new Uint8Array(r)])], 'index.htm.gz'));f.append('edit', 1);fetch('/upload',{method:'POST',body:f}).then(() => {window.location.href='/';});}); }</script>";
-      TXBuffer += "<a class=\"button link wide\" onclick=\"downloadUI()\">download new ui</a>";
+      TXBuffer += F("<script>function downloadUI() { fetch('https://raw.githubusercontent.com/ppisljar/espeasy_new_ui/master/build/index.htm.gz').then(r=>r.arrayBuffer()).then(r => {var f=new FormData();f.append('file', new File([new Blob([new Uint8Array(r)])], 'index.htm.gz'));f.append('edit', 1);fetch('/upload',{method:'POST',body:f}).then(() => {window.location.href='/';});}); }</script>");
+      TXBuffer += F("<a class=\"button link wide\" onclick=\"downloadUI()\">download new ui</a>");
       TXBuffer += F("</TD><TD>Download new UI</TD></TR>");
     }
   #endif

--- a/src/WebServer_Rules.ino
+++ b/src/WebServer_Rules.ino
@@ -56,7 +56,7 @@ void handle_rules_new() {
   int count = -1;
   HandlerFileInfo renderDetail = [/*&buffer,*/&count,endIdx](fileInfo fi){
     #ifdef WEBSERVER_RULES_DEBUG
-    Serial.print("Start generation of: ");
+    Serial.print(F("Start generation of: "));
     Serial.println(fi.Name);
     #endif
     if (fi.isDirectory)
@@ -109,7 +109,7 @@ void handle_rules_new() {
     }
     TXBuffer += F("</TD></TR>");
     #ifdef WEBSERVER_RULES_DEBUG
-    Serial.print("End generation of: ");
+    Serial.print(F("End generation of: "));
     Serial.println(fi.Name);
     #endif
 
@@ -152,7 +152,7 @@ void handle_rules_backup() {
     return;
   }
   #ifdef WEBSERVER_RULES_DEBUG
-  Serial.println("handle rules backup");
+  Serial.println(F("handle rules backup"));
   #endif
   if (!isLoggedIn() || !Settings.UseRules) return;
   if (!clientIPallowed()) return;
@@ -251,7 +251,7 @@ bool handle_rules_edit(String originalUri, bool isAddNew) {
 
   #ifdef WEBSERVER_RULES_DEBUG
   Serial.println(originalUri);
-  Serial.println("handle_rules_edit");
+  Serial.println(F("handle_rules_edit"));
   #endif
 
   if(isAddNew || (originalUri.startsWith(F("/rules/"))
@@ -288,7 +288,7 @@ bool handle_rules_edit(String originalUri, bool isAddNew) {
         eventName = FileNameToEvent(fileName);
       }
       #ifdef WEBSERVER_RULES_DEBUG
-      Serial.print("File name: ");
+      Serial.print(F("File name: "));
       Serial.println(fileName);
       #endif
       bool isEdit = SPIFFS.exists(fileName);
@@ -344,15 +344,15 @@ bool handle_rules_edit(String originalUri, bool isAddNew) {
 
       bool isReadOnly = !isOverwrite && ((isEdit && !isAddNew && !isNew) || (isAddNew && isNew));
       #ifdef WEBSERVER_RULES_DEBUG
-      Serial.print("Is Overwrite: ");
+      Serial.print(F("Is Overwrite: "));
       Serial.println(isOverwrite);
-      Serial.print("Is edit: ");
+      Serial.print(F("Is edit: "));
       Serial.println(isEdit);
-      Serial.print("Is addnew: ");
+      Serial.print(F("Is addnew: "));
       Serial.println(isAddNew);
-      Serial.print("Is New: ");
+      Serial.print(F("Is New: "));
       Serial.println(isNew);
-      Serial.print("Is Read Only: ");
+      Serial.print(F("Is Read Only: "));
       Serial.println(isReadOnly);
       #endif
 
@@ -421,7 +421,7 @@ bool handle_rules_edit(String originalUri, bool isAddNew) {
 bool Rule_Download(const String& path)
 {
   #ifdef WEBSERVER_RULES_DEBUG
-  Serial.print("Rule_Download path: ");
+  Serial.print(F("Rule_Download path: "));
   Serial.println(path);
   #endif
   fs::File dataFile = SPIFFS.open(path, "r");
@@ -457,7 +457,7 @@ bool EnumerateFileAndDirectory(String& rootPath
   bool next = true;
   #ifdef ESP8266
   fs::Dir dir = SPIFFS.openDir(rootPath);
-  Serial.print("Enumerate files of ");
+  Serial.print(F("Enumerate files of "));
   Serial.println(rootPath);
   while (next && dir.next()) {
     //Skip files

--- a/src/_CPlugin_Helper.h
+++ b/src/_CPlugin_Helper.h
@@ -224,15 +224,15 @@ struct ControllerDelayHandlerStruct {
     if (freeHeap > 5000) return false; // Memory is not an issue.
 #ifndef BUILD_NO_DEBUG
     if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
-      String log = F("Controller-");
+      String log = "Controller-";
       log += element.controller_idx +1;
-      log += F(" : Memory used: ");
+      log += " : Memory used: ";
       log += getQueueMemorySize();
-      log += F(" bytes ");
+      log += " bytes ";
       log += sendQueue.size();
-      log += F(" items ");
+      log += " items ";
       log += freeHeap;
-      log += F(" free");
+      log += " free";
       addLog(LOG_LEVEL_DEBUG, log);
     }
 #endif
@@ -258,7 +258,7 @@ struct ControllerDelayHandlerStruct {
 #ifndef BUILD_NO_DEBUG
     if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
       String log = get_formatted_Controller_number(element.controller_idx);
-      log += F(" : queue full");
+      log += " : queue full";
       addLog(LOG_LEVEL_DEBUG, log);
     }
 #endif

--- a/src/_CPlugin_Helper.h
+++ b/src/_CPlugin_Helper.h
@@ -224,15 +224,15 @@ struct ControllerDelayHandlerStruct {
     if (freeHeap > 5000) return false; // Memory is not an issue.
 #ifndef BUILD_NO_DEBUG
     if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
-      String log = "Controller-";
+      String log = F("Controller-");
       log += element.controller_idx +1;
-      log += " : Memory used: ";
+      log += F(" : Memory used: ");
       log += getQueueMemorySize();
-      log += " bytes ";
+      log += F(" bytes ");
       log += sendQueue.size();
-      log += " items ";
+      log += F(" items ");
       log += freeHeap;
-      log += " free";
+      log += F(" free");
       addLog(LOG_LEVEL_DEBUG, log);
     }
 #endif
@@ -258,7 +258,7 @@ struct ControllerDelayHandlerStruct {
 #ifndef BUILD_NO_DEBUG
     if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
       String log = get_formatted_Controller_number(element.controller_idx);
-      log += " : queue full";
+      log += F(" : queue full");
       addLog(LOG_LEVEL_DEBUG, log);
     }
 #endif

--- a/src/_P002_ADC.ino
+++ b/src/_P002_ADC.ino
@@ -83,6 +83,16 @@ boolean Plugin_002(byte function, struct EventStruct *event, String& string)
           note += String(raw_value);
           note += F(" = ");
           note += String(value, 3);
+
+          if (PCONFIG(3)) {
+            note += F(" min: ");
+            note += P002_applyCalibration(event, 0.0);
+            note += F(" max: ");
+            note += P002_applyCalibration(event, P002_MAX_ADC_VALUE);
+            float stepsize = P002_applyCalibration(event, 1.0) - P002_applyCalibration(event, 0.0);
+            note += F(" step: ");
+            note += String(stepsize, 3);
+          }
           addFormNote(note);
         }
 
@@ -168,6 +178,10 @@ float P002_getOutputValue(struct EventStruct *event, int16_t &raw_value) {
     raw_value = P002_performRead(event);
     float_value = static_cast<float>(raw_value);
   }
+  return P002_applyCalibration(event, float_value);
+}
+
+float P002_applyCalibration(struct EventStruct *event, float float_value) {
   if (PCONFIG(3))   //Calibration?
   {
     int adc1 = PCONFIG_LONG(0);

--- a/src/_P002_ADC.ino
+++ b/src/_P002_ADC.ino
@@ -77,23 +77,18 @@ boolean Plugin_002(byte function, struct EventStruct *event, String& string)
         addTextBox(F("p002_out2"), String(PCONFIG_FLOAT(1), 3), 10);
 
         {
+          // Output the statistics for the current settings.
           int16_t raw_value = 0;
           float value = P002_getOutputValue(event, raw_value);
-          String note = F("Current: ");
-          note += String(raw_value);
-          note += F(" = ");
-          note += String(value, 3);
+          P002_formatStatistics(F("Current"), raw_value, value);
 
           if (PCONFIG(3)) {
-            note += F(" min: ");
-            note += P002_applyCalibration(event, 0.0);
-            note += F(" max: ");
-            note += P002_applyCalibration(event, P002_MAX_ADC_VALUE);
+            P002_formatStatistics(F("Minimum"), 0, P002_applyCalibration(event, 0));
+            P002_formatStatistics(F("Maximum"), P002_MAX_ADC_VALUE, P002_applyCalibration(event, P002_MAX_ADC_VALUE));
+
             float stepsize = P002_applyCalibration(event, 1.0) - P002_applyCalibration(event, 0.0);
-            note += F(" step: ");
-            note += String(stepsize, 3);
+            P002_formatStatistics(F("Step size"), 1, stepsize);
           }
-          addFormNote(note);
         }
 
         success = true;
@@ -206,6 +201,13 @@ uint16_t P002_performRead(struct EventStruct *event) {
     value = analogRead(CONFIG_PIN1);
   #endif
   return value;
+}
+
+void P002_formatStatistics(const String& label, int16_t raw, float float_value) {
+  addRowLabel(label);
+  addHtml(String(raw));
+  html_add_estimate_symbol();
+  addHtml(String(float_value, 3));
 }
 
 #endif // USES_P002

--- a/src/_P002_ADC.ino
+++ b/src/_P002_ADC.ino
@@ -110,7 +110,7 @@ boolean Plugin_002(byte function, struct EventStruct *event, String& string)
       {
         if (PCONFIG(0))   //Oversampling?
         {
-          uint16_t currentValue = P002_performRead();
+          uint16_t currentValue = P002_performRead(event);
           Plugin_002_OversamplingValue += currentValue;
           ++Plugin_002_OversamplingCount;
           if (currentValue > Plugin_002_OversamplingMaxVal) {
@@ -165,7 +165,7 @@ float P002_getOutputValue(struct EventStruct *event, int16_t &raw_value) {
     float_value = sum / count;
     raw_value = static_cast<int16_t>(float_value);
   } else {
-    raw_value = P002_performRead();
+    raw_value = P002_performRead(event);
     float_value = static_cast<float>(raw_value);
   }
   if (PCONFIG(3))   //Calibration?
@@ -183,7 +183,7 @@ float P002_getOutputValue(struct EventStruct *event, int16_t &raw_value) {
   return float_value;
 }
 
-uint16_t P002_performRead() {
+uint16_t P002_performRead(struct EventStruct *event) {
   uint16_t value = 0;
   #if defined(ESP8266)
     value = analogRead(A0);

--- a/src/_P026_Sysinfo.ino
+++ b/src/_P026_Sysinfo.ino
@@ -75,7 +75,7 @@ boolean Plugin_026(byte function, struct EventStruct *event, String& string)
           byte choice = PCONFIG(i);
           label = F("Indicator ");
           label += (i+1);
-          id = "p026_";
+          id = F("p026_");
           id += (i+1);
           addFormSelector(label, id, 12, options, NULL, choice);
         }
@@ -88,7 +88,7 @@ boolean Plugin_026(byte function, struct EventStruct *event, String& string)
       {
         String id;
         for (byte i = 0; i < 4; ++i) {
-          id = "p026_";
+          id = F("p026_");
           id += (i+1);
           PCONFIG(i) = getFormItemInt(id);
         }

--- a/src/_P045_MPU6050.ino
+++ b/src/_P045_MPU6050.ino
@@ -38,10 +38,11 @@
 // Originally released in the PlayGround as Plugin 118.
 
 // Plugin var usage:
-// Globals    - int16_t axis[3][5] Array to store sensorvalues of the axis
-//              axis[0-2][x]  = x, y, z axis
-//              axis[x][0-4]  = min values, max values, range (max-min), a-values, g-values.
-//            - long nextUpdateMaxReadings = Timer to check values each 5 seconds
+// Globals    - int16_t _P045_axis[3][5][2] Array to store sensorvalues of the axis
+//              _P045_axis[0-2][x][x]  = x, y, z axis
+//              _P045_axis[x][0-4][x]  = min values, max values, range (max-min), a-values, g-values.
+//              _P045_axis[x][x][0-1]  = device address: 0=0x68, 1=0x69
+//            - long _P045_time[2] = Timer to check values each 5 seconds for each used device address.
 
 // Framework  - Settings.TaskDevicePluginConfig[x][0]     - Device address (0x68 | 0x69)
 //              Settings.TaskDevicePluginConfig[x][1]     - Instance function
@@ -53,6 +54,13 @@
 //              Settings.TaskDevicePluginConfig[x][7]     - Last known status of switch
 //              Settings.TaskDevicePluginConfigLong[x][0] - Minimal detection threshold counter
 //              Settings.TaskDevicePluginConfigLong[x][1] - Detection threshold window counter
+
+
+// FIXME TD-er: Reverted to old version before adding Plugin_task_data array
+// See issue: https://github.com/letscontrolit/ESPEasy/issues/2381
+// Commits:
+// https://github.com/letscontrolit/ESPEasy/commit/af20984079d3e7aa59e08fd9b232f6d17ba3b523#diff-ec860ac195fffa61ec11dd419fefa5b9
+// https://github.com/letscontrolit/ESPEasy/commit/6400c495e24f39ebac88eb634f29cfb73137fa2b#diff-ec860ac195fffa61ec11dd419fefa5b9
 
 
 #define MPU6050_RA_GYRO_CONFIG              0x1B
@@ -75,70 +83,284 @@
 #define PLUGIN_NAME_045                     "Gyro - MPU 6050 [TESTING]"
 #define PLUGIN_VALUENAME1_045               ""
 
-struct P045_data_struct : public PluginTaskData_base {
+int16_t _P045_axis[3][5][2];                // [xyz], [min/max/range,a,g], [0x68/0x69]
+unsigned long _P045_time[2];
 
-  P045_data_struct(uint8_t devAddr) : _devAddr(devAddr) {
-    if ((_devAddr < 0x68) || (_devAddr > 0x69)) { //  Just in case the address is not initialized, set it anyway.
-      _devAddr = 0x68;
-    }
-    // Initialize the MPU6050, for details look at the MPU6050 library: MPU6050::Initialize
-    writeBits(MPU6050_RA_PWR_MGMT_1, MPU6050_PWR1_CLKSEL_BIT, MPU6050_PWR1_CLKSEL_LENGTH, MPU6050_CLOCK_PLL_XGYRO);
-    writeBits(MPU6050_RA_GYRO_CONFIG, MPU6050_GCONFIG_FS_SEL_BIT, MPU6050_GCONFIG_FS_SEL_LENGTH, MPU6050_GYRO_FS_250);
-    writeBits(MPU6050_RA_ACCEL_CONFIG, MPU6050_ACONFIG_AFS_SEL_BIT, MPU6050_ACONFIG_AFS_SEL_LENGTH, MPU6050_ACCEL_FS_2);
-    writeBits(MPU6050_RA_PWR_MGMT_1, MPU6050_PWR1_SLEEP_BIT, 1, 0);
+boolean Plugin_045(byte function, struct EventStruct *event, String& string)
+{
+  boolean success = false;
 
-    // Read the MPU6050 once to clear out zeros (1st time reading MPU6050 returns all 0s)
-    int16_t ax, ay, az, gx, gy, gz;
-    get6AxisMotion(&ax, &ay, &az, &gx, &gy, &gz);
+  switch (function)
+  {
+
+    case PLUGIN_DEVICE_ADD:
+      {
+        Device[++deviceCount].Number = PLUGIN_ID_045;
+        Device[deviceCount].Type = DEVICE_TYPE_I2C;
+        Device[deviceCount].VType = SENSOR_TYPE_SINGLE;
+        Device[deviceCount].ValueCount = 1;                   // Unfortunatly domoticz has no custom multivalue sensors.
+        Device[deviceCount].SendDataOption = true;            //   and I use Domoticz ... so there.
+        Device[deviceCount].TimerOption = true;
+        Device[deviceCount].FormulaOption = false;
+        break;
+      }
+
+    case PLUGIN_GET_DEVICENAME:
+      {
+        string = F(PLUGIN_NAME_045);
+        break;
+      }
+
+    case PLUGIN_GET_DEVICEVALUENAMES:
+      {
+        strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[0], PSTR(PLUGIN_VALUENAME1_045));
+        break;
+      }
+
+    case PLUGIN_WEBFORM_LOAD:
+      {
+        // Setup webform for address selection
+        byte choice = PCONFIG(0);
+        /*
+        String options[10];
+        options[0] = F("0x68 - default settings (ADDR Low)");
+        options[1] = F("0x69 - alternate settings (ADDR High)");
+        */
+        int optionValues[2];
+        optionValues[0] = 0x68;
+        optionValues[1] = 0x69;
+        addFormSelectorI2C(F("p045_address"), 2, optionValues, choice);
+        addFormNote(F("ADDR Low=0x68, High=0x69"));
+
+        choice = PCONFIG(1);
+        String options[10];
+        options[0] = F("Movement detection");
+        options[1] = F("Range acceleration X");
+        options[2] = F("Range acceleration Y");
+        options[3] = F("Range acceleration Z");
+        options[4] = F("Acceleration X");
+        options[5] = F("Acceleration Y");
+        options[6] = F("Acceleration Z");
+        options[7] = F("G-force X");
+        options[8] = F("G-force Y");
+        options[9] = F("G-force Z");
+        addFormSelector(F("Function"), F("p045_function"), 10, options, NULL, choice);
+
+        if (choice == 0) {
+          // If this is instance function 0, setup webform for additional vars
+          // Show some user information about the webform and what the vars mean.
+          addHtml(F("<TR><TD><TD>The thresholdvalues (0-65535) can be used to set a threshold for one or more<br>"));
+          addHtml(F("axis. The axis will trigger when the range for that axis exceeds the threshold<br>"));
+          addHtml(F("value. A value of 0 disables movement detection for that axis."));
+
+        	addFormNumericBox(F("Detection threshold X"), F("p045_threshold_x"), PCONFIG(2), 0, 65535);
+        	addFormNumericBox(F("Detection threshold Y"), F("p045_threshold_y"), PCONFIG(3), 0, 65535);
+        	addFormNumericBox(F("Detection threshold Z"), F("p045_threshold_z"), PCONFIG(4), 0, 65535);
+
+          addHtml(F("<TR><TD><TD>Each 30 seconds a counter for the detection window is increased plus all axis<br>"));
+          addHtml(F("are checked and if they *all* exceeded the threshold values, a counter is increased.<br>"));
+          addHtml(F("Each period, defined by the [detection window], the counter is checked against<br>"));
+          addHtml(F("the [min. detection count] and if found equal or larger, movement is detected.<br>"));
+          addHtml(F("If in the next window the [min. detection count] value is not met, movement has stopped."));
+          addHtml(F("The [detection window] cannot be smaller than the [min. detection count]."));
+
+        	addFormNumericBox(F("Min. detection count"), F("p045_threshold_counter"), PCONFIG(5), 0, 999999);
+        	addFormNumericBox(F("Detection window"), F("p045_threshold_window"), PCONFIG(6), 0, 999999);
+
+        }
+        success = true;
+        break;
+      }
+
+    case PLUGIN_WEBFORM_SAVE:
+      {
+        // Save the vars
+        PCONFIG(0) = getFormItemInt(F("p045_address"));
+        PCONFIG(1) = getFormItemInt(F("p045_function"));
+        PCONFIG(2) = getFormItemInt(F("p045_threshold_x"));
+        PCONFIG(3) = getFormItemInt(F("p045_threshold_y"));
+        PCONFIG(4) = getFormItemInt(F("p045_threshold_z"));
+        PCONFIG(5) = getFormItemInt(F("p045_threshold_counter"));
+        PCONFIG(6) = getFormItemInt(F("p045_threshold_window"));
+        if (PCONFIG(6) < PCONFIG(5)) {
+          PCONFIG(6) = PCONFIG(5);
+        }
+        success = true;
+        break;
+      }
+
+    case PLUGIN_INIT:
+      {
+        // Initialize the MPU6050. This *can* be done multiple times per instance and device address.
+        // We could make sure that this is only done once per device address, but why bother?
+        uint8_t devAddr = PCONFIG(0);
+        if ((devAddr < 0x68) || (devAddr > 0x69)) { //  Just in case the address is not initialized, set it anyway.
+          devAddr = 0x68;
+          PCONFIG(0) = devAddr;
+        }
+        // Initialize the MPU6050, for details look at the MPU6050 library: MPU6050::Initialize
+        _P045_writeBits(devAddr, MPU6050_RA_PWR_MGMT_1, MPU6050_PWR1_CLKSEL_BIT, MPU6050_PWR1_CLKSEL_LENGTH, MPU6050_CLOCK_PLL_XGYRO);
+        _P045_writeBits(devAddr, MPU6050_RA_GYRO_CONFIG, MPU6050_GCONFIG_FS_SEL_BIT, MPU6050_GCONFIG_FS_SEL_LENGTH, MPU6050_GYRO_FS_250);
+        _P045_writeBits(devAddr, MPU6050_RA_ACCEL_CONFIG, MPU6050_ACONFIG_AFS_SEL_BIT, MPU6050_ACONFIG_AFS_SEL_LENGTH, MPU6050_ACCEL_FS_2);
+        _P045_writeBits(devAddr, MPU6050_RA_PWR_MGMT_1, MPU6050_PWR1_SLEEP_BIT, 1, 0);
+
+        // Read the MPU6050 once to clear out zeros (1st time reading MPU6050 returns all 0s)
+        int16_t ax, ay, az, gx, gy, gz;
+        _P045_getMotion6(devAddr, &ax, &ay, &az, &gx, &gy, &gz);
+
+        // Reset vars
+        PCONFIG(7) = 0;       // Last known value of "switch" is off
+        UserVar[event->BaseVarIndex] = 0;                               // Switch is off
+        PCONFIG_LONG(0) = 0;   // Minimal detection counter is zero
+        PCONFIG_LONG(1) = 0;   // Detection window counter is zero
+        success = true;
+        break;
+      }
+
+    case PLUGIN_ONCE_A_SECOND:
+      {
+        uint8_t devAddr = PCONFIG(0);
+        byte dev = devAddr & 1;
+
+        // Read the sensorvalues, we run this bit every 1/10th of a second
+        _P045_getMotion6(devAddr, &_P045_axis[0][3][dev], &_P045_axis[1][3][dev], &_P045_axis[2][3][dev], &_P045_axis[0][4][dev], &_P045_axis[1][4][dev], &_P045_axis[2][4][dev]);
+        // Set the minimum and maximum value for each axis a-value, overwrite previous values if smaller/larger
+        _P045_trackMinMax(_P045_axis[0][3][dev], &_P045_axis[0][0][dev], &_P045_axis[0][1][dev]);
+        _P045_trackMinMax(_P045_axis[1][3][dev], &_P045_axis[1][0][dev], &_P045_axis[1][1][dev]);
+        _P045_trackMinMax(_P045_axis[2][3][dev], &_P045_axis[2][0][dev], &_P045_axis[2][1][dev]);
+        //                              ^ current value @ 3     ^ min val @ 0           ^ max val @ 1
+
+/*      // Uncomment this block if you want to debug your MPU6050, but be prepared for a log overload
+        String log = F("MPU6050 : axis values: ");
+        log += _P045_axis[0][3][dev];
+        log += F(", ");
+        log += _P045_axis[1][3][dev];
+        log += F(", ");
+        log += _P045_axis[2][3][dev];
+        log += F(", g values: ");
+        log += _P045_axis[0][4][dev];
+        log += F(", ");
+        log += _P045_axis[1][4][dev];
+        log += F(", ");
+        log += _P045_axis[2][4][dev];
+        addLog(LOG_LEVEL_INFO,log);
+*/
+        // Run this bit every 5 seconds per deviceaddress (not per instance)
+        if (timeOutReached(_P045_time[dev] + 5000))
+        {
+          _P045_time[dev] = millis();
+
+          // Determine the maximum measured range of each axis
+          for (uint8_t i=0; i<3; i++) {
+            _P045_axis[i][2][dev] = abs(_P045_axis[i][1][dev] - _P045_axis[i][0][dev]);
+            _P045_axis[i][0][dev] = _P045_axis[i][3][dev];
+            _P045_axis[i][1][dev] = _P045_axis[i][3][dev];
+          }
+        }
+        success = true;
+        break;
+      }
+
+    case PLUGIN_READ:
+      {
+        int devAddr = PCONFIG(0);
+        byte dev = devAddr & 1;
+        int _P045_Function = PCONFIG(1);
+        switch (_P045_Function)
+        {
+          // Function 0 is for movement detection
+          case 0:
+          {
+            // Check if all (enabled, so !=0) thresholds are exceeded, if one fails then thresexceed (thesholds exceeded) is reset to false;
+            boolean thresexceed = true;
+            byte count = 0;                 // Counter to check if not all thresholdvalues are set to 0 or disabled
+            for (byte i=0; i<3; i++)
+            {
+              // for each axis:
+              if (PCONFIG(i + 2) != 0) {  // not disabled, check threshold
+                if (_P045_axis[i][2][dev] < PCONFIG(i + 2)) { thresexceed = false; }
+              } else { count++; } // If disabled count + 1
+            }
+            if (count == 3) { thresexceed = false; }  // If we counted to three, all three axis are disabled.
+
+            // If all enabled thresholds are exceeded the increase the counter
+            if (thresexceed) { PCONFIG_LONG(0)++; }
+            // And increase the window counter
+            PCONFIG_LONG(1)++;
+
+            if (PCONFIG_LONG(1) >= PCONFIG(6)) {
+              // Detection window has passed.
+              PCONFIG_LONG(1) = 0; // reset window counter
+
+              // Did we count more times exceeded then the minimum detection value?
+              if (PCONFIG_LONG(0) >= PCONFIG(5)) {
+                UserVar[event->BaseVarIndex] = 1; // x times threshold exceeded within window.
+              } else {
+                UserVar[event->BaseVarIndex] = 0; // reset because x times threshold within window not met.
+              }
+
+              // Check if UserVar changed so we do not overload homecontroller with the same readings
+              if (PCONFIG(7) != UserVar[event->BaseVarIndex]) {
+                PCONFIG(7) = UserVar[event->BaseVarIndex];
+                success = true;
+              } else {
+                success = false;
+              }
+              PCONFIG_LONG(0) = 0; // reset threshold exceeded counter
+            }
+            // The default sensorType of the device is a single sensor value. But for detection movement we want it to be
+            // a switch so we change the sensortype here. Looks like a legal thing to do because _P001_Switch does it as well.
+            event->sensorType = SENSOR_TYPE_SWITCH;
+            break;
+          }
+          // All other functions are reading values. So extract xyz value and wanted type from function number:
+          default:  // [1-3]: range-values, [4-6]: a-values, [7-9]: g-values
+          {
+            uint8_t reqaxis = (_P045_Function - 1) % 3;       // xyz         -> eg: function 5(ay) (5-1) % 3 = 1           (y)
+            uint8_t reqvar = ((_P045_Function - 1) / 3) + 2;  // range, a, g -> eg: function 9(gz) ((9-1) / 3 = 2) + 2 = 4 (g)
+            UserVar[event->BaseVarIndex] = float(_P045_axis[reqaxis][reqvar][dev]);
+            success = true;
+            break;
+          }
+        }
+        break;
+      }
   }
+  return success;
+}
 
-
-  /** Write multiple bits in an 8-bit device register.
-   * @param regAddr Register regAddr to write to
-   * @param bitStart First bit position to write (0-7)
-   * @param length Number of bits to write (not more than 8)
-   * @param data Right-aligned value to write
-   */
-  void writeBits(uint8_t regAddr, uint8_t bitStart, uint8_t length, uint8_t data) {
-      // From I2Cdev::writeBits by Jeff Rowberg
-      //      010 value to write
-      // 76543210 bit numbers
-    //    xxx   args: bitStart=4, length=3
-    // 00011100 mask byte
-    // 10101111 original value (sample)
-    // 10100011 original & ~mask
-    // 10101011 masked | value
-    bool is_ok = true;
-    uint8_t b = I2C_read8_reg(_devAddr, regAddr, &is_ok);
-    if (is_ok) {
-      uint8_t mask = ((1 << length) - 1) << (bitStart - length + 1);
-      data <<= (bitStart - length + 1); // shift data into correct position
-      data &= mask;                     // zero all non-important bits in data
-      b &= ~(mask); // zero all important bits in existing byte
-      b |= data;    // combine data with existing byte
-      I2C_write8_reg(_devAddr, regAddr, b);
-    }
+void _P045_trackMinMax(int16_t current, int16_t *min, int16_t *max)
+// From nodemcu-laundry.ino by Nolan Gilley
+{
+  if (current > *max)
+  {
+    *max = current;
   }
+  else if (current < *min)
+  {
+    *min = current;
+  }
+}
 
-  /** Get raw 6-axis motion sensor readings (accel/gyro).
-   * Retrieves all currently available motion sensor values.
-   * @param ax 16-bit signed integer container for accelerometer X-axis value
-   * @param ay 16-bit signed integer container for accelerometer Y-axis value
-   * @param az 16-bit signed integer container for accelerometer Z-axis value
-   * @param gx 16-bit signed integer container for gyroscope X-axis value
-   * @param gy 16-bit signed integer container for gyroscope Y-axis value
-   * @param gz 16-bit signed integer container for gyroscope Z-axis value
-   */
-  void get6AxisMotion(int16_t *ax, int16_t *ay, int16_t *az, int16_t *gx,
-                      int16_t *gy, int16_t *gz) {
-    // Todo TD-er: Maybe change to our own function readBytes?
+
+/** Get raw 6-axis motion sensor readings (accel/gyro).
+ * Retrieves all currently available motion sensor values.
+ * @param devAddr I2C slave device address
+ * @param ax 16-bit signed integer container for accelerometer X-axis value
+ * @param ay 16-bit signed integer container for accelerometer Y-axis value
+ * @param az 16-bit signed integer container for accelerometer Z-axis value
+ * @param gx 16-bit signed integer container for gyroscope X-axis value
+ * @param gy 16-bit signed integer container for gyroscope Y-axis value
+ * @param gz 16-bit signed integer container for gyroscope Z-axis value
+ */
+void _P045_getMotion6(uint8_t devAddr, int16_t* ax, int16_t* ay, int16_t* az, int16_t* gx, int16_t* gy, int16_t* gz) {
     // From I2Cdev::readBytes and MPU6050::getMotion6, both by Jeff Rowberg
     uint8_t buffer[14];
     uint8_t count = 0;
-    I2C_write8(_devAddr, MPU6050_RA_ACCEL_XOUT_H);
-    Wire.requestFrom(_devAddr, (uint8_t)14);
+    I2C_write8(devAddr, MPU6050_RA_ACCEL_XOUT_H);
+    Wire.requestFrom(devAddr, (uint8_t)14);
     for (; Wire.available(); count++) {
-      buffer[count] = Wire.read();
+        buffer[count] = Wire.read();
     }
     *ax = (((int16_t)buffer[0]) << 8) | buffer[1];
     *ay = (((int16_t)buffer[2]) << 8) | buffer[3];
@@ -146,300 +368,33 @@ struct P045_data_struct : public PluginTaskData_base {
     *gx = (((int16_t)buffer[8]) << 8) | buffer[9];
     *gy = (((int16_t)buffer[10]) << 8) | buffer[11];
     *gz = (((int16_t)buffer[12]) << 8) | buffer[13];
-  }
-
-  void trackMinMax(int16_t current, int16_t *min, int16_t *max)
-  // From nodemcu-laundry.ino by Nolan Gilley
-  {
-    if (current > *max) {
-      *max = current;
-    } else if (current < *min) {
-      *min = current;
-    }
-  }
-
-  void updateSensorReading() {
-    // Read the sensorvalues, we run this bit every 1/10th of a second
-    get6AxisMotion(&axis[0][3], &axis[1][3], &axis[2][3], &axis[0][4],
-                   &axis[1][4], &axis[2][4]);
-    // Set the minimum and maximum value for each axis a-value, overwrite
-    // previous values if smaller/larger
-    trackMinMax(axis[0][3], &axis[0][0], &axis[0][1]);
-    trackMinMax(axis[1][3], &axis[1][0], &axis[1][1]);
-    trackMinMax(axis[2][3], &axis[2][0], &axis[2][1]);
-    //  current value @ 3  min val @ 0  max val @ 1
-  }
-
-  void detemineMaxMeasuredRange() {
-    // Run this bit every 5 seconds per deviceaddress (not per instance)
-    if (timeOutReached(nextUpdateMaxReadings)) {
-      nextUpdateMaxReadings = millis() + 5000;
-
-      // Determine the maximum measured range of each axis
-      for (uint8_t i = 0; i < 3; i++) {
-        axis[i][2] = abs(axis[i][1] - axis[i][0]);
-        axis[i][0] = axis[i][3];
-        axis[i][1] = axis[i][3];
-      }
-    }
-  }
-
-  int16_t axis[3][5]; // [xyz], [min/max/range,a,g]
-  unsigned long nextUpdateMaxReadings;
-  uint8_t _devAddr;
-};
-
-boolean Plugin_045(byte function, struct EventStruct *event, String &string) {
-  boolean success = false;
-
-  switch (function) {
-
-    case PLUGIN_DEVICE_ADD: {
-      Device[++deviceCount].Number       = PLUGIN_ID_045;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = SENSOR_TYPE_SINGLE;
-      Device[deviceCount].ValueCount     = 1; // Unfortunatly domoticz has no custom multivalue sensors.
-      Device[deviceCount].SendDataOption = true; //   and I use Domoticz ... so there.
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].FormulaOption  = false;
-      break;
-    }
-
-    case PLUGIN_GET_DEVICENAME: {
-      string = F(PLUGIN_NAME_045);
-      break;
-    }
-
-    case PLUGIN_GET_DEVICEVALUENAMES: {
-      strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[0],
-               PSTR(PLUGIN_VALUENAME1_045));
-      break;
-    }
-
-    case PLUGIN_WEBFORM_LOAD: {
-      // Setup webform for address selection
-      byte choice = PCONFIG(0);
-      /*
-      String options[10];
-      options[0] = F("0x68 - default settings (ADDR Low)");
-      options[1] = F("0x69 - alternate settings (ADDR High)");
-      */
-      int optionValues[2];
-      optionValues[0] = 0x68;
-      optionValues[1] = 0x69;
-      addFormSelectorI2C(F("p045_address"), 2, optionValues, choice);
-      addFormNote(F("ADDR Low=0x68, High=0x69"));
-
-      choice = PCONFIG(1);
-      String options[10];
-      options[0] = F("Movement detection");
-      options[1] = F("Range acceleration X");
-      options[2] = F("Range acceleration Y");
-      options[3] = F("Range acceleration Z");
-      options[4] = F("Acceleration X");
-      options[5] = F("Acceleration Y");
-      options[6] = F("Acceleration Z");
-      options[7] = F("G-force X");
-      options[8] = F("G-force Y");
-      options[9] = F("G-force Z");
-      addFormSelector(F("Function"), F("p045_function"), 10, options, NULL,
-                      choice);
-
-      if (choice == 0) {
-        // If this is instance function 0, setup webform for additional vars
-        // Show some user information about the webform and what the vars mean.
-        addHtml(F("<TR><TD><TD>The thresholdvalues (0-65535) can be used to set "
-                  "a threshold for one or more<br>"));
-        addHtml(F("axis. The axis will trigger when the range for that axis "
-                  "exceeds the threshold<br>"));
-        addHtml(
-            F("value. A value of 0 disables movement detection for that axis."));
-
-        addFormNumericBox(F("Detection threshold X"), F("p045_threshold_x"),
-                          PCONFIG(2), 0, 65535);
-        addFormNumericBox(F("Detection threshold Y"), F("p045_threshold_y"),
-                          PCONFIG(3), 0, 65535);
-        addFormNumericBox(F("Detection threshold Z"), F("p045_threshold_z"),
-                          PCONFIG(4), 0, 65535);
-
-        addHtml(F("<TR><TD><TD>Each 30 seconds a counter for the detection "
-                  "window is increased plus all axis<br>"));
-        addHtml(F("are checked and if they *all* exceeded the threshold values, "
-                  "a counter is increased.<br>"));
-        addHtml(F("Each period, defined by the [detection window], the counter "
-                  "is checked against<br>"));
-        addHtml(F("the [min. detection count] and if found equal or larger, "
-                  "movement is detected.<br>"));
-        addHtml(F("If in the next window the [min. detection count] value is not "
-                  "met, movement has stopped."));
-        addHtml(F("The [detection window] cannot be smaller than the [min. "
-                  "detection count]."));
-
-        addFormNumericBox(F("Min. detection count"), F("p045_threshold_counter"),
-                          PCONFIG(5), 0, 999999);
-        addFormNumericBox(F("Detection window"), F("p045_threshold_window"),
-                          PCONFIG(6), 0, 999999);
-      }
-      success = true;
-      break;
-    }
-
-    case PLUGIN_WEBFORM_SAVE: {
-      // Save the vars
-      PCONFIG(0) = getFormItemInt(F("p045_address"));
-      PCONFIG(1) = getFormItemInt(F("p045_function"));
-      PCONFIG(2) = getFormItemInt(F("p045_threshold_x"));
-      PCONFIG(3) = getFormItemInt(F("p045_threshold_y"));
-      PCONFIG(4) = getFormItemInt(F("p045_threshold_z"));
-      PCONFIG(5) = getFormItemInt(F("p045_threshold_counter"));
-      PCONFIG(6) = getFormItemInt(F("p045_threshold_window"));
-      if (PCONFIG(6) < PCONFIG(5)) {
-        PCONFIG(6) = PCONFIG(5);
-      }
-      success = true;
-      break;
-    }
-
-    case PLUGIN_EXIT: {
-      clearPluginTaskData(event->TaskIndex);
-      success = true;
-      break;
-    }
-
-    case PLUGIN_INIT: {
-      initPluginTaskData(event->TaskIndex, new P045_data_struct(PCONFIG(0)));
-      P045_data_struct *P045_data =
-          static_cast<P045_data_struct *>(getPluginTaskData(event->TaskIndex));
-      if (nullptr == P045_data) {
-        return success;
-      }
-      PCONFIG(0) = P045_data->_devAddr;
-
-      // Reset vars
-      PCONFIG(7) = 0;                   // Last known value of "switch" is off
-      UserVar[event->BaseVarIndex] = 0; // Switch is off
-      PCONFIG_LONG(0) = 0;              // Minimal detection counter is zero
-      PCONFIG_LONG(1) = 0;              // Detection window counter is zero
-      success = true;
-      break;
-    }
-
-    case PLUGIN_ONCE_A_SECOND: {
-      P045_data_struct *P045_data =
-          static_cast<P045_data_struct *>(getPluginTaskData(event->TaskIndex));
-      if (nullptr == P045_data) {
-        break;
-      }
-
-      P045_data->updateSensorReading();
-
-      /*      // Uncomment this block if you want to debug your MPU6050, but be
-         prepared for a log overload
-              String log = F("MPU6050 : axis values: ");
-              log += P045_data->axis[0][3];
-              log += F(", ");
-              log += P045_data->axis[1][3];
-              log += F(", ");
-              log += P045_data->axis[2][3];
-              log += F(", g values: ");
-              log += P045_data->axis[0][4];
-              log += F(", ");
-              log += P045_data->axis[1][4];
-              log += F(", ");
-              log += P045_data->axis[2][4];
-              addLog(LOG_LEVEL_INFO,log);
-      */
-      P045_data->detemineMaxMeasuredRange();
-      success = true;
-      break;
-    }
-
-    case PLUGIN_READ: {
-      P045_data_struct *P045_data =
-          static_cast<P045_data_struct *>(getPluginTaskData(event->TaskIndex));
-      if (nullptr == P045_data) {
-        break;
-      }
-
-      int _P045_Function = PCONFIG(1);
-      switch (_P045_Function) {
-        // Function 0 is for movement detection
-        case 0: {
-          // Check if all (enabled, so !=0) thresholds are exceeded, if one fails
-          // then thresexceed (thesholds exceeded) is reset to false;
-          boolean thresexceed = true;
-          byte count = 0; // Counter to check if not all thresholdvalues are set to
-                          // 0 or disabled
-          for (byte i = 0; i < 3; i++) {
-            // for each axis:
-            if (PCONFIG(i + 2) != 0) { // not disabled, check threshold
-              if (P045_data->axis[i][2] < PCONFIG(i + 2)) {
-                thresexceed = false;
-              }
-            } else {
-              count++;
-            } // If disabled count + 1
-          }
-          if (count == 3) {
-            thresexceed = false;
-          } // If we counted to three, all three axis are disabled.
-
-          // If all enabled thresholds are exceeded the increase the counter
-          if (thresexceed) {
-            PCONFIG_LONG(0)++;
-          }
-          // And increase the window counter
-          PCONFIG_LONG(1)++;
-
-          if (PCONFIG_LONG(1) >= PCONFIG(6)) {
-            // Detection window has passed.
-            PCONFIG_LONG(1) = 0; // reset window counter
-
-            // Did we count more times exceeded then the minimum detection value?
-            if (PCONFIG_LONG(0) >= PCONFIG(5)) {
-              UserVar[event->BaseVarIndex] =
-                  1; // x times threshold exceeded within window.
-            } else {
-              UserVar[event->BaseVarIndex] =
-                  0; // reset because x times threshold within window not met.
-            }
-
-            // Check if UserVar changed so we do not overload homecontroller with
-            // the same readings
-            if (PCONFIG(7) != UserVar[event->BaseVarIndex]) {
-              PCONFIG(7) = UserVar[event->BaseVarIndex];
-              success = true;
-            } else {
-              success = false;
-            }
-            PCONFIG_LONG(0) = 0; // reset threshold exceeded counter
-          }
-          // The default sensorType of the device is a single sensor value. But for
-          // detection movement we want it to be
-          // a switch so we change the sensortype here. Looks like a legal thing to
-          // do because _P001_Switch does it as well.
-          event->sensorType = SENSOR_TYPE_SWITCH;
-          break;
-        }
-        // All other functions are reading values. So extract xyz value and wanted
-        // type from function number:
-        default: // [1-3]: range-values, [4-6]: a-values, [7-9]: g-values
-        {
-          uint8_t reqaxis =
-              (_P045_Function - 1) %
-              3; // xyz         -> eg: function 5(ay) (5-1) % 3 = 1           (y)
-          uint8_t reqvar =
-              ((_P045_Function - 1) / 3) +
-              2; // range, a, g -> eg: function 9(gz) ((9-1) / 3 = 2) + 2 = 4 (g)
-          UserVar[event->BaseVarIndex] = float(P045_data->axis[reqaxis][reqvar]);
-          success = true;
-          break;
-        }
-      }
-      break;
-    }
-  }
-  return success;
 }
 
+/** Write multiple bits in an 8-bit device register.
+ * @param devAddr I2C slave device address
+ * @param regAddr Register regAddr to write to
+ * @param bitStart First bit position to write (0-7)
+ * @param length Number of bits to write (not more than 8)
+ * @param data Right-aligned value to write
+ */
+void _P045_writeBits(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint8_t length, uint8_t data) {
+    // From I2Cdev::writeBits by Jeff Rowberg
+    //      010 value to write
+    // 76543210 bit numbers
+    //    xxx   args: bitStart=4, length=3
+    // 00011100 mask byte
+    // 10101111 original value (sample)
+    // 10100011 original & ~mask
+    // 10101011 masked | value
+    bool is_ok = true;
+    uint8_t b = I2C_read8_reg(devAddr, regAddr, &is_ok);
+    if (is_ok) {
+      uint8_t mask = ((1 << length) - 1) << (bitStart - length + 1);
+      data <<= (bitStart - length + 1); // shift data into correct position
+      data &= mask; // zero all non-important bits in data
+      b &= ~(mask); // zero all important bits in existing byte
+      b |= data; // combine data with existing byte
+      I2C_write8_reg(devAddr, regAddr, b);
+    }
+}
 #endif // USES_P045

--- a/src/_P052_SenseAir.ino
+++ b/src/_P052_SenseAir.ino
@@ -26,15 +26,6 @@
 
 #define P052_MEASUREMENT_INTERVAL 60000L
 
-#define P052_READ_HOLDING_REGISTERS 0x03
-#define P052_READ_INPUT_REGISTERS 0x04
-#define P052_WRITE_SINGLE_REGISTER 0x06
-
-#define P052_CMD_READ_RAM 0x44
-#define P052_CMD_READ_EEPROM 0x46
-#define P052_CMD_WRITE_RAM 0x41
-#define P052_CMD_WRITE_EEPROM 0x43
-
 // For layout and status flags in RAM/EEPROM, see document
 // "CO2-Engine-BLG_ELG configuration guide Rev 1_02.docx"
 
@@ -78,43 +69,32 @@
 #define P052_HR_SPACE_CO2 3
 #define P052_HR_ABC_PERIOD 31
 
-#define P052_MODBUS_RECEIVE_BUFFER 256
 #define P052_MODBUS_SLAVE_ADDRESS 0xFE // Modbus "any address"
-
-#define MODBUS_EXCEPTION_ILLEGAL_FUNCTION        1
-#define MODBUS_EXCEPTION_ILLEGAL_DATA_ADDRESS    2
-#define MODBUS_EXCEPTION_ILLEGAL_DATA_VALUE      3
-#define MODBUS_EXCEPTION_SLAVE_OR_SERVER_FAILURE 4
-#define MODBUS_EXCEPTION_ACKNOWLEDGE             5
-#define MODBUS_EXCEPTION_SLAVE_OR_SERVER_BUSY    6
-#define MODBUS_EXCEPTION_NEGATIVE_ACKNOWLEDGE    7
-#define MODBUS_EXCEPTION_MEMORY_PARITY           8
-#define MODBUS_EXCEPTION_NOT_DEFINED             9
-#define MODBUS_EXCEPTION_GATEWAY_PATH            10
-#define MODBUS_EXCEPTION_GATEWAY_TARGET          11
-
-/* Additional error codes for the Plugin_052_processCommand return values */
-#define Plugin_052_MODBUS_BADCRC   (MODBUS_EXCEPTION_GATEWAY_TARGET + 1)
-#define Plugin_052_MODBUS_BADDATA  (MODBUS_EXCEPTION_GATEWAY_TARGET + 2)
-#define Plugin_052_MODBUS_BADEXC   (MODBUS_EXCEPTION_GATEWAY_TARGET + 3)
-#define Plugin_052_MODBUS_UNKEXC   (MODBUS_EXCEPTION_GATEWAY_TARGET + 4)
-#define Plugin_052_MODBUS_MDATA    (MODBUS_EXCEPTION_GATEWAY_TARGET + 5)
-#define Plugin_052_MODBUS_BADSLAVE (MODBUS_EXCEPTION_GATEWAY_TARGET + 6)
 
 #include <ESPeasySerial.h>
 
-byte _plugin_052_sendframe[8] = {0};
-byte _plugin_052_sendframe_used = 0;
-byte _plugin_052_recv_buf[P052_MODBUS_RECEIVE_BUFFER] = {0xff};
-byte _plugin_052_recv_buf_used = 0;
-boolean Plugin_052_init = false;
-String detected_device_description;
+
+struct P052_data_struct : public PluginTaskData_base {
+  P052_data_struct() {}
+
+  ~P052_data_struct() { reset(); }
+
+  void reset() {
+    modbus.reset();
+  }
+
+  bool init(const int16_t serial_rx, const int16_t serial_tx) {
+    return modbus.init(serial_rx, serial_tx, 9600, P052_MODBUS_SLAVE_ADDRESS);
+  }
+
+  bool isInitialized() const {
+    return modbus.isInitialized();
+  }
+
+  ModbusRTU_struct modbus;
+};
 
 unsigned int _plugin_052_last_measurement = 0;
-uint32_t _plugin_052_reads_pass = 0;
-uint32_t _plugin_052_reads_crc_failed = 0;
-
-ESPeasySerial *P052_easySerial;
 
 boolean Plugin_052(byte function, struct EventStruct *event, String &string) {
   boolean success = false;
@@ -159,9 +139,25 @@ boolean Plugin_052(byte function, struct EventStruct *event, String &string) {
       int par1;
       if (validIntFromString(param1, par1)) {
         if (par1 == 0 || par1 == 1 || par1 == -1) {
-          Plugin_052_setRelayStatus(par1);
-          addLog(LOG_LEVEL_INFO,
-                 String(F("Senseair command: relay=")) + param1);
+          short relaystatus = 0; // 0x3FFF represents 100% output.
+          //  Refer to sensor model’s specification for voltage at 100% output.
+          switch (par1) {
+          case 0:
+            relaystatus = 0;
+            break;
+          case 1:
+            relaystatus = 0x3FFF;
+            break;
+          default:
+            relaystatus = 0x7FFF;
+            break;
+          }
+          P052_data_struct *P052_data =
+              static_cast<P052_data_struct *>(getPluginTaskData(event->TaskIndex));
+          if (nullptr != P052_data && P052_data->isInitialized()) {
+            P052_data->modbus.writeSingleRegister(0x18, relaystatus);
+            addLog(LOG_LEVEL_INFO, String(F("Senseair command: relay=")) + param1);
+          }
         }
       }
       success = true;
@@ -205,18 +201,22 @@ boolean Plugin_052(byte function, struct EventStruct *event, String &string) {
     NULL, choiceABCperiod);
     */
 
-    if (detected_device_description.length() > 0) {
-      String detectedString;
-      detectedString += detected_device_description;
-      detectedString += F("detected");
-      addFormNote(detectedString);
+    P052_data_struct *P052_data =
+        static_cast<P052_data_struct *>(getPluginTaskData(event->TaskIndex));
+    if (nullptr != P052_data && P052_data->isInitialized()) {
+      String detectedString = P052_data->modbus.detected_device_description;
+      if (detectedString.length() > 0) {
+        addFormNote(detectedString);
+      }
+      addRowLabel(F("Checksum (pass/fail)"));
+      uint32_t reads_pass, reads_crc_failed;
+      P052_data->modbus.getStatistics(reads_pass, reads_crc_failed);
+      String chksumStats;
+      chksumStats = reads_pass;
+      chksumStats += '/';
+      chksumStats += reads_crc_failed;
+      addHtml(chksumStats);
     }
-    addRowLabel(F("Checksum (pass/fail)"));
-    String chksumStats;
-    chksumStats = _plugin_052_reads_pass;
-    chksumStats += '/';
-    chksumStats += _plugin_052_reads_crc_failed;
-    addHtml(chksumStats);
     success = true;
     break;
   }
@@ -235,36 +235,46 @@ boolean Plugin_052(byte function, struct EventStruct *event, String &string) {
   }
 
   case PLUGIN_INIT: {
-    Plugin_052_init = true;
-    P052_easySerial = new ESPeasySerial(CONFIG_PIN1, CONFIG_PIN2);
+    const int16_t serial_rx = CONFIG_PIN1;
+    const int16_t serial_tx = CONFIG_PIN2;
+    initPluginTaskData(event->TaskIndex, new P052_data_struct());
+    P052_data_struct *P052_data =
+        static_cast<P052_data_struct *>(getPluginTaskData(event->TaskIndex));
+    if (nullptr == P052_data) {
+      return success;
+    }
+    if (P052_data->init(serial_rx, serial_tx)) {
+      /*
+      // ABC functionality disabled for now, due to a bug in the firmware.
+      // See https://github.com/letscontrolit/ESPEasy/issues/759
+      const int periodInHours[9] = {0, 1, 12, (24*1), (24*2), (24*4), (24*7),
+      (24*14), (24*30) };
+      byte choiceABCperiod = PCONFIG(1);
 
-    /*
-    // ABC functionality disabled for now, due to a bug in the firmware.
-    // See https://github.com/letscontrolit/ESPEasy/issues/759
-    const int periodInHours[9] = {0, 1, 12, (24*1), (24*2), (24*4), (24*7),
-    (24*14), (24*30) };
-    byte choiceABCperiod = PCONFIG(1);
+      Plugin_052_setABCperiod(periodInHours[choiceABCperiod]);
+      */
 
-    Plugin_052_setABCperiod(periodInHours[choiceABCperiod]);
-    */
+      success = true;
+    } else {
+      clearPluginTaskData(event->TaskIndex);
+    }
+    break;
+  }
 
+  case PLUGIN_EXIT: {
+    clearPluginTaskData(event->TaskIndex);
     success = true;
-    Plugin_052_modbus_log_MEI(P052_MODBUS_SLAVE_ADDRESS);
-    detected_device_description =
-        Plugin_052_getDevice_description(P052_MODBUS_SLAVE_ADDRESS);
-    addLog(LOG_LEVEL_INFO, detected_device_description);
-
     break;
   }
 
   case PLUGIN_READ: {
-
-    if (Plugin_052_init) {
-
+    P052_data_struct *P052_data =
+        static_cast<P052_data_struct *>(getPluginTaskData(event->TaskIndex));
+    if (nullptr != P052_data && P052_data->isInitialized()) {
       String log = F("Senseair: ");
       switch (PCONFIG(0)) {
       case 0: {
-        int errorWord = Plugin_052_readErrorStatus();
+        int errorWord = P052_data->modbus.readInputRegister(0x00);
         for (size_t i = 0; i < 9; i++) {
           if (bitRead(errorWord, i)) {
             UserVar[event->BaseVarIndex] = i;
@@ -280,35 +290,38 @@ boolean Plugin_052(byte function, struct EventStruct *event, String &string) {
         break;
       }
       case 1: {
-        int co2 = Plugin_052_readCo2();
+        int co2 = P052_data->modbus.readInputRegister(0x03);
         UserVar[event->BaseVarIndex] = co2;
         log += F("co2 = ");
         log += co2;
         break;
       }
       case 2: {
-        float temperature = Plugin_052_readTemperature();
+        int temperatureX100 = P052_data->modbus.readInputRegister(0x04);
+        float temperature = static_cast<float>(temperatureX100) / 100.0;
         UserVar[event->BaseVarIndex] = (float)temperature;
         log += F("temperature = ");
         log += (float)temperature;
         break;
       }
       case 3: {
-        float relativeHumidity = Plugin_052_readRelativeHumidity();
-        UserVar[event->BaseVarIndex] = (float)relativeHumidity;
+        int rhX100 = P052_data->modbus.readInputRegister(0x05);
+        float rh = static_cast<float>(rhX100) / 100.0;
+        UserVar[event->BaseVarIndex] = rh;
         log += F("humidity = ");
-        log += (float)relativeHumidity;
+        log += rh;
         break;
       }
       case 4: {
-        int relayStatus = Plugin_052_readRelayStatus();
+        int status = P052_data->modbus.readInputRegister(0x1C);
+        int relayStatus = (status >> 8) & 0x1;
         UserVar[event->BaseVarIndex] = relayStatus;
         log += F("relay status = ");
         log += relayStatus;
         break;
       }
       case 5: {
-        int temperatureAdjustment = Plugin_052_readTemperatureAdjustment();
+        int temperatureAdjustment = P052_data->modbus.readInputRegister(0x0A);
         UserVar[event->BaseVarIndex] = temperatureAdjustment;
         log += F("temperature adjustment = ");
         log += temperatureAdjustment;
@@ -326,221 +339,21 @@ boolean Plugin_052(byte function, struct EventStruct *event, String &string) {
   return success;
 }
 
-String Plugin_052_getDevice_description(byte slaveAddress) {
-  bool more_follows = true;
-  byte next_object_id = 0;
-  byte conformity_level = 0;
-  unsigned int object_value_int;
-  String description;
-  String obj_text;
-//  description = F("address: ");
-//  description += String(Plugin_052_readModbusAddress());
-  for (byte object_id = 0; object_id < 0x84; ++object_id) {
-    if (object_id == 6) {
-      object_id = 0x82; // Skip to the serialnr/sensor type
-    }
-    int result = Plugin_052_modbus_get_MEI(slaveAddress, object_id, obj_text,
-                                       object_value_int, next_object_id,
-                                       more_follows, conformity_level);
-    String label;
-    switch (object_id) {
-    case 0x01:
-      if (result == 0) label = F("Pcode");
-      break;
-    case 0x02:
-      if (result == 0) label = F("Rev");
-      break;
-    case 0x82:
-    {
-      if (result != 0) {
-        uint32_t sensorId = Plugin_052_readSensorId();
-        obj_text = String(sensorId, HEX);
-        result = 0;
+/*
+bool getBitOfInt(int reg, int pos) {
+  // Create a mask
+  int mask = 0x01 << pos;
 
-      }
-      if (result == 0) label = F("S/N");
-      break;
-    }
-    case 0x83:
-    {
-      if (result != 0) {
-        uint32_t sensorId = Plugin_052_readTypeId();
-        obj_text = String(sensorId, HEX);
-        result = 0;
-      }
-      if (result == 0) label = F("Type");
-      break;
-    }
-    default:
-      break;
-    }
-    if (result == 0) {
-      if (label.length() > 0) {
-        // description += Plugin_052_MEI_objectid_to_name(object_id);
-        description += label;
-        description += F(": ");
-      }
-      if (obj_text.length() > 0) {
-        description += obj_text;
-        description += F(" - ");
-      }
-    }
-  }
-  return description;
-}
+  // Mask the status register
+  int masked_register = mask & reg;
 
-// Read from RAM or EEPROM
-void Plugin_052_buildRead_RAM_EEPROM(byte slaveAddress, byte functionCode,
-                                     short startAddress, byte number_bytes) {
-  _plugin_052_sendframe[0] = slaveAddress;
-  _plugin_052_sendframe[1] = functionCode;
-  _plugin_052_sendframe[2] = (byte)(startAddress >> 8);
-  _plugin_052_sendframe[3] = (byte)(startAddress & 0xFF);
-  _plugin_052_sendframe[4] = number_bytes;
-  _plugin_052_sendframe_used = 5;
-}
-
-// Write to the Special Control Register (SCR)
-void Plugin_052_buildWriteCommandRegister(byte slaveAddress, byte value) {
-  _plugin_052_sendframe[0] = slaveAddress;
-  _plugin_052_sendframe[1] = P052_CMD_WRITE_RAM;
-  _plugin_052_sendframe[2] = 0;    // Address-Hi SCR  (0x0060)
-  _plugin_052_sendframe[3] = 0x60; // Address-Lo SCR
-  _plugin_052_sendframe[4] = 1;    // Count
-  _plugin_052_sendframe[5] = value;
-  _plugin_052_sendframe_used = 6;
-}
-
-void Plugin_052_buildFrame(byte slaveAddress, byte functionCode,
-                           short startAddress, short parameter) {
-  _plugin_052_sendframe[0] = slaveAddress;
-  _plugin_052_sendframe[1] = functionCode;
-  _plugin_052_sendframe[2] = (byte)(startAddress >> 8);
-  _plugin_052_sendframe[3] = (byte)(startAddress & 0xFF);
-  _plugin_052_sendframe[4] = (byte)(parameter >> 8);
-  _plugin_052_sendframe[5] = (byte)(parameter & 0xFF);
-  _plugin_052_sendframe_used = 6;
-}
-
-void Plugin_052_build_modbus_MEI_frame(byte slaveAddress, byte device_id,
-                                       byte object_id) {
-  _plugin_052_sendframe[0] = slaveAddress;
-  _plugin_052_sendframe[1] = 0x2B;
-  _plugin_052_sendframe[2] = 0x0E;
-
-  // The parameter "Read Device ID code" allows to define four access types :
-  // 01: request to get the basic device identification (stream access)
-  // 02: request to get the regular device identification (stream access)
-  // 03: request to get the extended device identification (stream access)
-  // 04: request to get one specific identification object (individual access)
-  _plugin_052_sendframe[3] = device_id;
-  _plugin_052_sendframe[4] = object_id;
-  _plugin_052_sendframe_used = 5;
-}
-
-String Plugin_052_MEI_objectid_to_name(byte object_id) {
-  switch (object_id) {
-  case 0:
-    return F("VendorName");
-  case 1:
-    return F("ProductCode");
-  case 2:
-    return F("MajorMinorRevision");
-  case 3:
-    return F("VendorUrl");
-  case 4:
-    return F("ProductName");
-  case 5:
-    return F("ModelName");
-  case 6:
-    return F("UserApplicationName");
-  case 0x80:
-    return F("MemoryMapVersion");
-  case 0x81:
-    return F("Firmware Rev.");
-  case 0x82:
-    return F("Sensor S/N");
-  case 0x83:
-    return F("Sensor type");
-  default:
-    return String(F("0x")) + String(object_id, HEX);
-  }
-}
-
-String Plugin_052_parse_modbus_MEI_response(unsigned int &object_value_int,
-                                            byte &next_object_id,
-                                            bool &more_follows,
-                                            byte &conformity_level) {
-  String result;
-  if (_plugin_052_recv_buf_used < 8) {
-    // Too small.
-    addLog(LOG_LEVEL_INFO,
-           String(F("MEI response too small: ")) + _plugin_052_recv_buf_used);
-    next_object_id = 0xFF;
-    more_follows = false;
-    return result;
-  }
-  int pos = 4; // Data skipped: slave_address, FunctionCode, MEI type, ReadDevId
-  // See http://www.modbus.org/docs/Modbus_Application_Protocol_V1_1b.pdf
-  // Page 45
-  conformity_level             = _plugin_052_recv_buf[pos++];
-  more_follows                 = _plugin_052_recv_buf[pos++] != 0;
-  next_object_id               = _plugin_052_recv_buf[pos++];
-  const byte number_objects    = _plugin_052_recv_buf[pos++];
-  byte object_id = 0;
-  for (int i = 0; i < number_objects; ++i) {
-    if ((pos + 3) < _plugin_052_recv_buf_used) {
-      object_id                = _plugin_052_recv_buf[pos++];
-      const byte object_length = _plugin_052_recv_buf[pos++];
-      if ((pos + object_length) < _plugin_052_recv_buf_used) {
-        String object_value;
-        if (object_id < 0x80) {
-          // Parse as type String
-          object_value.reserve(object_length);
-          object_value_int = static_cast<unsigned int>(-1);
-          for (int c = 0; c < object_length; ++c) {
-            object_value += char(_plugin_052_recv_buf[pos++]);
-          }
-        } else {
-          object_value.reserve(2 * object_length + 2);
-          object_value_int = 0;
-          for (int c = 0; c < object_length; ++c) {
-            object_value_int =
-                object_value_int << 8 | _plugin_052_recv_buf[pos++];
-          }
-          object_value = F("0x");
-          String hexvalue(object_value_int, HEX);
-          hexvalue.toUpperCase();
-          object_value += hexvalue;
-        }
-        if (i != 0) {
-          // Append to existing description
-          result += String(F(",  "));
-        }
-        result += object_value;
-      }
-    }
-  }
-  return result;
-}
-
-String Plugin_052_log_buffer(byte *buffer, int length) {
-  String log;
-  log.reserve(3 * length + 5);
-  for (int i = 0; i < length; ++i) {
-    String hexvalue(buffer[i], HEX);
-    hexvalue.toUpperCase();
-    log += hexvalue;
-    log += F(" ");
-  }
-  log += F("(");
-  log += length;
-  log += F(")");
-  return log;
+  // Shift the result of masked register back to position 0
+  int result = masked_register >> pos;
+  return (result == 1);
 }
 
 bool Plugin_052_check_error_status() {
-  byte error_status = Plugin_052_read_RAM_EEPROM(P052_CMD_READ_RAM,
+  byte error_status = P052_data->modbus.read_RAM_EEPROM(P052_CMD_READ_RAM,
                                                  P052_RAM_ADDR_ERROR_STATUS, 1);
   if (error_status == 0)
     return true;
@@ -581,303 +394,13 @@ bool Plugin_052_check_error_status() {
   return false;
 }
 
-void Plugin_052_logModbusException(byte value) {
-  if (value == 0)
-    return;
-  // Exception Response, see:
-  // http://digital.ni.com/public.nsf/allkb/E40CA0CFA0029B2286256A9900758E06?OpenDocument
-  String log = F("Modbus Exception - ");
-  switch (value) {
-  case MODBUS_EXCEPTION_ILLEGAL_FUNCTION: {
-    // The function code received in the query is not an allowable action for
-    // the slave.
-    // If a Poll Program Complete command was issued, this code indicates that
-    // no program function preceded it.
-    log += F("Illegal Function (not allowed by client)");
-    break;
-  }
-  case MODBUS_EXCEPTION_ILLEGAL_DATA_ADDRESS: {
-    // The data address received in the query is not an allowable address for
-    // the slave.
-    log += F("Illegal Data Address");
-    break;
-  }
-  case MODBUS_EXCEPTION_ILLEGAL_DATA_VALUE: {
-    // A value contained in the query data field is not an allowable value for
-    // the slave
-    log += F("Illegal Data Value");
-    break;
-  }
-  case MODBUS_EXCEPTION_SLAVE_OR_SERVER_FAILURE: {
-    // An unrecoverable error occurred while the slave was attempting to perform
-    // the requested action
-    log += F("Slave Device Failure");
-    break;
-  }
-  case MODBUS_EXCEPTION_ACKNOWLEDGE: {
-    // The slave has accepted the request and is processing it, but a long
-    // duration of time will be
-    // required to do so. This response is returned to prevent a timeout error
-    // from occurring in the master.
-    // The master can next issue a Poll Program Complete message to determine if
-    // processing is completed.
-    log += F("Acknowledge");
-    break; // Is this an error?
-  }
-  case MODBUS_EXCEPTION_SLAVE_OR_SERVER_BUSY: {
-    // The slave is engaged in processing a long-duration program command.
-    // The master should retransmit the message later when the slave is free.
-    log += F("Slave Device Busy");
-    break;
-  }
-  case MODBUS_EXCEPTION_NEGATIVE_ACKNOWLEDGE:
-    log += F("Negative acknowledge");
-    break;
-  case MODBUS_EXCEPTION_MEMORY_PARITY:
-    log += F("Memory parity error");
-    break;
-  case MODBUS_EXCEPTION_GATEWAY_PATH:
-    log += F("Gateway path unavailable");
-    break;
-  case MODBUS_EXCEPTION_GATEWAY_TARGET:
-    log += F("Target device failed to respond");
-    break;
-  case Plugin_052_MODBUS_BADCRC:
-    log += F("Invalid CRC");
-    break;
-  case Plugin_052_MODBUS_BADDATA:
-    log += F("Invalid data");
-    break;
-  case Plugin_052_MODBUS_BADEXC:
-    log += F("Invalid exception code");
-    break;
-  case Plugin_052_MODBUS_MDATA:
-    log += F("Too many data");
-    break;
-  case Plugin_052_MODBUS_BADSLAVE:
-    log += F("Response not from requested slave");
-    break;
-  default:
-    log += String(F("Unknown Exception code: ")) + value;
-    break;
-  }
-  log += F(" - sent: ");
-  log +=
-      Plugin_052_log_buffer(_plugin_052_sendframe, _plugin_052_sendframe_used);
-  log += F(" - received: ");
-  log += Plugin_052_log_buffer(_plugin_052_recv_buf, _plugin_052_recv_buf_used);
-  addLog(LOG_LEVEL_DEBUG_MORE, log);
-}
-
-byte Plugin_052_processCommand() {
-  // CRC-calculation
-  unsigned int crc =
-      Plugin_052_ModRTU_CRC(_plugin_052_sendframe, _plugin_052_sendframe_used);
-  // Note, this number has low and high bytes swapped, so use it accordingly (or
-  // swap bytes)
-  byte checksumHi = (byte)((crc >> 8) & 0xFF);
-  byte checksumLo = (byte)(crc & 0xFF);
-  _plugin_052_sendframe[_plugin_052_sendframe_used++] = checksumLo;
-  _plugin_052_sendframe[_plugin_052_sendframe_used++] = checksumHi;
-
-  int nrRetriesLeft = 2;
-  byte return_value = 0;
-  while (nrRetriesLeft > 0) {
-    return_value = 0;
-    // Send the byte array
-    P052_easySerial->write(_plugin_052_sendframe, _plugin_052_sendframe_used);
-    delay(50);
-
-    // Read answer from sensor
-    _plugin_052_recv_buf_used = 0;
-    while (P052_easySerial->available() &&
-           _plugin_052_recv_buf_used < P052_MODBUS_RECEIVE_BUFFER) {
-      _plugin_052_recv_buf[_plugin_052_recv_buf_used++] =
-          P052_easySerial->read();
-    }
-
-    // Check for MODBUS exception
-    const byte received_functionCode = _plugin_052_recv_buf[1];
-    if ((received_functionCode & 0x80) != 0) {
-      return_value = _plugin_052_recv_buf[2];
-    }
-    // Check checksum
-    crc = Plugin_052_ModRTU_CRC(_plugin_052_recv_buf, _plugin_052_recv_buf_used);
-    if (crc != 0u) {
-      ++_plugin_052_reads_crc_failed;
-      return_value = Plugin_052_MODBUS_BADCRC;
-    } else {
-      ++_plugin_052_reads_pass;
-    }
-    switch (return_value) {
-    case MODBUS_EXCEPTION_ACKNOWLEDGE:
-    case MODBUS_EXCEPTION_SLAVE_OR_SERVER_BUSY:
-    case Plugin_052_MODBUS_BADCRC:
-      // Bad communication, makes sense to retry.
-      break;
-    default:
-      nrRetriesLeft = 0; // When not supported, does not make sense to retry.
-      break;
-    }
-    --nrRetriesLeft;
-  }
-  return return_value;
-}
-
-uint32_t Plugin_052_read_32b_InputRegister(short address) {
-  uint32_t result = 0;
-  int idHigh = Plugin_052_readInputRegister(address);
-  int idLow = Plugin_052_readInputRegister(address + 1);
-  if (idHigh >= 0 && idLow >= 0) {
-    result = idHigh;
-    result = result << 16;
-    result += idLow;
-  }
-  return result;
-}
-
-int Plugin_052_readInputRegister(short address) {
-  // Only read 1 register
-  return Plugin_052_process_16b_register(P052_MODBUS_SLAVE_ADDRESS,
-                                         P052_READ_INPUT_REGISTERS, address, 1);
-}
-
-int Plugin_052_readHoldingRegister(short address) {
-  // Only read 1 register
-  return Plugin_052_process_16b_register(
-      P052_MODBUS_SLAVE_ADDRESS, P052_READ_HOLDING_REGISTERS, address, 1);
-}
-
-// Write to holding register.
-int Plugin_052_writeSingleRegister(short address, short value) {
-  // GN: Untested, will probably not work
-  return Plugin_052_process_16b_register(
-      P052_MODBUS_SLAVE_ADDRESS, P052_WRITE_SINGLE_REGISTER, address, value);
-}
-
-byte Plugin_052_modbus_get_MEI(byte slaveAddress, byte object_id,
-                               String &result, unsigned int &object_value_int,
-                               byte &next_object_id, bool &more_follows,
-                               byte &conformity_level) {
-  // Force device_id to 4 = individual access (reading one ID object per call)
-  Plugin_052_build_modbus_MEI_frame(slaveAddress, 4, object_id);
-  const byte process_result = Plugin_052_processCommand();
-  if (process_result == 0) {
-    result = Plugin_052_parse_modbus_MEI_response(object_value_int,
-                                                  next_object_id, more_follows,
-                                                  conformity_level);
-  } else {
-    more_follows = false;
-  }
-  return process_result;
-}
-
-void Plugin_052_modbus_log_MEI(byte slaveAddress) {
-  // Iterate over all Device identification items, using
-  // Modbus command (0x2B / 0x0E) Read Device Identification
-  // And add to log.
-  bool more_follows = true;
-  byte conformity_level = 0;
-  byte object_id = 0;
-  byte next_object_id = 0;
-  while (more_follows) {
-    String result;
-    unsigned int object_value_int;
-    const byte process_result = Plugin_052_modbus_get_MEI(
-        slaveAddress, object_id, result, object_value_int, next_object_id,
-        more_follows, conformity_level);
-    if (process_result == 0) {
-      if (result.length() > 0) {
-        String log = Plugin_052_MEI_objectid_to_name(object_id);
-        log += F(": ");
-        log += result;
-        addLog(LOG_LEVEL_INFO, log);
-      }
-    } else {
-      switch (process_result) {
-      case MODBUS_EXCEPTION_ILLEGAL_DATA_ADDRESS:
-        // No need to log this exception when scanning.
-        break;
-      default:
-        Plugin_052_logModbusException(process_result);
-        break;
-      }
-    }
-    // If more parts are needed, collect them or iterate over the known list.
-    // For example with "individual access" a new request has to be sent for each single item
-    if (more_follows) {
-      object_id = next_object_id;
-    } else if (object_id < 0x84) {
-      // Allow for scanning only the usual object ID's
-      // This range is vendor specific
-      more_follows = true;
-      object_id++;
-      if (object_id == 7) {
-        // Skip range 0x07...0x7F
-        object_id = 0x80;
-      }
-    }
-  }
-}
-
-int Plugin_052_process_16b_register(byte slaveAddress, byte functionCode,
-                                    short startAddress, short parameter) {
-  Plugin_052_buildFrame(slaveAddress, functionCode, startAddress, parameter);
-  const byte process_result = Plugin_052_processCommand();
-  if (process_result == 0) {
-    return (_plugin_052_recv_buf[3] << 8) | (_plugin_052_recv_buf[4]);
-  }
-  Plugin_052_logModbusException(process_result);
-  return -1;
-}
-
-int Plugin_052_writeSpecialCommandRegister(byte command) {
-  Plugin_052_buildWriteCommandRegister(P052_MODBUS_SLAVE_ADDRESS, command);
-  const byte process_result = Plugin_052_processCommand();
-  if (process_result == 0)
-    return 0;
-  Plugin_052_logModbusException(process_result);
-  return -1;
-}
-
-unsigned int Plugin_052_read_RAM_EEPROM(byte command, byte startAddress,
-                                        byte nrBytes) {
-  Plugin_052_buildRead_RAM_EEPROM(P052_MODBUS_SLAVE_ADDRESS, command,
-                                  startAddress, nrBytes);
-  const byte process_result = Plugin_052_processCommand();
-  if (process_result == 0) {
-    unsigned int result = 0;
-    for (int i = 0; i < _plugin_052_recv_buf[2]; ++i) {
-      // Most significant byte at lower address
-      result = (result << 8) | _plugin_052_recv_buf[i + 3];
-    }
-    return result;
-  }
-  Plugin_052_logModbusException(process_result);
-  return -1;
-}
-
-int Plugin_052_readErrorStatus(void) {
-  return Plugin_052_readInputRegister(0x00);
-}
-
-uint32_t Plugin_052_readTypeId() {
-  return Plugin_052_read_32b_InputRegister(25);
-}
-
-uint32_t Plugin_052_readSensorId() {
-  return Plugin_052_read_32b_InputRegister(29);
-}
-
-int Plugin_052_readCo2(void) { return Plugin_052_readInputRegister(0x03); }
-
 int Plugin_052_readCo2_from_RAM(void) {
   bool valid_measurement = Plugin_052_prepare_single_measurement_from_RAM();
   short co2 =
-      Plugin_052_read_RAM_EEPROM(P052_CMD_READ_RAM, P052_RAM_ADDR_CO2, 2);
-  short temperature = Plugin_052_read_RAM_EEPROM(
+      P052_data->modbus.read_RAM_EEPROM(P052_CMD_READ_RAM, P052_RAM_ADDR_CO2, 2);
+  short temperature = P052_data->modbus.read_RAM_EEPROM(
       P052_CMD_READ_RAM, P052_RAM_ADDR_SPACE_TEMPERATURE, 2);
-  short humidity = Plugin_052_read_RAM_EEPROM(
+  short humidity = P052_data->modbus.read_RAM_EEPROM(
       P052_CMD_READ_RAM, P052_RAM_ADDR_RELATIVE_HUMIDITY, 2);
   String log = F("P052: ");
   log += F("CO2: ");
@@ -894,7 +417,7 @@ int Plugin_052_readCo2_from_RAM(void) {
 }
 
 bool Plugin_052_measurement_active() {
-  unsigned int meter_status = Plugin_052_read_RAM_EEPROM(
+  unsigned int meter_status = P052_data->modbus.read_RAM_EEPROM(
       P052_CMD_READ_RAM, P052_RAM_ADDR_METER_STATUS, 1);
   // Meter Status bit 5 indicates single cycle measurement active
   return getBitOfInt(meter_status, 5);
@@ -941,80 +464,16 @@ bool Plugin_052_prepare_single_measurement_from_RAM() {
   return false;
 }
 
-float Plugin_052_readTemperature(void) {
-  int temperatureX100 = Plugin_052_readInputRegister(0x04);
-  float temperature = (float)temperatureX100 / 100.0;
-  return temperature;
-}
 
-float Plugin_052_readRelativeHumidity(void) {
-  int rhX100 = Plugin_052_readInputRegister(0x05);
-  float rh = 0.0;
-  rh = (float)rhX100 / 100;
-  return rh;
-}
 
-int Plugin_052_readRelayStatus(void) {
-  int status = Plugin_052_readInputRegister(0x1C);
-  bool result = status >> 8 & 0x1;
-  return result;
-}
-
-int Plugin_052_readTemperatureAdjustment(void) {
-  return Plugin_052_readInputRegister(0x0A);
-}
-
-void Plugin_052_setRelayStatus(int status) {
-  short relaystatus = 0; // 0x3FFF represents 100% output.
-  //  Refer to sensor model’s specification for voltage at 100% output.
-  switch (status) {
-  case 0:
-    relaystatus = 0;
-    break;
-  case 1:
-    relaystatus = 0x3FFF;
-    break;
-  default:
-    relaystatus = 0x7FFF;
-    break;
-  }
-  Plugin_052_writeSingleRegister(0x18, relaystatus);
-}
 
 int Plugin_052_readABCperiod(void) {
-  return Plugin_052_readHoldingRegister(0x1F);
+  return P052_data->modbus.readHoldingRegister(0x1F);
 }
 
 int Plugin_052_readModbusAddress(void) {
-  return Plugin_052_readHoldingRegister(63); // HR64 MAC address Modbus address, valid range 1 - 253
+  return P052_data->modbus.readHoldingRegister(63); // HR64 MAC address Modbus address, valid range 1 - 253
 }
+*/
 
-// Compute the MODBUS RTU CRC
-unsigned int Plugin_052_ModRTU_CRC(byte *buf, int len) {
-  unsigned int crc = 0xFFFF;
-  for (int pos = 0; pos < len; pos++) {
-    crc ^= (unsigned int)buf[pos]; // XOR byte into least sig. byte of crc
-
-    for (int i = 8; i != 0; i--) { // Loop over each bit
-      if ((crc & 0x0001) != 0) {   // If the LSB is set
-        crc >>= 1;                 // Shift right and XOR 0xA001
-        crc ^= 0xA001;
-      } else       // Else LSB is not set
-        crc >>= 1; // Just shift right
-    }
-  }
-  return crc;
-}
-
-bool getBitOfInt(int reg, int pos) {
-  // Create a mask
-  int mask = 0x01 << pos;
-
-  // Mask the status register
-  int masked_register = mask & reg;
-
-  // Shift the result of masked register back to position 0
-  int result = masked_register >> pos;
-  return (result == 1);
-}
 #endif // USES_P052

--- a/src/_P076_HLW8012.ino
+++ b/src/_P076_HLW8012.ino
@@ -270,11 +270,11 @@ boolean Plugin_076(byte function, struct EventStruct *event, String &string) {
     if (PLUGIN_076_DEBUG) {
       String log = F("P076: PIN Settings ");
 
-      log +=  " curr_read: ";
+      log +=  F(" curr_read: ");
       log +=  PCONFIG(4);
-      log +=  " cf_edge: ";
+      log +=  F(" cf_edge: ");
       log +=  PCONFIG(5);
-      log +=  " cf1_edge: ";
+      log +=  F(" cf1_edge: ");
       log +=  PCONFIG(6);
       addLog(LOG_LEVEL_INFO, log);
     }

--- a/src/_Plugin_Helper_serial.ino
+++ b/src/_Plugin_Helper_serial.ino
@@ -83,7 +83,9 @@ void serialHelper_webformLoad(struct EventStruct *event, bool allowSoftwareSeria
   if (Settings.UseSerial) {
     addFormNote(F("Do <b>NOT</b> combine HW Serial0 and log to serial on Tools->Advanced->Serial Port."));
   }
-  addFormNote(F("D8 (GPIO-15) requires a Buffer Circuit (PNP transistor) or ESP boot may fail."));
+  if (serialHelper_getRxPin(event) == 15 || serialHelper_getTxPin(event) == 15) {
+    addFormNote(F("GPIO-15 (D8) requires a Buffer Circuit (PNP transistor) or ESP boot may fail."));    
+  }
 }
 
 void serialHelper_webformSave(struct EventStruct *event) {

--- a/src/define_plugin_sets.h
+++ b/src/define_plugin_sets.h
@@ -509,7 +509,7 @@ To create/register a plugin, you have to :
     #define USES_P028   // BME280
     #define USES_P029   // Output
 
-    #define USES_P030   // BMP280
+//    #define USES_P030   // BMP280   (Made obsolete, now BME280 can handle both)
     #define USES_P031   // SHT1X
     #define USES_P032   // MS5611
     #define USES_P033   // Dummy

--- a/tools/build_ESPeasy.sh
+++ b/tools/build_ESPeasy.sh
@@ -6,7 +6,7 @@
 # Needed packages:
 # sudo apt-get update
 # sudo apt-get upgrade
-# sudo apt install python-minimal virtualenv build-essential zip
+# sudo apt install python-minimal virtualenv build-essential zip binutils
 
 VENV=~/.venv/python2.7
 SRC=~/GitHub/letscontrolit/ESPEasy


### PR DESCRIPTION
When using 'Oversampling' the Analog input plugin is simply summing all samples and upon calling the read function it will divide this sum by the number of samples.
This added filtering is keeping track of the lowest and highest value measured in this loop and excludes these extremes.
This makes the reading a lot more stable, since it is often only a single extreme value which causes noise in the reported values.

Also added a note to the setup page near the calibration points to make it easier to add calibration values. It shows the current raw value + its calibrated equivalent (if enabled).