### PR TITLE
[MH-Z19] Do not reset sensor for wrong values within 3 min after init (#2394)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -152,7 +152,7 @@ lib_deps                  = https://github.com/TD-er/ESPEasySerial.git
 monitor_speed             = 115200
 
 [debug_flags]
-build_flags               = -DBUILD_NO_DEBUG -DWEBSERVER_RULES_DEBUG=0
+build_flags               = ""
 
 [common]
 board_build.f_cpu         = 80000000L
@@ -783,6 +783,22 @@ board_build.f_cpu         = ${esp8266_4M.board_build.f_cpu}
 board_build.flash_mode    = ${esp8266_4M.board_build.flash_mode}
 build_unflags             = ${esp8266_4M.build_unflags}
 build_flags               = ${esp8266_4M.build_flags} ${normal_beta.build_flags}
+targets                   = ${common.targets}
+
+[env:normal_core_260_sdk222_alpha_ESP8266_4M]
+platform                  = ${testing_beta.platform}
+lib_deps                  = ${common.lib_deps}
+lib_ignore                = ${common.lib_ignore}
+lib_ldf_mode              = ${common.lib_ldf_mode}
+lib_archive               = ${common.lib_archive}
+framework                 = ${common.framework}
+board                     = ${esp8266_4M.board}
+upload_speed              = ${common.upload_speed}
+monitor_speed             = ${common.monitor_speed}
+board_build.f_cpu         = ${esp8266_4M.board_build.f_cpu}
+board_build.flash_mode    = ${esp8266_4M.board_build.flash_mode}
+build_unflags             = ${esp8266_4M.build_unflags}
+build_flags               = ${esp8266_4M.build_flags} ${normal_beta.build_flags} -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x
 targets                   = ${common.targets}
 
 

--- a/src/ESPEasyWifi.ino
+++ b/src/ESPEasyWifi.ino
@@ -870,9 +870,9 @@ String ESPeasyWifiStatusToString() {
 }
 
 void logConnectionStatus() {
-  const uint8_t arduino_corelib_wifistatus = WiFi.status();
   String log;
   #ifndef ESP32
+  const uint8_t arduino_corelib_wifistatus = WiFi.status();
   const uint8_t sdk_wifistatus = wifi_station_get_connect_status();
   if ((arduino_corelib_wifistatus == WL_CONNECTED) != (sdk_wifistatus == STATION_GOT_IP)) {
     if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
@@ -887,7 +887,7 @@ void logConnectionStatus() {
 #ifndef BUILD_NO_DEBUG
   if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE)) {
     String log = F("WIFI  : Arduino wifi status: ");
-    log += ArduinoWifiStatusToString(arduino_corelib_wifistatus);
+    log += ArduinoWifiStatusToString(WiFi.status());
     log += F(" ESPeasy internal wifi status: ");
     log += ESPeasyWifiStatusToString();
     addLog(LOG_LEVEL_DEBUG_MORE, log);

--- a/src/_CPlugin_Helper.h
+++ b/src/_CPlugin_Helper.h
@@ -710,7 +710,8 @@ bool send_via_http(const String& logIdentifier, WiFiClient& client, const String
       if (line.startsWith(F("HTTP/1.1 2")))
       {
         success = true;
-#ifndef BUILD_NO_DEBUG
+        // Leave this debug info in the build, regardless of the
+        // BUILD_NO_DEBUG flags.
         if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
           String log = F("HTTP : ");
           log += logIdentifier;
@@ -718,7 +719,6 @@ bool send_via_http(const String& logIdentifier, WiFiClient& client, const String
           log += line;
           addLog(LOG_LEVEL_DEBUG, log);
         }
-#endif
       } else if (line.startsWith(F("HTTP/1.1 4"))) {
         if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
           String log = F("HTTP : ");

--- a/src/define_plugin_sets.h
+++ b/src/define_plugin_sets.h
@@ -100,6 +100,14 @@ To create/register a plugin, you have to :
     #define  PLUGIN_SET_STABLE
     #define  CONTROLLER_SET_STABLE
     #define  NOTIFIER_SET_STABLE
+
+    #ifndef BUILD_NO_DEBUG
+      #define BUILD_NO_DEBUG
+    #endif
+    #ifdef WEBSERVER_RULES_DEBUG
+      #undef WEBSERVER_RULES_DEBUG
+    #endif
+    #define WEBSERVER_RULES_DEBUG 0
 #endif
 
 #ifdef PLUGIN_BUILD_MINIMAL_OTA


### PR DESCRIPTION
There may be some unexpected responses after the reset.
So do not reset the sensor unless > 10 unknown responses were seen and also do not reset within 3 minutes after sensor reset.
See #2394