### PR TITLE
Disable core 2.6.0 SDK3 builds

### DIFF
--- a/before_deploy
+++ b/before_deploy
@@ -64,8 +64,7 @@ for ENV in \
   test_core_250_ESP8266_4M\
   test_core_260_alpha_ESP8266_4M_VCC\
   test_core_260_sdk2_alpha_ESP8266_4M\
-  test_core_260_sdk222_alpha_ESP8266_4M\
-  test_core_260_sdk3_alpha_ESP8266_4M;\
+  test_core_260_sdk222_alpha_ESP8266_4M;\
 do
   MAX_FILESIZE=1044464
   if [[ ${ENV} == *"1024"* ]]; then

--- a/platformio.ini
+++ b/platformio.ini
@@ -835,21 +835,21 @@ build_flags               = ${esp8266_4M.build_flags} ${testing_beta.build_flags
 targets                   = ${common.targets}
 
 
-[env:test_core_260_sdk3_alpha_ESP8266_4M]
-platform                  = ${testing_beta.platform}
-lib_deps                  = ${common.lib_deps}
-lib_ignore                = ${common.lib_ignore}
-lib_ldf_mode              = ${common.lib_ldf_mode}
-lib_archive               = ${common.lib_archive}
-framework                 = ${common.framework}
-board                     = ${esp8266_4M.board}
-upload_speed              = ${common.upload_speed}
-monitor_speed             = ${common.monitor_speed}
-board_build.f_cpu         = ${esp8266_4M.board_build.f_cpu}
-board_build.flash_mode    = ${esp8266_4M.board_build.flash_mode}
-build_unflags             = ${esp8266_4M.build_unflags}
-build_flags               = ${esp8266_4M.build_flags} ${testing_beta.build_flags} -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK3
-targets                   = ${common.targets}
+;[env:test_core_260_sdk3_alpha_ESP8266_4M]
+;platform                  = ${testing_beta.platform}
+;lib_deps                  = ${common.lib_deps}
+;lib_ignore                = ${common.lib_ignore}
+;lib_ldf_mode              = ${common.lib_ldf_mode}
+;lib_archive               = ${common.lib_archive}
+;framework                 = ${common.framework}
+;board                     = ${esp8266_4M.board}
+;upload_speed              = ${common.upload_speed}
+;monitor_speed             = ${common.monitor_speed}
+;board_build.f_cpu         = ${esp8266_4M.board_build.f_cpu}
+;board_build.flash_mode    = ${esp8266_4M.board_build.flash_mode}
+;build_unflags             = ${esp8266_4M.build_unflags}
+;build_flags               = ${esp8266_4M.build_flags} ${testing_beta.build_flags} -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK3
+;targets                   = ${common.targets}
 
 
 ; TEST: 1024k version + FEATURE_ADC_VCC ----------


### PR DESCRIPTION
Due to this commit: https://github.com/esp8266/Arduino/commit/ca79f2ce39724527052319717a731b3501d5f0b2