### PR TITLE
Homie 3.0.0 & 4dev convention controller Plugin

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 
 [platformio]
 ;env_default = esp32dev
-;env_default = dev_ESP8266_4096
+env_default = dev_ESP8266_4M
 ;env_default = normal_ESP8266_1024
 ;env_default = normal_ESP8266_4096
 ; ..etc

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 
 [platformio]
 ;env_default = esp32dev
-env_default = dev_ESP8266_4M
+;env_default = dev_ESP8266_4096
 ;env_default = normal_ESP8266_1024
 ;env_default = normal_ESP8266_4096
 ; ..etc

--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -248,11 +248,11 @@ bool MQTTCheck(int controller_idx)
         // Homie 3 & 4dev Controller Plugin
         // Connect first and call all installed controller to publish autodiscover data
         // hope this is the right place ;)
-        if (MQTTConnect(controller_idx)) CPluginCall(CPLUGIN_CONNECTED, 0);
+        if (MQTTConnect(controller_idx)) CPluginCall(CPLUGIN_GOT_CONNECTED, 0);
       } else {
         connectionFailures += 2;
       }
-      return (!MQTTclient.connected() || MQTTConnect(controller_idx)); // either connected above or now!?
+      return MQTTConnect(controller_idx);
     } else if (connectionFailures) {
       connectionFailures--;
     }

--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -245,10 +245,14 @@ bool MQTTCheck(int controller_idx)
     {
       if (MQTTclient_should_reconnect) {
         addLog(LOG_LEVEL_ERROR, F("MQTT : Intentional reconnect"));
+        // Homie 3 & 4dev Controller Plugin
+        // Connect first and call all installed controller to publish autodiscover data
+        // hope this is the right place ;)
+        if (MQTTConnect(controller_idx)) CPluginCall(CPLUGIN_CONNECTED, 0);
       } else {
         connectionFailures += 2;
       }
-      return MQTTConnect(controller_idx);
+      return (!MQTTclient.connected() || MQTTConnect(controller_idx)); // either connected above or now!?
     } else if (connectionFailures) {
       connectionFailures--;
     }

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -306,6 +306,13 @@ void check_size() {
 #define CPLUGIN_INIT                       50
 #define CPLUGIN_UDP_IN                     51
 
+// new messages for autodiscover controller plugins (experimental) i.e. C014
+#define CPLUGIN_CONNECTED                  52 // call after connected to mqtt server to publich device autodicover features
+#define CPLUGIN_DICONNECT                  53 // should be called before major changes i.e. changing the device name to clean up data on the controller. !ToDo
+#define CPLUGIN_FALLING_ASLEEP             54 // call before falling asleep !ToDo
+#define CPLUGIN_SEND_STATS                 55 // call every interval loop
+#define CPLUGIN_SEND_FEEDBACK              56 // call for sending feedback !ToDo done by direct function call in PluginCall() for now.
+
 #define CONTROLLER_HOSTNAME                 1
 #define CONTROLLER_IP                       2
 #define CONTROLLER_PORT                     3

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -306,12 +306,12 @@ void check_size() {
 #define CPLUGIN_INIT                       50
 #define CPLUGIN_UDP_IN                     51
 
+#define CPLUGIN_FLUSH                      52
 // new messages for autodiscover controller plugins (experimental) i.e. C014
-#define CPLUGIN_CONNECTED                  52 // call after connected to mqtt server to publich device autodicover features
-#define CPLUGIN_DICONNECT                  53 // should be called before major changes i.e. changing the device name to clean up data on the controller. !ToDo
-#define CPLUGIN_FALLING_ASLEEP             54 // call before falling asleep !ToDo
-#define CPLUGIN_SEND_STATS                 55 // call every interval loop
-#define CPLUGIN_SEND_FEEDBACK              56 // call for sending feedback !ToDo done by direct function call in PluginCall() for now.
+#define CPLUGIN_GOT_CONNECTED              53 // call after connected to mqtt server to publich device autodicover features
+#define CPLUGIN_GOT_INVALID                54 // should be called before major changes i.e. changing the device name to clean up data on the controller. !ToDo
+#define CPLUGIN_INTERVAL                   55 // call every interval loop
+#define CPLUGIN_ACKNOWLEDGE                56 // call for sending acknolages !ToDo done by direct function call in PluginCall() for now.
 
 #define CONTROLLER_HOSTNAME                 1
 #define CONTROLLER_IP                       2

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -812,7 +812,7 @@ void runEach30Seconds()
   refreshNodeList();
 
   // sending $stats to homie controller
-  CPluginCall(CPLUGIN_SEND_STATS, 0);
+  CPluginCall(CPLUGIN_INTERVAL, 0);
 
   #if defined(ESP8266)
   if (Settings.UseSSDP)

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -811,6 +811,9 @@ void runEach30Seconds()
   sendSysInfoUDP(1);
   refreshNodeList();
 
+  // sending $stats to homie controller
+  CPluginCall(CPLUGIN_SEND_STATS, 0);
+
   #if defined(ESP8266)
   if (Settings.UseSSDP)
     SSDP_update();

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -1178,6 +1178,9 @@ void handle_config() {
   {
     if (strcmp(Settings.Name, name.c_str()) != 0) {
       addLog(LOG_LEVEL_INFO, F("Unit Name changed."));
+      if (CPluginCall(CPLUGIN_GOT_INVALID, 0)) { // inform controllers that the old name will be invalid from now on.
+        MQTTDisconnect(); // disconnect form MQTT Server if invalid message was sent succesfull.
+      }
       MQTTclient_should_reconnect = true;
     }
     // Unit name

--- a/src/_C014.ino
+++ b/src/_C014.ino
@@ -1,0 +1,686 @@
+#ifdef USES_C014
+//#######################################################################################################
+//################################# Controller Plugin 0014: Homie 3/4 ###################################
+//#######################################################################################################
+
+#define CPLUGIN_014
+#define CPLUGIN_ID_014              14
+
+// Define which Homie version to use
+//#define CPLUGIN_014_V3
+#define CPLUGIN_014_V4
+
+#ifdef CPLUGIN_014_V3
+  #define CPLUGIN_014_HOMIE_VERSION   "3.0.0"
+  #define CPLUGIN_NAME_014            "Homie MQTT (Version 3.0.1)"
+#endif
+#ifdef CPLUGIN_014_V4
+  #define CPLUGIN_014_HOMIE_VERSION   "4.0.0"
+  #define CPLUGIN_NAME_014            "Homie MQTT (Version 4.0.0 dev)"
+#endif
+
+// subscribe and publish shemes should not be changed by the user. This will probably break the homie convention. Do @ your own risk;)
+#define CPLUGIN_014_SUBSCRIBE       "homie/%sysname%/#" // "homie/%sysname%/+/+/#" causes problems (!ToDo)
+#define CPLUGIN_014_PUBLISH         "homie/%sysname%/%tskname%/%valname%"
+
+#define CPLUGIN_014_BASE_TOPIC      "homie/%sysname%/#"
+#define CPLUGIN_014_BASE_VALUE      "homie/%sysname%/%device%/%node%/%property%"
+#define CPLUGIN_014_INTERVAL        "90" // to prevent timeout !ToDo set by towest plugin interval
+#define CPLUGIN_014_SYSTEM_DEVICE   "SYSTEM" // name for system device Plugin for cmd and GIO values
+#define CPLUGIN_014_CMD_VALUE       "cmd" // name for command value
+#define CPLUGIN_014_GPIO_VALUE      "gpio" // name for gpio value i.e. "gpio1"
+#define CPLUGIN_014_CMD_VALUE_NAME  "Command" // human readabele name for command value
+
+byte msgCounter=0; // counter for sent Messages
+
+// !ToDo: should be integrated in bool CPlugin_014();
+bool CPlugin_014_Feedback(byte Function, struct EventStruct *event, String& str)
+{
+  MakeControllerSettings(ControllerSettings);
+  LoadControllerSettings(event->ControllerIndex, ControllerSettings);
+
+  if (str!="") {
+    String commandName = parseString(str, 1);
+    int errorCounter = 0;
+    if (commandName == F("gpio")) //!ToDo : As gpio is like any other plugin commands should be integrated below!
+    {
+      int port = parseString(str, 2).toInt();
+      int valueInt = parseString(str, 3).toInt();
+      String valueBool = "false";
+      if (valueInt==1) valueBool = "true";
+
+      String log = F("C014 : Feedback GPIO");
+      log += port;
+      log += F(" value:");
+      log += valueBool;
+      log += F(" (");
+      log += valueInt;
+      log += F(")");
+
+      String topic = ControllerSettings.Publish;
+      topic.replace(F("%sysname%"), Settings.Name);
+      topic.replace(F("%tskname%"), CPLUGIN_014_SYSTEM_DEVICE);
+      topic.replace(F("%valname%"), CPLUGIN_014_GPIO_VALUE + toString(port,0));
+
+      if (MQTTpublish(CPLUGIN_ID_014, topic.c_str(), valueBool.c_str(), errorCounter)) {addLog(LOG_LEVEL_INFO, log+" success!");}
+        else {addLog(LOG_LEVEL_ERROR, log+" ERROR!");  return false;}
+      return true;
+    } else
+    {
+      String topic = ControllerSettings.Publish;
+      topic.replace(F("%sysname%"), Settings.Name);
+      int deviceIndex = parseString(str, 2).toInt();
+      LoadTaskSettings(deviceIndex-1);
+      String deviceName = ExtraTaskSettings.TaskDeviceName;
+      topic.replace(F("%tskname%"), deviceName);
+      String valueName = ExtraTaskSettings.TaskDeviceValueNames[parseString(str, 3).toInt()-1];
+      topic.replace(F("%valname%"), valueName);
+
+      String log = F("C014 : Feedback ");
+      log += deviceName;
+      log += F(" var: ");
+      log += valueName;
+      log += F(" topic: ");
+      log += topic;
+      log += F(" value: ");
+
+      if ((commandName == F("taskvalueset")) || (commandName == F("dummyvalueset"))) // should work for both
+      {
+        String valueStr = parseString(str, 4);
+        log += valueStr;
+        if (MQTTpublish(CPLUGIN_ID_014, topic.c_str(), valueStr.c_str(), errorCounter)) {addLog(LOG_LEVEL_INFO, log+" success!");}
+          else {addLog(LOG_LEVEL_ERROR, log+" ERROR!");  return false;}
+        return true;
+      } else // feedback not implemented yet
+      {
+        String log = F("C014 : Plugin Feedback: ");
+        log+=Function;
+        log+=F(" / ");
+        log+=commandName;
+        log+=F(" cmd: ");
+        log+=str;
+        log+=F(" not implemented!");
+        addLog(LOG_LEVEL_ERROR, log);
+      }
+    }
+  }
+  return false;
+}
+
+// send MQTT Message with complete Topic / Payload
+bool CPlugin_014_sendMQTTmsg(String& topic, const char* payload, int& errorCounter) {
+        String log = F("C014 : msg T:");
+        log += topic;
+        log += F(" P: ");
+        log += payload;
+        if (MQTTpublish(CPLUGIN_ID_014, topic.c_str(), payload, 1)) {addLog(LOG_LEVEL_DEBUG_MORE, log+" success!"); msgCounter++;}
+            else {addLog(LOG_LEVEL_ERROR, log+" ERROR!"); errorCounter++; return false;}
+        return true;
+}
+
+// send MQTT Message with CPLUGIN_014_BASE_TOPIC Topic scheme / Payload
+bool CPlugin_014_sendMQTTdevice(String tmppubname, const char* topic, const char* payload, int& errorCounter) {
+        tmppubname.replace(F("#"), topic);
+        String log = F("C014 : T:");
+        log += topic;
+        log += F(" P: ");
+        log += payload;
+        if (MQTTpublish(CPLUGIN_ID_014, tmppubname.c_str(), payload, 1)) {addLog(LOG_LEVEL_DEBUG_MORE, log+" success!"); msgCounter++;}
+            else {addLog(LOG_LEVEL_ERROR, log+" ERROR!"); errorCounter++; return false;}
+        processMQTTdelayQueue();
+        return true;
+
+}
+
+// send MQTT Message with CPLUGIN_014_BASE_VALUE Topic scheme / Payload
+bool CPlugin_014_sendMQTTnode(String tmppubname, const char* node, const char* value, const char* topic, const char* payload, int& errorCounter) {
+        tmppubname.replace(F("%device%"), node);
+        tmppubname.replace(F("%node%"), value);
+        tmppubname.replace(F("/%property%"), topic); // leading forward slash required to send "homie/device/value" topics
+        String log = F("C014 : V:");
+        log += value;
+        log += F(" T: ");
+        log += topic;
+        log += F(" P: ");
+        log += payload;
+        if (MQTTpublish(CPLUGIN_ID_014, tmppubname.c_str(), payload, 1)) {addLog(LOG_LEVEL_DEBUG_MORE, log+" success!");msgCounter++;}
+            else {addLog(LOG_LEVEL_ERROR, log+" ERROR!"); errorCounter++; return false;}
+        processMQTTdelayQueue();
+        return true;
+
+}
+
+// and String a comma seperated list
+void CPLUGIN_014_addToList(String& valuesList, const char* node)
+{
+  if (valuesList.length()>0) valuesList += F(",");
+  valuesList += node;
+}
+
+// search for a Plugin by (user given) Name and gives back the Number in the Device List. Unique Dames are important!
+int CPlugin_014_getPluginNr(String& setNodeName)
+{
+  byte x = 0;
+
+  while (x < TASKS_MAX)
+  {
+    LoadTaskSettings(x);
+    if (strcmp(ExtraTaskSettings.TaskDeviceName,setNodeName.c_str())==0) return x;
+    x++;
+  }
+  return x;
+}
+
+// search for a value name and gives back the first value number in the Plugin. Unique names are REQUIRED!
+int CPlugin_014_getValueNr(int DeviceIndex, String& valueName)
+{
+  LoadTaskSettings(DeviceIndex);
+
+  for (byte varNr = 0; varNr < Device[getDeviceIndex(Settings.TaskDeviceNumber[DeviceIndex])].ValueCount; varNr++)
+  {
+    if (strcmp(ExtraTaskSettings.TaskDeviceValueNames[varNr],valueName.c_str())==0) return varNr;
+  }
+  return -1;
+}
+
+bool CPlugin_014(byte function, struct EventStruct *event, String& string)
+{
+  bool success = false;
+  int errorCounter = 0;
+  String log = "";
+  String pubname = "";
+  String tmppubname = "";
+
+  switch (function)
+  {
+    case CPLUGIN_PROTOCOL_ADD:
+      {
+        Protocol[++protocolCount].Number = CPLUGIN_ID_014;
+        Protocol[protocolCount].usesMQTT = true;
+        Protocol[protocolCount].usesTemplate = true;
+        Protocol[protocolCount].usesAccount = true;
+        Protocol[protocolCount].usesPassword = true;
+        Protocol[protocolCount].defaultPort = 1883;
+        Protocol[protocolCount].usesID = false;
+        break;
+      }
+
+    case CPLUGIN_GET_DEVICENAME:
+      {
+        string = F(CPLUGIN_NAME_014);
+        break;
+      }
+
+    case CPLUGIN_INIT:
+      {
+        MakeControllerSettings(ControllerSettings);
+        LoadControllerSettings(event->ControllerIndex, ControllerSettings);
+        MQTTDelayHandler.configureControllerSettings(ControllerSettings);
+        break;
+      }
+
+    case CPLUGIN_SEND_STATS:
+      {
+        if (MQTTclient.connected())
+        {
+          errorCounter = 0;
+
+          pubname = CPLUGIN_014_BASE_TOPIC; // Scheme to form device messages
+          pubname.replace(F("%sysname%"), Settings.Name);
+
+#ifdef CPLUGIN_014_V3
+          // $stats/uptime	Device → Controller	Time elapsed in seconds since the boot of the device	Yes	Yes
+          CPlugin_014_sendMQTTdevice(pubname,"$stats/uptime",toString((wdcounter / 2)*60,0).c_str(),errorCounter);
+
+          // $stats/signal	Device → Controller	Signal strength in %	Yes	No
+          float RssI = WiFi.RSSI();
+          RssI = isnan(RssI) ? -100.0 : RssI;
+          RssI = min(max(2 * (RssI + 100.0), 0.0), 100.0);
+
+          CPlugin_014_sendMQTTdevice(pubname,"$stats/signal",toString(RssI,1).c_str(),errorCounter);
+#endif
+          String log = F("C014 : $stats information sent with ");
+          if (errorCounter>0)
+          {
+            // alert: this is the state the device is when connected to the MQTT broker, but something wrong is happening. E.g. a sensor is not providing data and needs human intervention. You have to send this message when something is wrong.
+            CPlugin_014_sendMQTTdevice(pubname,"$state","alert",errorCounter);
+            log+=errorCounter;
+          } else {
+            // ready: this is the state the device is in when it is connected to the MQTT broker, has sent all Homie messages and is ready to operate. You have to send this message after all other announcements message have been sent.
+            CPlugin_014_sendMQTTdevice(pubname,"$state","ready",errorCounter);
+            log+=F("no");
+          }
+          log+=F(" errors! (");
+          log+=msgCounter;
+          log+=F(" messages)");
+          msgCounter=0;
+          addLog(LOG_LEVEL_DEBUG, log);
+        }
+        break;
+      }
+
+    case CPLUGIN_CONNECTED: //// call after connected to mqtt server to publich device autodicover features
+      {
+        MakeControllerSettings(ControllerSettings);
+        LoadControllerSettings(event->ControllerIndex, ControllerSettings);
+        if (!ControllerSettings.checkHostReachable(true)) {
+            success = false;
+            break;
+        }
+        statusLED(true);
+
+        // send autodiscover header
+        pubname = CPLUGIN_014_BASE_TOPIC; // Scheme to form device messages
+        pubname.replace(F("%sysname%"), Settings.Name);
+        int deviceCount = 1; // minimum the SYSTEM device exists
+        int nodeCount = 1; // minimum the cmd node exists
+        errorCounter = 0;
+
+        if (lastBootCause!=BOOT_CAUSE_DEEP_SLEEP) // skip sending autodiscover data when returning from deep sleep
+        {
+          String nodename = CPLUGIN_014_BASE_VALUE; // Scheme to form node messages
+          nodename.replace(F("%sysname%"), Settings.Name);
+          String nodesList = ""; // build comma separated List for nodes
+          String valuesList = ""; // build comma separated List for values
+          byte DeviceIndex = 0;
+          String deviceName = ""; // current Device Name nr:name
+          String valueName = ""; // current Value Name
+          String unitName = ""; // estaimate Units
+
+          // init: this is the state the device is in when it is connected to the MQTT broker, but has not yet sent all Homie messages and is not yet ready to operate. This is the first message that must that must be sent.
+          CPlugin_014_sendMQTTdevice(pubname,"$state","init",errorCounter);
+
+          // $homie	Device → Controller	Version of the Homie convention the device conforms to	Yes	Yes
+          CPlugin_014_sendMQTTdevice(pubname,"$homie",CPLUGIN_014_HOMIE_VERSION,errorCounter);
+
+          // $name	Device → Controller	Friendly name of the device	Yes	Yes
+          CPlugin_014_sendMQTTdevice(pubname,"$name",Settings.Name,errorCounter);
+
+          // $localip	Device → Controller	IP of the device on the local network	Yes	Yes
+#ifdef CPLUGIN_014_V3
+          CPlugin_014_sendMQTTdevice(pubname,"$localip",formatIP(WiFi.localIP()).c_str(),errorCounter);
+
+          // $mac	Device → Controller	Mac address of the device network interface. The format MUST be of the type A1:B2:C3:D4:E5:F6	Yes	Yes
+          CPlugin_014_sendMQTTdevice(pubname,"$mac",WiFi.macAddress().c_str(),errorCounter);
+
+          // $implementation	Device → Controller	An identifier for the Homie implementation (example esp8266)	Yes	Yes
+          #if defined(ESP8266)
+            CPlugin_014_sendMQTTdevice(pubname,"$implementation","ESP8266",errorCounter);
+          #endif
+          #if defined(ESP32)
+            CPlugin_014_sendMQTTdevice(pubname,"$implementation","ESP32",errorCounter);
+          #endif
+
+          // $fw/version	Device → Controller	Version of the firmware running on the device	Yes	Yes
+          CPlugin_014_sendMQTTdevice(pubname,"$fw/version",toString(Settings.Build,0).c_str(),errorCounter);
+
+          // $fw/name	Device → Controller	Name of the firmware running on the device. Allowed characters are the same as the device ID	Yes	Yes
+          CPlugin_014_sendMQTTdevice(pubname,"$fw/name",getNodeTypeDisplayString(NODE_TYPE_ID).c_str(),errorCounter);
+
+          // $stats/interval	Device → Controller	Interval in seconds at which the device refreshes its $stats/+: See next section for details about statistical attributes	Yes	Yes
+          CPlugin_014_sendMQTTdevice(pubname,"$stats/interval",CPLUGIN_014_INTERVAL,errorCounter);
+#endif
+
+          //always send the SYSTEM device with the cmd node
+          CPLUGIN_014_addToList(nodesList,CPLUGIN_014_SYSTEM_DEVICE);
+          CPLUGIN_014_addToList(valuesList,CPLUGIN_014_CMD_VALUE);
+
+          // $name	Device → Controller	Friendly name of the Node	Yes	Yes
+          CPlugin_014_sendMQTTnode(nodename, CPLUGIN_014_SYSTEM_DEVICE, "$name", "", CPLUGIN_014_SYSTEM_DEVICE, errorCounter);
+
+          //$name	Device → Controller	Friendly name of the property.	Any String	Yes	No ("")
+          CPlugin_014_sendMQTTnode(nodename, CPLUGIN_014_SYSTEM_DEVICE, CPLUGIN_014_CMD_VALUE, "/$name", CPLUGIN_014_CMD_VALUE_NAME, errorCounter);
+          //$datatype	The data type. See Payloads.	Enum: [integer, float, boolean, string, enum, color]
+          CPlugin_014_sendMQTTnode(nodename, CPLUGIN_014_SYSTEM_DEVICE, CPLUGIN_014_CMD_VALUE, "/$datatype", "string", errorCounter);
+
+          //$settable	Device → Controller	Specifies whether the property is settable (true) or readonly (false)	true or false	Yes	No (false)
+          CPlugin_014_sendMQTTnode(nodename, CPLUGIN_014_SYSTEM_DEVICE, CPLUGIN_014_CMD_VALUE, "/$settable", "true", errorCounter);
+
+          // enum all devices
+
+          // FIRST Standard GPIO tasks
+          int gpio = 0;
+          // FIXME TD-er: Max of 17 is a limit in the Settings.PinBootStates array???
+          while (gpio < MAX_GPIO  && gpio < 17) {
+            if (Settings.PinBootStates[gpio]>0) // anything but default
+            {
+              nodeCount++;
+              valueName = CPLUGIN_014_GPIO_VALUE;
+              valueName += toString(gpio,0);
+              CPLUGIN_014_addToList(valuesList,valueName.c_str());
+
+              //$name	Device → Controller	Friendly name of the property.	Any String	Yes	No ("")
+              CPlugin_014_sendMQTTnode(nodename, CPLUGIN_014_SYSTEM_DEVICE, valueName.c_str(), "/$name", valueName.c_str(), errorCounter);
+              //$datatype	The data type. See Payloads.	Enum: [integer, float, boolean,string, enum, color]
+              CPlugin_014_sendMQTTnode(nodename, CPLUGIN_014_SYSTEM_DEVICE, valueName.c_str(), "/$datatype", "boolean", errorCounter);
+              if (Settings.PinBootStates[gpio]<3) // defined as default low or high so output
+              {
+                //$settable	Device → Controller	Specifies whether the property is settable (true) or readonly (false)	true or false	Yes	No (false)
+                CPlugin_014_sendMQTTnode(nodename, CPLUGIN_014_SYSTEM_DEVICE, valueName.c_str(), "/$settable", "true", errorCounter);
+              }
+            }
+            ++gpio;
+          }
+
+          // $properties	Device → Controller	Properties the node exposes, with format id separated by a , if there are multiple nodes.	Yes	Yes
+          CPlugin_014_sendMQTTnode(nodename, CPLUGIN_014_SYSTEM_DEVICE, "$properties", "", valuesList.c_str(), errorCounter);
+          valuesList = "";
+          deviceCount++;
+
+          // SECOND Plugins
+          for (byte x = 0; x < TASKS_MAX; x++)
+          {
+            if (Settings.TaskDeviceNumber[x] != 0)
+            {
+              LoadTaskSettings(x);
+              DeviceIndex = getDeviceIndex(Settings.TaskDeviceNumber[x]);
+              deviceName = ExtraTaskSettings.TaskDeviceName;
+
+              if (Settings.TaskDeviceEnabled[x])  // Device is enabled so send information
+              { // device enabled
+                CPLUGIN_014_addToList(nodesList,deviceName.c_str());
+                deviceCount++;
+                // $name	Device → Controller	Friendly name of the Node	Yes	Yes
+                CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), "$name", "",ExtraTaskSettings.TaskDeviceName, errorCounter);
+
+                // $type	Device → Controller	Type of the node	Yes	Yes
+                CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), "$type", "", getPluginNameFromDeviceIndex(DeviceIndex).c_str(), errorCounter);
+
+                valuesList="";
+
+                if (!Device[DeviceIndex].SendDataOption) // check if device is not sending data = assume that it can receive.
+                {
+                  if (Device[DeviceIndex].Number==12) // LCD 2 or 4 Lines
+                  {
+                    CPLUGIN_014_addToList(valuesList,"LCD");
+                    CPLUGIN_014_addToList(valuesList,"LCDCMD");
+                    //$settable	Device → Controller	Specifies whether the property is settable (true) or readonly (false)	true or false	Yes	No (false)
+                    CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), "LCD", "/$settable", "true", errorCounter);
+                    CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), "LCDCMD", "/$settable", "true", errorCounter);
+
+                    //$name	Device → Controller	Friendly name of the property.	Any String	Yes	No ("")
+                    CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), "LCD", "/$name","LCD text", errorCounter);
+                    CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), "LCDCMD", "/$name","LCD command", errorCounter);
+
+                    //$datatype	The data type. See Payloads.	Enum: [integer, float, boolean,string, enum, color]
+                    CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), "LCD", "/$datatype", "string", errorCounter);
+                    CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), "LCDCMD", "/$datatype", "string", errorCounter);
+
+                    nodeCount++;
+                  }
+                } else {
+                  // ignore cutom values for now! Assume all Values are standard float.
+                  // customValues = PluginCall(PLUGIN_WEBFORM_SHOW_VALUES, &TempEvent,TXBuffer.buf);
+                  byte customValues = false;
+                  if (!customValues)
+                  { // standard Values
+                    for (byte varNr = 0; varNr < Device[DeviceIndex].ValueCount; varNr++)
+                    {
+                      if (Settings.TaskDeviceNumber[x] != 0)
+                      {
+                        if (ExtraTaskSettings.TaskDeviceValueNames[varNr][0]!=0) // do not send if Value Name is empty!
+                        {
+                          CPLUGIN_014_addToList(valuesList,ExtraTaskSettings.TaskDeviceValueNames[varNr]);
+
+                          //$name	Device → Controller	Friendly name of the property.	Any String	Yes	No ("")
+                          CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), ExtraTaskSettings.TaskDeviceValueNames[varNr], "/$name", ExtraTaskSettings.TaskDeviceValueNames[varNr], errorCounter);
+                          //$datatype	The data type. See Payloads.	Enum: [integer, float, boolean,string, enum, color]
+                          CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), ExtraTaskSettings.TaskDeviceValueNames[varNr], "/$datatype", "float", errorCounter);
+
+                          if (Device[DeviceIndex].Number==33) // Dummy Device can send AND receive Data
+                            CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), ExtraTaskSettings.TaskDeviceValueNames[varNr], "/$settable", "true", errorCounter);
+
+                          nodeCount++;
+                          // because values in ESPEasy are unitless lets assueme some units by the value name (still case sensitive)
+                          if (strstr(ExtraTaskSettings.TaskDeviceValueNames[varNr], "temp") != NULL )
+                          {
+                            unitName = "°C";
+                          } else if (strstr(ExtraTaskSettings.TaskDeviceValueNames[varNr], "humi") != NULL )
+                          {
+                            unitName = "%";
+                          } else if (strstr(ExtraTaskSettings.TaskDeviceValueNames[varNr], "press") != NULL )
+                          {
+                            unitName = "Pa";
+                          } // ToDo: .... and more
+
+                          if (unitName != "")  // found a unit match
+                          {
+                            // $unit	Device → Controller	A string containing the unit of this property. You are not limited to the recommended values, although they are the only well known ones that will have to be recognized by any Homie consumer.	Recommended: Yes	No ("")
+                            CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), ExtraTaskSettings.TaskDeviceValueNames[varNr], "/$unit", unitName.c_str(), errorCounter);
+                          }
+                          unitName = "";
+                        }
+                      }
+                    } // end loop throug values
+                  } else { // Device has custom Values
+                    log = F("C014 : Device has custom values: ");
+                    log += getPluginNameFromDeviceIndex(Settings.TaskDeviceNumber[x]);
+                    addLog(LOG_LEVEL_INFO, log+" ?!")
+                  }
+                }
+                if (valuesList!="")
+                {
+                  // $properties	Device → Controller	Properties the node exposes, with format id separated by a , if there are multiple nodes.	Yes	Yes
+                  CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), "$properties", "", valuesList.c_str(), errorCounter);
+                  valuesList="";
+                }
+              } else { // device not enabeled
+                log = F("C014 : Device Disabled: ");
+                log += getPluginNameFromDeviceIndex(Settings.TaskDeviceNumber[x]);
+                addLog(LOG_LEVEL_INFO, log+" not propagated!")
+              }
+            } // device configured
+          } // loop through devices
+
+          // and finally ...
+          // $nodes	Device → Controller	Nodes the device exposes, with format id separated by a , if there are multiple nodes. To make a node an array, append [] to the ID.	Yes	Yes
+          CPlugin_014_sendMQTTdevice(pubname, "$nodes", nodesList.c_str(), errorCounter);
+        }
+
+        log = F("C014 : autodiscover information of ");
+        log += deviceCount;
+        log += F(" Devices and ");
+        log += nodeCount;
+        log += F(" Nodes sent with ");
+        if (errorCounter>0)
+        {
+          // alert: this is the state the device is when connected to the MQTT broker, but something wrong is happening. E.g. a sensor is not providing data and needs human intervention. You have to send this message when something is wrong.
+          CPlugin_014_sendMQTTdevice(pubname,"$state","alert",errorCounter);
+          log+=errorCounter;
+        } else {
+          // ready: this is the state the device is in when it is connected to the MQTT broker, has sent all Homie messages and is ready to operate. You have to send this message after all other announcements message have been sent.
+          CPlugin_014_sendMQTTdevice(pubname,"$state","ready",errorCounter);
+          log+=F("no");
+        }
+        log+=F(" errors! (");
+        log+=msgCounter;
+        log+=F(" messages)");
+        msgCounter = 0;
+        errorCounter = 0;
+        addLog(LOG_LEVEL_DEBUG, log);
+
+        break;
+      }
+
+    case CPLUGIN_PROTOCOL_TEMPLATE:
+      {
+        event->String1 = F(CPLUGIN_014_SUBSCRIBE);
+        event->String2 = F(CPLUGIN_014_PUBLISH);
+        break;
+      }
+
+    case CPLUGIN_DICONNECT:
+      {
+        pubname = CPLUGIN_014_BASE_TOPIC; // Scheme to form device messages
+        pubname.replace(F("%sysname%"), Settings.Name);
+        // disconnected: this is the state the device is in when it is cleanly disconnected from the MQTT broker. You must send this message before cleanly disconnecting
+        CPlugin_014_sendMQTTdevice(pubname,"$state","disconnected",errorCounter);
+        break;
+      }
+
+    case CPLUGIN_FALLING_ASLEEP:
+      {
+        pubname = CPLUGIN_014_BASE_TOPIC; // Scheme to form device messages
+        pubname.replace(F("%sysname%"), Settings.Name);
+        // sleeping: this is the state the device is in when the device is sleeping. You have to send this message before sleeping.
+        CPlugin_014_sendMQTTdevice(pubname,"$state","sleeping",errorCounter);
+        break;
+      }
+
+    case CPLUGIN_PROTOCOL_RECV:
+      {
+        byte ControllerID = findFirstEnabledControllerWithId(CPLUGIN_ID_014);
+        if (ControllerID == CONTROLLER_MAX) {
+          // Controller is not enabled.
+          break;
+        } else {
+          String cmd;
+          struct EventStruct TempEvent;
+          TempEvent.TaskIndex = event->TaskIndex;
+          TempEvent.Source = VALUE_SOURCE_MQTT; // to trigger the correct feedback
+          bool validTopic = false;
+          int lastindex = event->String1.lastIndexOf('/');
+          const String lastPartTopic = event->String1.substring(lastindex + 1);
+          errorCounter = 0;
+          log=F("C014 : MQTT received: ");
+          if (event->String1.substring(lastindex + 1) == F("set"))
+          {
+            pubname = event->String1.substring(0,lastindex);
+            lastindex = pubname.lastIndexOf('/');
+            String nodeName = pubname.substring(0,lastindex);
+            String valueName = pubname. substring(lastindex+1);
+            lastindex = nodeName.lastIndexOf('/');
+            nodeName = nodeName. substring(lastindex+1);
+            log+=F("/set: N: ");
+            log+=nodeName;
+            log+=F(" V: ");
+            log+=valueName;
+
+            if (nodeName == F(CPLUGIN_014_SYSTEM_DEVICE)) // msg to a system device
+            {
+              if (valueName.substring(0,strlen(CPLUGIN_014_GPIO_VALUE)) == F(CPLUGIN_014_GPIO_VALUE)) // msg to to set gpio values
+              {
+                cmd = ("GPIO,");
+                cmd += valueName.substring(strlen(CPLUGIN_014_GPIO_VALUE)).toInt(); // get the GPIO
+                if (event->String2=="true" || event->String2=="1") cmd += F(",1");
+                  else cmd += F(",0");
+                validTopic = true;
+              } else if (valueName==CPLUGIN_014_CMD_VALUE) // msg to send a command
+              {
+                cmd = event->String2;
+                validTopic = true;
+              } else
+              {
+                cmd = "SYSTEM not found";
+              }
+            } else if (nodeName == F(CPLUGIN_014_CMD_VALUE)) // legethy homie/system/cmd topic
+            {
+              cmd = event->String2;
+              TempEvent.Source = VALUE_SOURCE_MQTT; // to trigger the correct feedback
+              validTopic = true;
+            } else // msg to a receiving plugin (?)
+            {
+              int deviceNr=CPlugin_014_getPluginNr(nodeName);
+              int pluginID=Device[getDeviceIndex(Settings.TaskDeviceNumber[deviceNr])].Number;
+
+              if (pluginID==12) // Plugin 12 LCD
+              {
+                cmd = valueName; // LCD or LCDCMD
+                cmd += F(",");
+                cmd += event->String2; // line,pos,Text or command as payload
+                validTopic = true;
+              } else if (pluginID==33) // Plugin 33 Dummy Device
+              { // DummyValueSet,<task/device nr>,<value nr>,<value/formula (!ToDo) >, works only with new version of P033!
+                int valueNr = CPlugin_014_getValueNr(deviceNr,valueName);
+                if (valueNr > -1) // value Name identified
+                {
+                  cmd = F("DummyValueSet,"); // Set a Dummy Device Value
+                  cmd += (deviceNr+1); // set the device Number
+                  cmd += F(",");
+                  cmd += (valueNr+1); // set the value Number
+                  cmd += F(",");
+                  cmd += event->String2; // expect float as payload!
+                  validTopic = true;
+                }
+              }
+            }
+
+            if (validTopic) {
+              parseCommandString(&TempEvent, cmd);
+              log+=F(" cmd: ");
+              log+=cmd;
+              addLog(LOG_LEVEL_INFO, log+ F(" OK"));
+            } else {
+              addLog(LOG_LEVEL_INFO, log+ F(" ERROR"));
+            }
+
+            // Feedback should not be sent here because here it will only confirm sucessfull retreval of the message!
+            // CPlugin_014_sendMQTTmsg(pubname, event->String2.c_str(), errorCounter);
+
+          }
+
+          if (validTopic) {
+            log=F("C014 : Exec > ");
+            // in case of event, store to buffer and return...
+            String command = parseString(cmd, 1);
+            if (command == F("event"))
+            {
+              log+=F("Event!");
+              eventBuffer = cmd.substring(6);
+            } else {
+              log=F("C014 : PluginCall:");
+              if (!PluginCall(PLUGIN_WRITE, &TempEvent, cmd)) {
+                remoteConfig(&TempEvent, cmd);
+                log +=F(" FALSE! remoteConfig?");
+              } else {
+                log +=F(" OK!");
+              }
+              addLog(LOG_LEVEL_INFO, log);
+            }
+
+          } else TempEvent.Source = 0; // something whent wrong
+
+        }
+        break;
+      }
+
+    case CPLUGIN_PROTOCOL_SEND:
+      {
+        MakeControllerSettings(ControllerSettings);
+        LoadControllerSettings(event->ControllerIndex, ControllerSettings);
+        if (!ControllerSettings.checkHostReachable(true)) {
+            success = false;
+            break;
+        }
+        statusLED(true);
+
+        if (ExtraTaskSettings.TaskIndex != event->TaskIndex)
+          PluginCall(PLUGIN_GET_DEVICEVALUENAMES, event, dummyString);
+
+        String pubname = ControllerSettings.Publish;
+        parseControllerVariables(pubname, event, false);
+
+        String value = "";
+        // byte DeviceIndex = getDeviceIndex(Settings.TaskDeviceNumber[event->TaskIndex]);
+        byte valueCount = getValueCountFromSensorType(event->sensorType);
+        for (byte x = 0; x < valueCount; x++)
+        {
+          String tmppubname = pubname;
+          tmppubname.replace(F("%valname%"), ExtraTaskSettings.TaskDeviceValueNames[x]);
+          value = formatUserVarNoCheck(event, x);
+
+          MQTTpublish(event->ControllerIndex, tmppubname.c_str(), value.c_str(), Settings.MQTTRetainFlag);
+
+          String log = F("C014 : Sent to ");
+          log += tmppubname;
+          log += ' ';
+          log += value;
+          addLog(LOG_LEVEL_DEBUG, log);
+        }
+        break;
+      }
+  }
+
+  return success;
+}
+#endif

--- a/src/_P001_Switch.ino
+++ b/src/_P001_Switch.ino
@@ -423,7 +423,7 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
           if (round(PCONFIG_FLOAT(3)) && state != currentStatus.state && PCONFIG_LONG(3)==0)
           {
 #ifndef BUILD_NO_DEBUG
-            addLog(LOG_LEVEL_DEBUG,F("SW  :SafeButton 1st click"));
+            addLog(LOG_LEVEL_DEBUG,F("SW  : 1st click"));
 #endif
             PCONFIG_LONG(3) = 1;
           }

--- a/src/_P033_Dummy.ino
+++ b/src/_P033_Dummy.ino
@@ -98,6 +98,37 @@ boolean Plugin_033(byte function, struct EventStruct *event, String& string)
         success = true;
         break;
       }
+
+    case PLUGIN_WRITE:
+      {
+        String command = parseString(string, 1);
+        if (command == F("dummyvalueset"))
+        {
+          int deviceNr=parseString(string, 2).toInt(); // Index from 1-12;
+          if (deviceNr == event->TaskIndex+1) // make shure that this instance is the target
+          {
+            int valueNr=parseString(string, 3).toInt();
+            float value=0;
+            String valueStr=parseString(string, 4);
+            if (valueStr=="true") value=1;
+              else if(valueStr=="false") value=0;
+              else value=valueStr.toFloat();
+
+            String log = F("Dummy: Index ");
+            log += deviceNr;
+            log += F(" value ");
+            log += valueNr;
+            log += F(" set to ");
+            log += value;
+
+            UserVar[event->BaseVarIndex+valueNr-1]=value;
+
+            addLog(LOG_LEVEL_INFO,log);
+            success = true;
+          }
+        }
+        break;
+      }
   }
   return success;
 }

--- a/src/_P033_Dummy.ino
+++ b/src/_P033_Dummy.ino
@@ -104,27 +104,36 @@ boolean Plugin_033(byte function, struct EventStruct *event, String& string)
         String command = parseString(string, 1);
         if (command == F("dummyvalueset"))
         {
-          int deviceNr=parseString(string, 2).toInt(); // Index from 1-12;
-          if (deviceNr == event->TaskIndex+1) // make shure that this instance is the target
+          if (event->Par1 == event->TaskIndex+1) // make sure that this instance is the target
           {
-            int valueNr=parseString(string, 3).toInt();
-            float value=0;
-            String valueStr=parseString(string, 4);
-            if (valueStr=="true") value=1;
-              else if(valueStr=="false") value=0;
-              else value=valueStr.toFloat();
-
-            String log = F("Dummy: Index ");
-            log += deviceNr;
-            log += F(" value ");
-            log += valueNr;
-            log += F(" set to ");
-            log += value;
-
-            UserVar[event->BaseVarIndex+valueNr-1]=value;
-
-            addLog(LOG_LEVEL_INFO,log);
-            success = true;
+            float floatValue=0;
+            if (string2float(parseString(string, 4),floatValue))
+            {
+              if (loglevelActiveFor(LOG_LEVEL_INFO))
+              {
+                String log = F("Dummy: Index ");
+                log += event->Par1;
+                log += F(" value ");
+                log += event->Par2;
+                log += F(" set to ");
+                log += floatValue;
+                addLog(LOG_LEVEL_INFO,log);
+              }
+              UserVar[event->BaseVarIndex+event->Par2-1]=floatValue;
+              success = true;
+            } else { // float conversion failed!
+              if (loglevelActiveFor(LOG_LEVEL_ERROR))
+              {
+                String log = F("Dummy: Index ");
+                log += event->Par1;
+                log += F(" value ");
+                log += event->Par2;
+                log += F(" parameter3: ");
+                log += parseString(string, 4);
+                log += F(" not a float value!");
+                addLog(LOG_LEVEL_ERROR,log);
+              }
+            }
           }
         }
         break;

--- a/src/__CPlugin.ino
+++ b/src/__CPlugin.ino
@@ -18,6 +18,15 @@ static const char ADDCPLUGIN_ERROR[] PROGMEM = "System: Error - To much C-Plugin
 */
 #define ADDCPLUGIN(NNN) if (x < CPLUGIN_MAX) { CPlugin_id[x] = CPLUGIN_ID_##NNN; CPlugin_ptr[x++] = &CPlugin_##NNN; } else addLog(LOG_LEVEL_ERROR, FPSTR(ADDCPLUGIN_ERROR));
 
+void CPluginConnected(void)
+{
+    CPluginCall(CPLUGIN_CONNECTED, 0);
+}
+
+void CPluginDisonnect(void)
+{
+    CPluginCall(CPLUGIN_DICONNECT, 0);
+}
 
 void CPluginInit(void)
 {
@@ -168,6 +177,26 @@ bool CPluginCall(byte Function, struct EventStruct *event)
           CPluginCall(x, Function, event, dummyString);
         }
       }
+      return true;
+      break;
+
+    // calls to send autodetect information
+    case CPLUGIN_CONNECTED:
+      for (byte x=0; x < CONTROLLER_MAX; x++)
+        if (Settings.Protocol[x] != 0 && Settings.ControllerEnabled[x]) {
+          event->ProtocolIndex = getProtocolIndex(Settings.Protocol[x]);
+          CPluginCall(event->ProtocolIndex, Function, event, dummyString);
+        }
+      return true;
+      break;
+
+    // calls to send stats information
+    case CPLUGIN_SEND_STATS:
+      for (byte x=0; x < CONTROLLER_MAX; x++)
+        if (Settings.Protocol[x] != 0 && Settings.ControllerEnabled[x]) {
+          event->ProtocolIndex = getProtocolIndex(Settings.Protocol[x]);
+          CPluginCall(event->ProtocolIndex, Function, event, dummyString);
+        }
       return true;
       break;
 

--- a/src/__CPlugin.ino
+++ b/src/__CPlugin.ino
@@ -18,16 +18,6 @@ static const char ADDCPLUGIN_ERROR[] PROGMEM = "System: Error - To much C-Plugin
 */
 #define ADDCPLUGIN(NNN) if (x < CPLUGIN_MAX) { CPlugin_id[x] = CPLUGIN_ID_##NNN; CPlugin_ptr[x++] = &CPlugin_##NNN; } else addLog(LOG_LEVEL_ERROR, FPSTR(ADDCPLUGIN_ERROR));
 
-void CPluginGotConnected(void)
-{
-    CPluginCall(CPLUGIN_GOT_CONNECTED, 0);
-}
-
-void CPluginGotInvalid(void)
-{
-    CPluginCall(CPLUGIN_GOT_INVALID, 0);
-}
-
 void CPluginInit(void)
 {
   byte x;
@@ -187,6 +177,7 @@ bool CPluginCall(byte Function, struct EventStruct *event, String& str)
     case CPLUGIN_FLUSH: // calls befor sleep to fush data
     case CPLUGIN_INTERVAL: // calls to send stats information
     case CPLUGIN_GOT_CONNECTED: // calls to send autodetect information
+    case CPLUGIN_GOT_INVALID: // calls to mark unit as invalid
       for (byte x=0; x < CONTROLLER_MAX; x++)
         if (Settings.Protocol[x] != 0 && Settings.ControllerEnabled[x]) {
           event->ProtocolIndex = getProtocolIndex(Settings.Protocol[x]);

--- a/src/__Plugin.ino
+++ b/src/__Plugin.ino
@@ -1167,6 +1167,7 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
     case PLUGIN_WRITE:
     case PLUGIN_REQUEST:
       {
+        bool retval = false;
         for (byte y = 0; y < TASKS_MAX; y++)
         {
           if (Settings.TaskDeviceEnabled[y] && Settings.TaskDeviceNumber[y] != 0)
@@ -1181,10 +1182,15 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
                 TempEvent.sensorType = Device[DeviceIndex].VType;
                 checkRAM(F("PluginCall_s"),x);
                 START_TIMER;
-                bool retval = (Plugin_ptr[x](Function, &TempEvent, str));
+                retval = (Plugin_ptr[x](Function, &TempEvent, str));
                 STOP_TIMER_TASK(x,Function);
                 delay(0); // SMY: call delay(0) unconditionally
                 if (retval) {
+#ifdef USES_C014  // Homie 3 & 4dev Controller
+                  // check if ther is usefull information which should be sent to a controller too.
+                  // for TESTING! Not shure if here is the right place. Should perhaps be passed to all controllers in the future.
+                  CPlugin_014_Feedback(Function, &TempEvent, str);
+#endif
                   return true;
                 }
               }
@@ -1196,6 +1202,10 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
           if (Plugin_id[x] != 0) {
             if (Plugin_ptr[x](Function, event, str)) {
               delay(0); // SMY: call delay(0) unconditionally
+#ifdef USES_C014
+              // and here too?
+              CPlugin_014_Feedback(Function, &TempEvent, str);
+#endif
               return true;
             }
           }

--- a/src/__Plugin.ino
+++ b/src/__Plugin.ino
@@ -1167,7 +1167,6 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
     case PLUGIN_WRITE:
     case PLUGIN_REQUEST:
       {
-        bool retval = false;
         for (byte y = 0; y < TASKS_MAX; y++)
         {
           if (Settings.TaskDeviceEnabled[y] && Settings.TaskDeviceNumber[y] != 0)
@@ -1182,15 +1181,11 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
                 TempEvent.sensorType = Device[DeviceIndex].VType;
                 checkRAM(F("PluginCall_s"),x);
                 START_TIMER;
-                retval = (Plugin_ptr[x](Function, &TempEvent, str));
+                bool retval = (Plugin_ptr[x](Function, &TempEvent, str));
                 STOP_TIMER_TASK(x,Function);
                 delay(0); // SMY: call delay(0) unconditionally
                 if (retval) {
-#ifdef USES_C014  // Homie 3 & 4dev Controller
-                  // check if ther is usefull information which should be sent to a controller too.
-                  // for TESTING! Not shure if here is the right place. Should perhaps be passed to all controllers in the future.
-                  CPlugin_014_Feedback(Function, &TempEvent, str);
-#endif
+                  CPluginCall(CPLUGIN_ACKNOWLEDGE, &TempEvent, str);
                   return true;
                 }
               }
@@ -1202,10 +1197,7 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
           if (Plugin_id[x] != 0) {
             if (Plugin_ptr[x](Function, event, str)) {
               delay(0); // SMY: call delay(0) unconditionally
-#ifdef USES_C014
-              // and here too?
-              CPlugin_014_Feedback(Function, &TempEvent, str);
-#endif
+              CPluginCall(CPLUGIN_ACKNOWLEDGE, event, str);
               return true;
             }
           }

--- a/src/define_plugin_sets.h
+++ b/src/define_plugin_sets.h
@@ -621,6 +621,7 @@ To create/register a plugin, you have to :
 #ifdef CONTROLLER_SET_TESTING
     #define USES_C011   // Generic HTTP Advanced
     #define USES_C012   // Blynk HTTP
+    #define USES_C014   // homie 3 & 4dev MQTT
 #endif
 
 


### PR DESCRIPTION
This is the 1st Version of a Homie convention controller plugin.
for more information [Homie - An MQTT Convention for IoT/M2M](https://homieiot.github.io/)

- sending "complete" auto-discover information (in openhab no typing required) not working reliable with build in broker due to retain=1 messages via QoS=0 issue (internal broker ignores the retain flag if a messages arrivis with QoS=0). With an external broker like mosquitto on default settings it should work. 
- There are known issues with MQTT Homie binding in 2.4 stable. After restart (or a longer period of time) openHAB get silent (not sending or receiving updates). 2.5 snapshot builds should resolve that issue. [see on openHAB forum](https://community.openhab.org/search?q=homie)
- can be compiled as homie 3.0.0 or 4.0.0 default to 4.0.0 because 4.0.0 do not require as many topics as 3.0.0
- providing a `homie/%sysname%/SYSTEM/cmd/set` topic for sending commands
- providing a homie/%sysname%/SYSTEM/gpio#/set  , topic to handle gpio switches (if port is set to default LOW or HIGH)
- dummy devices can receive value updates (new command DummyValueSet with same Parameters as TaskValueSet now build into P033_Dummy.
- most (only tested a few) plugin and event commands can be send over .../SYSTEM/cmd/set topic
- all devices which worked with the openHAB plugin should be able to send updates
- changing the unit name will send "disconnect" message and reconnects to the new topics and send new auto-discover messages. New unit (thing) should pop up in the inbox instantly. (old thing will not be deleted)

some known issues / ToDos

- [X] Acknowledgments should be integrated as controller command
- [X] good hook for "CPLUGIN_GOT_CONNECTED" function to send once after reboot
- [X] good hook for "CPLUGIN_FLUSH" before sleep mode
- [X] good hook for "CPLUGIN_GOT_DISCONNECT" if a device is renamed to delete the old
- [X] good hook for "CPLUGIN_INTERVAL" (if necessary because only for homie 3.0)
- [X] good hook for "CPLUGIN_ACKNOWLEDGE" to be triggered for all state changes to keep the controller up to date.
- [ ] autodiscover should provide units (needs a global concept for handling Units in ESPEasy)
- [ ] more actors to be implemented if useful
- [ ] update auto-discover data if devices are added or changed (currently you have to perform a reset)
- [ ] more ... 

![image](https://user-images.githubusercontent.com/15779507/55594690-d8e63600-5740-11e9-996b-76bcd628378c.png)

![image](https://user-images.githubusercontent.com/15779507/55594801-4db97000-5741-11e9-9d86-b765f2ff8fd0.png)

![image](https://user-images.githubusercontent.com/15779507/55594758-2662a300-5741-11e9-82d5-96560bdc599e.png)

My first pull request ;)