### PR TITLE
Fix P005_DHT enabling interrupts on error reading.

### DIFF
--- a/src/_P005_DHT.ino
+++ b/src/_P005_DHT.ino
@@ -174,7 +174,11 @@ bool P005_do_plugin_read(struct EventStruct *event) {
   if(!P005_waitState(0)) {P005_log(event, P005_error_no_reading); return false; }
   if(!P005_waitState(1)) {P005_log(event, P005_error_no_reading); return false; }
   noInterrupts();
-  if(!P005_waitState(0)) {P005_log(event, P005_error_no_reading); return false; }
+  if(!P005_waitState(0)) {
+    interrupts();
+    P005_log(event, P005_error_no_reading);
+    return false;
+  }
   bool readingAborted = false;
   byte dht_dat[5];
   for (i = 0; i < 5 && !readingAborted; i++)


### PR DESCRIPTION
Inspired by this remark: https://github.com/letscontrolit/ESPEasy/issues/1774#issuecomment-483059794
When looking for the use of interrupts, I found this bug, where it is possible the interrupts were not enabled anymore if there was no reading.