### PR TITLE
Handling incomming Homie messages via receiver Plugin

### DIFF
--- a/docs/source/Controller/C014.rst
+++ b/docs/source/Controller/C014.rst
@@ -40,6 +40,8 @@ Idea is to provide an easy way to include ESPEasy in modern home automation syst
 
 When a MQTT connection is established after (re-)boot the controller sends auto-discovery information for system services like commands, basic GPIO functions and for all configured devices and there values. When all messages where sent successfully a homie compatible home automation server/hub or other compatible controllers should be able to detect the unit and establish two way communication.
 
+The :ref:`P086_page` plug-in can be used to set values and trigger actions / rules.
+
 MQTT topic scheme
 -----------------
 
@@ -104,6 +106,7 @@ The controller currently supports these features
 - receive commands through the ``homie/%unitName%/SYSTEM/cmd/set`` topic.
 - switch GPIOs through ``homie/%unitName%/SYSTEM/gpio#/set`` topic. The GPIO port must be set to **default low** or **default high** in the hardware tab to be included during auto-discover.
 - send updates of GPIO ports to ``homie/%unitName%/SYSTEM/gpio#`` regardless from where the change is triggered (to be fully tested).
+- in conjunction with :ref:`P086_page` actuators can be used according to the Homie convetion using rules.
 - receive values for dummy devices via ``homie/%unitName%/%dummyDeviceName%/%valueName%/set``. From there the values can be processed further by using rules.
 - handle ``$state`` attribute (for complete list see attribute table below)
 
@@ -119,11 +122,10 @@ The controller currently supports these features
 Future / planned features
 -------------------------
 
-- a special Homie Plugin is in devolopment to pass ``\set`` messages to rules for further handling. Here ``$datatype`` and ``$format`` attributes for ``$setable`` values can be specified there. This will enable ESPEasy to handle direct inputs to plug-ins like dimmers (%,0:100), colors (RGB & HSV, 255,255,255), enum devices like remote controls (Play, Pause, Vol+, Vol-, ...).
-- Currently receiving plug-ins can only be controlled by sending the corresponding command to ``../SYSTEM/cmd/set`` (except the **dummy device**).
+- a special Homie Plugin is in devolopment to pass ``\set`` messages to rules for further handling. Here ``$datatype`` and ``$format`` attributes for ``$setable`` values can be specified there. This will enable ESPEasy to handle direct inputs to plug-ins like dimmers (%,0:100), colors (RGB & HSV, 255,255,255), enum devices like remote controls (Play, Pause, Vol+, Vol-, ...). :yellow:`Testing` see :ref:`P086_page`
 - Further in field testing with different MQTT brokers and home automation systems.
 - Handling units via the ``$unit`` attribute. As ESPEasy is currenty "unitless" this needs a global concept within ESPEasy
-- Handling ``$datatype`` attribute. Currenly all values (except cmd and gpio) are defined as ``float``.
+- Handling ``$datatype`` attribute. Currenly all values (except cmd and gpio) are defined as ``float``. :yellow:`Testing` see :ref:`P086_page` 
 - Prepare some "working examples".
 
 Under the hood

--- a/docs/source/Plugin/P086_Homie.rst
+++ b/docs/source/Plugin/P086_Homie.rst
@@ -1,0 +1,121 @@
+.. include:: ../Plugin/_plugin_substitutions_p08x.repl
+.. _P086_page:
+
+|P086_typename|
+==================================================
+
+|P086_shortinfo|
+
+Plugin details
+--------------
+
+Type: |P086_type|
+
+Name: |P086_name|
+
+Status: |P086_status|
+
+GitHub: |P086_github|_
+
+Maintainer: |P086_maintainer|
+
+Introduction
+------------
+
+This generic Device work together with the Homie controller (C014) :ref:`C014_page` and helps to handle incoming data. According to the `Homie convention <https://homieiot.github.io/>`_ every value can be announced as "setable" when the ``$setable`` flag is true.
+
+ESPEasy initially designed as a sensor firmware receive data via commands. If you need to send data from your controller to a device you have to prepare the command in your controller software and send it to ESPEasy via ``cmd=`` or trigger rules by ``event=`` and send the command from there. To send values directly this plug-in can be used. It "only" defines the necessary parameters and the Homie controller sends the auto-discover information to the MQTT broker. To translate and direct this information to one or several commands a rule is used.
+
+Setup
+-----
+
+The :ref:`C014_page` must be installed and enabled. Multiple instances of the plug-in are possible. One instance of the plug-in can define 4 different values / events.
+
+.. include:: P086_settings.repl
+
+After reboot the controller should receive auto-discover information. Depending on the controller software used correct settings should be selected by default.
+
+Define a rule for every value defined. Every rule should end with the ``HomieValueSet`` command to acknowledge the value back to the controller. The value must not necessarily be the same as the sent value (i.e. after extra limit checks). Numeric values are stored in the device. Due to RAM limitations String values are not saved.
+For some controllers or dataset types it is not necessary to acknowledge the new value. They simply assume that the value arrived and processed correctly. Sometimes it could be useful not to acknowledge the value i.e. for slides sending updates frequently. The value can already be renewed when the acknowledgement arrives causing undesirable results or only to process values faster. For Switches it is essential to acknowledge the set state to keep the user aware of the real state and not the assumed state.
+
+Example Rules for every value / event type
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: html
+
+    // The "homie controller" schedules the event defined in the plug-in.
+    // Does NOT store string values or arrays in the "homie receiver" plug-in.
+    // Use homieValueSet to save numeric value in the plugin.
+    // This will also acknowledge the value back to the controller to get out of "predicted" state.
+    // Adjust device and event number according to your configuration
+
+    On eventInteger do
+     // insert your code here
+     homieValueSet,1,1,%eventvalue1%
+    endon
+
+    On eventFloat do
+     // insert your code here
+     homieValueSet,1,2,%eventvalue1%
+    endon
+
+    On eventBoolean do
+     // insert your code here
+     homieValueSet,1,3,%eventvalue1% // true or false (0/1 is stored in uservar)
+    endon
+
+    On eventString do
+     // insert your code here
+     homieValueSet,1,4,"%eventvalue%" // quotation requited for Strings!
+    endon
+
+    On eventEnum do
+     // insert your code here
+     homieValueSet,2,1,%eventvalue2% // name of picked item (number in %eventvalue1% and stored in uservar)
+    endon
+
+    On eventRGB do
+     // insert your code here
+     NeoPixelAll,%eventvalue1%,%eventvalue2%,%eventvalue3% // example for NeoPixel
+     homieValueSet,2,2,%eventvalue1%,%eventvalue2%,%eventvalue3%
+    endon
+
+    On eventHSV do
+     // insert your code here
+     NeoPixelAllHSV,%eventvalue1%,%eventvalue2%,%eventvalue3% // example for NeoPixel
+     homieValueSet,2,3,%eventvalue1%,%eventvalue2%,%eventvalue3%
+    endon
+
+Examples (coming soon)
+----------------------
+
+- A sprinkler system switches 8 valves via relays. The relays are connected by PCF8574 port expander.
+- Color LED using NeoPixel RGB & RGBW (WS2812B or SK6812)
+
+Under the hood
+--------------
+
+The Homie convention defines several value types and some parameters for every value to enable the controller software to send standardized values to Homie enabled devices. Therefore the device has to send ``$datatype`` and ``$format`` attributes to describe the value type, format and range. This is all done for you by the :ref:`C014_page` according to the settings in this plug-in.
+
+When a message arrives to the ``.../%deviceName%/%eventName%/set`` topic an event is triggered. From there commands can be used to perform certain actions. The parameters are passed by %eventvalue% variables:
+
+- %eventvalue1% holds the numeric values for ``float`` and ``integer``
+- %eventvalue1% holds the string value for ``string`` datatypes
+- %eventvalue1% holds the number of the selected item of a enumerating list where %eventvalue2% holds the item name
+- %eventvalue1%, %eventvalue2%, %eventvalue3% holds the intensity values of rgb or hsv ``color`` datatypes
+
+Use the command ``homieValueSet,deviceNr,eventNr,value`` similar to ``TaskValueSet`` or ``DummieValueSet`` to acknowledge the received or new value back to the controller.
+
+Datatypes (``$datatype`` defaults to ``string``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. include:: P086_datatype_attributes.repl
+
+format (``$format`` required for color values)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. include:: P086_format_attributes.repl
+
+
+.. More pictures
+.. -------------

--- a/docs/source/Plugin/P086_datatype_attributes.repl
+++ b/docs/source/Plugin/P086_datatype_attributes.repl
@@ -1,0 +1,10 @@
+.. csv-table::
+        :header: "Parameter", "Description", "UI Element", "value example", "3.0.1 & 4.0.0"
+        :widths: 10, 55, 10, 10, 15
+
+        "``integer``","Hole numbers (positive or negative). Minimum and maximum limits can be set.","Number Box", "1234",":red:`required`"
+        "``float``","Floating point values. Minimum and maximum limits can be set.","Slider / Dimmer", "1.123",":red:`required`"
+        "``boolean``","Boolean true or false","switch", "true,false",":red:`required`"
+        "``string``","Textual value","text box","display this!", ":green:`default`"
+        "``enum``","One item out of a comma seperated list","drop down list", "option 1,option 2,option 3",":red:`required`"
+        "``color``","Color value defined by rgb or hsv values. ``$fomat`` attribute required defining if ``rgb`` or ``hsv`` values are expected.","color picker", "255,255,255",":red:`required`"

--- a/docs/source/Plugin/P086_format_attributes.repl
+++ b/docs/source/Plugin/P086_format_attributes.repl
@@ -1,0 +1,7 @@
+.. csv-table::
+        :header: "Parameter", "Description", "UI Element", "Example", "3.0.1 & 4.0.0"
+        :widths: 10, 55, 10, 10, 15
+
+        "``min:max``","Range from min to max for numeric vaues.","gauges and sliders","0:100", ":yellow:`optional`"
+        "``rgb``","Colour value defined by red, green and blue values. Good to have direct control over each LED intensity of an RGB light.","colour picker", "255,255,255",":red:`required`"
+        "``hsv``","Color value defined by hue, saturation and value / intensity. Intuitive description of colours independent of the technology producing the colour. Good to drive RGBW LEDs","colour picker", "360,100,100",":red:`required`"

--- a/docs/source/Plugin/P086_settings.repl
+++ b/docs/source/Plugin/P086_settings.repl
@@ -1,0 +1,9 @@
+.. csv-table::
+        :header: "Parameter", "Description", "used by", "3.0.1 & 4.0.0"
+        :widths: 20, 40, 20, 20
+
+        "**event name**","Name of the event which should be triggered as soon as a value arrives on the ``.../%eventName%/set`` topic ",":green:`all`",":red:`required`"
+        "**minimum**","Minimum limits of the value. Suitable for sliders and gauges. If min and max both are 0 no limits will be send.",":blue:`integer` :blue:`float`",":yellow:`optional`"
+        "**maximum**","Maximum limits of the value. Suitable for sliders and gauges. If min and max both are 0 no limits will be send.",":blue:`integer` :blue:`float`",":yellow:`optional`"
+        "**decimals**","As every data is sent over MQTT is sent as string a number of valid decimals can be specified",":blue:`integer` :blue:`float`",":yellow:`optional`"
+        "**enum values**","Comma separated list of possible states, or default text for string values",":blue:`enum`", ":red:`required for enum`"

--- a/docs/source/Plugin/_Plugin.rst
+++ b/docs/source/Plugin/_Plugin.rst
@@ -106,6 +106,7 @@ There's three different released versions of ESP Easy:
    ":ref:`P080_page`","|P080_status|","P080"
    ":ref:`P081_page`","|P081_status|","P081"
    ":ref:`P082_page`","|P082_status|","P082"
+   ":ref:`P086_page`","|P086_status|","P086"
 
 
 

--- a/docs/source/Plugin/_plugin_substitutions_p08x.repl
+++ b/docs/source/Plugin/_plugin_substitutions_p08x.repl
@@ -33,3 +33,15 @@
 .. |P082_maintainer| replace:: `TD-er`
 .. |P082_compileinfo| replace:: `.`
 .. |P082_usedlibraries| replace:: https://github.com/mikalhart/TinyGPSPlus/tree/v1.0.2
+
+.. |P086_name| replace:: :cyan:`Homie receiver`
+.. |P086_type| replace:: :cyan:`Generic`
+.. |P086_typename| replace:: :cyan:`Generic - Homie receiver`
+.. |P086_status| replace:: :yellow:`TESTING`
+.. |P086_github| replace:: P086_Homie.ino
+.. _P086_github: https://github.com/letscontrolit/ESPEasy/blob/mega/src/_P086_Homie.ino
+.. |P086_usedby| replace:: `.`
+.. |P086_shortinfo| replace:: `Triggers configurable events when data is received form the Homie controller (C014).`
+.. |P086_maintainer| replace:: `.`
+.. |P086_compileinfo| replace:: `.`
+.. |P086_usedlibraries| replace:: `.`

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -2824,3 +2824,83 @@ uint16_t getPluginFromKey(uint32_t key) {
 uint16_t getPortFromKey(uint32_t key) {
   return (uint16_t)(key);
 }
+
+//#######################################################################################################
+//############################ quite acurate but slow color converter####################################
+//#######################################################################################################
+// uses H 0..360 S 1..100 I/V 1..100 (according to homie convention)
+// Source https://blog.saikoled.com/post/44677718712/how-to-convert-from-hsi-to-rgb-white
+
+void HSV2RGB(float H, float S, float I, int rgb[3]) {
+  int r, g, b;
+  H = fmod(H,360); // cycle H around to 0-360 degrees
+  H = 3.14159*H/(float)180; // Convert to radians.
+  S = S / 100;
+  S = S>0?(S<1?S:1):0; // clamp S and I to interval [0,1]
+  I = I / 100;
+  I = I>0?(I<1?I:1):0;
+
+  // Math! Thanks in part to Kyle Miller.
+  if(H < 2.09439) {
+    r = 255*I/3*(1+S*cos(H)/cos(1.047196667-H));
+    g = 255*I/3*(1+S*(1-cos(H)/cos(1.047196667-H)));
+    b = 255*I/3*(1-S);
+  } else if(H < 4.188787) {
+    H = H - 2.09439;
+    g = 255*I/3*(1+S*cos(H)/cos(1.047196667-H));
+    b = 255*I/3*(1+S*(1-cos(H)/cos(1.047196667-H)));
+    r = 255*I/3*(1-S);
+  } else {
+    H = H - 4.188787;
+    b = 255*I/3*(1+S*cos(H)/cos(1.047196667-H));
+    r = 255*I/3*(1+S*(1-cos(H)/cos(1.047196667-H)));
+    g = 255*I/3*(1-S);
+  }
+  rgb[0]=r;
+  rgb[1]=g;
+  rgb[2]=b;
+}
+
+// uses H 0..360 S 1..100 I/V 1..100 (according to homie convention)
+// Source https://blog.saikoled.com/post/44677718712/how-to-convert-from-hsi-to-rgb-white
+
+void HSV2RGBW(float H, float S, float I, int rgbw[4]) {
+  int r, g, b, w;
+  float cos_h, cos_1047_h;
+  H = fmod(H,360); // cycle H around to 0-360 degrees
+  H = 3.14159*H/(float)180; // Convert to radians.
+  S = S / 100;
+  S = S>0?(S<1?S:1):0; // clamp S and I to interval [0,1]
+  I = I / 100;
+  I = I>0?(I<1?I:1):0;
+
+  if(H < 2.09439) {
+    cos_h = cos(H);
+    cos_1047_h = cos(1.047196667-H);
+    r = S*255*I/3*(1+cos_h/cos_1047_h);
+    g = S*255*I/3*(1+(1-cos_h/cos_1047_h));
+    b = 0;
+    w = 255*(1-S)*I;
+  } else if(H < 4.188787) {
+    H = H - 2.09439;
+    cos_h = cos(H);
+    cos_1047_h = cos(1.047196667-H);
+    g = S*255*I/3*(1+cos_h/cos_1047_h);
+    b = S*255*I/3*(1+(1-cos_h/cos_1047_h));
+    r = 0;
+    w = 255*(1-S)*I;
+  } else {
+    H = H - 4.188787;
+    cos_h = cos(H);
+    cos_1047_h = cos(1.047196667-H);
+    b = S*255*I/3*(1+cos_h/cos_1047_h);
+    r = S*255*I/3*(1+(1-cos_h/cos_1047_h));
+    g = 0;
+    w = 255*(1-S)*I;
+  }
+
+  rgbw[0]=r;
+  rgbw[1]=g;
+  rgbw[2]=b;
+  rgbw[3]=w;
+}

--- a/src/_C014.ino
+++ b/src/_C014.ino
@@ -345,36 +345,54 @@ bool CPlugin_014(byte function, struct EventStruct *event, String& string)
 
               if (Settings.TaskDeviceEnabled[x])  // Device is enabled so send information
               { // device enabled
-                CPLUGIN_014_addToList(nodesList,deviceName.c_str());
-                deviceCount++;
-                // $name	Device → Controller	Friendly name of the Node	Yes	Yes
-                CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), "$name", "",ExtraTaskSettings.TaskDeviceName, errorCounter);
-
-                // $type	Device → Controller	Type of the node	Yes	Yes
-                CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), "$type", "", getPluginNameFromDeviceIndex(DeviceIndex).c_str(), errorCounter);
-
                 valuesList="";
 
                 if (!Device[DeviceIndex].SendDataOption) // check if device is not sending data = assume that it can receive.
                 {
-/*                  if (Device[DeviceIndex].Number==12) // LCD 2 or 4 Lines
+                  if (Device[DeviceIndex].Number==85) // Homie receiver
                   {
-                    CPLUGIN_014_addToList(valuesList,"LCD");
-                    CPLUGIN_014_addToList(valuesList,"LCDCMD");
-                    //$settable	Device → Controller	Specifies whether the property is settable (true) or readonly (false)	true or false	Yes	No (false)
-                    CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), "LCD", "/$settable", "true", errorCounter);
-                    CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), "LCDCMD", "/$settable", "true", errorCounter);
-
-                    //$name	Device → Controller	Friendly name of the property.	Any String	Yes	No ("")
-                    CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), "LCD", "/$name","LCD text", errorCounter);
-                    CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), "LCDCMD", "/$name","LCD command", errorCounter);
-
-                    //$datatype	The data type. See Payloads.	Enum: [integer, float, boolean,string, enum, color]
-                    CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), "LCD", "/$datatype", "string", errorCounter);
-                    CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), "LCDCMD", "/$datatype", "string", errorCounter);
-
-                    nodeCount++;
-                  } */
+                    for (byte varNr = 0; varNr < Device[DeviceIndex].ValueCount; varNr++) {
+                      if (Settings.TaskDeviceNumber[x] != 0) {
+                        if (ExtraTaskSettings.TaskDeviceValueNames[varNr][0]!=0) { // do not send if Value Name is empty!
+                          CPLUGIN_014_addToList(valuesList,ExtraTaskSettings.TaskDeviceValueNames[varNr]);
+                          //$settable	Device → Controller	Specifies whether the property is settable (true) or readonly (false)	true or false	Yes	No (false)
+                          CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), ExtraTaskSettings.TaskDeviceValueNames[varNr], "/$settable", "true", errorCounter);
+                          //$name	Device → Controller	Friendly name of the property.	Any String	Yes	No ("")
+                          valueName = F("Homie Receiver: ");
+                          valueName += ExtraTaskSettings.TaskDeviceValueNames[varNr];
+                          CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), ExtraTaskSettings.TaskDeviceValueNames[varNr], "/$name",valueName.c_str(), errorCounter);
+                          //$datatype	The data type. See Payloads.	Enum: [integer, float, boolean,string, enum, color]
+                          unitName = "";
+                          switch(Settings.TaskDevicePluginConfig[x][varNr]) {
+                            case 0: valueName = F("integer");
+                                    if (ExtraTaskSettings.TaskDevicePluginConfig[varNr]!=0 || ExtraTaskSettings.TaskDevicePluginConfig[varNr+5]!=0) {
+                                      unitName = ExtraTaskSettings.TaskDevicePluginConfig[varNr];
+                                      unitName += ":";
+                                      unitName += ExtraTaskSettings.TaskDevicePluginConfig[varNr+Device[DeviceIndex].ValueCount];
+                                    }
+                                    break;
+                            case 1: valueName = F("float");
+                                    if (ExtraTaskSettings.TaskDevicePluginConfig[varNr]!=0 || ExtraTaskSettings.TaskDevicePluginConfig[varNr+5]!=0) {
+                                      unitName = ExtraTaskSettings.TaskDevicePluginConfig[varNr];
+                                      unitName += ":";
+                                      unitName += ExtraTaskSettings.TaskDevicePluginConfig[varNr+Device[DeviceIndex].ValueCount];
+                                    }
+                                    break;
+                            case 2: valueName = F("boolean"); break;
+                            case 3: valueName = F("string"); break;
+                            case 4: valueName = F("enum");
+                                    unitName = ExtraTaskSettings.TaskDeviceFormula[varNr];
+                                    break;
+                            case 5: valueName = F("rgb"); break;
+                            case 6: valueName = F("hsv"); break;
+                          }
+                          CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), ExtraTaskSettings.TaskDeviceValueNames[varNr], "/$datatype", valueName.c_str(), errorCounter);
+                          if (unitName!="") CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), ExtraTaskSettings.TaskDeviceValueNames[varNr], "/$format", unitName.c_str(), errorCounter);
+                          nodeCount++;
+                        }
+                      }
+                    }
+                  }
                 } else {
                   // ignore cutom values for now! Assume all Values are standard float.
                   // customValues = PluginCall(PLUGIN_WEBFORM_SHOW_VALUES, &TempEvent,TXBuffer.buf);
@@ -429,6 +447,16 @@ bool CPlugin_014(byte function, struct EventStruct *event, String& string)
                 }
                 if (valuesList!="")
                 {
+                  // only add device to list if it has nodes!
+                  // $name	Device → Controller	Friendly name of the Node	Yes	Yes
+                  CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), "$name", "",ExtraTaskSettings.TaskDeviceName, errorCounter);
+
+                  // $type	Device → Controller	Type of the node	Yes	Yes
+                  CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), "$type", "", getPluginNameFromDeviceIndex(DeviceIndex).c_str(), errorCounter);
+
+                  // add device to device list
+                  CPLUGIN_014_addToList(nodesList,deviceName.c_str());
+                  deviceCount++;
                   // $properties	Device → Controller	Properties the node exposes, with format id separated by a , if there are multiple nodes.	Yes	Yes
                   CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), "$properties", "", valuesList.c_str(), errorCounter);
                   valuesList="";
@@ -517,6 +545,8 @@ bool CPlugin_014(byte function, struct EventStruct *event, String& string)
           break;
         } else {
           String cmd;
+          int valueNr=0;
+          int deviceNr=0;
           struct EventStruct TempEvent;
           TempEvent.TaskIndex = event->TaskIndex;
           TempEvent.Source = VALUE_SOURCE_MQTT; // to trigger the correct acknowledgment
@@ -558,12 +588,12 @@ bool CPlugin_014(byte function, struct EventStruct *event, String& string)
               }
             } else // msg to a receiving plugin
             {
-              int deviceNr=CPlugin_014_getPluginNr(nodeName);
+              deviceNr=CPlugin_014_getPluginNr(nodeName);
               int pluginID=Device[getDeviceIndex(Settings.TaskDeviceNumber[deviceNr])].Number;
 
               if (pluginID==33) // Plugin 33 Dummy Device
               { // DummyValueSet,<task/device nr>,<value nr>,<value/formula (!ToDo) >, works only with new version of P033!
-                int valueNr = CPlugin_014_getValueNr(deviceNr,valueName);
+                valueNr = CPlugin_014_getValueNr(deviceNr,valueName);
                 if (valueNr > -1) // value Name identified
                 {
                   cmd = F("DummyValueSet,"); // Set a Dummy Device Value
@@ -574,6 +604,19 @@ bool CPlugin_014(byte function, struct EventStruct *event, String& string)
                   cmd += event->String2; // expect float as payload!
                   validTopic = true;
                 }
+              } else if (pluginID==85) { // Plugin Homie receiver. Schedules the event defined in the plugin. Does NOT store the value. Use HomieValueSet to save the value. This will acknolage back to the controller too.
+                valueNr = CPlugin_014_getValueNr(deviceNr,valueName);
+                cmd = F("event,");
+                cmd += valueName;
+                cmd += "=";
+                if (Settings.TaskDevicePluginConfig[deviceNr][valueNr]==3) { // Quote Sting parameters. PLUGIN_085_VALUE_STRING
+                  cmd += '"';
+                  cmd += event->String2;
+                  cmd += '"';
+                } else {
+                  cmd += event->String2;
+                }
+                validTopic = true;
               }
             }
 
@@ -586,23 +629,28 @@ bool CPlugin_014(byte function, struct EventStruct *event, String& string)
               }
             } else {
               if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-                addLog(LOG_LEVEL_INFO, log+ F(" ERROR"));
+                addLog(LOG_LEVEL_INFO, log+ F(" INVALID MSG"));
               }
             }
           }
 
           if (validTopic) {
-            if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-              log=F("C014 : Exec > ");
-            }
             // in case of event, store to buffer and return...
             String command = parseString(cmd, 1);
             if (command == F("event"))
             {
-              if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-                log+=F("Event!");
-              }
               eventBuffer = cmd.substring(6);
+              if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+                log=F("C014 : deviceNr:");
+                log+=deviceNr;
+                log+=F(" valueNr:");
+                log+=valueNr;
+                log+=F(" valueType:");
+                log+=Settings.TaskDevicePluginConfig[deviceNr][valueNr];
+                log+=F(" Event: ");
+                log+=eventBuffer;
+                addLog(LOG_LEVEL_INFO, log);
+              }
             } else { // not an event
               if (loglevelActiveFor(LOG_LEVEL_INFO)) {
                 log=F("C014 : PluginCall:");
@@ -610,7 +658,7 @@ bool CPlugin_014(byte function, struct EventStruct *event, String& string)
               if (!PluginCall(PLUGIN_WRITE, &TempEvent, cmd)) {
                 remoteConfig(&TempEvent, cmd);
                 if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-                  log +=F(" remoteConfig?");
+                  log +=F(" failed! remoteConfig?");
                 }
               } else {
                 if (loglevelActiveFor(LOG_LEVEL_INFO)) {
@@ -668,7 +716,7 @@ bool CPlugin_014(byte function, struct EventStruct *event, String& string)
       case CPLUGIN_ACKNOWLEDGE:
       {
         LoadTaskSettings(event->Par1-1);
-        if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+/*        if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
           String log = F("CPLUGIN_ACKNOWLEDGE: ");
           log += string;
           log += F(" / ");
@@ -702,7 +750,7 @@ bool CPlugin_014(byte function, struct EventStruct *event, String& string)
           log += F(" P5:");
           log += event->Par5;
           addLog(LOG_LEVEL_DEBUG, log);
-        }
+        } */
         success = false;
         if (string!="") {
           String commandName = parseString(string, 1); // could not find a way to get the command out of the event structure.
@@ -749,10 +797,12 @@ bool CPlugin_014(byte function, struct EventStruct *event, String& string)
             topic.replace(F("%tskname%"), deviceName);
             String valueName = ExtraTaskSettings.TaskDeviceValueNames[event->Par2-1]; //parseString(string, 3).toInt()-1];
             topic.replace(F("%valname%"), valueName);
+            String valueStr = "";
+            int valueInt = 0;
 
             if ((commandName == F("taskvalueset")) || (commandName == F("dummyvalueset"))) // should work for both
             {
-              String valueStr = toString(UserVar[event->BaseVarIndex+event->Par2-1],ExtraTaskSettings.TaskDeviceValueDecimals[event->Par2-1]); //parseString(string, 4);
+              valueStr = toString(UserVar[event->BaseVarIndex+event->Par2-1],ExtraTaskSettings.TaskDeviceValueDecimals[event->Par2-1]); //parseString(string, 4);
               success = MQTTpublish(CPLUGIN_ID_014, topic.c_str(), valueStr.c_str(), false);
               if (loglevelActiveFor(LOG_LEVEL_INFO) && success) {
                 String log = F("C014 : Acknowledged: ");
@@ -776,9 +826,70 @@ bool CPlugin_014(byte function, struct EventStruct *event, String& string)
                 log += valueStr;
                 addLog(LOG_LEVEL_ERROR, log+" ERROR!");
               }
+            } else if (parseString(commandName, 1) == F("homievalueset")) { // acknolages value form P085 Homie Receiver
+              switch (Settings.TaskDevicePluginConfig[deviceIndex-1][event->Par2-1]) {
+                case 0: // PLUGIN_085_VALUE_INTEGER
+                  valueInt = static_cast<int>(UserVar[event->BaseVarIndex+event->Par2-1]);
+                  valueStr = toString(UserVar[event->BaseVarIndex+event->Par2-1],0);
+                  break;
+                case 1: // PLUGIN_085_VALUE_FLOAT
+                  valueStr = toString(UserVar[event->BaseVarIndex+event->Par2-1],ExtraTaskSettings.TaskDeviceValueDecimals[event->Par2-1]);
+                  break;
+                case 2: // PLUGIN_085_VALUE_BOOLEAN
+                  if ( UserVar[event->BaseVarIndex+event->Par2-1] == 1) valueStr="true";
+                    else valueStr = "false";
+                  break;
+                case 3: // PLUGIN_085_VALUE_STRING
+                  //valueStr = ExtraTaskSettings.TaskDeviceFormula[event->Par2-1];
+                  valueStr = parseStringToEndKeepCase(string,4);
+                  break;
+                case 4: // PLUGIN_085_VALUE_ENUM
+                  valueInt = static_cast<int>(UserVar[event->BaseVarIndex+event->Par2-1]);
+                  valueStr = parseStringKeepCase(ExtraTaskSettings.TaskDeviceFormula[event->Par2-1],valueInt);
+                  break;
+                case 5: // PLUGIN_085_VALUE_RGB
+                  //valueStr = ExtraTaskSettings.TaskDeviceFormula[event->Par2-1];
+                  valueStr = parseStringToEnd(string,4);
+                  break;
+                case 6: // PLUGIN_085_VALUE_HSV
+                  //valueStr = ExtraTaskSettings.TaskDeviceFormula[event->Par2-1];
+                  valueStr = parseStringToEnd(string,4);
+                  break;
+              }
+              success = MQTTpublish(CPLUGIN_ID_014, topic.c_str(), valueStr.c_str(), false);
+              if (loglevelActiveFor(LOG_LEVEL_INFO) && success) {
+                String log = F("C014 : homie acknowledge: ");
+                log += deviceName;
+                log += F(" deviceNr:");
+                log += deviceIndex;
+                log += F(" valueNr:");
+                log += event->Par2;
+                log += F(" valueName:");
+                log += valueName;
+                log += F(" valueType:");
+                log += Settings.TaskDevicePluginConfig[deviceIndex-1][event->Par2-1];
+                log += F(" topic:");
+                log += topic;
+                log += F(" valueInt:");
+                log += valueInt;
+                log += F(" valueStr:");
+                log += valueStr;
+                addLog(LOG_LEVEL_INFO, log+" success!");
+              }
+              if (loglevelActiveFor(LOG_LEVEL_ERROR) && !success) {
+                String log = F("C014 : homie acknowledge: ");
+                log += deviceName;
+                log += F(" var: ");
+                log += valueName;
+                log += F(" topic: ");
+                log += topic;
+                log += F(" value: ");
+                log += valueStr;
+                addLog(LOG_LEVEL_ERROR, log+" failed!");
+              }
             } else // Acknowledge not implemented yet
             {
-              if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+/*              if (loglevelActiveFor(LOG_LEVEL_INFO)) {
                 String log = F("C014 : Plugin acknowledged: ");
                 log+=function;
                 log+=F(" / ");
@@ -787,7 +898,7 @@ bool CPlugin_014(byte function, struct EventStruct *event, String& string)
                 log+=string;
                 log+=F(" not implemented!");
                 addLog(LOG_LEVEL_ERROR, log);
-              }
+              } */
               success = false;
             }
           }

--- a/src/_P085_Homie.ino
+++ b/src/_P085_Homie.ino
@@ -1,0 +1,407 @@
+#ifdef USES_P085
+//#######################################################################################################
+//################################## Plugin 085: Homie receiver##########################################
+//#######################################################################################################
+
+#define PLUGIN_085
+#define PLUGIN_ID_085         85
+#define PLUGIN_NAME_085       "Generic - Homie receiver"
+
+// empty default names because settings will be ignored / not used if value name is empty
+#define PLUGIN_VALUENAME1_085 ""
+#define PLUGIN_VALUENAME2_085 ""
+#define PLUGIN_VALUENAME3_085 ""
+#define PLUGIN_VALUENAME4_085 ""
+
+#define PLUGIN_085_VALUE_INTEGER    0
+#define PLUGIN_085_VALUE_FLOAT      1
+#define PLUGIN_085_VALUE_BOOLEAN    2
+#define PLUGIN_085_VALUE_STRING     3
+#define PLUGIN_085_VALUE_ENUM       4
+#define PLUGIN_085_VALUE_RGB        5
+#define PLUGIN_085_VALUE_HSV        6
+
+#define PLUGIN_085_VALUE_TYPES      7
+#define PLUGIN_085_VALUE_MAX        4
+
+#define PLUGIN_085_DEBUG            true
+
+boolean Plugin_085(byte function, struct EventStruct *event, String& string)
+{
+  boolean success = false;
+
+  switch (function)
+  {
+
+    case PLUGIN_DEVICE_ADD:
+      {
+        Device[++deviceCount].Number = PLUGIN_ID_085;
+        Device[deviceCount].Type = DEVICE_TYPE_DUMMY;
+        Device[deviceCount].VType = SENSOR_TYPE_NONE;
+        Device[deviceCount].Ports = 0;
+        Device[deviceCount].PullUpOption = false;
+        Device[deviceCount].InverseLogicOption = false;
+        Device[deviceCount].FormulaOption = false;
+        Device[deviceCount].DecimalsOnly = true;
+        Device[deviceCount].ValueCount = PLUGIN_085_VALUE_MAX;
+        Device[deviceCount].SendDataOption = false;
+        Device[deviceCount].TimerOption = false;
+        Device[deviceCount].GlobalSyncOption = false;
+        Device[deviceCount].Custom = true;
+        break;
+      }
+
+    case PLUGIN_GET_DEVICENAME:
+      {
+        string = F(PLUGIN_NAME_085);
+        break;
+      }
+
+    case PLUGIN_GET_DEVICEVALUENAMES:
+      {
+        strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[0], PSTR(PLUGIN_VALUENAME1_085));
+        strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[1], PSTR(PLUGIN_VALUENAME2_085));
+        strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[2], PSTR(PLUGIN_VALUENAME3_085));
+        strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[3], PSTR(PLUGIN_VALUENAME4_085));
+
+        break;
+      }
+
+    case PLUGIN_WEBFORM_LOAD:
+      {
+        addFormNote(F("Translation Plugin for controllers able to recieve value updates according to Homie convention."));
+
+        byte choice = 0;
+        String labelText = "";
+        String keyName = "";
+        String options[PLUGIN_085_VALUE_TYPES];
+        options[0] = F("integer");
+        options[1] = F("float");
+        options[2] = F("boolean");
+        options[3] = F("string");
+        options[4] = F("enum");
+        options[5] = F("rgb");
+        options[6] = F("hsv");
+        int optionValues[PLUGIN_085_VALUE_TYPES];
+        optionValues[0] = PLUGIN_085_VALUE_INTEGER;
+        optionValues[1] = PLUGIN_085_VALUE_FLOAT;
+        optionValues[2] = PLUGIN_085_VALUE_BOOLEAN;
+        optionValues[3] = PLUGIN_085_VALUE_STRING;
+        optionValues[4] = PLUGIN_085_VALUE_ENUM;
+        optionValues[5] = PLUGIN_085_VALUE_RGB;
+        optionValues[6] = PLUGIN_085_VALUE_HSV;
+        for (int i=0;i<PLUGIN_085_VALUE_MAX;i++) {
+          labelText = F("Function #");
+          labelText += (i+1);
+          addFormSubHeader(labelText);
+          choice = PCONFIG(i);
+          if (i==0) addFormNote(F("Triggers an event when a ../%event%/set topic arrives"));
+          labelText = F("Event Name");
+          keyName = F("p085_functionName");
+          keyName += i;
+          addFormTextBox(labelText, keyName, ExtraTaskSettings.TaskDeviceValueNames[i], NAME_FORMULA_LENGTH_MAX);
+          labelText = F("Parameter Type");
+          keyName = F("p085_valueType");
+          keyName += i;
+          addFormSelector(labelText, keyName, PLUGIN_085_VALUE_TYPES, options, optionValues, choice );
+          keyName += F("_min");
+          addFormNumericBox(F("Min"),keyName,ExtraTaskSettings.TaskDevicePluginConfig[i]);
+          keyName = F("p085_valueType");
+          keyName += i;
+          keyName += F("_max");
+          addFormNumericBox(F("Max"),keyName,ExtraTaskSettings.TaskDevicePluginConfig[i+PLUGIN_085_VALUE_MAX]);
+          if (i==0) addFormNote(F("min max values only valid for numeric parameter"));
+          keyName = F("p085_decimals");
+          keyName += i;
+          addFormNumericBox(F("Decimals"),keyName,ExtraTaskSettings.TaskDeviceValueDecimals[i],0,8);
+          if (i==0) addFormNote(F("Decimal counts for float parameter"));
+          keyName = F("p085_string");
+          keyName += i;
+          addFormTextBox(F("String or enum"), keyName, ExtraTaskSettings.TaskDeviceFormula[i], NAME_FORMULA_LENGTH_MAX);
+          if (i==0) addFormNote(F("String content. Enum expects comma seperated list"));
+        }
+        success = true;
+        break;
+      }
+
+    case PLUGIN_WEBFORM_SAVE:
+      {
+        String keyName = "";
+        for (int i=0;i<PLUGIN_085_VALUE_MAX;i++) {
+          keyName = F("p085_valueType");
+          keyName += i;
+          PCONFIG(i) = getFormItemInt(keyName);
+          keyName = F("p085_functionName");
+          keyName += i;
+          strncpy_webserver_arg(ExtraTaskSettings.TaskDeviceValueNames[i], keyName);
+          keyName = F("p085_valueType");
+          keyName += i;
+          keyName += F("_min");
+          ExtraTaskSettings.TaskDevicePluginConfig[i]=getFormItemInt(keyName);
+          keyName = F("p085_valueType");
+          keyName += i;
+          keyName += F("_max");
+          ExtraTaskSettings.TaskDevicePluginConfig[i+PLUGIN_085_VALUE_MAX]=getFormItemInt(keyName);
+          keyName = F("p085_decimals");
+          keyName += i;
+          ExtraTaskSettings.TaskDeviceValueDecimals[i]=getFormItemInt(keyName);
+          keyName = F("p085_string");
+          keyName += i;
+          strncpy_webserver_arg(ExtraTaskSettings.TaskDeviceFormula[i], keyName);
+        }
+        success = true;
+        break;
+      }
+
+    case PLUGIN_READ:
+      {
+        for (byte x=0; x<PLUGIN_085_VALUE_MAX;x++)
+        {
+          String log = F("P085 : Value ");
+          log += x+1;
+          log += F(": ");
+          log += UserVar[event->BaseVarIndex+x];
+          addLog(LOG_LEVEL_INFO,log);
+        }
+        success = true;
+        break;
+      }
+
+    case PLUGIN_WRITE:
+      {
+        String command = parseString(string, 1);
+        if (command == F("homievalueset"))
+        {
+          if (event->Par1 == event->TaskIndex+1) {// make sure that this instance is the target
+            LoadTaskSettings(event->Par1 -1);
+            String parameter = parseStringToEndKeepCase(string,4);
+            String log = "";
+/*            if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+              log = F("P085 : Acknowledge :");
+              log += string;
+              log += F(" / ");
+              log += ExtraTaskSettings.TaskDeviceName;
+              log += F(" / ");
+              log += ExtraTaskSettings.TaskDeviceValueNames[event->Par2-1];
+              log += F(" sensorType:");
+              log += event->sensorType;
+              log += F(" Source:");
+              log += event->Source;
+              log += F(" idx:");
+              log += event->idx;
+              log += F(" S1:");
+              log += event->String1;
+              log += F(" S2:");
+              log += event->String2;
+              log += F(" S3:");
+              log += event->String3;
+              log += F(" S4:");
+              log += event->String4;
+              log += F(" S5:");
+              log += event->String5;
+              log += F(" P1:");
+              log += event->Par1;
+              log += F(" P2:");
+              log += event->Par2;
+              log += F(" P3:");
+              log += event->Par3;
+              log += F(" P4:");
+              log += event->Par4;
+              log += F(" P5:");
+              log += event->Par5;
+              addLog(LOG_LEVEL_DEBUG, log);
+            } */
+            float floatValue = 0;
+            String enumList = "";
+            int i = 0;
+            if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+              log = F("P085 : deviceNr:");
+              log += event->Par1;
+              log += F(" valueNr:");
+              log += event->Par2;
+              log += F(" valueType:");
+              log += Settings.TaskDevicePluginConfig[event->Par1-1][event->Par2-1];
+            }
+
+            switch (Settings.TaskDevicePluginConfig[event->Par1-1][event->Par2-1]) {
+              case PLUGIN_085_VALUE_INTEGER:
+              case PLUGIN_085_VALUE_FLOAT:
+                if (parameter!="") {
+                  if (string2float(parameter,floatValue)) {
+                    if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+                      log += F(" integer/float set to ");
+                      log += floatValue;
+                      addLog(LOG_LEVEL_INFO,log);
+                    }
+                    UserVar[event->BaseVarIndex+event->Par2-1]=floatValue;
+                  } else { // float conversion failed!
+                    if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
+                      log += F(" parameter:");
+                      log += parameter;
+                      log += F(" not a float value!");
+                      addLog(LOG_LEVEL_ERROR,log);
+                    }
+                  }
+                } else {
+                  if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+                    log += F(" value:");
+                    log += UserVar[event->BaseVarIndex+event->Par2-1];
+                    addLog(LOG_LEVEL_INFO,log);
+                  }
+                }
+                break;
+
+              case PLUGIN_085_VALUE_BOOLEAN:
+                if (parameter=="false") {
+                  floatValue = 0;
+                } else {
+                  floatValue = 1;
+                }
+                UserVar[event->BaseVarIndex+event->Par2-1]=floatValue;
+                if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+                  log += F(" boolean set to ");
+                  log += floatValue;
+                  addLog(LOG_LEVEL_INFO,log);
+                }
+                break;
+
+              case PLUGIN_085_VALUE_STRING:
+                //String values not stored to conserve flash memory
+                //safe_strncpy(ExtraTaskSettings.TaskDeviceFormula[event->Par2-1], parameter.c_str(), sizeof(ExtraTaskSettings.TaskDeviceFormula[event->Par2-1]));
+                if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+                  log += F(" string set to ");
+                  log += parameter;
+                  addLog(LOG_LEVEL_INFO,log);
+                }
+                break;
+
+              case PLUGIN_085_VALUE_ENUM:
+                enumList = ExtraTaskSettings.TaskDeviceFormula[event->Par2-1];
+                i = 1;
+                while (parseString(enumList,i)!="") { // lookup result in enum List
+                  if (parseString(enumList,i)==parameter) {
+                    floatValue = i;
+                    break;
+                  }
+                  i++;
+                }
+                UserVar[event->BaseVarIndex+event->Par2-1]=floatValue;
+                if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+                  log += F(" enum set to ");
+                  log += floatValue;
+                  log += F(" (");
+                  log += parameter;
+                  log += F(")");
+                  addLog(LOG_LEVEL_INFO,log);
+                }
+                break;
+
+              case PLUGIN_085_VALUE_RGB:
+                //String values not stored to conserve flash memory
+                //safe_strncpy(ExtraTaskSettings.TaskDeviceFormula[event->Par2-1], parameter.c_str(), sizeof(ExtraTaskSettings.TaskDeviceFormula[event->Par2-1]));
+                if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+                  log += F(" RGB received ");
+                  log += parameter;
+                  addLog(LOG_LEVEL_INFO,log);
+                }
+                break;
+
+              case PLUGIN_085_VALUE_HSV:
+                //String values not stored to conserve flash memory
+                //safe_strncpy(ExtraTaskSettings.TaskDeviceFormula[event->Par2-1], parameter.c_str(), sizeof(ExtraTaskSettings.TaskDeviceFormula[event->Par2-1]));
+                if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+                  log += F(" HSV received ");
+                  log += parameter;
+                  addLog(LOG_LEVEL_INFO,log);
+                }
+                break;
+            }
+            success = true;
+          }
+        }
+        break;
+      }
+  }
+  return success;
+}
+
+// acurate color converter (should be perhaps moved to a more prominent place to be used by others too)
+// uses H 0..360 S 1..100 I/V 1..100 (according to homie convention)
+// Source https://blog.saikoled.com/post/44677718712/how-to-convert-from-hsi-to-rgb-white
+
+void HSV2RGB(float H, float S, float I, int rgb[3]) {
+  int r, g, b;
+  H = fmod(H,360); // cycle H around to 0-360 degrees
+  H = 3.14159*H/(float)180; // Convert to radians.
+  S = S / 100;
+  S = S>0?(S<1?S:1):0; // clamp S and I to interval [0,1]
+  I = I / 100;
+  I = I>0?(I<1?I:1):0;
+
+  // Math! Thanks in part to Kyle Miller.
+  if(H < 2.09439) {
+    r = 255*I/3*(1+S*cos(H)/cos(1.047196667-H));
+    g = 255*I/3*(1+S*(1-cos(H)/cos(1.047196667-H)));
+    b = 255*I/3*(1-S);
+  } else if(H < 4.188787) {
+    H = H - 2.09439;
+    g = 255*I/3*(1+S*cos(H)/cos(1.047196667-H));
+    b = 255*I/3*(1+S*(1-cos(H)/cos(1.047196667-H)));
+    r = 255*I/3*(1-S);
+  } else {
+    H = H - 4.188787;
+    b = 255*I/3*(1+S*cos(H)/cos(1.047196667-H));
+    r = 255*I/3*(1+S*(1-cos(H)/cos(1.047196667-H)));
+    g = 255*I/3*(1-S);
+  }
+  rgb[0]=r;
+  rgb[1]=g;
+  rgb[2]=b;
+}
+
+// uses H 0..360 S 1..100 I/V 1..100 (according to homie convention)
+// Source https://blog.saikoled.com/post/44677718712/how-to-convert-from-hsi-to-rgb-white
+
+void HSV2RGBW(float H, float S, float I, int rgbw[4]) {
+  int r, g, b, w;
+  float cos_h, cos_1047_h;
+  H = fmod(H,360); // cycle H around to 0-360 degrees
+  H = 3.14159*H/(float)180; // Convert to radians.
+  S = S / 100;
+  S = S>0?(S<1?S:1):0; // clamp S and I to interval [0,1]
+  I = I / 100;
+  I = I>0?(I<1?I:1):0;
+
+  if(H < 2.09439) {
+    cos_h = cos(H);
+    cos_1047_h = cos(1.047196667-H);
+    r = S*255*I/3*(1+cos_h/cos_1047_h);
+    g = S*255*I/3*(1+(1-cos_h/cos_1047_h));
+    b = 0;
+    w = 255*(1-S)*I;
+  } else if(H < 4.188787) {
+    H = H - 2.09439;
+    cos_h = cos(H);
+    cos_1047_h = cos(1.047196667-H);
+    g = S*255*I/3*(1+cos_h/cos_1047_h);
+    b = S*255*I/3*(1+(1-cos_h/cos_1047_h));
+    r = 0;
+    w = 255*(1-S)*I;
+  } else {
+    H = H - 4.188787;
+    cos_h = cos(H);
+    cos_1047_h = cos(1.047196667-H);
+    b = S*255*I/3*(1+cos_h/cos_1047_h);
+    r = S*255*I/3*(1+(1-cos_h/cos_1047_h));
+    g = 0;
+    w = 255*(1-S)*I;
+  }
+
+  rgbw[0]=r;
+  rgbw[1]=g;
+  rgbw[2]=b;
+  rgbw[3]=w;
+}
+
+
+#endif // USES_P085

--- a/src/_P086_Homie.ino
+++ b/src/_P086_Homie.ino
@@ -1,32 +1,32 @@
-#ifdef USES_P085
+#ifdef USES_P086
 //#######################################################################################################
-//################################## Plugin 085: Homie receiver##########################################
+//################################## Plugin 086: Homie receiver##########################################
 //#######################################################################################################
 
-#define PLUGIN_085
-#define PLUGIN_ID_085         85
-#define PLUGIN_NAME_085       "Generic - Homie receiver"
+#define PLUGIN_086
+#define PLUGIN_ID_086         86
+#define PLUGIN_NAME_086       "Generic - Homie receiver"
 
 // empty default names because settings will be ignored / not used if value name is empty
-#define PLUGIN_VALUENAME1_085 ""
-#define PLUGIN_VALUENAME2_085 ""
-#define PLUGIN_VALUENAME3_085 ""
-#define PLUGIN_VALUENAME4_085 ""
+#define PLUGIN_VALUENAME1_086 ""
+#define PLUGIN_VALUENAME2_086 ""
+#define PLUGIN_VALUENAME3_086 ""
+#define PLUGIN_VALUENAME4_086 ""
 
-#define PLUGIN_085_VALUE_INTEGER    0
-#define PLUGIN_085_VALUE_FLOAT      1
-#define PLUGIN_085_VALUE_BOOLEAN    2
-#define PLUGIN_085_VALUE_STRING     3
-#define PLUGIN_085_VALUE_ENUM       4
-#define PLUGIN_085_VALUE_RGB        5
-#define PLUGIN_085_VALUE_HSV        6
+#define PLUGIN_086_VALUE_INTEGER    0
+#define PLUGIN_086_VALUE_FLOAT      1
+#define PLUGIN_086_VALUE_BOOLEAN    2
+#define PLUGIN_086_VALUE_STRING     3
+#define PLUGIN_086_VALUE_ENUM       4
+#define PLUGIN_086_VALUE_RGB        5
+#define PLUGIN_086_VALUE_HSV        6
 
-#define PLUGIN_085_VALUE_TYPES      7
-#define PLUGIN_085_VALUE_MAX        4
+#define PLUGIN_086_VALUE_TYPES      7
+#define PLUGIN_086_VALUE_MAX        4
 
-#define PLUGIN_085_DEBUG            true
+#define PLUGIN_086_DEBUG            true
 
-boolean Plugin_085(byte function, struct EventStruct *event, String& string)
+boolean Plugin_086(byte function, struct EventStruct *event, String& string)
 {
   boolean success = false;
 
@@ -35,7 +35,7 @@ boolean Plugin_085(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_DEVICE_ADD:
       {
-        Device[++deviceCount].Number = PLUGIN_ID_085;
+        Device[++deviceCount].Number = PLUGIN_ID_086;
         Device[deviceCount].Type = DEVICE_TYPE_DUMMY;
         Device[deviceCount].VType = SENSOR_TYPE_NONE;
         Device[deviceCount].Ports = 0;
@@ -43,7 +43,7 @@ boolean Plugin_085(byte function, struct EventStruct *event, String& string)
         Device[deviceCount].InverseLogicOption = false;
         Device[deviceCount].FormulaOption = false;
         Device[deviceCount].DecimalsOnly = true;
-        Device[deviceCount].ValueCount = PLUGIN_085_VALUE_MAX;
+        Device[deviceCount].ValueCount = PLUGIN_086_VALUE_MAX;
         Device[deviceCount].SendDataOption = false;
         Device[deviceCount].TimerOption = false;
         Device[deviceCount].GlobalSyncOption = false;
@@ -53,16 +53,16 @@ boolean Plugin_085(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_GET_DEVICENAME:
       {
-        string = F(PLUGIN_NAME_085);
+        string = F(PLUGIN_NAME_086);
         break;
       }
 
     case PLUGIN_GET_DEVICEVALUENAMES:
       {
-        strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[0], PSTR(PLUGIN_VALUENAME1_085));
-        strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[1], PSTR(PLUGIN_VALUENAME2_085));
-        strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[2], PSTR(PLUGIN_VALUENAME3_085));
-        strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[3], PSTR(PLUGIN_VALUENAME4_085));
+        strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[0], PSTR(PLUGIN_VALUENAME1_086));
+        strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[1], PSTR(PLUGIN_VALUENAME2_086));
+        strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[2], PSTR(PLUGIN_VALUENAME3_086));
+        strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[3], PSTR(PLUGIN_VALUENAME4_086));
 
         break;
       }
@@ -74,7 +74,7 @@ boolean Plugin_085(byte function, struct EventStruct *event, String& string)
         byte choice = 0;
         String labelText = "";
         String keyName = "";
-        String options[PLUGIN_085_VALUE_TYPES];
+        String options[PLUGIN_086_VALUE_TYPES];
         options[0] = F("integer");
         options[1] = F("float");
         options[2] = F("boolean");
@@ -82,43 +82,43 @@ boolean Plugin_085(byte function, struct EventStruct *event, String& string)
         options[4] = F("enum");
         options[5] = F("rgb");
         options[6] = F("hsv");
-        int optionValues[PLUGIN_085_VALUE_TYPES];
-        optionValues[0] = PLUGIN_085_VALUE_INTEGER;
-        optionValues[1] = PLUGIN_085_VALUE_FLOAT;
-        optionValues[2] = PLUGIN_085_VALUE_BOOLEAN;
-        optionValues[3] = PLUGIN_085_VALUE_STRING;
-        optionValues[4] = PLUGIN_085_VALUE_ENUM;
-        optionValues[5] = PLUGIN_085_VALUE_RGB;
-        optionValues[6] = PLUGIN_085_VALUE_HSV;
-        for (int i=0;i<PLUGIN_085_VALUE_MAX;i++) {
+        int optionValues[PLUGIN_086_VALUE_TYPES];
+        optionValues[0] = PLUGIN_086_VALUE_INTEGER;
+        optionValues[1] = PLUGIN_086_VALUE_FLOAT;
+        optionValues[2] = PLUGIN_086_VALUE_BOOLEAN;
+        optionValues[3] = PLUGIN_086_VALUE_STRING;
+        optionValues[4] = PLUGIN_086_VALUE_ENUM;
+        optionValues[5] = PLUGIN_086_VALUE_RGB;
+        optionValues[6] = PLUGIN_086_VALUE_HSV;
+        for (int i=0;i<PLUGIN_086_VALUE_MAX;i++) {
           labelText = F("Function #");
           labelText += (i+1);
           addFormSubHeader(labelText);
           choice = PCONFIG(i);
           if (i==0) addFormNote(F("Triggers an event when a ../%event%/set topic arrives"));
           labelText = F("Event Name");
-          keyName = F("p085_functionName");
+          keyName = F("p086_functionName");
           keyName += i;
           addFormTextBox(labelText, keyName, ExtraTaskSettings.TaskDeviceValueNames[i], NAME_FORMULA_LENGTH_MAX);
           labelText = F("Parameter Type");
-          keyName = F("p085_valueType");
+          keyName = F("p086_valueType");
           keyName += i;
-          addFormSelector(labelText, keyName, PLUGIN_085_VALUE_TYPES, options, optionValues, choice );
+          addFormSelector(labelText, keyName, PLUGIN_086_VALUE_TYPES, options, optionValues, choice );
           keyName += F("_min");
           addFormNumericBox(F("Min"),keyName,ExtraTaskSettings.TaskDevicePluginConfig[i]);
-          keyName = F("p085_valueType");
+          keyName = F("p086_valueType");
           keyName += i;
           keyName += F("_max");
-          addFormNumericBox(F("Max"),keyName,ExtraTaskSettings.TaskDevicePluginConfig[i+PLUGIN_085_VALUE_MAX]);
+          addFormNumericBox(F("Max"),keyName,ExtraTaskSettings.TaskDevicePluginConfig[i+PLUGIN_086_VALUE_MAX]);
           if (i==0) addFormNote(F("min max values only valid for numeric parameter"));
-          keyName = F("p085_decimals");
+          keyName = F("p086_decimals");
           keyName += i;
           addFormNumericBox(F("Decimals"),keyName,ExtraTaskSettings.TaskDeviceValueDecimals[i],0,8);
           if (i==0) addFormNote(F("Decimal counts for float parameter"));
-          keyName = F("p085_string");
+          keyName = F("p086_string");
           keyName += i;
           addFormTextBox(F("String or enum"), keyName, ExtraTaskSettings.TaskDeviceFormula[i], NAME_FORMULA_LENGTH_MAX);
-          if (i==0) addFormNote(F("String content. Enum expects comma seperated list"));
+          if (i==0) addFormNote(F("Default string or enumumeration list (comma seperated)."));
         }
         success = true;
         break;
@@ -127,25 +127,25 @@ boolean Plugin_085(byte function, struct EventStruct *event, String& string)
     case PLUGIN_WEBFORM_SAVE:
       {
         String keyName = "";
-        for (int i=0;i<PLUGIN_085_VALUE_MAX;i++) {
-          keyName = F("p085_valueType");
+        for (int i=0;i<PLUGIN_086_VALUE_MAX;i++) {
+          keyName = F("p086_valueType");
           keyName += i;
           PCONFIG(i) = getFormItemInt(keyName);
-          keyName = F("p085_functionName");
+          keyName = F("p086_functionName");
           keyName += i;
           strncpy_webserver_arg(ExtraTaskSettings.TaskDeviceValueNames[i], keyName);
-          keyName = F("p085_valueType");
+          keyName = F("p086_valueType");
           keyName += i;
           keyName += F("_min");
           ExtraTaskSettings.TaskDevicePluginConfig[i]=getFormItemInt(keyName);
-          keyName = F("p085_valueType");
+          keyName = F("p086_valueType");
           keyName += i;
           keyName += F("_max");
-          ExtraTaskSettings.TaskDevicePluginConfig[i+PLUGIN_085_VALUE_MAX]=getFormItemInt(keyName);
-          keyName = F("p085_decimals");
+          ExtraTaskSettings.TaskDevicePluginConfig[i+PLUGIN_086_VALUE_MAX]=getFormItemInt(keyName);
+          keyName = F("p086_decimals");
           keyName += i;
           ExtraTaskSettings.TaskDeviceValueDecimals[i]=getFormItemInt(keyName);
-          keyName = F("p085_string");
+          keyName = F("p086_string");
           keyName += i;
           strncpy_webserver_arg(ExtraTaskSettings.TaskDeviceFormula[i], keyName);
         }
@@ -155,9 +155,9 @@ boolean Plugin_085(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_READ:
       {
-        for (byte x=0; x<PLUGIN_085_VALUE_MAX;x++)
+        for (byte x=0; x<PLUGIN_086_VALUE_MAX;x++)
         {
-          String log = F("P085 : Value ");
+          String log = F("P086 : Value ");
           log += x+1;
           log += F(": ");
           log += UserVar[event->BaseVarIndex+x];
@@ -177,7 +177,7 @@ boolean Plugin_085(byte function, struct EventStruct *event, String& string)
             String parameter = parseStringToEndKeepCase(string,4);
             String log = "";
 /*            if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
-              log = F("P085 : Acknowledge :");
+              log = F("P086 : Acknowledge :");
               log += string;
               log += F(" / ");
               log += ExtraTaskSettings.TaskDeviceName;
@@ -215,7 +215,7 @@ boolean Plugin_085(byte function, struct EventStruct *event, String& string)
             String enumList = "";
             int i = 0;
             if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-              log = F("P085 : deviceNr:");
+              log = F("P086 : deviceNr:");
               log += event->Par1;
               log += F(" valueNr:");
               log += event->Par2;
@@ -224,8 +224,8 @@ boolean Plugin_085(byte function, struct EventStruct *event, String& string)
             }
 
             switch (Settings.TaskDevicePluginConfig[event->Par1-1][event->Par2-1]) {
-              case PLUGIN_085_VALUE_INTEGER:
-              case PLUGIN_085_VALUE_FLOAT:
+              case PLUGIN_086_VALUE_INTEGER:
+              case PLUGIN_086_VALUE_FLOAT:
                 if (parameter!="") {
                   if (string2float(parameter,floatValue)) {
                     if (loglevelActiveFor(LOG_LEVEL_INFO)) {
@@ -251,7 +251,7 @@ boolean Plugin_085(byte function, struct EventStruct *event, String& string)
                 }
                 break;
 
-              case PLUGIN_085_VALUE_BOOLEAN:
+              case PLUGIN_086_VALUE_BOOLEAN:
                 if (parameter=="false") {
                   floatValue = 0;
                 } else {
@@ -265,7 +265,7 @@ boolean Plugin_085(byte function, struct EventStruct *event, String& string)
                 }
                 break;
 
-              case PLUGIN_085_VALUE_STRING:
+              case PLUGIN_086_VALUE_STRING:
                 //String values not stored to conserve flash memory
                 //safe_strncpy(ExtraTaskSettings.TaskDeviceFormula[event->Par2-1], parameter.c_str(), sizeof(ExtraTaskSettings.TaskDeviceFormula[event->Par2-1]));
                 if (loglevelActiveFor(LOG_LEVEL_INFO)) {
@@ -275,7 +275,7 @@ boolean Plugin_085(byte function, struct EventStruct *event, String& string)
                 }
                 break;
 
-              case PLUGIN_085_VALUE_ENUM:
+              case PLUGIN_086_VALUE_ENUM:
                 enumList = ExtraTaskSettings.TaskDeviceFormula[event->Par2-1];
                 i = 1;
                 while (parseString(enumList,i)!="") { // lookup result in enum List
@@ -296,7 +296,7 @@ boolean Plugin_085(byte function, struct EventStruct *event, String& string)
                 }
                 break;
 
-              case PLUGIN_085_VALUE_RGB:
+              case PLUGIN_086_VALUE_RGB:
                 //String values not stored to conserve flash memory
                 //safe_strncpy(ExtraTaskSettings.TaskDeviceFormula[event->Par2-1], parameter.c_str(), sizeof(ExtraTaskSettings.TaskDeviceFormula[event->Par2-1]));
                 if (loglevelActiveFor(LOG_LEVEL_INFO)) {
@@ -306,7 +306,7 @@ boolean Plugin_085(byte function, struct EventStruct *event, String& string)
                 }
                 break;
 
-              case PLUGIN_085_VALUE_HSV:
+              case PLUGIN_086_VALUE_HSV:
                 //String values not stored to conserve flash memory
                 //safe_strncpy(ExtraTaskSettings.TaskDeviceFormula[event->Par2-1], parameter.c_str(), sizeof(ExtraTaskSettings.TaskDeviceFormula[event->Par2-1]));
                 if (loglevelActiveFor(LOG_LEVEL_INFO)) {
@@ -324,84 +324,4 @@ boolean Plugin_085(byte function, struct EventStruct *event, String& string)
   }
   return success;
 }
-
-// acurate color converter (should be perhaps moved to a more prominent place to be used by others too)
-// uses H 0..360 S 1..100 I/V 1..100 (according to homie convention)
-// Source https://blog.saikoled.com/post/44677718712/how-to-convert-from-hsi-to-rgb-white
-
-void HSV2RGB(float H, float S, float I, int rgb[3]) {
-  int r, g, b;
-  H = fmod(H,360); // cycle H around to 0-360 degrees
-  H = 3.14159*H/(float)180; // Convert to radians.
-  S = S / 100;
-  S = S>0?(S<1?S:1):0; // clamp S and I to interval [0,1]
-  I = I / 100;
-  I = I>0?(I<1?I:1):0;
-
-  // Math! Thanks in part to Kyle Miller.
-  if(H < 2.09439) {
-    r = 255*I/3*(1+S*cos(H)/cos(1.047196667-H));
-    g = 255*I/3*(1+S*(1-cos(H)/cos(1.047196667-H)));
-    b = 255*I/3*(1-S);
-  } else if(H < 4.188787) {
-    H = H - 2.09439;
-    g = 255*I/3*(1+S*cos(H)/cos(1.047196667-H));
-    b = 255*I/3*(1+S*(1-cos(H)/cos(1.047196667-H)));
-    r = 255*I/3*(1-S);
-  } else {
-    H = H - 4.188787;
-    b = 255*I/3*(1+S*cos(H)/cos(1.047196667-H));
-    r = 255*I/3*(1+S*(1-cos(H)/cos(1.047196667-H)));
-    g = 255*I/3*(1-S);
-  }
-  rgb[0]=r;
-  rgb[1]=g;
-  rgb[2]=b;
-}
-
-// uses H 0..360 S 1..100 I/V 1..100 (according to homie convention)
-// Source https://blog.saikoled.com/post/44677718712/how-to-convert-from-hsi-to-rgb-white
-
-void HSV2RGBW(float H, float S, float I, int rgbw[4]) {
-  int r, g, b, w;
-  float cos_h, cos_1047_h;
-  H = fmod(H,360); // cycle H around to 0-360 degrees
-  H = 3.14159*H/(float)180; // Convert to radians.
-  S = S / 100;
-  S = S>0?(S<1?S:1):0; // clamp S and I to interval [0,1]
-  I = I / 100;
-  I = I>0?(I<1?I:1):0;
-
-  if(H < 2.09439) {
-    cos_h = cos(H);
-    cos_1047_h = cos(1.047196667-H);
-    r = S*255*I/3*(1+cos_h/cos_1047_h);
-    g = S*255*I/3*(1+(1-cos_h/cos_1047_h));
-    b = 0;
-    w = 255*(1-S)*I;
-  } else if(H < 4.188787) {
-    H = H - 2.09439;
-    cos_h = cos(H);
-    cos_1047_h = cos(1.047196667-H);
-    g = S*255*I/3*(1+cos_h/cos_1047_h);
-    b = S*255*I/3*(1+(1-cos_h/cos_1047_h));
-    r = 0;
-    w = 255*(1-S)*I;
-  } else {
-    H = H - 4.188787;
-    cos_h = cos(H);
-    cos_1047_h = cos(1.047196667-H);
-    b = S*255*I/3*(1+cos_h/cos_1047_h);
-    r = S*255*I/3*(1+(1-cos_h/cos_1047_h));
-    g = 0;
-    w = 255*(1-S)*I;
-  }
-
-  rgbw[0]=r;
-  rgbw[1]=g;
-  rgbw[2]=b;
-  rgbw[3]=w;
-}
-
-
-#endif // USES_P085
+#endif // USES_P086

--- a/src/_P086_Homie.ino
+++ b/src/_P086_Homie.ino
@@ -5,7 +5,7 @@
 
 #define PLUGIN_086
 #define PLUGIN_ID_086         86
-#define PLUGIN_NAME_086       "Generic - Homie receiver"
+#define PLUGIN_NAME_086       "Generic - Homie receiver [TESTING]"
 
 // empty default names because settings will be ignored / not used if value name is empty
 #define PLUGIN_VALUENAME1_086 ""
@@ -69,7 +69,7 @@ boolean Plugin_086(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_WEBFORM_LOAD:
       {
-        addFormNote(F("Translation Plugin for controllers able to recieve value updates according to Homie convention."));
+        addFormNote(F("Translation Plugin for controllers able to receive value updates according to the Homie convention."));
 
         byte choice = 0;
         String labelText = "";

--- a/src/define_plugin_sets.h
+++ b/src/define_plugin_sets.h
@@ -615,7 +615,7 @@ To create/register a plugin, you have to :
     #define USES_P081   // Cron
     #define USES_P082   // GPS
     #define USES_P083   // SGP30
-    #define USES_P085   // Homie translate receiving values to rule events Works together with C014 Homie controller
+    #define USES_P086   // Homie translate receiving values to rule events Works together with C014 Homie controller
 #endif
 
 

--- a/src/define_plugin_sets.h
+++ b/src/define_plugin_sets.h
@@ -615,6 +615,7 @@ To create/register a plugin, you have to :
     #define USES_P081   // Cron
     #define USES_P082   // GPS
     #define USES_P083   // SGP30
+    #define USES_P085   // Homie translate receiving values to rule events Works together with C014 Homie controller
 #endif
 
 

--- a/src/define_plugin_sets.h
+++ b/src/define_plugin_sets.h
@@ -616,8 +616,8 @@ To create/register a plugin, you have to :
     #define USES_P082   // GPS
     #define USES_P083   // SGP30
     #define USES_P084   // VEML6070
-
-    #define USES_P086   // Homie translate receiving values to rule events Works together with C014 Homie controller
+    #define USES_P085   // AcuDC24x
+    #define USES_P086   // Receiving values according Homie convention. Works together with C014 Homie controller
 #endif
 
 


### PR DESCRIPTION
I think I found a good way to handle incoming messages via a "homie receiver" plugin. This defines the parameters, names, types and ranges and triggers a rule when a message arrives.

Test configuration:

![image](https://user-images.githubusercontent.com/15779507/57739610-8b040c80-76b4-11e9-995b-f6af9fa82380.png)

![image](https://user-images.githubusercontent.com/15779507/57739652-bedf3200-76b4-11e9-9a0d-2ce5f508c8de.png)
I had a RGB strip with 8 pixels on my desk
![image](https://user-images.githubusercontent.com/15779507/57739670-cbfc2100-76b4-11e9-9d3b-66b1e746edc0.png)
Sliders (Dimmers) in openhab only work from 0-1
![image](https://user-images.githubusercontent.com/15779507/57739681-dc140080-76b4-11e9-8e9f-8ff57756b6af.png)
![image](https://user-images.githubusercontent.com/15779507/57739707-f948cf00-76b4-11e9-83ba-d529fce115b7.png)
![image](https://user-images.githubusercontent.com/15779507/57739728-0e256280-76b5-11e9-8f28-99de9360fe10.png)
![image](https://user-images.githubusercontent.com/15779507/57739754-1c737e80-76b5-11e9-93a0-f979b75236a0.png)
![image](https://user-images.githubusercontent.com/15779507/57739778-30b77b80-76b5-11e9-9f47-dd9844f63efa.png)

Rules:

```
// The "homie controller" schedules the event defined in the plug-in. 
// Does NOT store string values or arrays in the "homie receiver" plug-in. 
// Use homieValueSet to save numeric value in the plugin.
// This will also acknowledge the value back to the controller to get out of "predicted" state.

On eventInteger do
 // insert your code here
 homieValueSet,1,1,%eventvalue1%
endon

On eventFloat do
 // insert your code here
 homieValueSet,1,2,%eventvalue1%
endon

On eventBoolean do
 // insert your code here
 homieValueSet,1,3,%eventvalue1% // true or false (0/1 is stored in uservar)
endon

On eventString do
 // insert your code here
 homieValueSet,1,4,"%eventvalue%" // quotation requited for Strings!
endon

On eventEnum do
 // insert your code here
 homieValueSet,2,1,%eventvalue1% // name of picked item (number is stored in uservar)
endon

On eventRGB do
 NeoPixelAll,%eventvalue1%,%eventvalue2%,%eventvalue3%
 homieValueSet,2,2,%eventvalue1%,%eventvalue2%,%eventvalue3%
endon

On eventHSV do
 NeoPixelAllHSV,%eventvalue1%,%eventvalue2%,%eventvalue3%
 homieValueSet,2,3,%eventvalue1%,%eventvalue2%,%eventvalue3%
endon

```

Result in Openhab 2.5snapshot
![image](https://user-images.githubusercontent.com/15779507/57739863-7116f980-76b5-11e9-9f83-cb00d42867cd.png)

And to have fun with RGBW serial LED on Habpanel 
![image](https://user-images.githubusercontent.com/15779507/57739893-9146b880-76b5-11e9-9173-8aa0cd737273.png)

Therefor I expanded the Neopixel plug-in a little to handle HSV color values. 

Except writing the rules no coding is required. 

