### PR TITLE
Allow GPIO-16 for software serial (ESP82xx)

### DIFF
--- a/lib/ESPEasySerial/ESPEasySoftwareSerial.cpp
+++ b/lib/ESPEasySerial/ESPEasySoftwareSerial.cpp
@@ -29,7 +29,7 @@ extern "C" {
 
 #include <ESPEasySoftwareSerial.h>
 
-#define MAX_PIN 15
+#define MAX_PIN 16
 #define USABLE_PINS 10
 #define NR_CONCURRENT_SOFT_SERIALS 3
 


### PR DESCRIPTION
Since Release mega-20190215, the plugin “ P065_DRF0299_MP3.ino “ wasn’t functioning on GPIO16.
With this small change, it’s operational once again and also available to connect other serial (non-critical) devices on GPIO16.