### PR TITLE
Changes from SPIFFS to FS

### DIFF
--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -567,10 +567,10 @@ bool showSettingsFileLayout = false;
   extern "C" {
   #include "spi_flash.h"
   }
-  extern "C" uint32_t _SPIFFS_start;
-  extern "C" uint32_t _SPIFFS_end;
-  extern "C" uint32_t _SPIFFS_page;
-  extern "C" uint32_t _SPIFFS_block;
+  extern "C" uint32_t _FS_start;
+  extern "C" uint32_t _FS_end;
+  extern "C" uint32_t _FS_page;
+  extern "C" uint32_t _FS_block;
   #ifdef FEATURE_MDNS
     #include <ESP8266mDNS.h>
   #endif

--- a/src/ESPEasyStorage.ino
+++ b/src/ESPEasyStorage.ino
@@ -856,8 +856,8 @@ int SpiffsSectors()
 {
   checkRAM(F("SpiffsSectors"));
   #if defined(ESP8266)
-    uint32_t _sectorStart = ((uint32_t)&_SPIFFS_start - 0x40200000) / SPI_FLASH_SEC_SIZE;
-    uint32_t _sectorEnd = ((uint32_t)&_SPIFFS_end - 0x40200000) / SPI_FLASH_SEC_SIZE;
+    uint32_t _sectorStart = ((uint32_t)&_FS_start - 0x40200000) / SPI_FLASH_SEC_SIZE;
+    uint32_t _sectorEnd = ((uint32_t)&_FS_end - 0x40200000) / SPI_FLASH_SEC_SIZE;
     return _sectorEnd - _sectorStart;
   #endif
   #if defined(ESP32)


### PR DESCRIPTION
Small change for people that want to use the esp8266 GIT core where they changed from SPIFFS to LittleFS. Still uses SPIFFS format though but some variables changed. 
_SPIFFS_* => _FS_*
See also: https://github.com/esp8266/Arduino/commit/a389a995fb12459819e33970ec80695f1eaecc58
