### PR TITLE
increase max field length

### DIFF
--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -406,7 +406,7 @@ struct SecurityStruct
   char          WifiSSID2[32];
   char          WifiKey2[64];
   char          WifiAPKey[64];
-  char          ControllerUser[CONTROLLER_MAX][26];
+  char          ControllerUser[CONTROLLER_MAX][64];
   char          ControllerPassword[CONTROLLER_MAX][64];
   char          Password[26];
   //its safe to extend this struct, up to 4096 bytes, default values in config are 0


### PR DESCRIPTION
increase MQTT controller password field length to 64 chars due to compatible with node-red broker