### PR TITLE
Rename OpenHAB MQTT to Home Assistant (openHAB) MQTT

### DIFF
--- a/docs/source/Controller/_controller_substitutions.repl
+++ b/docs/source/Controller/_controller_substitutions.repl
@@ -45,9 +45,9 @@
 .. |C004_maintainer| replace:: `.`
 .. |C004_compileinfo| replace:: `.`
 
-.. |C005_name| replace:: :cyan:`OpenHAB MQTT`
+.. |C005_name| replace:: :cyan:`Home Assistant (openHAB) MQTT`
 .. |C005_type| replace:: :cyan:`Controller`
-.. |C005_typename| replace:: :cyan:`Controller - OpenHAB MQTT`
+.. |C005_typename| replace:: :cyan:`Controller - Home Assistant (openHAB) MQTT`
 .. |C005_status| replace:: :green:`NORMAL`
 .. |C005_github| replace:: C005.ino
 .. _C005_github: https://github.com/letscontrolit/ESPEasy/blob/mega/src/_C005.ino

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -90,7 +90,7 @@ void check_size() {
 //   2 = Domoticz MQTT
 //   3 = Nodo Telnet
 //   4 = ThingSpeak
-//   5 = OpenHAB MQTT
+//   5 = Home Assistant (openHAB) MQTT
 //   6 = PiDome MQTT
 //   7 = EmonCMS
 //   8 = Generic HTTP

--- a/src/_C005.ino
+++ b/src/_C005.ino
@@ -41,8 +41,8 @@ bool CPlugin_005(byte function, struct EventStruct *event, String& string)
 
     case CPLUGIN_PROTOCOL_TEMPLATE:
       {
-        event->String1 = F("/%sysname%/#");
-        event->String2 = F("/%sysname%/%tskname%/%valname%");
+        event->String1 = F("%sysname%/#");
+        event->String2 = F("%sysname%/%tskname%/%valname%");
         break;
       }
 

--- a/src/_C005.ino
+++ b/src/_C005.ino
@@ -1,11 +1,11 @@
 #ifdef USES_C005
 //#######################################################################################################
-//########################### Controller Plugin 005: OpenHAB MQTT #######################################
+//################### Controller Plugin 005: Home Assistant (openHAB) MQTT ##############################
 //#######################################################################################################
 
 #define CPLUGIN_005
 #define CPLUGIN_ID_005         5
-#define CPLUGIN_NAME_005       "OpenHAB MQTT"
+#define CPLUGIN_NAME_005       "Home Assistant (openHAB) MQTT"
 
 bool CPlugin_005(byte function, struct EventStruct *event, String& string)
 {

--- a/src/define_plugin_sets.h
+++ b/src/define_plugin_sets.h
@@ -134,7 +134,7 @@ To create/register a plugin, you have to :
 
     #define USES_C001   // Domoticz HTTP
     #define USES_C002   // Domoticz MQTT
-    #define USES_C005   // OpenHAB MQTT
+    #define USES_C005   // Home Assistant (openHAB) MQTT
 //    #define USES_C006   // PiDome MQTT
     #define USES_C008   // Generic HTTP
     #define USES_C009   // FHEM HTTP
@@ -570,7 +570,7 @@ To create/register a plugin, you have to :
     #define USES_C002   // Domoticz MQTT
     #define USES_C003   // Nodo telnet
     #define USES_C004   // ThingSpeak
-    #define USES_C005   // OpenHAB MQTT
+    #define USES_C005   // Home Assistant (openHAB) MQTT
     #define USES_C006   // PiDome MQTT
     #define USES_C007   // Emoncms
     #define USES_C008   // Generic HTTP


### PR DESCRIPTION
As described by @davidgraeff openHAB is supporting Home Assistant MQTT convention, so C005 should have Home Assistant in the name - https://github.com/letscontrolit/ESPEasy/issues/1314#issuecomment-512497131
Arguments:

- openHAB is following Home Assistant convention, not the other way (new version of openHAB is using Homie convention)

- this will help new users (like me) to set up ESPEasy with Home Assistant