### PR TITLE
Dummy save and load commands

### DIFF
--- a/src/_P033_Dummy.ino
+++ b/src/_P033_Dummy.ino
@@ -83,12 +83,12 @@ boolean Plugin_033(byte function, struct EventStruct *event, String& string)
       case PLUGIN_SET_CONFIG:
       {
         String command = parseString(string, 1);
-        if (command == F("save"))
+        if (command == F("dummysave"))
         {
           SaveCustomTaskSettings(event->TaskIndex, (byte *)&UserVar[event->BaseVarIndex], VARS_PER_TASK * sizeof(float));
           success = true;
         }
-        else if (command == F("load"))
+        else if (command == F("dummyload"))
         {
           LoadCustomTaskSettings(event->TaskIndex, (byte *)&UserVar[event->BaseVarIndex], VARS_PER_TASK*sizeof(float));
           success = true;

--- a/src/_P033_Dummy.ino
+++ b/src/_P033_Dummy.ino
@@ -80,7 +80,24 @@ boolean Plugin_033(byte function, struct EventStruct *event, String& string)
         break;
       }
 
-    case PLUGIN_WRITE:
+      case PLUGIN_SET_CONFIG:
+      {
+        String command = parseString(string, 1);
+        if (command == F("save"))
+        {
+          SaveCustomTaskSettings(event->TaskIndex, (byte *)&UserVar[event->BaseVarIndex], VARS_PER_TASK * sizeof(float));
+          success = true;
+        }
+        else if (command == F("load"))
+        {
+          LoadCustomTaskSettings(event->TaskIndex, (byte *)&UserVar[event->BaseVarIndex], VARS_PER_TASK*sizeof(float));
+          success = true;
+        }
+        
+        break;
+      }
+      
+      case PLUGIN_WRITE:
       {
         String command = parseString(string, 1);
         if (command == F("dummyvalueset"))


### PR DESCRIPTION
New `config` subcommands for Dummy plugin. Usage:
```
config,task,<DummyTaskName>,dummysave
config,task,<DummyTaskName>,dummyload
```
Command "save" stores task values to SPIFFS to be available for restore after power outage with command "load".