### PR TITLE
[P076] setMode is not needed in interrupt mode

### DIFF
--- a/src/_P076_HLW8012.ino
+++ b/src/_P076_HLW8012.ino
@@ -324,8 +324,13 @@ boolean Plugin_076(byte function, struct EventStruct *event, String &string) {
     if (Plugin_076_hlw) {
       if (p076_read_stage == 0) {
         // Force a measurement start.
-        ++p076_read_stage;
-      } else if (p076_read_stage > 3) {
+//        ++p076_read_stage;
+//      } else if (p076_read_stage > 3) {
+          p076_hpower = Plugin_076_hlw->getActivePower();
+          p076_hvoltage = Plugin_076_hlw->getVoltage();
+          p076_hcurrent = Plugin_076_hlw->getCurrent();
+          p076_hpowfact = (int)(100 * Plugin_076_hlw->getPowerFactor());
+        
         // Measurement is complete.
         p076_read_stage = 0;
         if (PLUGIN_076_DEBUG) {


### PR DESCRIPTION
@TD-er are you able to prepare test build for this?
@ingoiot #1962 simple fix