### PR TITLE
Reduce bin size by excluding unneeded parts

### DIFF
--- a/src/Command.ino
+++ b/src/Command.ino
@@ -5,7 +5,9 @@
 #include "Commands/Diagnostic.h"
 #include "Commands/HTTP.h"
 #include "Commands/i2c.h"
+#ifdef USES_MQTT
 #include "Commands/MQTT.h"
+#endif //USES_MQTT
 #include "Commands/Networks.h"
 #include "Commands/Notifications.h"
 #include "Commands/RTC.h"
@@ -104,8 +106,10 @@ String doExecuteCommand(const char *cmd, struct EventStruct *event, const char *
       COMMAND_CASE("malloc",         Command_Malloc);            // Diagnostic.h
       COMMAND_CASE("meminfo",        Command_MemInfo);           // Diagnostic.h
       COMMAND_CASE("meminfodetail",  Command_MemInfo_detail);    // Diagnostic.h
+#ifdef USES_MQTT      
       COMMAND_CASE("messagedelay",   Command_MQTT_messageDelay); // MQTT.h
       COMMAND_CASE("mqttretainflag", Command_MQTT_Retain);       // MQTT.h
+#endif //USES_MQTT
       break;
     }
     case 'n': {
@@ -117,7 +121,9 @@ String doExecuteCommand(const char *cmd, struct EventStruct *event, const char *
     }
     case 'p': {
       COMMAND_CASE("password", Command_Settings_Password); // Settings.h
+#ifdef USES_MQTT
       COMMAND_CASE("publish",  Command_MQTT_Publish);      // MQTT.h
+#endif //USES_MQTT
       break;
     }
     case 'r': {

--- a/src/Command.ino
+++ b/src/Command.ino
@@ -1,9 +1,7 @@
 
 #include "Commands/Common.h"
-#ifdef USES_BLYNK
 #include "Commands/Blynk.h"
 #include "Commands/Blynk_c015.h"
-#endif //USES_BLYNK
 #include "Commands/Diagnostic.h"
 #include "Commands/HTTP.h"
 #include "Commands/i2c.h"
@@ -55,14 +53,12 @@ String doExecuteCommand(const char *cmd, struct EventStruct *event, const char *
     }
     case 'b': {
       COMMAND_CASE("background", Command_Background); // Diagnostic.h
-#ifdef USES_BLYNK
     #ifdef USES_C012
       COMMAND_CASE("blynkget",   Command_Blynk_Get);
     #endif // ifdef USES_C012
     #ifdef USES_C015
       COMMAND_CASE("blynkset",   Command_Blynk_Set);
     #endif // ifdef USES_C015
-#endif //USES_BLYNK
       COMMAND_CASE("build",      Command_Settings_Build); // Settings.h
       break;
     }

--- a/src/Command.ino
+++ b/src/Command.ino
@@ -1,7 +1,9 @@
 
 #include "Commands/Common.h"
+#ifdef USES_BLYNK
 #include "Commands/Blynk.h"
 #include "Commands/Blynk_c015.h"
+#endif //USES_BLYNK
 #include "Commands/Diagnostic.h"
 #include "Commands/HTTP.h"
 #include "Commands/i2c.h"
@@ -53,12 +55,14 @@ String doExecuteCommand(const char *cmd, struct EventStruct *event, const char *
     }
     case 'b': {
       COMMAND_CASE("background", Command_Background); // Diagnostic.h
+#ifdef USES_BLYNK
     #ifdef USES_C012
       COMMAND_CASE("blynkget",   Command_Blynk_Get);
     #endif // ifdef USES_C012
     #ifdef USES_C015
       COMMAND_CASE("blynkset",   Command_Blynk_Set);
     #endif // ifdef USES_C015
+#endif //USES_BLYNK
       COMMAND_CASE("build",      Command_Settings_Build); // Settings.h
       break;
     }

--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -98,6 +98,7 @@ bool validUserVar(struct EventStruct *event) {
   return true;
 }
 
+#ifdef USES_MQTT
 /*********************************************************************************************\
 * Handle incoming MQTT messages
 \*********************************************************************************************/
@@ -321,6 +322,7 @@ bool MQTTCheck(int controller_idx)
   // When no MQTT protocol is enabled, all is fine.
   return true;
 }
+#endif //USES_MQTT
 
 /*********************************************************************************************\
 * Send status info to request source
@@ -347,15 +349,18 @@ void SendStatus(byte source, const String& status)
         printWebString += status;
       }
       break;
+#ifdef USES_MQTT
     case VALUE_SOURCE_MQTT:
       MQTTStatus(status);
       break;
+#endif //USES_MQTT
     case VALUE_SOURCE_SERIAL:
       serialPrintln(status);
       break;
   }
 }
 
+#ifdef USES_MQTT
 boolean MQTTpublish(int controller_idx, const char *topic, const char *payload, boolean retained)
 {
   const bool success = MQTTDelayHandler.addToQueue(MQTT_queue_element(controller_idx, topic, payload, retained));
@@ -409,3 +414,4 @@ void MQTTStatus(const String& status)
     MQTTpublish(enabledMqttController, pubname.c_str(), status.c_str(), Settings.MQTTRetainFlag);
   }
 }
+#endif //USES_MQTT

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -655,7 +655,9 @@ bool showSettingsFileLayout = false;
 #include <DNSServer.h>
 #include <Wire.h>
 #include <SPI.h>
+#ifdef USES_MQTT
 #include <PubSubClient.h>
+#endif //USES_MQTT
 #include <FS.h>
 #ifdef FEATURE_SD
 #include <SD.h>
@@ -689,12 +691,14 @@ IPAddress apIP(DEFAULT_AP_IP);
 DNSServer dnsServer;
 bool dnsServerActive = false;
 
+#ifdef USES_MQTT
 // MQTT client
 WiFiClient mqtt;
 PubSubClient MQTTclient(mqtt);
 bool MQTTclient_should_reconnect = true;
 bool MQTTclient_connected = false;
 int mqtt_reconnect_count = 0;
+#endif //USES_MQTT
 
 //NTP status
 bool statusNTPInitialized = false;

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -575,7 +575,7 @@ void flushAndDisconnectAllClients() {
       MQTTclient.disconnect();
       updateMQTTclient_connected();
     }
-#endif USES_MQTT      
+#endif //USES_MQTT      
     saveToRTC();
     delay(100); // Flush anything in the network buffers.
   }

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -89,6 +89,7 @@
 // Plugin helper needs the defined controller sets, thus include after 'define_plugin_sets.h'
 #include "_CPlugin_Helper.h"
 
+#ifdef USES_BLYNK
 // Blynk_get prototype
 boolean Blynk_get(const String& command, byte controllerIndex,float *data = NULL );
 
@@ -101,6 +102,7 @@ int firstEnabledBlynkController() {
   }
   return -1;
 }
+#endif //USES_BLYNK
 
 //void checkRAM( const __FlashStringHelper* flashString);
 

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -89,7 +89,6 @@
 // Plugin helper needs the defined controller sets, thus include after 'define_plugin_sets.h'
 #include "_CPlugin_Helper.h"
 
-#ifdef USES_BLYNK
 // Blynk_get prototype
 boolean Blynk_get(const String& command, byte controllerIndex,float *data = NULL );
 
@@ -102,7 +101,6 @@ int firstEnabledBlynkController() {
   }
   return -1;
 }
-#endif //USES_BLYNK
 
 //void checkRAM( const __FlashStringHelper* flashString);
 

--- a/src/ESPEasyWifi_ProcessEvent.ino
+++ b/src/ESPEasyWifi_ProcessEvent.ino
@@ -251,10 +251,12 @@ void processGotIP() {
   if (systemTimePresent()) {
     initTime();
   }
+#ifdef USES_MQTT
   mqtt_reconnect_count        = 0;
   MQTTclient_should_reconnect = true;
   timermqtt_interval          = 100;
   setIntervalTimer(TIMER_MQTT);
+#endif //USES_MQTT
   sendGratuitousARP_now();
 
   if (Settings.UseRules)

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -31,6 +31,7 @@ String getSettingsTypeString(SettingsType settingsType) {
   return "";
 }
 
+#ifdef USES_MQTT
 String getMQTT_state() {
   switch (MQTTclient.state()) {
     case MQTT_CONNECTION_TIMEOUT     : return F("Connection timeout");
@@ -47,6 +48,7 @@ String getMQTT_state() {
   }
   return "";
 }
+#endif //USES_MQTT
 
 /********************************************************************************************\
   Get system information

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -1597,7 +1597,9 @@ void addToLog(byte logLevel, const char *line)
   \*********************************************************************************************/
 void prepareShutdown()
 {
+#ifdef USES_MQTT
   runPeriodicalMQTT();  // Flush outstanding MQTT messages
+#endif //USES_MQTT
   process_serialWriteBuffer();
   flushAndDisconnectAllClients();
   saveUserVarToRTC();

--- a/src/Modbus.ino
+++ b/src/Modbus.ino
@@ -1,4 +1,4 @@
-
+#ifdef USES_MODBUS
 #ifndef MODBUS_H
 # define MODBUS_H
 
@@ -258,3 +258,4 @@ bool Modbus::tryRead(uint8_t ModbusID, uint16_t M_register,  MODBUS_registerType
   }
   return false;
 }
+#endif //USES_MODBUS

--- a/src/Modbus_RTU.ino
+++ b/src/Modbus_RTU.ino
@@ -1,3 +1,4 @@
+#ifdef USES_MODBUS
 #include <Arduino.h>
 #include <ESPeasySerial.h>
 
@@ -775,3 +776,4 @@ private:
 
   ESPeasySerial *easySerial;
 };
+#endif //USES_MODBUS

--- a/src/Scheduler.ino
+++ b/src/Scheduler.ino
@@ -214,7 +214,9 @@ void process_interval_timer(unsigned long id, unsigned long lasttimer) {
       break;
     case TIMER_1SEC:             runOncePerSecond();      break;
     case TIMER_30SEC:            runEach30Seconds();      break;
+#ifdef USES_MQTT
     case TIMER_MQTT:             runPeriodicalMQTT();     break;
+#endif //USES_MQTT    
     case TIMER_STATISTICS:       logTimerStatistics();    break;
     case TIMER_GRATUITOUS_ARP:
 
@@ -229,7 +231,9 @@ void process_interval_timer(unsigned long id, unsigned long lasttimer) {
         sendGratuitousARP();
       }
       break;
+#ifdef USES_MQTT      
     case TIMER_MQTT_DELAY_QUEUE: processMQTTdelayQueue(); break;
+#endif //USES_MQTT
   #ifdef USES_C001
     case TIMER_C001_DELAY_QUEUE:
       process_c001_delay_queue();
@@ -456,6 +460,7 @@ void schedule_all_task_device_timers() {
   }
 }
 
+#ifdef USES_MQTT
 void schedule_all_tasks_using_MQTT_controller() {
   int ControllerIndex = firstEnabledMQTTController();
 
@@ -470,6 +475,7 @@ void schedule_all_tasks_using_MQTT_controller() {
     }
   }
 }
+#endif //USES_MQTT
 
 void schedule_task_device_timer(unsigned long task_index, unsigned long runAt) {
   /*

--- a/src/StringConverter.ino
+++ b/src/StringConverter.ino
@@ -216,7 +216,7 @@ String doFormatUserVar(struct EventStruct *event, byte rel_index, bool mustCheck
 
     if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
       String log = F("Invalid float value for TaskIndex: ");
-      log += TaskIndex;
+      log += event->TaskIndex;
       log += F(" varnumber: ");
       log += rel_index;
       addLog(LOG_LEVEL_DEBUG, log);

--- a/src/StringConverter.ino
+++ b/src/StringConverter.ino
@@ -698,7 +698,9 @@ void parseSystemVariables(String& s, boolean useURLencode)
   SMART_REPL_T(F("%sunrise"), replSunRiseTimeString)
 
   if (s.indexOf(F("%is")) != -1) {
+#ifdef USES_MQTT
     SMART_REPL(F("%ismqtt%"),    String(MQTTclient_connected));
+#endif    
     SMART_REPL(F("%iswifi%"),    String(wifiStatus)); // 0=disconnected, 1=connected, 2=got ip, 3=services initialized
     SMART_REPL(F("%isntp%"),     String(statusNTPInitialized));
     #ifdef USES_P037

--- a/src/WebServer_ConfigPage.ino
+++ b/src/WebServer_ConfigPage.ino
@@ -35,9 +35,13 @@ void handle_config() {
       addLog(LOG_LEVEL_INFO, F("Unit Name changed."));
 
       if (CPluginCall(CPLUGIN_GOT_INVALID, 0)) { // inform controllers that the old name will be invalid from now on.
+#ifdef USES_MQTT
         MQTTDisconnect();                        // disconnect form MQTT Server if invalid message was sent succesfull.
+#endif //USES_MQTT
       }
+#ifdef USES_MQTT
       MQTTclient_should_reconnect = true;
+#endif //USES_MQTT
     }
 
     // Unit name

--- a/src/_CPlugin_DomoticzHelper.ino
+++ b/src/_CPlugin_DomoticzHelper.ino
@@ -1,3 +1,4 @@
+#ifdef USES_DOMOTICZ
 // HUM_STAT can be one of:
 
 // 0=Normal
@@ -167,3 +168,4 @@ String formatDomoticzSensorType(struct EventStruct *event) {
   }
   return values;
 }
+#endif // USES_DOMOTICZ

--- a/src/_CPlugin_Helper.h
+++ b/src/_CPlugin_Helper.h
@@ -522,7 +522,7 @@ ControllerDelayHandlerStruct<MQTT_queue_element> MQTTDelayHandler;
 // *INDENT-OFF*
 
 
-// This macro defines the code needed to create the 'process_c##NNN##_delay_queue()'
+// This macro defines the code needed to create the 'process_c##NNN####M##_delay_queue()'
 // function and all needed objects and forward declarations.
 // It is a macro to prevent common typo errors.
 // This function will perform the (re)scheduling and mark if it is processed (and can be removed)
@@ -532,95 +532,95 @@ ControllerDelayHandlerStruct<MQTT_queue_element> MQTTDelayHandler;
 // N.B. some controllers only can send one value per iteration, so a returned "false" can mean it
 //      was still successful. The controller should keep track of the last value sent
 //      in the element stored in the queue.
-#define DEFINE_Cxxx_DELAY_QUEUE_MACRO(NNN, M)                                                              \
-  ControllerDelayHandlerStruct<C##NNN##_queue_element>C##NNN##_DelayHandler;                               \
-  bool do_process_c##NNN##_delay_queue(int controller_number,                                              \
-                                           const C##NNN##_queue_element & element,                         \
-                                           ControllerSettingsStruct & ControllerSettings);                 \
-  void process_c##NNN##_delay_queue() {                                                                    \
-    C##NNN##_queue_element *element(C##NNN##_DelayHandler.getNext());                                      \
-    if (element == NULL) return;                                                                           \
-    MakeControllerSettings (ControllerSettings);                                                           \
-    LoadControllerSettings(element->controller_idx, ControllerSettings);                                   \
-    C##NNN##_DelayHandler.configureControllerSettings(ControllerSettings);                                 \
-    if (!WiFiConnected(10)) {                                                                              \
-      scheduleNextDelayQueue(TIMER_C##NNN##_DELAY_QUEUE, C##NNN##_DelayHandler.getNextScheduleTime());     \
-      return;                                                                                              \
-    }                                                                                                      \
-    START_TIMER;                                                                                           \
-    C##NNN##_DelayHandler.markProcessed(do_process_c##NNN##_delay_queue(M, *element, ControllerSettings)); \
-    STOP_TIMER(C##NNN##_DELAY_QUEUE);                                                                      \
-    scheduleNextDelayQueue(TIMER_C##NNN##_DELAY_QUEUE, C##NNN##_DelayHandler.getNextScheduleTime());       \
+#define DEFINE_Cxxx_DELAY_QUEUE_MACRO(NNN, M)                                                                        \
+  ControllerDelayHandlerStruct<C##NNN####M##_queue_element>C##NNN####M##_DelayHandler;                               \
+  bool do_process_c##NNN####M##_delay_queue(int controller_number,                                                   \
+                                           const C##NNN####M##_queue_element & element,                              \
+                                           ControllerSettingsStruct & ControllerSettings);                           \
+  void process_c##NNN####M##_delay_queue() {                                                                         \
+    C##NNN####M##_queue_element *element(C##NNN####M##_DelayHandler.getNext());                                      \
+    if (element == NULL) return;                                                                                     \
+    MakeControllerSettings (ControllerSettings);                                                                     \
+    LoadControllerSettings(element->controller_idx, ControllerSettings);                                             \
+    C##NNN####M##_DelayHandler.configureControllerSettings(ControllerSettings);                                      \
+    if (!WiFiConnected(10)) {                                                                                        \
+      scheduleNextDelayQueue(TIMER_C##NNN####M##_DELAY_QUEUE, C##NNN####M##_DelayHandler.getNextScheduleTime());     \
+      return;                                                                                                        \
+    }                                                                                                                \
+    START_TIMER;                                                                                                     \
+    C##NNN####M##_DelayHandler.markProcessed(do_process_c##NNN####M##_delay_queue(M, *element, ControllerSettings)); \
+    STOP_TIMER(C##NNN####M##_DELAY_QUEUE);                                                                           \
+    scheduleNextDelayQueue(TIMER_C##NNN####M##_DELAY_QUEUE, C##NNN####M##_DelayHandler.getNextScheduleTime());       \
   }
 
 // Define the function wrappers to handle the calling to Cxxx_DelayHandler etc.
 // If someone knows how to add leading zeros in macros, please be my guest :)
 #ifdef USES_C001
-DEFINE_Cxxx_DELAY_QUEUE_MACRO(001,  1)
+DEFINE_Cxxx_DELAY_QUEUE_MACRO(00,  1)
 #endif // ifdef USES_C001
 #ifdef USES_C003
-DEFINE_Cxxx_DELAY_QUEUE_MACRO(003,  3)
+DEFINE_Cxxx_DELAY_QUEUE_MACRO(00,  3)
 #endif // ifdef USES_C003
 #ifdef USES_C004
-DEFINE_Cxxx_DELAY_QUEUE_MACRO(004,  4)
+DEFINE_Cxxx_DELAY_QUEUE_MACRO(00,  4)
 #endif // ifdef USES_C004
 #ifdef USES_C007
-DEFINE_Cxxx_DELAY_QUEUE_MACRO(007,  7)
+DEFINE_Cxxx_DELAY_QUEUE_MACRO(00,  7)
 #endif // ifdef USES_C007
 #ifdef USES_C008
-DEFINE_Cxxx_DELAY_QUEUE_MACRO(008, 8)
+DEFINE_Cxxx_DELAY_QUEUE_MACRO(00, 8)
 #endif // ifdef USES_C008
 #ifdef USES_C009
-DEFINE_Cxxx_DELAY_QUEUE_MACRO(009, 9)
+DEFINE_Cxxx_DELAY_QUEUE_MACRO(00, 9)
 #endif // ifdef USES_C009
 #ifdef USES_C010
-DEFINE_Cxxx_DELAY_QUEUE_MACRO(010,  10)
+DEFINE_Cxxx_DELAY_QUEUE_MACRO(0,  10)
 #endif // ifdef USES_C010
 #ifdef USES_C011
-DEFINE_Cxxx_DELAY_QUEUE_MACRO(011,  11)
+DEFINE_Cxxx_DELAY_QUEUE_MACRO(0,  11)
 #endif // ifdef USES_C011
 #ifdef USES_C012
-DEFINE_Cxxx_DELAY_QUEUE_MACRO(012,  12)
+DEFINE_Cxxx_DELAY_QUEUE_MACRO(0,  12)
 #endif // ifdef USES_C012
 
 /*
  #ifdef USES_C013
-   DEFINE_Cxxx_DELAY_QUEUE_MACRO(013, 13)
+   DEFINE_Cxxx_DELAY_QUEUE_MACRO(0, 13)
  #endif
  */
 
 /*
  #ifdef USES_C014
-   DEFINE_Cxxx_DELAY_QUEUE_MACRO(014, 14)
+   DEFINE_Cxxx_DELAY_QUEUE_MACRO(0, 14)
  #endif
  */
 #ifdef USES_C015
-DEFINE_Cxxx_DELAY_QUEUE_MACRO(015, 15)
+DEFINE_Cxxx_DELAY_QUEUE_MACRO(0, 15)
 #endif // ifdef USES_C015
 
 #ifdef USES_C016
-DEFINE_Cxxx_DELAY_QUEUE_MACRO(016, 16)
+DEFINE_Cxxx_DELAY_QUEUE_MACRO(0, 16)
 #endif // ifdef USES_C016
 
 
 #ifdef USES_C017
-DEFINE_Cxxx_DELAY_QUEUE_MACRO(017, 17)
+DEFINE_Cxxx_DELAY_QUEUE_MACRO(0, 17)
 #endif // ifdef USES_C017
 
 #ifdef USES_C018
-DEFINE_Cxxx_DELAY_QUEUE_MACRO(018, 18)
+DEFINE_Cxxx_DELAY_QUEUE_MACRO(0, 18)
 #endif
 
 
 /*
  #ifdef USES_C019
-   DEFINE_Cxxx_DELAY_QUEUE_MACRO(019, 19)
+   DEFINE_Cxxx_DELAY_QUEUE_MACRO(0, 19)
  #endif
  */
 
 /*
  #ifdef USES_C020
-   DEFINE_Cxxx_DELAY_QUEUE_MACRO(020, 20)
+   DEFINE_Cxxx_DELAY_QUEUE_MACRO(0, 20)
  #endif
  */
 

--- a/src/_CPlugin_Helper.h
+++ b/src/_CPlugin_Helper.h
@@ -46,16 +46,21 @@ public:
 };
 
 
+#ifdef USES_C001
 /*********************************************************************************************\
 * C001_queue_element for queueing requests for C001.
 \*********************************************************************************************/
 #define C001_queue_element simple_queue_element_string_only
+#endif //USES_C001
 
+#ifdef USES_C003
 /*********************************************************************************************\
 * C003_queue_element for queueing requests for C003 Nodo Telnet.
 \*********************************************************************************************/
 #define C003_queue_element simple_queue_element_string_only
+#endif //USES_C003
 
+#ifdef USES_C004
 /*********************************************************************************************\
 * C004_queue_element for queueing requests for C004 ThingSpeak.
 *   Typical use case for Thingspeak is to only send values every N seconds/minutes.
@@ -86,7 +91,9 @@ public:
   byte sensorType;
   String txt;
 };
+#endif //USES_C004
 
+#ifdef USES_C007
 /*********************************************************************************************\
 * C007_queue_element for queueing requests for C007 Emoncms
 \*********************************************************************************************/
@@ -110,6 +117,7 @@ public:
   int idx;
   byte sensorType;
 };
+#endif //USES_C007
 
 /*********************************************************************************************\
 * Base class for controllers that only send a single value per request and thus needs to
@@ -150,12 +158,15 @@ public:
 };
 
 
+#ifdef USES_C008
 /*********************************************************************************************\
 * C008_queue_element for queueing requests for 008: Generic HTTP
 * Using queue_element_single_value_base
 \*********************************************************************************************/
 #define C008_queue_element queue_element_single_value_base
+#endif //USES_C008
 
+#ifdef USES_C009
 /*********************************************************************************************\
 * C009_queue_element for queueing requests for C009: FHEM HTTP.
 \*********************************************************************************************/
@@ -185,25 +196,33 @@ public:
   int idx;
   byte sensorType;
 };
+#endif //USES_C009
 
 
+#ifdef USES_C010
 /*********************************************************************************************\
 * C010_queue_element for queueing requests for 010: Generic UDP
 * Using queue_element_single_value_base
 \*********************************************************************************************/
 #define C010_queue_element queue_element_single_value_base
+#endif //USES_C010
 
+#ifdef USES_C011
 /*********************************************************************************************\
 * C011_queue_element for queueing requests for 011: Generic HTTP Advanced
 \*********************************************************************************************/
 #define C011_queue_element simple_queue_element_string_only
+#endif //USES_C011
 
+#ifdef USES_C012
 /*********************************************************************************************\
 * C012_queue_element for queueing requests for 012: Blynk
 * Using queue_element_single_value_base
 \*********************************************************************************************/
 #define C012_queue_element queue_element_single_value_base
+#endif //USES_C012
 
+#ifdef USES_C015
 /*********************************************************************************************\
 * C015_queue_element for queueing requests for 015: Blynk
 * Using queue_element_single_value_base
@@ -244,7 +263,9 @@ public:
   mutable byte valuesSent; // Value must be set by const function checkDone()
   byte valueCount;
 };
+#endif //USES_C015
 
+#ifdef USES_C016
 /*********************************************************************************************\
 * C016_queue_element for queueing requests for C016: Cached HTTP.
 \*********************************************************************************************/
@@ -283,6 +304,9 @@ public:
   byte valueCount;
 };
 
+#endif //USES_C016
+
+#ifdef USES_C017
 /*********************************************************************************************\
 * C017_queue_element for queueing requests for C017: Zabbix Trapper Protocol.
 \*********************************************************************************************/
@@ -312,7 +336,9 @@ public:
   int idx;
   byte sensorType;
 };
+#endif //USES_C017
 
+#ifdef USES_C018
 /*********************************************************************************************\
 * C018_queue_element for queueing requests for C018: TTN/RN2483
 \*********************************************************************************************/
@@ -340,6 +366,7 @@ public:
   String packed;
 };
 
+#endif //USES_C018
 
 /*********************************************************************************************\
 * ControllerDelayHandlerStruct

--- a/src/_CPlugin_Helper.h
+++ b/src/_CPlugin_Helper.h
@@ -46,21 +46,21 @@ public:
 };
 
 
-#ifdef USES_C001
+//#ifdef USES_C001
 /*********************************************************************************************\
 * C001_queue_element for queueing requests for C001.
 \*********************************************************************************************/
 #define C001_queue_element simple_queue_element_string_only
-#endif //USES_C001
+//#endif //USES_C001
 
-#ifdef USES_C003
+//#ifdef USES_C003
 /*********************************************************************************************\
 * C003_queue_element for queueing requests for C003 Nodo Telnet.
 \*********************************************************************************************/
 #define C003_queue_element simple_queue_element_string_only
-#endif //USES_C003
+//#endif //USES_C003
 
-#ifdef USES_C004
+//#ifdef USES_C004
 /*********************************************************************************************\
 * C004_queue_element for queueing requests for C004 ThingSpeak.
 *   Typical use case for Thingspeak is to only send values every N seconds/minutes.
@@ -91,9 +91,9 @@ public:
   byte sensorType;
   String txt;
 };
-#endif //USES_C004
+//#endif //USES_C004
 
-#ifdef USES_C007
+//#ifdef USES_C007
 /*********************************************************************************************\
 * C007_queue_element for queueing requests for C007 Emoncms
 \*********************************************************************************************/
@@ -117,7 +117,7 @@ public:
   int idx;
   byte sensorType;
 };
-#endif //USES_C007
+//#endif //USES_C007
 
 /*********************************************************************************************\
 * Base class for controllers that only send a single value per request and thus needs to
@@ -158,15 +158,15 @@ public:
 };
 
 
-#ifdef USES_C008
+//#ifdef USES_C008
 /*********************************************************************************************\
 * C008_queue_element for queueing requests for 008: Generic HTTP
 * Using queue_element_single_value_base
 \*********************************************************************************************/
 #define C008_queue_element queue_element_single_value_base
-#endif //USES_C008
+//#endif //USES_C008
 
-#ifdef USES_C009
+//#ifdef USES_C009
 /*********************************************************************************************\
 * C009_queue_element for queueing requests for C009: FHEM HTTP.
 \*********************************************************************************************/
@@ -196,33 +196,33 @@ public:
   int idx;
   byte sensorType;
 };
-#endif //USES_C009
+//#endif //USES_C009
 
 
-#ifdef USES_C010
+//#ifdef USES_C010
 /*********************************************************************************************\
 * C010_queue_element for queueing requests for 010: Generic UDP
 * Using queue_element_single_value_base
 \*********************************************************************************************/
 #define C010_queue_element queue_element_single_value_base
-#endif //USES_C010
+//#endif //USES_C010
 
-#ifdef USES_C011
+//#ifdef USES_C011
 /*********************************************************************************************\
 * C011_queue_element for queueing requests for 011: Generic HTTP Advanced
 \*********************************************************************************************/
 #define C011_queue_element simple_queue_element_string_only
-#endif //USES_C011
+//#endif //USES_C011
 
-#ifdef USES_C012
+//#ifdef USES_C012
 /*********************************************************************************************\
 * C012_queue_element for queueing requests for 012: Blynk
 * Using queue_element_single_value_base
 \*********************************************************************************************/
 #define C012_queue_element queue_element_single_value_base
-#endif //USES_C012
+//#endif //USES_C012
 
-#ifdef USES_C015
+//#ifdef USES_C015
 /*********************************************************************************************\
 * C015_queue_element for queueing requests for 015: Blynk
 * Using queue_element_single_value_base
@@ -263,9 +263,9 @@ public:
   mutable byte valuesSent; // Value must be set by const function checkDone()
   byte valueCount;
 };
-#endif //USES_C015
+//#endif //USES_C015
 
-#ifdef USES_C016
+//#ifdef USES_C016
 /*********************************************************************************************\
 * C016_queue_element for queueing requests for C016: Cached HTTP.
 \*********************************************************************************************/
@@ -304,9 +304,9 @@ public:
   byte valueCount;
 };
 
-#endif //USES_C016
+//#endif //USES_C016
 
-#ifdef USES_C017
+//#ifdef USES_C017
 /*********************************************************************************************\
 * C017_queue_element for queueing requests for C017: Zabbix Trapper Protocol.
 \*********************************************************************************************/
@@ -336,9 +336,9 @@ public:
   int idx;
   byte sensorType;
 };
-#endif //USES_C017
+//#endif //USES_C017
 
-#ifdef USES_C018
+//#ifdef USES_C018
 /*********************************************************************************************\
 * C018_queue_element for queueing requests for C018: TTN/RN2483
 \*********************************************************************************************/
@@ -366,7 +366,7 @@ public:
   String packed;
 };
 
-#endif //USES_C018
+//#endif //USES_C018
 
 /*********************************************************************************************\
 * ControllerDelayHandlerStruct

--- a/src/_P026_Sysinfo.ino
+++ b/src/_P026_Sysinfo.ino
@@ -144,9 +144,9 @@ boolean Plugin_026(byte function, struct EventStruct *event, String& string)
       success = true;
       break;
     }
-    case PLUGIN_GET_PACKED_RAW_DATA:
+#ifdef USES_PACKED_RAW_DATA
+   case PLUGIN_GET_PACKED_RAW_DATA:
     {
-      #ifdef USES_PACKED_RAW_DATA
       // Matching JS code:
       // return decode(bytes, 
       //  [header, uint24, uint24, int8, vcc, pct_8, uint8, uint8, uint8, uint8, uint24, uint16],
@@ -165,9 +165,9 @@ boolean Plugin_026(byte function, struct EventStruct *event, String& string)
       string += LoRa_addInt(P026_get_value(index++), PackedData_uint16);  // freestack
       event->Par1 = index; // valuecount
       success = true;
-      #endif // USES_PACKED_RAW_DATA
       break;
     }
+#endif // USES_PACKED_RAW_DATA
   }
   return success;
 }

--- a/src/_P037_MQTTImport.ino
+++ b/src/_P037_MQTTImport.ino
@@ -21,9 +21,11 @@
 // Declare a Wifi client for this plugin only
 
 // TODO TD-er: These must be kept in some vector to allow multiple instances of MQTT import.
+#ifdef USES_MQTT
 WiFiClient espclient_037;
 PubSubClient *MQTTclient_037 = NULL;
 bool MQTTclient_037_connected = false;
+#endif //USES_MQTT
 int reconnectCount = 0;
 
 String getClientName() {

--- a/src/_P082_GPS.ino
+++ b/src/_P082_GPS.ino
@@ -520,13 +520,13 @@ boolean Plugin_082(byte function, struct EventStruct *event, String& string) {
       }
       break;
     }
+#ifdef USES_PACKED_RAW_DATA
     case PLUGIN_GET_PACKED_RAW_DATA:
     {
       P082_data_struct *P082_data =
         static_cast<P082_data_struct *>(getPluginTaskData(event->TaskIndex));
 
       if ((nullptr != P082_data) && P082_data->isInitialized()) {
-        #ifdef USES_PACKED_RAW_DATA
         // Matching JS code:
         // return decode(bytes, [header, latLng, latLng, altitude, uint16_1e2, hdop, uint8, uint8],
         //      ['header', 'latitude', 'longitude', 'altitude', 'speed', 'hdop', 'max_snr', 'sat_tracked']);
@@ -541,10 +541,11 @@ boolean Plugin_082(byte function, struct EventStruct *event, String& string) {
         event->Par1 = 7; // valuecount 7 
         
         success = true;
-        #endif // USES_PACKED_RAW_DATA
       }
       break;
     }
+#endif // USES_PACKED_RAW_DATA
+
   }
   return success;
 }

--- a/src/define_plugin_sets.h
+++ b/src/define_plugin_sets.h
@@ -809,3 +809,15 @@ To create/register a plugin, you have to :
 #if defined(USES_C018)
   #define USES_PACKED_RAW_DATA
 #endif
+
+#if defined(USES_P085) || defined (USES_P052) || defined(USES_P078)
+  #define USES_MODBUS
+#endif
+
+#if defined(USES_C081) || defined (USES_C002) || defined(USES_P029)
+  #define USES_DOMOTICZ
+#endif
+
+#if defined(USES_C082) || defined (USES_C005) || defined(USES_C006) || defined(USES_C014)
+  #define USES_MQTT
+#endif

--- a/src/define_plugin_sets.h
+++ b/src/define_plugin_sets.h
@@ -814,10 +814,10 @@ To create/register a plugin, you have to :
   #define USES_MODBUS
 #endif
 
-#if defined(USES_C081) || defined (USES_C002) || defined(USES_P029)
+#if defined(USES_C001) || defined (USES_C002) || defined(USES_P029)
   #define USES_DOMOTICZ
 #endif
 
-#if defined(USES_C082) || defined (USES_C005) || defined(USES_C006) || defined(USES_C014)
+#if defined(USES_C001) || defined(USES_C002) || defined (USES_C005) || defined(USES_C006) || defined(USES_C014)
   #define USES_MQTT
 #endif

--- a/src/define_plugin_sets.h
+++ b/src/define_plugin_sets.h
@@ -793,11 +793,12 @@ To create/register a plugin, you have to :
   #define DISABLE_SOFTWARE_SERIAL
 #endif
 
-
+#ifdef USES_MQTT
 // MQTT_MAX_PACKET_SIZE : Maximum packet size
 #ifndef MQTT_MAX_PACKET_SIZE
   #define MQTT_MAX_PACKET_SIZE 1024 // Is also used in PubSubClient
 #endif
+#endif //USES_MQTT
 
 /*
 #if defined(USES_P00x) || defined(USES_P00y)
@@ -818,6 +819,6 @@ To create/register a plugin, you have to :
   #define USES_DOMOTICZ
 #endif
 
-#if defined(USES_C002) || defined (USES_C005) || defined(USES_C006) || defined(USES_C014)
+#if defined(USES_C002) || defined (USES_C005) || defined(USES_C006) || defined(USES_C014) || defined(USES_P037)
   #define USES_MQTT
 #endif

--- a/src/define_plugin_sets.h
+++ b/src/define_plugin_sets.h
@@ -822,7 +822,3 @@ To create/register a plugin, you have to :
 #if defined(USES_C002) || defined (USES_C005) || defined(USES_C006) || defined(USES_C014) || defined(USES_P037)
   #define USES_MQTT
 #endif
-
-#if defined(USES_C012) || defined (USES_C015)
-  #define USES_BLYNK
-#endif

--- a/src/define_plugin_sets.h
+++ b/src/define_plugin_sets.h
@@ -818,6 +818,6 @@ To create/register a plugin, you have to :
   #define USES_DOMOTICZ
 #endif
 
-#if defined(USES_C001) || defined(USES_C002) || defined (USES_C005) || defined(USES_C006) || defined(USES_C014)
+#if defined(USES_C002) || defined (USES_C005) || defined(USES_C006) || defined(USES_C014)
   #define USES_MQTT
 #endif

--- a/src/define_plugin_sets.h
+++ b/src/define_plugin_sets.h
@@ -822,3 +822,7 @@ To create/register a plugin, you have to :
 #if defined(USES_C002) || defined (USES_C005) || defined(USES_C006) || defined(USES_C014) || defined(USES_P037)
   #define USES_MQTT
 #endif
+
+#if defined(USES_C012) || defined (USES_C015)
+  #define USES_BLYNK
+#endif


### PR DESCRIPTION
Trying to reduce size of the compiled binaries by  excluding certain parts of the code if not needed.

See definitions at the end of  'define_plugin_sets.h'
 Currently done:
- Casting all controllers that are not included
- Casting all MQTT related code
- Casting all Domoticz related code