### PR TITLE
Add plugin sets PLUGIN_SET_ONLY_SWITCH and PLUGIN_SET_ONLY_TEMP_HUM t…

### DIFF
--- a/src/define_plugin_sets.h
+++ b/src/define_plugin_sets.h
@@ -250,6 +250,8 @@ To create/register a plugin, you have to :
     // The following define is needed for extended decoding of A/C Messages and or using standardised common arguments for controlling all deeply supported A/C units
     #define P016_P035_Extended_AC
     #define USES_P088      //ToniA IR plugin
+    #define PLUGIN_SET_ONLY_SWITCH
+    #define PLUGIN_SET_ONLY_TEMP_HUM
 #endif
 
 #ifdef PLUGIN_BUILD_IR_EXTENDED_NO_RX

--- a/src/define_plugin_sets.h
+++ b/src/define_plugin_sets.h
@@ -249,8 +249,9 @@ To create/register a plugin, you have to :
     #define USES_P035      // IRTX
     // The following define is needed for extended decoding of A/C Messages and or using standardised common arguments for controlling all deeply supported A/C units
     #define P016_P035_Extended_AC
-    #define USES_P088      //ToniA IR plugin
+    #define USES_P088      // ToniA IR plugin
     #define PLUGIN_SET_ONLY_SWITCH
+    #define USES_P029      // Output - Domoticz MQTT Helper
     #define PLUGIN_SET_ONLY_TEMP_HUM
 #endif
 


### PR DESCRIPTION
…o the minimal_IRext_ESP8266_1M image

This makes the image more useful, as it has support for temperature/humidity sensors, switch input and also the MQTT import.

Image size changes from 811824 bytes to 830992 bytes.