### PR TITLE
Update ccronexpr library to v20190415

### DIFF
--- a/lib/ccronexpr/.travis.yml
+++ b/lib/ccronexpr/.travis.yml
@@ -28,6 +28,9 @@ script:
   - $CC ccronexpr.c ccronexpr_test.c -I. -Wall -Wextra -std=c89 -DCRON_TEST_MALLOC -o a.out && ./a.out
   - $CXX ccronexpr.c ccronexpr_test.c -I. -Wall -Wextra -std=c++11 -DCRON_TEST_MALLOC -o a.out && ./a.out
   - $CXX ccronexpr.c ccronexpr_test.c -I. -Wall -Wextra -std=c++11 -DCRON_TEST_MALLOC -DCRON_COMPILE_AS_CXX -o a.out && ./a.out
+  - $CC -DCRON_USE_LOCAL_TIME ccronexpr.c ccronexpr_test.c -I. -Wall -Wextra -std=c89 -DCRON_TEST_MALLOC -o a.out && TZ="America/Toronto" ./a.out
+  - $CXX -DCRON_USE_LOCAL_TIME ccronexpr.c ccronexpr_test.c -I. -Wall -Wextra -std=c++11 -DCRON_TEST_MALLOC -o a.out && TZ="America/Toronto" ./a.out
+  - $CXX -DCRON_USE_LOCAL_TIME ccronexpr.c ccronexpr_test.c -I. -Wall -Wextra -std=c++11 -DCRON_TEST_MALLOC -DCRON_COMPILE_AS_CXX -o a.out && TZ="America/Toronto" ./a.out
 
 notifications:
   email:

--- a/lib/ccronexpr/README.md
+++ b/lib/ccronexpr/README.md
@@ -57,7 +57,9 @@ Timezones
 This implementation does not support explicit timezones handling. By default all dates are
 processed as UTC (GMT) dates without timezone infomation. 
 
-To use local dates (current system timezone) instead of GMT compile with `-DCRON_USE_LOCAL_TIME`.
+To use local dates (current system timezone) instead of GMT compile with `-DCRON_USE_LOCAL_TIME`, example:
+
+    gcc -DCRON_USE_LOCAL_TIME ccronexpr.c ccronexpr_test.c -I. -Wall -Wextra -std=c89 -DCRON_TEST_MALLOC -o a.out && TZ="America/Toronto" ./a.out
 
 License information
 -------------------
@@ -66,6 +68,10 @@ This project is released under the [Apache License 2.0](http://www.apache.org/li
 
 Changelog
 ---------
+
+**2019-03-27**
+
+ * `CRON_USE_LOCAL_TIME` usage fixes
 
 **2018-05-23**
 

--- a/lib/ccronexpr/ccronexpr.c
+++ b/lib/ccronexpr/ccronexpr.c
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-/*
+/* 
  * File:   ccronexpr.c
  * Author: alex
- *
+ * 
  * Created on February 24, 2015, 9:35 AM
  */
 
@@ -30,30 +30,6 @@
 #include <math.h>
 
 #include "ccronexpr.h"
-
-#define CRON_MAX_SECONDS 60
-#define CRON_MAX_MINUTES 60
-#define CRON_MAX_HOURS 24
-#define CRON_MAX_DAYS_OF_WEEK 8
-#define CRON_MAX_DAYS_OF_MONTH 32
-#define CRON_MAX_MONTHS 12
-#define CRON_MAX_YEARS_DIFF 4
-
-#define CRON_CF_SECOND 0
-#define CRON_CF_MINUTE 1
-#define CRON_CF_HOUR_OF_DAY 2
-#define CRON_CF_DAY_OF_WEEK 3
-#define CRON_CF_DAY_OF_MONTH 4
-#define CRON_CF_MONTH 5
-#define CRON_CF_YEAR 6
-
-#define CRON_CF_ARR_LEN 7
-
-
-static const char* const DAYS_ARR[] = { "SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT" };
-#define CRON_DAYS_ARR_LEN 7
-static const char* const MONTHS_ARR[] = { "FOO", "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC" };
-#define CRON_MONTHS_ARR_LEN 13
 
 #define CRON_MAX_STR_LEN_TO_SPLIT 256
 #define CRON_MAX_NUM_TO_SRING 1000000000
@@ -76,86 +52,121 @@ void* cron_malloc(size_t n);
 void cron_free(void* p);
 #endif /* CRON_TEST_MALLOC */
 
-#ifdef _WIN32
-#ifdef CRON_USE_LOCAL_TIME
-time_t cron_mktime(struct tm* tm) {
-    return mktime(tm);
-}
+/**
+ * Time functions from standard library.
+ * This part defines: cron_mktime: create time_t from tm
+ *                    cron_time: create tm from time_t
+ */
 
-struct tm* cron_time(time_t* date, struct tm* out) {
-    errno_t err = localtime_s(out, date);
-    return 0 == err ? out : NULL;
-}
-#else /* CRON_USE_LOCAL_TIME */
+/* forward declarations for platforms that may need them */
+/* can be hidden in time.h */
+#if !defined(_WIN32) && !defined(__AVR__) && !(defined(ESP8266) || defined(ESP32)) && !defined(ANDROID)
+struct tm *gmtime_r(const time_t *timep, struct tm *result);
+time_t timegm(struct tm* __tp);
+struct tm *localtime_r(const time_t *timep, struct tm *result);
+#endif /* PLEASE CHECK _WIN32 AND ANDROID NEEDS FOR THESE DECLARATIONS */
 #ifdef __MINGW32__
 /* To avoid warning when building with mingw */
 time_t _mkgmtime(struct tm* tm);
 #endif /* __MINGW32__ */
 
-time_t cron_mktime(struct tm* tm) {
+/* function definitions */
+time_t cron_mktime_gm(struct tm* tm) {
+#if defined(_WIN32)
+/* http://stackoverflow.com/a/22557778 */
     return _mkgmtime(tm);
-}
-
-struct tm* cron_time(time_t* date, struct tm* out) {
-#ifdef __MINGW32__
-    (void)(out); /* To avoid unused warning */
-    return gmtime(date);
-#else /* !__MINGW32__ */
-    errno_t err = gmtime_s(out, date);
-    return 0 == err ? out : NULL;
-#endif
-}
-
-#endif /* CRON_USE_LOCAL_TIME */
+#elif defined(__AVR__)
+/* https://www.nongnu.org/avr-libc/user-manual/group__avr__time.html */
+    return mk_gmtime(tm);
+#elif (defined(ESP8266) || defined(ESP32))
+    /* https://linux.die.net/man/3/timegm */
+    /* http://www.catb.org/esr/time-programming/ */
+    /* portable version of timegm() */
+    time_t ret;
+    char *tz;
+    tz = getenv("TZ");
+    if (tz)
+        tz = strdup(tz);
+    setenv("TZ", "UTC+0", 1);
+    tzset();
+    ret = mktime(tm);
+    if (tz) {
+        setenv("TZ", tz, 1);
+        free(tz);
+    } else
+        unsetenv("TZ");
+    tzset();
+    return ret;
 #elif defined(ANDROID)
-struct tm *gmtime_r(const time_t *timep, struct tm *result);
-
-#ifdef CRON_USE_LOCAL_TIME
-struct tm *localtime_r(const time_t *timep, struct tm *result);
-
-time_t cron_mktime(struct tm* tm) {
-    return mktime(tm);
-}
-
-struct tm* cron_time(time_t* date, struct tm* out) {
-    return localtime_r(date, out);
-}
-#else /* CRON_USE_LOCAL_TIME */
-time_t cron_mktime(struct tm* tm) {
-        /* https://github.com/adobe/chromium/blob/cfe5bf0b51b1f6b9fe239c2a3c2f2364da9967d7/base/os_compat_android.cc#L20 */
+    /* https://github.com/adobe/chromium/blob/cfe5bf0b51b1f6b9fe239c2a3c2f2364da9967d7/base/os_compat_android.cc#L20 */
     static const time_t kTimeMax = ~(1L << (sizeof (time_t) * CHAR_BIT - 1));
     static const time_t kTimeMin = (1L << (sizeof (time_t) * CHAR_BIT - 1));
     time64_t result = timegm64(tm);
     if (result < kTimeMin || result > kTimeMax) return -1;
     return result;
+#else
+    return timegm(tm);
+#endif
+}
+
+struct tm* cron_time_gm(time_t* date, struct tm* out) {
+#if defined(__MINGW32__)
+    (void)(out); /* To avoid unused warning */
+    return gmtime(date);
+#elif defined(_WIN32)
+    errno_t err = gmtime_s(out, date);
+    return 0 == err ? out : NULL;
+#elif defined(__AVR__)
+    /* https://www.nongnu.org/avr-libc/user-manual/group__avr__time.html */
+    gmtime_r(date, out);
+    return out;
+#else
+    return gmtime_r(date, out);
+#endif
+}
+
+time_t cron_mktime_local(struct tm* tm) {
+    tm->tm_isdst = -1;
+    return mktime(tm);
+}
+
+struct tm* cron_time_local(time_t* date, struct tm* out) {
+#if defined(_WIN32)
+    errno_t err = localtime_s(out, date);
+    return 0 == err ? out : NULL;
+#elif defined(__AVR__)
+    /* https://www.nongnu.org/avr-libc/user-manual/group__avr__time.html */
+    localtime_r(date, out);
+    return out;
+#else
+    return localtime_r(date, out);
+#endif
+}
+
+/* Defining 'cron_' time functions to use use UTC (default) or local time */
+#ifndef CRON_USE_LOCAL_TIME
+time_t cron_mktime(struct tm* tm) {
+    return cron_mktime_gm(tm);
 }
 
 struct tm* cron_time(time_t* date, struct tm* out) {
-    return gmtime_r(date, out);
+    return cron_time_gm(date, out);
 }
-#endif /* CRON_USE_LOCAL_TIME */
-#elif defined(ESP8266) || defined(ESP32)
-#ifdef CRON_USE_LOCAL_TIME
-time_t cron_mktime(struct tm* tm) {
-   return mktime(tm);
-}
-struct tm* cron_time(time_t* date, struct tm* out) {
-    return localtime_r(date, out);
-}
+
 #else /* CRON_USE_LOCAL_TIME */
 time_t cron_mktime(struct tm* tm) {
-  time_t t = mktime( tm );
-  #ifdef __TM_GMTOFF
-    return t + localtime( &t )->tm_gmtoff;
-  #else
-    return t;
-  #endif
+    return cron_mktime_local(tm);
 }
+
 struct tm* cron_time(time_t* date, struct tm* out) {
-    return gmtime_r(date, out);
+    return cron_time_local(date, out);
 }
-#endif /* CRON_USE_LOCAL_TIME*/
-#endif
+
+#endif /* CRON_USE_LOCAL_TIME */
+
+/**
+ * Functions.
+ */
 
 void cron_set_bit(uint8_t* rbyte, int idx) {
     uint8_t j = (uint8_t) (idx / 8);
@@ -828,17 +839,17 @@ static void set_number_hits(const char* value, uint8_t* target, unsigned int min
 }
 
 static void set_months(char* value, uint8_t* targ, const char** error) {
-    int err;
     unsigned int i;
     unsigned int max = 12;
 
     char* replaced = NULL;
 
-    err = to_upper(value);
-    if (err) return;
+    to_upper(value);
     replaced = replace_ordinals(value, MONTHS_ARR, CRON_MONTHS_ARR_LEN);
-    if (!replaced) return;
-
+    if (!replaced) {
+        *error = "Invalid month format";
+        return;
+    }
     set_number_hits(replaced, targ, 1, max + 1, error);
     cron_free(replaced);
 
@@ -851,11 +862,26 @@ static void set_months(char* value, uint8_t* targ, const char** error) {
     }
 }
 
-static void set_days(char* field, uint8_t* targ, int max, const char** error) {
+static void set_days_of_week(char* field, uint8_t* targ, const char** error) {
+    unsigned int max = 7;
+    char* replaced = NULL;
+
     if (1 == strlen(field) && '?' == field[0]) {
         field[0] = '*';
     }
-    set_number_hits(field, targ, 0, max, error);
+    to_upper(field);
+    replaced = replace_ordinals(field, DAYS_ARR, CRON_DAYS_ARR_LEN);
+    if (!replaced) {
+        *error = "Invalid day format";
+        return;
+    }
+    set_number_hits(replaced, targ, 0, max + 1, error);
+    cron_free(replaced);
+    if (cron_get_bit(targ, 7)) {
+        /* Sunday can be represented as 0 or 7*/
+        cron_set_bit(targ, 0);
+        cron_del_bit(targ, 7);
+    }
 }
 
 static void set_days_of_month(char* field, uint8_t* targ, const char** error) {
@@ -870,7 +896,6 @@ void cron_parse_expr(const char* expression, cron_expr* target, const char** err
     const char* err_local;
     size_t len = 0;
     char** fields = NULL;
-    char* days_replaced = NULL;
     if (!error) {
         error = &err_local;
     }
@@ -879,36 +904,33 @@ void cron_parse_expr(const char* expression, cron_expr* target, const char** err
         *error = "Invalid NULL expression";
         goto return_res;
     }
+    if (!target) {
+        *error = "Invalid NULL target";
+        goto return_res;
+    }
 
     fields = split_str(expression, ' ', &len);
     if (len != 6) {
         *error = "Invalid number of fields, expression must consist of 6 fields";
         goto return_res;
     }
+    memset(target, 0, sizeof(*target));
     set_number_hits(fields[0], target->seconds, 0, 60, error);
     if (*error) goto return_res;
     set_number_hits(fields[1], target->minutes, 0, 60, error);
     if (*error) goto return_res;
     set_number_hits(fields[2], target->hours, 0, 24, error);
     if (*error) goto return_res;
-    to_upper(fields[5]);
-    days_replaced = replace_ordinals(fields[5], DAYS_ARR, CRON_DAYS_ARR_LEN);
-    set_days(days_replaced, target->days_of_week, 8, error);
-    cron_free(days_replaced);
-    if (*error) goto return_res;
-    if (cron_get_bit(target->days_of_week, 7)) {
-        /* Sunday can be represented as 0 or 7*/
-        cron_set_bit(target->days_of_week, 0);
-        cron_del_bit(target->days_of_week, 7);
-    }
     set_days_of_month(fields[3], target->days_of_month, error);
     if (*error) goto return_res;
     set_months(fields[4], target->months, error);
     if (*error) goto return_res;
+    set_days_of_week(fields[5], target->days_of_week, error);
+    if (*error) goto return_res;
 
     goto return_res;
 
-    return_res:
+    return_res: 
     free_splitted(fields, len);
 }
 

--- a/lib/ccronexpr/ccronexpr.h
+++ b/lib/ccronexpr/ccronexpr.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/*
+/* 
  * File:   ccronexpr.h
  * Author: alex
  *
@@ -39,7 +39,7 @@ extern "C" {
 /**
  * Parsed cron expression
  */
-typedef struct cron_expr_t{
+typedef struct {
     uint8_t seconds[8];
     uint8_t minutes[8];
     uint8_t hours[3];
@@ -48,10 +48,9 @@ typedef struct cron_expr_t{
     uint8_t months[2];
 } cron_expr;
 
-#define CRON_INVALID_INSTANT ((time_t) -1)
 /**
  * Parses specified cron expression.
- *
+ * 
  * @param expression cron expression as nul-terminated string,
  *        should be no longer that 256 bytes
  * @param pointer to cron expression structure, it's client code responsibility
@@ -64,10 +63,10 @@ void cron_parse_expr(const char* expression, cron_expr* target, const char** err
 
 /**
  * Uses the specified expression to calculate the next 'fire' date after
- * the specified date. All dates are processed as UTC (GMT) dates
- * without timezones information. To use local dates (current system timezone)
+ * the specified date. All dates are processed as UTC (GMT) dates 
+ * without timezones information. To use local dates (current system timezone) 
  * instead of GMT compile with '-DCRON_USE_LOCAL_TIME'
- *
+ * 
  * @param expr parsed cron expression to use in next date calculation
  * @param date start date to start calculation from
  * @return next 'fire' date in case of success, '((time_t) -1)' in case of error.
@@ -76,10 +75,10 @@ time_t cron_next(cron_expr* expr, time_t date);
 
 /**
  * Uses the specified expression to calculate the previous 'fire' date after
- * the specified date. All dates are processed as UTC (GMT) dates
- * without timezones information. To use local dates (current system timezone)
+ * the specified date. All dates are processed as UTC (GMT) dates 
+ * without timezones information. To use local dates (current system timezone) 
  * instead of GMT compile with '-DCRON_USE_LOCAL_TIME'
- *
+ * 
  * @param expr parsed cron expression to use in previous date calculation
  * @param date start date to start calculation from
  * @return previous 'fire' date in case of success, '((time_t) -1)' in case of error.
@@ -91,4 +90,30 @@ time_t cron_prev(cron_expr* expr, time_t date);
 } /* extern "C"*/
 #endif
 
+#define CRON_MAX_SECONDS 60
+#define CRON_MAX_MINUTES 60
+#define CRON_MAX_HOURS 24
+#define CRON_MAX_DAYS_OF_WEEK 8
+#define CRON_MAX_DAYS_OF_MONTH 32
+#define CRON_MAX_MONTHS 12
+#define CRON_MAX_YEARS_DIFF 4
+
+#define CRON_CF_SECOND 0
+#define CRON_CF_MINUTE 1
+#define CRON_CF_HOUR_OF_DAY 2
+#define CRON_CF_DAY_OF_WEEK 3
+#define CRON_CF_DAY_OF_MONTH 4
+#define CRON_CF_MONTH 5
+#define CRON_CF_YEAR 6
+
+#define CRON_CF_ARR_LEN 7
+
+#define CRON_INVALID_INSTANT ((time_t) -1)
+
+static const char* const DAYS_ARR[] = { "SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT" };
+#define CRON_DAYS_ARR_LEN 7
+static const char* const MONTHS_ARR[] = { "FOO", "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC" };
+#define CRON_MONTHS_ARR_LEN 13
 #endif /* CCRONEXPR_H */
+
+


### PR DESCRIPTION
- false valid check
- drop two unused variables
- CRON_USE_LOCAL_TIME: use DST offsets
- Initialize passed cron_expr to zero