### PR TITLE
[Build] Fix binary size check for xxx_1M builds

### DIFF
--- a/before_deploy
+++ b/before_deploy
@@ -94,16 +94,16 @@ do
     FILESIZE=$(stat -c%s `echo "${FIRMWARE_BIN}"` )
     if (( FILESIZE < MAX_FILESIZE )); then
       echo
-      echo "SUCCESS:  $FILESIZE < $MAX_FILESIZE Bytes. \t(${ENV})" >> ${BUILD_LOG}
+      echo "SUCCESS:  $FILESIZE < $MAX_FILESIZE Bytes. (${ENV})" >> ${BUILD_LOG}
       BIN=${BINARY_PATH}/${ENV}/ESP_Easy_${VERSION}_${ENV}.bin
       cp ${FIRMWARE_BIN} $BIN
       python2 crc2.py $BIN
       mv $BIN "${TMP_DIST}/bin/ESP_Easy_${VERSION}_${ENV}.bin"
     else
-      echo "FAILED: too large $FILESIZE > $MAX_FILESIZE Bytes. \t(${ENV})" >> ${BUILD_LOG}
+      echo "FAILED: too large $FILESIZE > $MAX_FILESIZE Bytes. (${ENV})" >> ${BUILD_LOG}
     fi
   else
-    echo "FAILED: No file created. \t(${ENV})" >> ${BUILD_LOG}
+    echo "FAILED: No file created. (${ENV})" >> ${BUILD_LOG}
   fi
 
   ELFFILE=`echo "${BINARY_PATH}/${ENV}/firmware.elf"`

--- a/before_deploy
+++ b/before_deploy
@@ -73,11 +73,11 @@ for ENV in \
   hard_Ventus_W266;\
 do
   MAX_FILESIZE=1044464
-  if [[ ${ENV} == *"1M"* ]]; then
+  if [[ ${ENV} == *"_1M"* ]]; then
     # max 871 kiB
     MAX_FILESIZE=892912
   fi
-  if [[ ${ENV} == *"1M_OTA"* ]]; then
+  if [[ ${ENV} == *"_1M_OTA"* ]]; then
     # max 602 kiB
     MAX_FILESIZE=616448
   fi
@@ -90,24 +90,21 @@ do
 
   FIRMWARE_BIN=`echo "${BINARY_PATH}/${ENV}/firmware.bin"`
 
-  echo "ESP_Easy_${VERSION}_${ENV}.bin : " >> ${BUILD_LOG}
   if [ -f $FIRMWARE_BIN ]; then
     FILESIZE=$(stat -c%s `echo "${FIRMWARE_BIN}"` )
     if (( FILESIZE < MAX_FILESIZE )); then
       echo
-      echo "Build SUCCESS for $ENV :  $FILESIZE < $MAX_FILESIZE Bytes" >> ${BUILD_LOG}
+      echo "SUCCESS:  $FILESIZE < $MAX_FILESIZE Bytes. \t(${ENV})" >> ${BUILD_LOG}
       BIN=${BINARY_PATH}/${ENV}/ESP_Easy_${VERSION}_${ENV}.bin
       cp ${FIRMWARE_BIN} $BIN
       python2 crc2.py $BIN
       mv $BIN "${TMP_DIST}/bin/ESP_Easy_${VERSION}_${ENV}.bin"
     else
-      echo "Build FAILED: too large for $ENV  $FILESIZE > $MAX_FILESIZE Bytes" >> ${BUILD_LOG}
+      echo "FAILED: too large $FILESIZE > $MAX_FILESIZE Bytes. \t(${ENV})" >> ${BUILD_LOG}
     fi
   else
-    echo "Build FAILED: No file created." >> ${BUILD_LOG}
+    echo "FAILED: No file created. \t(${ENV})" >> ${BUILD_LOG}
   fi
-
-  echo "---" >> ${BUILD_LOG}
 
   ELFFILE=`echo "${BINARY_PATH}/${ENV}/firmware.elf"`
   if [ -f $ELFFILE ]; then
@@ -117,6 +114,7 @@ do
     objdump  -s -j .rodata ${ELFFILE} > ${STRINGS_STATS}
   fi
 done
+
 
 #create a source structure that is the same as the original ESPEasy project (and works with the howto on the wiki)
 #rm -rf dist/Source 2>/dev/null
@@ -132,8 +130,11 @@ echo
 echo "### Creating zip archive"
 zip -qq ${CURPATH}/ESPEasy_$VERSION.zip -r .
 
+
+
 # Display the build log.
 cat ${BUILD_LOG}
+
 
 rm -Rf ${TMP_DIST}/* 2>/dev/null
 rmdir ${TMP_DIST}


### PR DESCRIPTION
The build envs now have _4M1M in their name so must not match on `1M`, but on `_1M` to adapt for 1 MB size.