### PR TITLE
fixed serious bug for MONITOR command for offline PCF or MCP (P009 and P019)

### DIFF
--- a/src/_P009_MCP.ino
+++ b/src/_P009_MCP.ino
@@ -255,7 +255,7 @@ boolean Plugin_009(byte function, struct EventStruct *event, String& string)
           const portStatusStruct currentStatus = globalMapPortStatus[key];
 
           //if (currentStatus.monitor || currentStatus.command || currentStatus.init) {
-            byte state = Plugin_009_Read(event->Par1);
+            const int8_t state = Plugin_009_Read(event->Par1);
             if (currentStatus.state != state || currentStatus.forceMonitor) {
               if (!currentStatus.task) globalMapPortStatus[key].state = state; //do not update state if task flag=1 otherwise it will not be picked up by 10xSEC function
               if (currentStatus.monitor) {
@@ -527,7 +527,7 @@ boolean Plugin_009(byte function, struct EventStruct *event, String& string)
             // So the next command should be part of each command:
             tempStatus = globalMapPortStatus[key];
 
-            int8_t currentState = Plugin_009_Read(event->Par1);
+            const int8_t currentState = Plugin_009_Read(event->Par1);
 
             if (currentState == -1) {
               tempStatus.mode=PIN_MODE_OFFLINE;
@@ -565,7 +565,7 @@ boolean Plugin_009(byte function, struct EventStruct *event, String& string)
             // WARNING: operator [] creates an entry in the map if key does not exist
             // So the next command should be part of each command:
             tempStatus = globalMapPortStatus[key];
-            int8_t currentState = Plugin_009_Read(event->Par1);
+            const int8_t currentState = Plugin_009_Read(event->Par1);
             bool needToSave = false;
 
             if (currentState == -1) {
@@ -652,7 +652,7 @@ boolean Plugin_009(byte function, struct EventStruct *event, String& string)
               SendStatusOnlyIfNeeded(event->Source, SEARCH_PIN_STATE, key, dummyString, 0);
             else
            {
-             int state = Plugin_009_Read(event->Par2); // report as input
+             const int8_t state = Plugin_009_Read(event->Par2); // report as input
              if (state != -1)
                SendStatusOnlyIfNeeded(event->Source, NO_SEARCH_PIN_STATE, key, dummyString, state);
              }

--- a/src/_P019_PCF8574.ino
+++ b/src/_P019_PCF8574.ino
@@ -252,7 +252,7 @@ boolean Plugin_019(byte function, struct EventStruct *event, String& string)
           const portStatusStruct currentStatus = globalMapPortStatus[key];
 
         //  if (currentStatus.monitor || currentStatus.command || currentStatus.init) {
-            byte state = Plugin_019_Read(event->Par1);
+            const int8_t state = Plugin_019_Read(event->Par1);
             if (currentStatus.state != state || currentStatus.forceMonitor) {
               if (!currentStatus.task) globalMapPortStatus[key].state = state; //do not update state if task flag=1 otherwise it will not be picked up by 10xSEC function
               if (currentStatus.monitor) {
@@ -525,7 +525,7 @@ boolean Plugin_019(byte function, struct EventStruct *event, String& string)
             // So the next command should be part of each command:
             tempStatus = globalMapPortStatus[key];
 
-            int8_t currentState = Plugin_019_Read(event->Par1);
+            const int8_t currentState = Plugin_019_Read(event->Par1);
 
             if (currentState == -1) {
               tempStatus.mode=PIN_MODE_OFFLINE;
@@ -570,7 +570,7 @@ boolean Plugin_019(byte function, struct EventStruct *event, String& string)
             // WARNING: operator [] creates an entry in the map if key does not exist
             // So the next command should be part of each command:
             tempStatus = globalMapPortStatus[key];
-            int8_t currentState = Plugin_019_Read(event->Par1);
+            const int8_t currentState = Plugin_019_Read(event->Par1);
             bool needToSave = false;
 
             if (currentState == -1) {
@@ -661,7 +661,7 @@ boolean Plugin_019(byte function, struct EventStruct *event, String& string)
               SendStatusOnlyIfNeeded(event->Source, SEARCH_PIN_STATE, key, dummyString, 0);
             else
             {
-              int state = Plugin_019_Read(event->Par2); // report as input
+              const int8_t state = Plugin_019_Read(event->Par2); // report as input
               if (state != -1)
                 SendStatusOnlyIfNeeded(event->Source, NO_SEARCH_PIN_STATE, key, dummyString, state);
             }


### PR DESCRIPTION
Fixed a bug 1 year old (in my own code) in P009 and P019 that was returing a state of 255 instead of -1 in case of state=offline.
The reason of the bug was that the Read function was casted to a byte variable instead of a int8_t variable.

This could generate a loop (and eventually a crash) if the monitor command was set to a pin that was offline. Infact the state returned was 255 and the current state was -1, so they never matched and a new event was created every 1/10 seconds.