### PR TITLE
[OTA] Fix minimal OTA size computations (#2707) & Rules bug (#2704)

### DIFF
--- a/before_deploy
+++ b/before_deploy
@@ -74,12 +74,12 @@ for ENV in \
 do
   MAX_FILESIZE=1044464
   if [[ ${ENV} == *"_1M"* ]]; then
-    # max 871 kiB
+    # max 872 kiB - 16 bytes
     MAX_FILESIZE=892912
   fi
   if [[ ${ENV} == *"_1M_OTA"* ]]; then
-    # max 602 kiB
-    MAX_FILESIZE=616448
+    # max 600 kiB - 16 bytes
+    MAX_FILESIZE=614384
   fi
   if [[ ${ENV} == *"esp32"* ]]; then
     MAX_FILESIZE=1310720

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -161,7 +161,7 @@ extern NotificationStruct Notification[NPLUGIN_MAX];
     #include <ESP8266mDNS.h>
   #endif
   #define SMALLEST_OTA_IMAGE 276848 // smallest known 2-step OTA image
-  #define MAX_SKETCH_SIZE 1044464
+  #define MAX_SKETCH_SIZE 1044464   // 1020 kB - 16 bytes
   #define PIN_D_MAX        16
 #endif
 #if defined(ESP32)

--- a/src/ESPEasyRules.ino
+++ b/src/ESPEasyRules.ino
@@ -452,6 +452,7 @@ void processMatchedRule(String& action, String& event,
         }
         else {
           String check = lcAction.substring(split + 7);
+          check.trim();
           condition[ifBlock - 1] = conditionMatchExtended(check);
 #ifndef BUILD_NO_DEBUG
 
@@ -476,6 +477,7 @@ void processMatchedRule(String& action, String& event,
         if (isCommand) {
           ifBlock++;
           String check = lcAction.substring(split + 3);
+          check.trim();
           condition[ifBlock - 1] = conditionMatchExtended(check);
           ifBranche[ifBlock - 1] = true;
 #ifndef BUILD_NO_DEBUG
@@ -752,56 +754,57 @@ bool findCompareCondition(const String& check, char& compare, int& posStart, int
   posStart = check.length();
   posEnd   = posStart;
   int comparePos = 0;
+  bool found = false;
 
   if (((comparePos = check.indexOf("!=")) > 0) && (comparePos < posStart)) {
     posStart = comparePos;
     posEnd   = posStart + 2;
     compare  = '!' + '=';
-    return true;
+    found = true;
   }
 
   if (((comparePos = check.indexOf("<>")) > 0) && (comparePos < posStart)) {
     posStart = comparePos;
     posEnd   = posStart + 2;
     compare  = '!' + '=';
-    return true;
+    found = true;
   }
 
   if (((comparePos = check.indexOf(">=")) > 0) && (comparePos < posStart)) {
     posStart = comparePos;
     posEnd   = posStart + 2;
     compare  = '>' + '=';
-    return true;
+    found = true;
   }
 
   if (((comparePos = check.indexOf("<=")) > 0) && (comparePos < posStart)) {
     posStart = comparePos;
     posEnd   = posStart + 2;
     compare  = '<' + '=';
-    return true;
+    found = true;
   }
 
   if (((comparePos = check.indexOf("<")) > 0) && (comparePos < posStart)) {
     posStart = comparePos;
     posEnd   = posStart + 1;
     compare  = '<';
-    return true;
+    found = true;
   }
 
   if (((comparePos = check.indexOf(">")) > 0) && (comparePos < posStart)) {
     posStart = comparePos;
     posEnd   = posStart + 1;
     compare  = '>';
-    return true;
+    found = true;
   }
 
   if (((comparePos = check.indexOf("=")) > 0) && (comparePos < posStart)) {
     posStart = comparePos;
     posEnd   = posStart + 1;
     compare  = '=';
-    return true;
+    found = true;
   }
-  return false;
+  return found;
 }
 
 bool compareValues(char compare, float Value1, float Value2)
@@ -849,7 +852,21 @@ bool conditionMatch(const String& check) {
     }
   }
 
-  return compareValues(compare, Value1, Value2);
+  bool result = compareValues(compare, Value1, Value2);
+  #ifndef BUILD_NO_DEBUG
+  if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+    String log = F("compareValues: _");
+    log += check;
+    log += F("_ val1: ");
+    log += Value1;
+    log += F(" val2: ");
+    log += Value2;
+    log += F(" = ");
+    log += boolToString(result);
+    addLog(LOG_LEVEL_DEBUG, log);
+  }
+  #endif
+  return result;
 }
 
 /********************************************************************************************\

--- a/src/StringProvider.ino
+++ b/src/StringProvider.ino
@@ -91,6 +91,9 @@ String getLabel(LabelType::Enum label) {
     case LabelType::SKETCH_FREE:            return F("Sketch Free");
     case LabelType::SPIFFS_SIZE:            return F("SPIFFS Size");
     case LabelType::SPIFFS_FREE:            return F("SPIFFS Free");
+    case LabelType::MAX_OTA_SKETCH_SIZE:    return F("Max. OTA Sketch Size");
+    case LabelType::OTA_2STEP:              return F("OTA 2-step Needed");
+    case LabelType::OTA_POSSIBLE:           return F("OTA possible");
 
   }
   return F("MissingString");
@@ -189,6 +192,9 @@ String getValue(LabelType::Enum label) {
     case LabelType::SKETCH_FREE:            break;
     case LabelType::SPIFFS_SIZE:            break;
     case LabelType::SPIFFS_FREE:            break;
+    case LabelType::MAX_OTA_SKETCH_SIZE:    break;
+    case LabelType::OTA_2STEP:              break;
+    case LabelType::OTA_POSSIBLE:           break;
 
   }
   return F("MissingString");

--- a/src/StringProviderTypes.h
+++ b/src/StringProviderTypes.h
@@ -91,6 +91,9 @@ enum Enum : short {
   SKETCH_FREE,
   SPIFFS_SIZE,
   SPIFFS_FREE,
+  MAX_OTA_SKETCH_SIZE,
+  OTA_2STEP,
+  OTA_POSSIBLE,
 
 
 };

--- a/src/WebServer_SysInfoPage.ino
+++ b/src/WebServer_SysInfoPage.ino
@@ -521,15 +521,15 @@ void handle_sysinfo_Storage() {
   TXBuffer += RTC.flashCounter;
   TXBuffer += F(" boot");
 
-  addRowLabel(getLabel(LabelType::SKETCH_SIZE));
   # if defined(ESP8266)
-  TXBuffer += ESP.getSketchSize() / 1024;
-  TXBuffer += F(" kB (");
-  TXBuffer += ESP.getFreeSketchSpace() / 1024;
-  TXBuffer += F(" kB free)");
-  # endif // if defined(ESP8266)
-
   {
+    // FIXME TD-er: Must also add this for ESP32.
+    addRowLabel(getLabel(LabelType::SKETCH_SIZE));
+    TXBuffer += ESP.getSketchSize() / 1024;
+    TXBuffer += F(" kB (");
+    TXBuffer += ESP.getFreeSketchSpace() / 1024;
+    TXBuffer += F(" kB free)");
+
     uint32_t maxSketchSize;
     bool     use2step;
     bool     otaEnabled = OTA_possible(maxSketchSize, use2step);
@@ -546,6 +546,7 @@ void handle_sysinfo_Storage() {
     addRowLabel(getLabel(LabelType::OTA_2STEP));
     TXBuffer += boolToString(use2step);
   }
+  # endif // if defined(ESP8266)
 
   addRowLabel(getLabel(LabelType::SPIFFS_SIZE));
   TXBuffer += SpiffsTotalBytes() / 1024;

--- a/src/WebServer_SysInfoPage.ino
+++ b/src/WebServer_SysInfoPage.ino
@@ -529,6 +529,24 @@ void handle_sysinfo_Storage() {
   TXBuffer += F(" kB free)");
   # endif // if defined(ESP8266)
 
+  {
+    uint32_t maxSketchSize;
+    bool     use2step;
+    bool     otaEnabled = OTA_possible(maxSketchSize, use2step);
+
+    addRowLabel(getLabel(LabelType::MAX_OTA_SKETCH_SIZE));
+    TXBuffer += maxSketchSize / 1024;
+    TXBuffer += F(" kB (");
+    TXBuffer += maxSketchSize;
+    TXBuffer += F(" bytes)");
+
+    addRowLabel(getLabel(LabelType::OTA_POSSIBLE));
+    TXBuffer += boolToString(otaEnabled);
+
+    addRowLabel(getLabel(LabelType::OTA_2STEP));
+    TXBuffer += boolToString(use2step);
+  }
+
   addRowLabel(getLabel(LabelType::SPIFFS_SIZE));
   TXBuffer += SpiffsTotalBytes() / 1024;
   TXBuffer += F(" kB (");
@@ -597,4 +615,4 @@ void handle_sysinfo_Storage() {
   # endif // ifdef ESP32
 }
 
-#endif // ifdef WEBSERVER_SYSINFO
+#endif    // ifdef WEBSERVER_SYSINFO

--- a/src/WebServer_ToolsPage.ino
+++ b/src/WebServer_ToolsPage.ino
@@ -136,7 +136,9 @@ void handle_tools() {
       }
       TXBuffer += F(" Max sketch size: ");
       TXBuffer += maxSketchSize / 1024;
-      TXBuffer += F(" kB");
+      TXBuffer += F(" kB (");
+      TXBuffer += maxSketchSize;
+      TXBuffer += F(" bytes)");
     }
     #  endif // ifndef NO_HTTP_UPDATER
   }


### PR DESCRIPTION
Fixes: #2707
The computations did not take into account the needed extra space for 4k block alignment for OTA.

Fixes: #2704
Multiple compares in a rules line would be wrongly computed.