### PR TITLE
fix Publish to send JSON string with ',' char inside

### DIFF
--- a/src/src/Commands/MQTT.cpp
+++ b/src/src/Commands/MQTT.cpp
@@ -52,7 +52,7 @@ String Command_MQTT_Publish(struct EventStruct *event, const char *Line)
     if (enabledMqttController >= 0) {
       // Command structure:  Publish,<topic>,<value>
       String topic = parseStringKeepCase(Line, 2);
-      String value = parseStringKeepCase(Line, 3);
+      String value = parseStringToEndKeepCase(Line, 3);
       addLog(LOG_LEVEL_DEBUG, String(F("Publish: ")) + topic + value);
 
       if ((topic.length() > 0) && (value.length() > 0)) {


### PR DESCRIPTION
for support of rules with Domoticz structure like `Publish domoticz/in,{"idx":26,"nvalue":0,"svalue":"[AQ#TVOC]"}`