### PR TITLE
[MQTT] Update last activity timestamp only when data was sent to broker

### DIFF
--- a/lib/pubsubclient/src/PubSubClient.cpp
+++ b/lib/pubsubclient/src/PubSubClient.cpp
@@ -398,7 +398,8 @@ boolean PubSubClient::publish(const char* topic, const uint8_t* payload, unsigne
             return false;
         }
         // Leave room in the buffer for header and variable length field
-        uint16_t length = writeString(topic,buffer,length);
+        uint16_t length = MQTT_MAX_HEADER_SIZE;
+        length = writeString(topic,buffer,length);
         uint16_t i;
         for (i=0;i<plength;i++) {
             buffer[length++] = payload[i];

--- a/lib/pubsubclient/src/PubSubClient.cpp
+++ b/lib/pubsubclient/src/PubSubClient.cpp
@@ -462,7 +462,7 @@ boolean PubSubClient::publish_P(const char* topic, const uint8_t* payload, unsig
     }
 
     // Header (1 byte) + llen + identifier (2 bytes)  + topic len + payload len
-    const int expectedLength = 1 + llen + 2 + tlen + plength;
+    const unsigned int expectedLength = 1 + llen + 2 + tlen + plength;
     return (rc == expectedLength);
 }
 

--- a/lib/pubsubclient/src/PubSubClient.cpp
+++ b/lib/pubsubclient/src/PubSubClient.cpp
@@ -127,7 +127,7 @@ boolean PubSubClient::connect(const char *id, const char *user, const char *pass
         if (_client->connected()) {
             result = 1;
         } else {
-            if (domain != NULL) {
+            if (domain.length() != 0) {
                 result = _client->connect(this->domain.c_str(), this->port);
             } else {
                 result = _client->connect(this->ip, this->port);

--- a/platformio.ini
+++ b/platformio.ini
@@ -218,7 +218,8 @@ board_build.f_cpu         = 80000000L
 build_flags               = ${debug_flags.build_flags} ${mqtt_flags.build_flags} -DHTTPCLIENT_1_1_COMPATIBLE=0
 build_unflags             = -DDEBUG_ESP_PORT
 lib_deps                  = https://github.com/TD-er/ESPEasySerial.git
-lib_ignore                = ESP32_ping, ESP32WebServer, IRremoteESP8266, HeatpumpIR
+lib_ignore                = ESP32_ping, ESP32WebServer, IRremoteESP8266, HeatpumpIR, SD(esp8266), SDFS
+;lib_ignore                = ESP32_ping, ESP32WebServer, IRremoteESP8266, HeatpumpIR
 lib_ldf_mode              = chain
 lib_archive               = false
 upload_speed              = 115200

--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -159,8 +159,8 @@ void MQTTDisconnect()
   if (MQTTclient.connected()) {
     MQTTclient.disconnect();
     addLog(LOG_LEVEL_INFO, F("MQTT : Disconnected from broker"));
-    updateMQTTclient_connected();
   }
+  updateMQTTclient_connected();
 }
 
 /*********************************************************************************************\
@@ -178,8 +178,8 @@ bool MQTTConnect(int controller_idx)
 
   if (MQTTclient.connected()) {
     MQTTclient.disconnect();
-    updateMQTTclient_connected();
   }
+  updateMQTTclient_connected();
   mqtt = WiFiClient(); // workaround see: https://github.com/esp8266/Arduino/issues/4497#issuecomment-373023864
   mqtt.setTimeout(ControllerSettings.ClientTimeout);
   MQTTclient.setClient(mqtt);

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -2,6 +2,7 @@
 #define _TAIL true
 #define CHUNKED_BUFFER_SIZE          400
 
+#include <WString.h>
 
 #include "src/Globals/Device.h"
 #include "src/Static/WebStaticData.h"
@@ -696,6 +697,48 @@ void getErrorNotifications() {
 #define MENU_INDEX_TOOLS         7
 static byte navMenuIndex = MENU_INDEX_MAIN;
 
+// See https://github.com/letscontrolit/ESPEasy/issues/1650
+String getGpMenuIcon(byte index) {
+  switch (index) {
+    case MENU_INDEX_MAIN          : return F("&#8962;");  
+    case MENU_INDEX_CONFIG        : return F("&#9881;");  
+    case MENU_INDEX_CONTROLLERS   : return F("&#128172;");
+    case MENU_INDEX_HARDWARE      : return F("&#128204;");
+    case MENU_INDEX_DEVICES       : return F("&#128268;");
+    case MENU_INDEX_RULES         : return F("&#10740;"); 
+    case MENU_INDEX_NOTIFICATIONS : return F("&#9993;");  
+    case MENU_INDEX_TOOLS         : return F("&#128295;");
+  }
+  return "";
+}
+
+String getGpMenuLabel(byte index) {
+  switch (index) {
+    case MENU_INDEX_MAIN          : return F("Main");         
+    case MENU_INDEX_CONFIG        : return F("Config");       
+    case MENU_INDEX_CONTROLLERS   : return F("Controllers");  
+    case MENU_INDEX_HARDWARE      : return F("Hardware");     
+    case MENU_INDEX_DEVICES       : return F("Devices");      
+    case MENU_INDEX_RULES         : return F("Rules");        
+    case MENU_INDEX_NOTIFICATIONS : return F("Notifications");
+    case MENU_INDEX_TOOLS         : return F("Tools");        
+  }
+  return "";
+}
+
+String getGpMenuURL(byte index) {
+  switch (index) {
+    case MENU_INDEX_MAIN          : return F("/");             
+    case MENU_INDEX_CONFIG        : return F("/config");       
+    case MENU_INDEX_CONTROLLERS   : return F("/controllers");  
+    case MENU_INDEX_HARDWARE      : return F("/hardware");     
+    case MENU_INDEX_DEVICES       : return F("/devices");      
+    case MENU_INDEX_RULES         : return F("/rules");        
+    case MENU_INDEX_NOTIFICATIONS : return F("/notifications");
+    case MENU_INDEX_TOOLS         : return F("/tools");        
+  }
+  return "";
+}
 
 void getWebPageTemplateVar(const String& varName)
 {
@@ -715,19 +758,6 @@ void getWebPageTemplateVar(const String& varName)
 
   else if (varName == F("menu"))
   {
-    static const __FlashStringHelper *gpMenu[8][3] = {
-      // See https://github.com/letscontrolit/ESPEasy/issues/1650
-      // Icon,        Full width label,   URL
-      F("&#8962;"),   F("Main"),          F("/"),              // 0
-      F("&#9881;"),   F("Config"),        F("/config"),        // 1
-      F("&#128172;"), F("Controllers"),   F("/controllers"),   // 2
-      F("&#128204;"), F("Hardware"),      F("/hardware"),      // 3
-      F("&#128268;"), F("Devices"),       F("/devices"),       // 4
-      F("&#10740;"),  F("Rules"),         F("/rules"),         // 5
-      F("&#9993;"),   F("Notifications"), F("/notifications"), // 6
-      F("&#128295;"), F("Tools"),         F("/tools"),         // 7
-    };
-
     TXBuffer += F("<div class='menubar'>");
 
     for (byte i = 0; i < 8; i++)
@@ -748,11 +778,11 @@ void getWebPageTemplateVar(const String& varName)
         TXBuffer += F(" active");
       }
       TXBuffer += F("' href='");
-      TXBuffer += gpMenu[i][2];
+      TXBuffer += getGpMenuURL(i);
       TXBuffer += "'>";
-      TXBuffer += gpMenu[i][0];
+      TXBuffer += getGpMenuIcon(i);
       TXBuffer += F("<span class='showmenulabel'>");
-      TXBuffer += gpMenu[i][1];
+      TXBuffer += getGpMenuLabel(i);
       TXBuffer += F("</span>");
       TXBuffer += F("</a>");
     }

--- a/src/_C002.ino
+++ b/src/_C002.ino
@@ -134,14 +134,15 @@ bool CPlugin_002(byte function, struct EventStruct *event, String& string)
                   }
                   break;
                 }
-#ifdef USES_P115
+#if defined(USES_P088) || defined(USES_P115)
+                case 88: // Send heatpump IR (P088) if IDX matches
                 case 115: // Send heatpump IR (P115) if IDX matches
                 {
                   action = F("heatpumpir,");
                   action += svalue1; // svalue1 is like 'gree,1,1,0,22,0,0'
                   break;
                 }
-#endif // USES_P115
+#endif // USES_P088 || USES_P115
                 default:
                   break;
               }

--- a/src/define_plugin_sets.h
+++ b/src/define_plugin_sets.h
@@ -21,7 +21,7 @@ To create/register a plugin, you have to :
  adding "#define PLUGIN_BUILD_DEV" at the top of the ESPEasy.ino file
  - You will then have to push a PR including your plugin + the corret line (#define USES_P777) added to this file
 
- When found stable enought, the maintainer (and only him) will choose to move it to TESTING or STABLE
+ When found stable enough, the maintainer (and only him) will choose to move it to TESTING or STABLE
 */
 
 //#define FEATURE_SD


### PR DESCRIPTION
The PubSubClient does keep track of the last incoming and outgoing activity.
These timestamps are used to determine when a keep-alive packet has to be sent.
However, there was no check for the return value of writing data to the broker.
So the client could mistakenly assume it was sending keep-alive packets while the broker was not receiving any.
This can lead to strange situations where the connected state was not the same on the client side and the broker side.