### PR TITLE
Adding the subscribe command

### DIFF
--- a/src/Command.ino
+++ b/src/Command.ino
@@ -198,6 +198,7 @@ String doExecuteCommand(const char *cmd, struct EventStruct *event, const char *
     }
     case 's': {
       COMMAND_CASE(       "save", Command_Settings_Save,   0); // Settings.h
+	    COMMAND_CASE(  "subscribe", Command_MQTT_Subscribe,  1);  // MQTT.h  //MFD: adding subscrie command
         #ifdef FEATURE_SD
       COMMAND_CASE(     "sdcard", Command_SD_LS,           0); // SDCARDS.h
       COMMAND_CASE(   "sdremove", Command_SD_Remove,       1); // SDCARDS.h

--- a/src/src/Commands/MQTT.cpp
+++ b/src/src/Commands/MQTT.cpp
@@ -74,4 +74,27 @@ String Command_MQTT_Publish(struct EventStruct *event, const char *Line)
   return return_not_connected();
 }
 
+//MFD: adding subscribe command
+String Command_MQTT_Subscribe(struct EventStruct *event, const char* Line)
+{
+  if (wifiStatus == ESPEASY_WIFI_SERVICES_INITIALIZED ) {
+    // ToDo TD-er: Not sure about this function, but at least it sends to an existing MQTTclient
+    int enabledMqttController = firstEnabledMQTTController();
+    if (enabledMqttController >= 0) {
+      String eventName = Line;
+      String topic = eventName.substring(10);
+      if (MQTTsubscribe(enabledMqttController, topic.c_str(), Settings.MQTTRetainFlag))
+      {
+        return return_command_success();
+      }
+      else
+        return return_command_failed();
+
+    }
+    return F("No MQTT controller enabled");
+  }
+  return return_not_connected();
+}
+
+
 #endif // ifdef USES_MQTT

--- a/src/src/Commands/MQTT.h
+++ b/src/src/Commands/MQTT.h
@@ -19,4 +19,8 @@ String Command_MQTT_Publish(struct EventStruct *event,
 #endif // ifdef USES_MQTT
 
 
+//MFD: adding subscribe command
+extern boolean MQTTsubscribe(int controller_idx, const char* topic, boolean retained);
+String Command_MQTT_Subscribe(struct EventStruct *event, const char* Line);
+
 #endif // COMMAND_MQTT_H


### PR DESCRIPTION
 Adding the subscribe command to allow for subscribing to other topic in the rules.
For example when MQTT#connect event is fired all the devices can subscribe to a specific topic thus all responding to the same command if needed. 
Can act as a broadcast and founded very useful in my setup.
NOTE: 
All the supporting functions are there and just added the wrapper function and the entry point.