### PR TITLE
Adding the subscribe command

### DIFF
--- a/docs/source/Plugin/P000_commands.repl
+++ b/docs/source/Plugin/P000_commands.repl
@@ -166,6 +166,12 @@
 
     ``Publish,<topic>,<value>``"
     "
+    Subscribe","
+    :green:`Rules`","
+    Subscribes to a specific topic using MQTT broker service
+
+    ``Subscribe,<topic>``"
+    "
     SendTo","
     :green:`Rules`","
     Send command to other ESP (using UDP)

--- a/src/Command.ino
+++ b/src/Command.ino
@@ -198,6 +198,7 @@ String doExecuteCommand(const char *cmd, struct EventStruct *event, const char *
     }
     case 's': {
       COMMAND_CASE(       "save", Command_Settings_Save,   0); // Settings.h
+	  COMMAND_CASE(  "subscribe", Command_MQTT_Subscribe,  1);  // MQTT.h  //MFD: adding subscrie command
         #ifdef FEATURE_SD
       COMMAND_CASE(     "sdcard", Command_SD_LS,           0); // SDCARDS.h
       COMMAND_CASE(   "sdremove", Command_SD_Remove,       1); // SDCARDS.h

--- a/src/Command.ino
+++ b/src/Command.ino
@@ -198,7 +198,9 @@ String doExecuteCommand(const char *cmd, struct EventStruct *event, const char *
     }
     case 's': {
       COMMAND_CASE(       "save", Command_Settings_Save,   0); // Settings.h
-	    COMMAND_CASE(  "subscribe", Command_MQTT_Subscribe,  1);  // MQTT.h  //MFD: adding subscrie command
+    #ifdef USES_MQTT
+	    COMMAND_CASE(  "subscribe", Command_MQTT_Subscribe,  1);  // MQTT.h  
+    #endif // USES_MQTT
         #ifdef FEATURE_SD
       COMMAND_CASE(     "sdcard", Command_SD_LS,           0); // SDCARDS.h
       COMMAND_CASE(   "sdremove", Command_SD_Remove,       1); // SDCARDS.h

--- a/src/Command.ino
+++ b/src/Command.ino
@@ -198,7 +198,7 @@ String doExecuteCommand(const char *cmd, struct EventStruct *event, const char *
     }
     case 's': {
       COMMAND_CASE(       "save", Command_Settings_Save,   0); // Settings.h
-	  COMMAND_CASE(  "subscribe", Command_MQTT_Subscribe,  1);  // MQTT.h  //MFD: adding subscrie command
+	    COMMAND_CASE(  "subscribe", Command_MQTT_Subscribe,  1);  // MQTT.h  //MFD: adding subscrie command
         #ifdef FEATURE_SD
       COMMAND_CASE(     "sdcard", Command_SD_LS,           0); // SDCARDS.h
       COMMAND_CASE(   "sdremove", Command_SD_Remove,       1); // SDCARDS.h

--- a/src/ESPEasy_fdwdecl.h
+++ b/src/ESPEasy_fdwdecl.h
@@ -190,4 +190,6 @@ void printDirectory(File dir, int numTabs);
 
 void delayBackground(unsigned long dsdelay);
 
+void setIntervalTimerOverride(unsigned long id, unsigned long msecFromNow); //implemented in Scheduler.ino
+
 #endif // ESPEASY_FWD_DECL_H

--- a/src/src/Commands/MQTT.cpp
+++ b/src/src/Commands/MQTT.cpp
@@ -75,7 +75,7 @@ String Command_MQTT_Publish(struct EventStruct *event, const char *Line)
   return return_not_connected();
 }
 
-//MFD: adding subscribe command
+
 boolean MQTTsubscribe(int controller_idx, const char* topic, boolean retained)
 {
   if (MQTTclient.subscribe(topic)) {

--- a/src/src/Commands/MQTT.cpp
+++ b/src/src/Commands/MQTT.cpp
@@ -1,5 +1,6 @@
 #include "../../define_plugin_sets.h"
-
+#include "../Globals/MQTT.h"
+#include "../DataStructs/SchedulerTimers.h"
 #ifdef USES_MQTT
 
 #include "../Commands/MQTT.h"
@@ -73,5 +74,36 @@ String Command_MQTT_Publish(struct EventStruct *event, const char *Line)
   }
   return return_not_connected();
 }
+
+//MFD: adding subscribe command
+boolean MQTTsubscribe(int controller_idx, const char* topic, boolean retained)
+{
+  if (MQTTclient.subscribe(topic)) {
+    setIntervalTimerOverride(TIMER_MQTT, 10); // Make sure the MQTT is being processed as soon as possible.
+    String log = F("Subscribed to: ");  log += topic;
+    addLog(LOG_LEVEL_INFO, log);
+    return true;
+  }
+  addLog(LOG_LEVEL_ERROR, F("MQTT : subscribe failed"));
+  return false;
+}
+
+String Command_MQTT_Subscribe(struct EventStruct *event, const char* Line)
+{
+  if (MQTTclient.connected() ) {
+    // ToDo TD-er: Not sure about this function, but at least it sends to an existing MQTTclient
+    int enabledMqttController = firstEnabledMQTTController();
+    if (enabledMqttController >= 0) {
+      String eventName = Line;
+      String topic = eventName.substring(10);
+      if (!MQTTsubscribe(enabledMqttController, topic.c_str(), Settings.MQTTRetainFlag))
+         return_command_failed();
+      return_command_success();
+    }
+    return F("No MQTT controller enabled");
+  }
+  return return_not_connected();
+}
+
 
 #endif // ifdef USES_MQTT

--- a/src/src/Commands/MQTT.h
+++ b/src/src/Commands/MQTT.h
@@ -16,7 +16,13 @@ String Command_MQTT_messageDelay(struct EventStruct *event,
 String Command_MQTT_Publish(struct EventStruct *event,
                             const char         *Line);
 
-#endif // ifdef USES_MQTT
 
+
+
+//MFD: adding subscribe command
+extern void setIntervalTimerOverride(unsigned long id, unsigned long msecFromNow); //defined in Scheduler.ino
+String Command_MQTT_Subscribe(struct EventStruct *event, const char* Line);
+
+#endif // ifdef USES_MQTT
 
 #endif // COMMAND_MQTT_H

--- a/src/src/Commands/MQTT.h
+++ b/src/src/Commands/MQTT.h
@@ -16,13 +16,8 @@ String Command_MQTT_messageDelay(struct EventStruct *event,
 String Command_MQTT_Publish(struct EventStruct *event,
                             const char         *Line);
 
-
-
-
-//MFD: adding subscribe command
-extern void setIntervalTimerOverride(unsigned long id, unsigned long msecFromNow); //defined in Scheduler.ino
-boolean MQTTsubscribe(int controller_idx, const char* topic, boolean retained);
-String Command_MQTT_Subscribe(struct EventStruct *event, const char* Line);
+String Command_MQTT_Subscribe(struct EventStruct *event,
+                              const char* Line);
 
 #endif // ifdef USES_MQTT
 

--- a/src/src/Commands/MQTT.h
+++ b/src/src/Commands/MQTT.h
@@ -21,6 +21,7 @@ String Command_MQTT_Publish(struct EventStruct *event,
 
 //MFD: adding subscribe command
 extern void setIntervalTimerOverride(unsigned long id, unsigned long msecFromNow); //defined in Scheduler.ino
+boolean MQTTsubscribe(int controller_idx, const char* topic, boolean retained);
 String Command_MQTT_Subscribe(struct EventStruct *event, const char* Line);
 
 #endif // ifdef USES_MQTT


### PR DESCRIPTION
Adding the subscribe command to allow for subscribing to other topic in the rules.
For example when MQTT#connect event is fired all the devices can subscribe to a specific topic thus all responding to the same command if needed.
Can act as a broadcast and founded very useful in my setup.
NOTE:
All the supporting functions are there and just added the wrapper function and the entry point.