### PR TITLE
Add options in custom.h to enable first controller at startup

### DIFF
--- a/src/Custom-sample.h
+++ b/src/Custom-sample.h
@@ -65,6 +65,7 @@
 // --- Default Controller ------------------------------------------------------------------------------
 #define DEFAULT_CONTROLLER   false                                          // true or false enabled or disabled, set 1st controller
                                                                             // defaults
+#define DEFAULT_CONTROLLER_ENABLED true                                     // Enable default controller by default
 
 // using a default template, you also need to set a DEFAULT PROTOCOL to a suitable MQTT protocol !
 #define DEFAULT_PUB         "sensors/espeasy/%sysname%/%tskname%/%valname%" // Enter your pub

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -1215,7 +1215,7 @@ void ResetFactory()
 
   // advanced Settings
   Settings.UseRules 		= DEFAULT_USE_RULES;
-
+  Settings.ControllerEnabled[0] = DEFAULT_CONTROLLER_ENABLED;
   Settings.MQTTRetainFlag	= DEFAULT_MQTT_RETAIN;
   Settings.MessageDelay	= DEFAULT_MQTT_DELAY;
   Settings.MQTTUseUnitNameAsClientId = DEFAULT_MQTT_USE_UNITNAME_AS_CLIENTID;

--- a/src/src/DataStructs/ESPEasyDefaults.h
+++ b/src/src/DataStructs/ESPEasyDefaults.h
@@ -89,6 +89,10 @@
 #ifndef DEFAULT_CONTROLLER
 #define DEFAULT_CONTROLLER   false              // true or false enabled or disabled, set 1st controller defaults
 #endif
+
+#ifndef DEFAULT_CONTROLLER_ENABLED
+#define DEFAULT_CONTROLLER_ENABLED   false     // Enable default controller by default
+#endif
 // using a default template, you also need to set a DEFAULT PROTOCOL to a suitable MQTT protocol !
 #ifndef DEFAULT_PUB
 #define DEFAULT_PUB         "sensors/espeasy/%sysname%/%tskname%/%valname%" // Enter your pub


### PR DESCRIPTION
By default the controller is disabled. Add an option in the custom.h file to enable it at startup.

For example, it can be used to automatically flash ESP and let them connect to the MQTT broker without any required actions by the user. We can easily check that the ESP is correctly connected by checking message in the default topic.