### PR TITLE
Clean Warning messages inside external libraries: AS_BH1750 & Adafruit

### DIFF
--- a/lib/AS_BH1750/AS_BH1750A.cpp
+++ b/lib/AS_BH1750/AS_BH1750A.cpp
@@ -515,7 +515,7 @@ bool AS_BH1750A::startMeasurementAsync(TimeFuncPtr fTimePtr) {
   _fTimePtr = fTimePtr;
   _stage = 0;
   _nextDelay = 0;
-  int _lastResult = -1;
+  //int _lastResult = -1;
   _lastTimestamp=fTimePtr();
   return readLightLevelAsync()!=-1;
 }

--- a/lib/AS_BH1750/AS_BH1750A.h
+++ b/lib/AS_BH1750/AS_BH1750A.h
@@ -77,7 +77,7 @@
 // Device is automatically set to Power Down after measurement.
 #define BH1750_ONE_TIME_LOW_RES_MODE  0x23
 
-#define MAX_U_LONG 4294967295;
+#define MAX_U_LONG 4294967295
 
 /** Virtual Modi */
 typedef enum
@@ -192,8 +192,8 @@ private:
   
   TimeFuncPtr _fTimePtr;
   int _stage = 0;
-  int _nextDelay = 0;
-  int _lastTimestamp = 0;
+  unsigned long _nextDelay = 0;
+  unsigned long _lastTimestamp = 0;
   float _lastResult = -100;
   bool delayExpired();
   void selectAutoMode();

--- a/lib/Adafruit_Motor_Shield_V2/Adafruit_MotorShield.cpp
+++ b/lib/Adafruit_Motor_Shield_V2/Adafruit_MotorShield.cpp
@@ -74,7 +74,7 @@ Adafruit_DCMotor *Adafruit_MotorShield::getMotor(uint8_t num) {
     // not init'd yet!
     dcmotors[num].motornum = num;
     dcmotors[num].MC = this;
-    uint8_t pwm, in1, in2;
+    uint8_t pwm=0, in1=0, in2=0;
     if (num == 0) {
       pwm = 8; in2 = 9; in1 = 10;
     } else if (num == 1) {
@@ -102,7 +102,7 @@ Adafruit_StepperMotor *Adafruit_MotorShield::getStepper(uint16_t steps, uint8_t 
     steppers[num].steppernum = num;
     steppers[num].revsteps = steps;
     steppers[num].MC = this;
-    uint8_t pwma, pwmb, ain1, ain2, bin1, bin2;
+    uint8_t pwma=0, pwmb=0, ain1=0, ain2=0, bin1=0, bin2=0;
     if (num == 0) {
       pwma = 8; ain2 = 9; ain1 = 10;
       pwmb = 13; bin2 = 12; bin1 = 11;
@@ -217,7 +217,7 @@ void Adafruit_StepperMotor::release(void) {
 
 void Adafruit_StepperMotor::step(uint16_t steps, uint8_t dir,  uint8_t style) {
   uint32_t uspers = usperstep;
-  uint8_t ret = 0;
+  //uint8_t ret = 0;
 
   if (style == INTERLEAVE) {
     uspers /= 2;
@@ -232,14 +232,14 @@ void Adafruit_StepperMotor::step(uint16_t steps, uint8_t dir,  uint8_t style) {
 
   while (steps--) {
     //Serial.println("step!"); Serial.println(uspers);
-    ret = onestep(dir, style);
+    onestep(dir, style);
     delayMicroseconds(uspers);
     yield(); // required for ESP8266
   }
 }
 
 uint8_t Adafruit_StepperMotor::onestep(uint8_t dir, uint8_t style) {
-  uint8_t a, b, c, d;
+  //uint8_t a, b, c, d;
   uint8_t ocrb, ocra;
 
   ocra = ocrb = 255;

--- a/lib/Adafruit_SGP30-1.0.0.13/Adafruit_SGP30.cpp
+++ b/lib/Adafruit_SGP30-1.0.0.13/Adafruit_SGP30.cpp
@@ -165,7 +165,7 @@ boolean Adafruit_SGP30::setIAQBaseline(uint16_t eco2_base, uint16_t tvoc_base) {
 
 boolean Adafruit_SGP30::readWordFromCommand(uint8_t command[], uint8_t commandLength, uint16_t delayms, uint16_t *readdata, uint8_t readlen)
 {
-  uint8_t data;
+  //uint8_t data;
 
   _i2c->beginTransmission(_i2caddr);
 

--- a/lib/Adafruit_TSL2591/Adafruit_TSL2591.cpp
+++ b/lib/Adafruit_TSL2591/Adafruit_TSL2591.cpp
@@ -175,7 +175,7 @@ float Adafruit_TSL2591::calculateLuxf(uint16_t ch0, uint16_t ch1)
 {
   float    atime, again;
   float    cpl, lux1, lux2, lux;
-  uint32_t chan0, chan1;
+  //uint32_t chan0, chan1;
 
   // Check for overflow conditions first
   if ((ch0 == 0xFFFF) | (ch1 == 0xFFFF))


### PR DESCRIPTION
There were type incompatibilities, unused variables and uninitialized variables inside external libraries.
I also found a #define MAX_U_LONG  that had semicolon at end then later on was used inside formulas thus compiler ignoring everything after it.