### PR TITLE
[DHT]New DHT11 support decimal and negative values.

### DIFF
--- a/src/_P005_DHT.ino
+++ b/src/_P005_DHT.ino
@@ -205,9 +205,6 @@ bool P005_do_plugin_read(struct EventStruct *event) {
   float humidity = NAN;
   switch (Par3) {
     case P005_DHT11:
-      temperature = float(dht_dat[2]); // Temperature
-      humidity = float(dht_dat[0]); // Humidity
-      break;
     case P005_DHT12:
       temperature = float(dht_dat[2]*10 + (dht_dat[3] & 0x7f)) / 10.0; // Temperature
       if (dht_dat[3] & 0x80) { temperature = -temperature; } // Negative temperature


### PR DESCRIPTION
New ASAIR brand DHT11 can support decimal and negative values.
Change conversion coding As same as DHT12.
Old type DHT11 also OK.

DHT11 datasheet. 2017-03-31 V1.3
4. 5.2 temperature parameter list to update the tabular form, measuring
range is 0 to 50 to - 20 to 60 .