### PR TITLE
[Rules] Parse template for all command calls

### DIFF
--- a/docs/source/Controller/C013.rst
+++ b/docs/source/Controller/C013.rst
@@ -175,13 +175,7 @@ The entire message processed as a command like this:
 .. code-block:: C++
 
   packetBuffer[len] = 0;
-  String request = &packetBuffer[0];
-  struct EventStruct TempEvent;
-  parseCommandString(&TempEvent, request);
-  TempEvent.Source = VALUE_SOURCE_SYSTEM;
-  if (!PluginCall(PLUGIN_WRITE, &TempEvent, request)) {
-    ExecuteCommand(VALUE_SOURCE_SYSTEM, &packetBuffer[0]);
-  }
+  ExecuteCommand_all(VALUE_SOURCE_SYSTEM, &packetBuffer[0]);
 
 As can be seen, no checks for size, and it is just expected to be a valid ESPeasy command.
 Also no check to see if the command is supported by the receiving end and no feedback to the sender.

--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -329,15 +329,22 @@ bool MQTTCheck(int controller_idx)
 /*********************************************************************************************\
 * Send status info to request source
 \*********************************************************************************************/
-void SendStatusOnlyIfNeeded(int eventSource, bool param1, uint32_t key, const String& param2, int16_t param3) {
+void SendStatusOnlyIfNeeded(byte eventSource, bool param1, uint32_t key, const String& param2, int16_t param3) {
+  if (SourceNeedsStatusUpdate(eventSource)) {
+    SendStatus(eventSource, getPinStateJSON(param1, key, param2, param3));
+  }
+}
+
+bool SourceNeedsStatusUpdate(byte eventSource)
+{
   switch (eventSource) {
     case VALUE_SOURCE_HTTP:
     case VALUE_SOURCE_SERIAL:
     case VALUE_SOURCE_MQTT:
     case VALUE_SOURCE_WEB_FRONTEND:
-      SendStatus(eventSource, getPinStateJSON(param1, key, param2, param3));
-      break;
+      return true;
   }
+  return false;
 }
 
 void SendStatus(byte source, const String& status)

--- a/src/Custom-sample.h
+++ b/src/Custom-sample.h
@@ -60,7 +60,9 @@
 #define DEFAULT_WIFI_NONE_SLEEP              false // When set, the wifi will be set to no longer sleep (more power
 // used and need reboot to reset mode)
 #define DEFAULT_GRATUITOUS_ARP               false // When set, the node will send periodical gratuitous ARP
-// packets to announce itself.
+                                                   // packets to announce itself.
+#define DEFAULT_TOLERANT_LAST_ARG_PARSE      false // When set, the last argument of some commands will be parsed to the end of the line
+                                                   // See: https://github.com/letscontrolit/ESPEasy/issues/2724
 
 // --- Default Controller ------------------------------------------------------------------------------
 #define DEFAULT_CONTROLLER   false                                          // true or false enabled or disabled, set 1st controller

--- a/src/ESPEasy-Globals.cpp
+++ b/src/ESPEasy-Globals.cpp
@@ -2,6 +2,7 @@
 
 #include "ESPEasy-Globals.h"
 
+
 NotificationStruct Notification[NPLUGIN_MAX];
 
 #if defined(ESP32)
@@ -76,7 +77,7 @@ bool webserverRunning(false);
 bool webserver_init(false);
 
 
-String eventBuffer;
+EventQueueStruct eventQueue;
 
 
 

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -28,6 +28,7 @@
 #include "ESPEasy_fdwdecl.h"
 
 #include "src/DataStructs/ESPEasyLimits.h"
+#include "src/DataStructs/EventQueue.h"
 #include "ESPEasy_plugindefs.h"
 
 
@@ -342,7 +343,7 @@ extern bool webserverRunning;
 extern bool webserver_init;
 
 
-extern String eventBuffer;
+extern EventQueueStruct eventQueue;
 
 
 extern bool shouldReboot;

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -326,8 +326,7 @@ extern String dummyString;  // FIXME @TD-er  This may take a lot of memory over 
 enum PluginPtrType {
   TaskPluginEnum,
   ControllerPluginEnum,
-  NotificationPluginEnum,
-  CommandTimerEnum
+  NotificationPluginEnum
 };
 void schedule_event_timer(PluginPtrType ptr_type, byte Index, byte Function, struct EventStruct* event);
 unsigned long createSystemEventMixedId(PluginPtrType ptr_type, byte Index, byte Function);

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -359,13 +359,13 @@ void setup()
   {
     String event = F("System#NoSleep=");
     event += Settings.deepSleep_wakeTime;
-    rulesProcessing(event);
+    rulesProcessing(event); // TD-er: Process events in the setup() now.
   }
 
   if (Settings.UseRules)
   {
     String event = F("System#Wake");
-    rulesProcessing(event);
+    rulesProcessing(event); // TD-er: Process events in the setup() now.
   }
 
   WiFiConnectRelaxed();
@@ -394,7 +394,7 @@ void setup()
   if (Settings.UseRules)
   {
     String event = F("System#Boot");
-    rulesProcessing(event);
+    rulesProcessing(event); // TD-er: Process events in the setup() now.
   }
 
   writeDefaultCSS();
@@ -556,7 +556,7 @@ void loop()
      {
         String event = F("System#NoSleep=");
         event += Settings.deepSleep_wakeTime;
-        rulesProcessing(event);
+        eventQueue.add(event);
      }
 
 
@@ -643,8 +643,11 @@ void updateMQTTclient_connected() {
       schedule_all_tasks_using_MQTT_controller();
     }
     if (Settings.UseRules) {
-      String event = MQTTclient_connected ? F("MQTT#Connected") : F("MQTT#Disconnected");
-      rulesProcessing(event);
+      if (MQTTclient_connected) {
+        eventQueue.add(F("MQTT#Connected"));
+      } else {
+        eventQueue.add(F("MQTT#Disconnected"));
+      }
     }
   }
   if (!MQTTclient_connected) {
@@ -736,10 +739,9 @@ void run10TimesPerSecond() {
     PluginCall(PLUGIN_MONITOR, 0, dummy);
     STOP_TIMER(PLUGIN_CALL_10PSU);
   }
-  if (Settings.UseRules && eventBuffer.length() > 0)
+  if (Settings.UseRules)
   {
-    rulesProcessing(eventBuffer);
-    eventBuffer = "";
+    processNextEvent();
   }
   #ifdef USES_C015
   if (WiFiConnected())

--- a/src/ESPEasyRules.ino
+++ b/src/ESPEasyRules.ino
@@ -550,32 +550,7 @@ void processMatchedRule(String& action, String& event,
       addLog(LOG_LEVEL_INFO, log);
     }
 
-    struct EventStruct TempEvent;
-    parseCommandString(&TempEvent, action);
-
-    // FIXME TD-er: This part seems a bit strange.
-    // It can't schedule a call to PLUGIN_WRITE.
-    // Maybe ExecuteCommand can be scheduled?
-    delay(0);
-
-    // Use a tmp string to call PLUGIN_WRITE, since PluginCall may inadvertenly
-    // alter the string.
-    String tmpAction(action);
-
-    if (!PluginCall(PLUGIN_WRITE, &TempEvent, tmpAction)) {
-      if (!tmpAction.equals(action)) {
-        if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
-          String log = F("PLUGIN_WRITE altered the string: ");
-          log += action;
-          log += F(" to: ");
-          log += tmpAction;
-          addLog(LOG_LEVEL_ERROR, log);
-        }
-
-        // TODO: assign here modified action???
-      }
-      ExecuteCommand(VALUE_SOURCE_SYSTEM, action.c_str());
-    }
+    ExecuteCommand_all(VALUE_SOURCE_SYSTEM, action.c_str());
     delay(0);
   }
 }

--- a/src/ESPEasyStorage.ino
+++ b/src/ESPEasyStorage.ino
@@ -297,6 +297,9 @@ void afterloadSettings() {
     ResetFactoryDefaultPreference = Settings.ResetFactoryDefaultPreference;
   }
   msecTimerHandler.setEcoMode(Settings.EcoPowerMode());
+  if (!Settings.UseRules) {
+    eventQueue.clear();
+  }
   set_mDNS(); // To update changes in hostname.
 }
 

--- a/src/ESPEasyWifi.ino
+++ b/src/ESPEasyWifi.ino
@@ -391,8 +391,7 @@ void setAPinternal(bool enable)
 
     if (WiFi.softAP(softAPSSID.c_str(), pwd.c_str())) {
       if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-        String event = F("WiFi#APmodeEnabled");
-        rulesProcessing(event);
+        eventQueue.add(F("WiFi#APmodeEnabled"));
         String log(F("WIFI : AP Mode ssid will be "));
         log += softAPSSID;
         log += F(" with address ");
@@ -477,8 +476,7 @@ void setWifiMode(WiFiMode_t wifimode) {
   bool new_mode_AP_enabled = WifiIsAP(wifimode);
 
   if (WifiIsAP(cur_mode) && !new_mode_AP_enabled) {
-    String event = F("WiFi#APmodeDisabled");
-    rulesProcessing(event);
+    eventQueue.add(F("WiFi#APmodeDisabled"));
   }
 
   if (WifiIsAP(cur_mode) != new_mode_AP_enabled) {

--- a/src/ESPEasyWifi_ProcessEvent.ino
+++ b/src/ESPEasyWifi_ProcessEvent.ino
@@ -132,8 +132,7 @@ void processDisconnect() {
   delay(100); // FIXME TD-er: See https://github.com/letscontrolit/ESPEasy/issues/1987#issuecomment-451644424
 
   if (Settings.UseRules) {
-    String event = F("WiFi#Disconnected");
-    rulesProcessing(event);
+    eventQueue.add(F("WiFi#Disconnected"));
   }
 
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
@@ -182,15 +181,15 @@ void processConnect() {
     addLog(LOG_LEVEL_INFO, log);
   }
 
-  if (Settings.UseRules && bssid_changed) {
-    String event = F("WiFi#ChangedAccesspoint");
-    rulesProcessing(event);
-  }
+  if (Settings.UseRules) {
+    if (bssid_changed) {
+      eventQueue.add(F("WiFi#ChangedAccesspoint"));
+    }
 
-  if (Settings.UseRules && channel_changed) {
-    String event = F("WiFi#ChangedWiFichannel");
-    rulesProcessing(event);
-  }
+    if (channel_changed) {
+      eventQueue.add(F("WiFi#ChangedWiFichannel"));
+    }
+  } 
 
   if (useStaticIP()) {
     markGotIP(); // in static IP config the got IP event is never fired.
@@ -270,8 +269,7 @@ void processGotIP() {
 
   if (Settings.UseRules)
   {
-    String event = F("WiFi#Connected");
-    rulesProcessing(event);
+    eventQueue.add(F("WiFi#Connected"));
   }
   statusLED(true);
 

--- a/src/ESPEasy_fdwdecl.h
+++ b/src/ESPEasy_fdwdecl.h
@@ -165,7 +165,7 @@ String describeAllowedIPrange();
 void clearAccessBlock();
 String rulesProcessingFile(const String& fileName, String& event);
 int Calculate(const char *input, float* result);
-
+bool SourceNeedsStatusUpdate(byte eventSource);
 
 void WifiScan(bool async, bool quick = false);
 void WifiScan();

--- a/src/ESPEasy_fdwdecl.h
+++ b/src/ESPEasy_fdwdecl.h
@@ -158,6 +158,7 @@ String parseString(const String& string, byte indexFind);
 String parseStringKeepCase(const String& string, byte indexFind);
 String parseStringToEnd(const String& string, byte indexFind);
 String parseStringToEndKeepCase(const String& string, byte indexFind);
+String tolerantParseStringKeepCase(const String& string, byte indexFind);
 
 int parseCommandArgumentInt(const String& string, unsigned int argc);
 

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -409,8 +409,10 @@ void prepare_deepSleep(int dsdelay)
 
     if (Settings.UseRules && isDeepSleepEnabled())
     {
-      String event = F("System#NoSleep=30");
-      rulesProcessing(event);
+      eventQueue.add(F("System#NoSleep=30"));
+      while (processNextEvent()) {
+        delay(1);
+      }
     }
     delayBackground(30000);
 
@@ -429,8 +431,10 @@ void deepSleepStart(int dsdelay)
   // separate function that is called from above function or directly from rules, usign deepSleep_wakeTime as a one-shot
   if (Settings.UseRules)
   {
-    String event = F("System#Sleep");
-    rulesProcessing(event);
+    eventQueue.add(F("System#Sleep"));
+    while (processNextEvent()) {
+      delay(1);
+    }
   }
 
   addLog(LOG_LEVEL_INFO, F("SLEEP: Powering down to deepsleep..."));

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -476,6 +476,8 @@ bool remoteConfig(struct EventStruct *event, const String& string)
     if (parseString(string, 2) == F("task"))
     {
       String configTaskName = parseStringKeepCase(string, 3);
+      // FIXME TD-er: This command is not using the tolerance setting
+      // tolerantParseStringKeepCase(Line, 4);
       String configCommand  = parseStringToEndKeepCase(string, 4);
 
       if ((configTaskName.length() == 0) || (configCommand.length() == 0)) {

--- a/src/Networking.ino
+++ b/src/Networking.ino
@@ -138,17 +138,8 @@ void checkUDP()
         if (packetBuffer[0] != 255)
         {
           packetBuffer[len] = 0;
-          String request = &packetBuffer[0];
-#ifndef BUILD_NO_DEBUG
-          addLog(LOG_LEVEL_DEBUG, request);
-#endif // ifndef BUILD_NO_DEBUG
-          struct EventStruct TempEvent;
-          parseCommandString(&TempEvent, request);
-          TempEvent.Source = VALUE_SOURCE_SYSTEM;
-
-          if (!PluginCall(PLUGIN_WRITE, &TempEvent, request)) {
-            ExecuteCommand(VALUE_SOURCE_SYSTEM, &packetBuffer[0]);
-          }
+          addLog(LOG_LEVEL_DEBUG, &packetBuffer[0]);
+          ExecuteCommand_all(VALUE_SOURCE_SYSTEM, &packetBuffer[0]);
         }
         else
         {

--- a/src/Serial.ino
+++ b/src/Serial.ino
@@ -35,15 +35,7 @@ void serial()
       InputBuffer_Serial[SerialInByteCounter] = 0; // serial data completed
       Serial.write('>');
       serialPrintln(InputBuffer_Serial);
-      String action = InputBuffer_Serial;
-      struct EventStruct TempEvent;
-      action = parseTemplate(action, action.length()); // @giig1967g: parseTemplate before executing the command bug#1977
-      parseCommandString(&TempEvent, action);
-      TempEvent.Source = VALUE_SOURCE_SERIAL;
-
-      if (!PluginCall(PLUGIN_WRITE, &TempEvent, action)) {
-        ExecuteCommand(VALUE_SOURCE_SERIAL, action.c_str());
-      }
+      ExecuteCommand_all(VALUE_SOURCE_SERIAL, InputBuffer_Serial);
       SerialInByteCounter   = 0;
       InputBuffer_Serial[0] = 0; // serial data processed, clear buffer
     }

--- a/src/StringConverter.ino
+++ b/src/StringConverter.ino
@@ -436,6 +436,14 @@ String parseStringToEndKeepCase(const String& string, byte indexFind) {
   return stripQuotes(result);
 }
 
+String tolerantParseStringKeepCase(const String& string, byte indexFind)
+{
+  if (Settings.TolerantLastArgParse()) {
+    return parseStringToEndKeepCase(string, indexFind);
+  } 
+  return parseStringKeepCase(string, indexFind);
+}
+
 // escapes special characters in strings for use in html-forms
 void htmlEscape(String& html)
 {

--- a/src/TimeESPeasy.ino
+++ b/src/TimeESPeasy.ino
@@ -259,8 +259,11 @@ unsigned long now() {
     calcSunRiseAndSet();
 
     if (Settings.UseRules) {
-      String event = statusNTPInitialized ? F("Time#Set") : F("Time#Initialized");
-      rulesProcessing(event);
+      if (statusNTPInitialized) {
+        eventQueue.add(F("Time#Set"));
+      } else {
+        eventQueue.add(F("Time#Initialized"));
+      }
     }
     statusNTPInitialized = true; // @giig1967g: setting system variable %isntp%
   }
@@ -366,6 +369,7 @@ void checkTime()
         event += '0';
       }
       event += minute();
+      // TD-er: Do not add to the eventQueue, but execute right now.
       rulesProcessing(event);
     }
   }

--- a/src/WebServer_AdvancedConfigPage.ino
+++ b/src/WebServer_AdvancedConfigPage.ino
@@ -65,6 +65,7 @@ void handle_advanced() {
     Settings.Latitude  = getFormItemFloat(F("latitude"));
     Settings.Longitude = getFormItemFloat(F("longitude"));
     Settings.OldRulesEngine(isFormItemChecked(F("oldrulesengine")));
+    Settings.TolerantLastArgParse(isFormItemChecked(F("tolerantargparse")));
     Settings.ForceWiFi_bg_mode(isFormItemChecked(getInternalLabel(LabelType::FORCE_WIFI_BG)));
     Settings.WiFiRestart_connection_lost(isFormItemChecked(getInternalLabel(LabelType::RESTART_WIFI_LOST_CONN)));
     Settings.EcoPowerMode(isFormItemChecked(getInternalLabel(LabelType::CPU_ECO_MODE)));
@@ -89,6 +90,8 @@ void handle_advanced() {
 
   addFormCheckBox(F("Rules"),      F("userules"),       Settings.UseRules);
   addFormCheckBox(F("Old Engine"), F("oldrulesengine"), Settings.OldRulesEngine());
+  addFormCheckBox(F("Tolerant last parameter"), F("tolerantargparse"), Settings.TolerantLastArgParse());
+  addFormNote(F("Perform less strict parsing on last argument of some commands (e.g. publish and sendToHttp)"));
 
   addFormSubHeader(F("Controller Settings"));
 

--- a/src/WebServer_ControlPage.ino
+++ b/src/WebServer_ControlPage.ino
@@ -25,7 +25,7 @@ void handle_control() {
 
   if (command == F("event"))
   {
-    eventBuffer = webrequest.substring(6);
+    eventQueue.add(webrequest.substring(6));
     handledCmd  = true;
   }
   else if (command.equalsIgnoreCase(F("taskrun")) ||

--- a/src/WebServer_ControlPage.ino
+++ b/src/WebServer_ControlPage.ino
@@ -35,7 +35,7 @@ void handle_control() {
            command.equalsIgnoreCase(F("logPortStatus")) ||
            command.equalsIgnoreCase(F("jsonportstatus")) ||
            command.equalsIgnoreCase(F("rules"))) {
-    ExecuteCommand(VALUE_SOURCE_HTTP, webrequest.c_str());
+    ExecuteCommand_internal(VALUE_SOURCE_HTTP, webrequest.c_str());
     handledCmd = true;
   }
 
@@ -45,19 +45,9 @@ void handle_control() {
     TXBuffer.endStream();
     return;
   }
-
-  struct EventStruct TempEvent;
-  parseCommandString(&TempEvent, webrequest);
-  TempEvent.Source = VALUE_SOURCE_HTTP;
-
   printToWeb     = true;
   printWebString = "";
-
-  bool unknownCmd = false;
-
-  if (PluginCall(PLUGIN_WRITE, &TempEvent, webrequest)) {}
-  else if (remoteConfig(&TempEvent, webrequest)) {}
-  else { unknownCmd = true; }
+  bool unknownCmd = !ExecuteCommand_plugin_config(VALUE_SOURCE_HTTP, webrequest.c_str());
 
   if (printToWebJSON) { // it is setted in PLUGIN_WRITE (SendStatus)
     TXBuffer.startJsonStream();

--- a/src/WebServer_CustomPage.ino
+++ b/src/WebServer_CustomPage.ino
@@ -111,15 +111,7 @@ boolean handle_custom(String path) {
   String webrequest = WebServer.arg(F("cmd"));
 
   if (webrequest.length() > 0) {
-    struct EventStruct TempEvent;
-    parseCommandString(&TempEvent, webrequest);
-    TempEvent.Source = VALUE_SOURCE_HTTP;
-
-    if (PluginCall(PLUGIN_WRITE, &TempEvent, webrequest)) {}
-    else if (remoteConfig(&TempEvent, webrequest)) {}
-    else if (webrequest.startsWith(F("event"))) {
-      ExecuteCommand(VALUE_SOURCE_HTTP, webrequest.c_str());
-    }
+    ExecuteCommand_all_config_eventOnly(VALUE_SOURCE_HTTP, webrequest.c_str());
 
     // handle some update processes first, before returning page update...
     String dummy;

--- a/src/WebServer_RootPage.ino
+++ b/src/WebServer_RootPage.ino
@@ -42,7 +42,7 @@ void handle_root() {
     printWebString = "";
 
     if (sCommand.length() > 0) {
-      ExecuteCommand(VALUE_SOURCE_HTTP, sCommand.c_str());
+      ExecuteCommand_internal(VALUE_SOURCE_HTTP, sCommand.c_str());
     }
 
     // IPAddress ip = WiFi.localIP();
@@ -205,7 +205,7 @@ void handle_root() {
       TXBuffer           += F(
         "OK. Please wait > 1 min and connect to Acces point.<BR><BR>PW=configesp<BR>URL=<a href='http://192.168.4.1'>192.168.4.1</a>");
       TXBuffer.endStream();
-      ExecuteCommand(VALUE_SOURCE_HTTP, sCommand.c_str());
+      ExecuteCommand_internal(VALUE_SOURCE_HTTP, sCommand.c_str());
     }
 
     TXBuffer += "OK";

--- a/src/WebServer_ToolsPage.ino
+++ b/src/WebServer_ToolsPage.ino
@@ -32,14 +32,7 @@ void handle_tools() {
 
   if (webrequest.length() > 0)
   {
-    struct EventStruct TempEvent;
-    webrequest = parseTemplate(webrequest, webrequest.length()); // @giig1967g: parseTemplate before executing the command
-    parseCommandString(&TempEvent, webrequest);
-    TempEvent.Source = VALUE_SOURCE_WEB_FRONTEND;
-
-    if (!PluginCall(PLUGIN_WRITE, &TempEvent, webrequest)) {
-      ExecuteCommand(VALUE_SOURCE_WEB_FRONTEND, webrequest.c_str());
-    }
+    ExecuteCommand_all(VALUE_SOURCE_WEB_FRONTEND, webrequest.c_str());
   }
 
   if (printWebString.length() > 0)

--- a/src/WebServer_login.ino
+++ b/src/WebServer_login.ino
@@ -44,6 +44,7 @@ void handle_login() {
       if (Settings.UseRules)
       {
         String event = F("Login#Failed");
+        // TD-er: Do not add to the eventQueue, but execute right now.
         rulesProcessing(event);
       }
     }

--- a/src/_C002.ino
+++ b/src/_C002.ino
@@ -148,13 +148,13 @@ bool CPlugin_002(byte function, struct EventStruct *event, String& string)
               }
 
               if (action.length() > 0) {
-                struct EventStruct TempEvent;
-                TempEvent.TaskIndex = x;
-                parseCommandString(&TempEvent, action);
-                PluginCall(PLUGIN_WRITE, &TempEvent, action);
+                ExecuteCommand_plugin(x, VALUE_SOURCE_MQTT, action.c_str());
 
                 // trigger rulesprocessing
                 if (Settings.UseRules) {
+                  struct EventStruct TempEvent;
+                  TempEvent.TaskIndex = x;
+                  parseCommandString(&TempEvent, action);
                   createRuleEvents(&TempEvent);
                 }
               }

--- a/src/_C005.ino
+++ b/src/_C005.ino
@@ -53,6 +53,7 @@ bool CPlugin_005(byte function, struct EventStruct *event, String& string)
           // Controller is not enabled.
           break;
         } else {
+          // FIXME TD-er: Command is not parsed for template arguments.
           String cmd;
           struct EventStruct TempEvent;
           TempEvent.TaskIndex = event->TaskIndex;

--- a/src/_C005.ino
+++ b/src/_C005.ino
@@ -82,7 +82,7 @@ bool CPlugin_005(byte function, struct EventStruct *event, String& string)
             // in case of event, store to buffer and return...
             String command = parseString(cmd, 1);
             if (command == F("event")) {
-            eventBuffer = cmd.substring(6);
+            eventQueue.add(cmd.substring(6));
             } else if (!PluginCall(PLUGIN_WRITE, &TempEvent, cmd)) {
               remoteConfig(&TempEvent, cmd);
             }

--- a/src/_C014.ino
+++ b/src/_C014.ino
@@ -658,6 +658,7 @@ bool CPlugin_014(byte function, struct EventStruct *event, String& string)
               if (loglevelActiveFor(LOG_LEVEL_INFO)) {
                 log=F("C014 : PluginCall:");
               }
+              // FIXME TD-er: Command is not parsed, should we call ExecuteCommand here?
               if (!PluginCall(PLUGIN_WRITE, &TempEvent, cmd)) {
                 remoteConfig(&TempEvent, cmd);
                 if (loglevelActiveFor(LOG_LEVEL_INFO)) {

--- a/src/_C014.ino
+++ b/src/_C014.ino
@@ -638,21 +638,24 @@ bool CPlugin_014(byte function, struct EventStruct *event, String& string)
             String command = parseString(cmd, 1);
             if (command == F("event"))
             {
-              eventBuffer = cmd.substring(6);
-              if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-                log=F("C014 : taskIndex:");
-                if (!validTaskIndex(taskIndex)) {
-                  log += F("Invalid");
-                } else {
-                  log+=taskIndex;
-                  log+=F(" valueNr:");
-                  log+=valueNr;
-                  log+=F(" valueType:");                
-                  log+=Settings.TaskDevicePluginConfig[taskIndex][valueNr];
+              if (Settings.UseRules) {
+                String newEvent = cmd.substring(6); 
+                eventQueue.add(newEvent);
+                if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+                  log=F("C014 : taskIndex:");
+                  if (!validTaskIndex(taskIndex)) {
+                    log += F("Invalid");
+                  } else {
+                    log+=taskIndex;
+                    log+=F(" valueNr:");
+                    log+=valueNr;
+                    log+=F(" valueType:");                
+                    log+=Settings.TaskDevicePluginConfig[taskIndex][valueNr];
+                  }
+                  log+=F(" Event: ");
+                  log+=newEvent;
+                  addLog(LOG_LEVEL_INFO, log);
                 }
-                log+=F(" Event: ");
-                log+=eventBuffer;
-                addLog(LOG_LEVEL_INFO, log);
               }
             } else { // not an event
               if (loglevelActiveFor(LOG_LEVEL_INFO)) {

--- a/src/_C015.ino
+++ b/src/_C015.ino
@@ -360,38 +360,48 @@ boolean Blynk_send_c015(const String& value, int vPin )
 BLYNK_WRITE_DEFAULT() {
   byte vPin = request.pin;
   float pinValue = param.asFloat();
-  String log = F(C015_LOG_PREFIX "server set v");
-  log += vPin;
-  log += F(" to ");
-  log += pinValue;
-  addLog(LOG_LEVEL_INFO, log);
-  String eventCommand = F("blynkv");
-  eventCommand += vPin;
-  eventCommand += F("=");
-  eventCommand += pinValue;
-  rulesProcessing(eventCommand);
+  if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+    String log = F(C015_LOG_PREFIX "server set v");
+    log += vPin;
+    log += F(" to ");
+    log += pinValue;
+    addLog(LOG_LEVEL_INFO, log);
+  }
+  if (Settings.UseRules) {
+    String eventCommand = F("blynkv");
+    eventCommand += vPin;
+    eventCommand += F("=");
+    eventCommand += pinValue;
+    eventQueue.add(eventCommand);
+  }
 }
 
 BLYNK_CONNECTED() {
-// Your code here when hardware connects to Blynk Cloud or private server.
-// It’s common to call sync functions inside of this function.
-// Requests all stored on the server latest values for all widgets.
-  String eventCommand = F("blynk_connected");
-  rulesProcessing(eventCommand);
+  // Your code here when hardware connects to Blynk Cloud or private server.
+  // It’s common to call sync functions inside of this function.
+  // Requests all stored on the server latest values for all widgets.
+  if (Settings.UseRules) {
+    String eventCommand = F("blynk_connected");
+    eventQueue.add(eventCommand);
+  }
   // addLog(LOG_LEVEL_INFO, F(C015_LOG_PREFIX "connected handler"));
 }
 
 // This is called when Smartphone App is opened
 BLYNK_APP_CONNECTED() {
-  String eventCommand = F("blynk_app_connected");
-  rulesProcessing(eventCommand);
+  if (Settings.UseRules) {
+    String eventCommand = F("blynk_app_connected");
+    eventQueue.add(eventCommand);
+  }
   // addLog(LOG_LEVEL_INFO, F(C015_LOG_PREFIX "app connected handler"));
 }
 
 // This is called when Smartphone App is closed
 BLYNK_APP_DISCONNECTED() {
-  String eventCommand = F("blynk_app_disconnected");
-  rulesProcessing(eventCommand);
+  if (Settings.UseRules) {
+    String eventCommand = F("blynk_app_disconnected");
+    eventQueue.add(eventCommand);
+  }
   // addLog(LOG_LEVEL_INFO, F(C015_LOG_PREFIX "app disconnected handler"));
 }
 

--- a/src/_P020_Ser2Net.ino
+++ b/src/_P020_Ser2Net.ino
@@ -300,7 +300,7 @@ boolean Plugin_020(byte function, struct EventStruct *event, String& string)
           } // switch
 
           if (eventString.length() > 0)
-            rulesProcessing(eventString);
+            eventQueue.add(eventString);
 
         } // if rules
         success = true;

--- a/src/_P044_P1WifiGateway.ino
+++ b/src/_P044_P1WifiGateway.ino
@@ -334,7 +334,7 @@ boolean Plugin_044(byte function, struct EventStruct *event, String& string)
                   LoadTaskSettings(event->TaskIndex);
                   String eventString = getTaskDeviceName(event->TaskIndex);
                   eventString += F("#Data");
-                  rulesProcessing(eventString);
+                  eventQueue.add(eventString);
                 }
 
               } else {

--- a/src/_P081_Cron.ino
+++ b/src/_P081_Cron.ino
@@ -260,8 +260,9 @@ boolean Plugin_081(byte function, struct EventStruct *event, String& string)
 #endif
             addLog(LOG_LEVEL_DEBUG, String(F("Next execution:")) + getDateTimeString(*gmtime(&next)));
             LoadTaskSettings(event->TaskIndex);
-            if(function != PLUGIN_TIME_CHANGE)
-              rulesProcessing(String(F("Cron#")) + String(ExtraTaskSettings.TaskDeviceName));
+            if(function != PLUGIN_TIME_CHANGE) {
+              eventQueue.add(String(F("Cron#")) + String(ExtraTaskSettings.TaskDeviceName));
+            }
           }
           else
           {

--- a/src/_P082_GPS.ino
+++ b/src/_P082_GPS.ino
@@ -446,7 +446,7 @@ boolean Plugin_082(byte function, struct EventStruct *event, String& string) {
         if (activeFix != curFixStatus) {
           // Fix status changed, send events.
           String event = curFixStatus ? F("GPS#GotFix") : F("GPS#LostFix");
-          rulesProcessing(event);
+          eventQueue.add(event);
           activeFix = curFixStatus;
         }
         double distance = 0.0;

--- a/src/src/Commands/Common.cpp
+++ b/src/src/Commands/Common.cpp
@@ -21,7 +21,7 @@ String return_command_failed()
 
 String return_incorrect_nr_arguments()
 {
-  return F("Too many arguments, try using quotes");
+  return F("Too many arguments, try using quotes!");
 }
 
 String return_not_connected()

--- a/src/src/Commands/Diagnostic.cpp
+++ b/src/src/Commands/Diagnostic.cpp
@@ -145,7 +145,7 @@ String Command_Debug(struct EventStruct *event, const char *Line)
 String Command_logentry(struct EventStruct *event, const char *Line)
 {
   // FIXME TD-er: Add an extra optional parameter to set log level.
-  addLog(LOG_LEVEL_INFO, parseStringKeepCase(Line, 2));
+  addLog(LOG_LEVEL_INFO, tolerantParseStringKeepCase(Line, 2));
   return return_command_success();
 }
 

--- a/src/src/Commands/HTTP.cpp
+++ b/src/src/Commands/HTTP.cpp
@@ -13,9 +13,8 @@
 String Command_HTTP_SendToHTTP(struct EventStruct *event, const char* Line)
 {
 	if (WiFiConnected()) {
-		String strLine = Line;
-		String host = parseString(strLine, 2);
-		const int port = parseCommandArgumentInt(strLine, 2);
+		String host = parseString(Line, 2);
+		const int port = parseCommandArgumentInt(Line, 2);
 		if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
 			String log = F("SendToHTTP: Host: ");
 			log += host;
@@ -24,7 +23,9 @@ String Command_HTTP_SendToHTTP(struct EventStruct *event, const char* Line)
 			addLog(LOG_LEVEL_DEBUG, log);
 		}
 		if (!port < 0 || port > 65535) return return_command_failed();
-		String path = parseStringToEndKeepCase(strLine, 4);
+		// FIXME TD-er: This is not using the tolerant settings option.
+    // String path = tolerantParseStringKeepCase(Line, 4);
+		String path = parseStringToEndKeepCase(Line, 4);
 #ifndef BUILD_NO_DEBUG
 		if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
 			String log = F("SendToHTTP: Path: ");

--- a/src/src/Commands/MQTT.cpp
+++ b/src/src/Commands/MQTT.cpp
@@ -52,7 +52,7 @@ String Command_MQTT_Publish(struct EventStruct *event, const char *Line)
   if (enabledMqttController >= 0) {
     // Command structure:  Publish,<topic>,<value>
     String topic = parseStringKeepCase(Line, 2);
-    String value = parseStringKeepCase(Line, 3);
+    String value = tolerantParseStringKeepCase(Line, 3);
     addLog(LOG_LEVEL_DEBUG, String(F("Publish: ")) + topic + value);
 
     if ((topic.length() > 0) && (value.length() > 0)) {

--- a/src/src/Commands/Rules.cpp
+++ b/src/src/Commands/Rules.cpp
@@ -36,7 +36,11 @@ String Command_Rules_Events(struct EventStruct *event, const char *Line)
   eventName.replace('$', '#');
 
   if (Settings.UseRules) {
-    rulesProcessing(eventName);
+    if (SourceNeedsStatusUpdate(event->Source)) {
+      rulesProcessing(eventName); // TD-er: Process right now 
+    } else {
+      eventQueue.add(eventName);
+    }
   }
   return return_command_success();
 }

--- a/src/src/Commands/Tasks.cpp
+++ b/src/src/Commands/Tasks.cpp
@@ -105,6 +105,7 @@ String Command_Task_RemoteConfig(struct EventStruct *event, const char* Line)
 	struct EventStruct TempEvent;
 	TempEvent.TaskIndex = event->TaskIndex;
 	String request = Line;
+	// FIXME TD-er: Should we call ExecuteCommand here? The command is not parsed like any other call.
 	remoteConfig(&TempEvent, request);
 	return return_command_success();
 }

--- a/src/src/Commands/Timer.cpp
+++ b/src/src/Commands/Timer.cpp
@@ -48,7 +48,7 @@ String Command_Timer_Pause(struct EventStruct *event, const char *Line)
       {
         String eventName = F("Rules#TimerPause=");
         eventName += event->Par1;
-        rulesProcessing(eventName);
+        rulesProcessing(eventName); // TD-er: Process right now
         RulesTimer[timerId].paused   = true;
         RulesTimer[timerId].interval = -delta; // set remaind time
       }
@@ -75,7 +75,7 @@ String Command_Timer_Resume(struct EventStruct *event, const char *Line)
       {
         String eventName = F("Rules#TimerResume=");
         eventName += event->Par1;
-        rulesProcessing(eventName);
+        rulesProcessing(eventName); // TD-er: Process right now
         RulesTimer[timerId].timestamp = millis() + (RulesTimer[timerId].interval);
         RulesTimer[timerId].paused    = false;
       }

--- a/src/src/Commands/UDP.cpp
+++ b/src/src/Commands/UDP.cpp
@@ -31,7 +31,7 @@ String Command_UPD_SendTo(struct EventStruct *event, const char *Line)
   int destUnit = parseCommandArgumentInt(Line, 1);
   if ((destUnit > 0) && (destUnit < 255))
   {
-    String eventName = parseStringKeepCase(Line, 3);
+    String eventName = tolerantParseStringKeepCase(Line, 3);
     SendUDPCommand(destUnit, eventName.c_str(), eventName.length());
   }
   return return_command_success();
@@ -40,12 +40,13 @@ String Command_UPD_SendTo(struct EventStruct *event, const char *Line)
 String Command_UDP_SendToUPD(struct EventStruct *event, const char *Line)
 {
   if (WiFiConnected()) {
-    String strLine = Line;
-    String ip      = parseString(strLine, 2);
-    int port    = parseCommandArgumentInt(strLine, 2);
+    String ip      = parseString(Line, 2);
+    int port    = parseCommandArgumentInt(Line, 2);
 
     if (port < 0 || port > 65535) return return_command_failed();
-    String message = parseStringToEndKeepCase(strLine, 4);
+    // FIXME TD-er: This command is not using the tolerance setting
+    // tolerantParseStringKeepCase(Line, 4);
+    String message = parseStringToEndKeepCase(Line, 4);
     IPAddress UDP_IP;
 
     if (UDP_IP.fromString(ip)) {

--- a/src/src/DataStructs/ESPEasyDefaults.h
+++ b/src/src/DataStructs/ESPEasyDefaults.h
@@ -84,6 +84,10 @@
 #ifndef DEFAULT_GRATUITOUS_ARP
 #define DEFAULT_GRATUITOUS_ARP           false  // When set, the node will send periodical gratuitous ARP packets to announce itself.
 #endif
+#ifndef DEFAULT_TOLERANT_LAST_ARG_PARSE
+#define DEFAULT_TOLERANT_LAST_ARG_PARSE  false  // When set, the last argument of some commands will be parsed to the end of the line
+                                                // See: https://github.com/letscontrolit/ESPEasy/issues/2724
+#endif
 
 // --- Default Controller ------------------------------------------------------------------------------
 #ifndef DEFAULT_CONTROLLER

--- a/src/src/DataStructs/EventQueue.cpp
+++ b/src/src/DataStructs/EventQueue.cpp
@@ -1,0 +1,28 @@
+#include "EventQueue.h"
+
+EventQueueStruct::EventQueueStruct() {}
+
+void EventQueueStruct::add(const String& event)
+{
+  _eventQueue.push_back(event);
+}
+
+bool EventQueueStruct::getNext(String& event)
+{
+  if (_eventQueue.empty()) {
+    return false;
+  }
+  event = _eventQueue.front();
+  _eventQueue.pop_front();
+  return true;
+}
+
+void EventQueueStruct::clear()
+{
+  _eventQueue.clear();
+}
+
+bool EventQueueStruct::isEmpty() const
+{
+  return _eventQueue.empty();
+}

--- a/src/src/DataStructs/EventQueue.h
+++ b/src/src/DataStructs/EventQueue.h
@@ -1,0 +1,28 @@
+#ifndef DATASTRUCTS_EVENTQUEUE_H
+#define DATASTRUCTS_EVENTQUEUE_H
+
+
+#include <list>
+#include "../../ESPEasy_common.h"
+
+#include "src/Globals/Plugins.h"
+
+
+struct EventQueueStruct {
+  EventQueueStruct();
+
+  void add(const String& event);
+
+  bool getNext(String& event);
+
+  void clear();
+
+  bool isEmpty() const;
+
+private:
+
+  std::list<String>_eventQueue;
+};
+
+
+#endif // DATASTRUCTS_EVENTQUEUE_H

--- a/src/src/DataStructs/SettingsStruct.cpp
+++ b/src/src/DataStructs/SettingsStruct.cpp
@@ -92,6 +92,16 @@ void SettingsStruct_tmpl<N_TASKS>::gratuitousARP(bool value) {
 }
 
 template<unsigned int N_TASKS>
+bool SettingsStruct_tmpl<N_TASKS>::TolerantLastArgParse() {
+  return getBitFromUL(VariousBits1, 9);
+}
+
+template<unsigned int N_TASKS>
+void SettingsStruct_tmpl<N_TASKS>::TolerantLastArgParse(bool value) {
+  setBitToUL(VariousBits1, 9, value);
+}
+
+template<unsigned int N_TASKS>
 void SettingsStruct_tmpl<N_TASKS>::validate() {
   if (UDPPort > 65535) { UDPPort = 0; }
 
@@ -213,6 +223,7 @@ void SettingsStruct_tmpl<N_TASKS>::clearMisc() {
   EcoPowerMode(DEFAULT_ECO_MODE);
   WifiNoneSleep(DEFAULT_WIFI_NONE_SLEEP);
   gratuitousARP(DEFAULT_GRATUITOUS_ARP);
+  TolerantLastArgParse(DEFAULT_TOLERANT_LAST_ARG_PARSE);
 }
 
 template<unsigned int N_TASKS>

--- a/src/src/DataStructs/SettingsStruct.h
+++ b/src/src/DataStructs/SettingsStruct.h
@@ -42,6 +42,11 @@ class SettingsStruct_tmpl
   bool gratuitousARP();
   void gratuitousARP(bool value);
 
+  // Be a bit more tolerant when parsing the last argument of a command.
+  // See: https://github.com/letscontrolit/ESPEasy/issues/2724
+  bool TolerantLastArgParse();
+  void TolerantLastArgParse(bool value);
+
   void validate();
 
   bool networkSettingsEmpty() const;


### PR DESCRIPTION
Until now a lot of ways to handle a command were handling the pre-processing of the command differently.
So the source of the command can make a difference whether system variables can be used for example.

Now all use the same function to pre-process the commands.