### PR TITLE
[WiFi] Use last known BSSID & channel from RTC + MQTT fixes

### DIFF
--- a/docs/source/WiFi/WiFi.rst
+++ b/docs/source/WiFi/WiFi.rst
@@ -50,7 +50,7 @@ Start AP timer is set or cleared at:
 Quick reconnect (using BSSID/channel of last connection) when both apply:
 
 - If wifi_connect_attempt < 3
-- lastBSSID is known
+- RTC.lastBSSID is known
 
 Change of wifi settings when both apply:
 

--- a/platformio_core_defs.ini
+++ b/platformio_core_defs.ini
@@ -130,8 +130,8 @@ build_flags               = ${esp82xx_2_6_x.build_flags}
                             -DARDUINO_ESP8266_RELEASE='"2.7.0-dev stage"'
                             -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_191105
 
-[core_esp32_1_11_1]
-platform                  = espressif32@1.11.1
+[core_esp32_1_11_0]
+platform                  = espressif32@1.11.0
 
 [core_esp32_stage]
 platform                  = https://github.com/platformio/platform-espressif32.git#feature/stage

--- a/platformio_core_defs.ini
+++ b/platformio_core_defs.ini
@@ -95,18 +95,32 @@ lib_ignore                = ESP32_ping, ESP32WebServer, IRremoteESP8266, Heatpum
 
 ; See for SDK flags: https://github.com/esp8266/Arduino/blob/master/tools/platformio-build.py
 
-[core_2_6_0]
-platform                  = https://github.com/Jason2866/platform-espressif8266.git#core_2_6_0
+;[core_2_6_0]
+;platform                  = https://github.com/Jason2866/platform-espressif8266.git#core_2_6_0
+;build_flags               = ${esp82xx_2_6_x.build_flags} 
+                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190703
+
+;[core_2_6_1]
+;platform                  = https://github.com/Jason2866/platform-espressif8266.git#core_2_6_1
+;build_flags               = ${esp82xx_2_6_x.build_flags} 
+                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190703
+
+;[core_2_6_1_sdk3]
+;platform                  = https://github.com/Jason2866/platform-espressif8266.git#core_2_6_1
+;build_flags               = ${esp82xx_2_6_x.build_flags} 
+                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK3
+
+[core_2_6_2]
+platform                  = espressif8266@2.3.1
+platform_packages         =
+	framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git#2.6.2
 build_flags               = ${esp82xx_2_6_x.build_flags} 
                             -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190703
 
-[core_2_6_1]
-platform                  = https://github.com/Jason2866/platform-espressif8266.git#core_2_6_1
-build_flags               = ${esp82xx_2_6_x.build_flags} 
-                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190703
-
-[core_2_6_1_sdk3]
-platform                  = https://github.com/Jason2866/platform-espressif8266.git#core_2_6_1
+[core_2_6_2_sdk3]
+platform                  = espressif8266@2.3.1
+platform_packages         =
+	framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git#2.6.2
 build_flags               = ${esp82xx_2_6_x.build_flags} 
                             -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK3
 

--- a/platformio_esp32_envs.ini
+++ b/platformio_esp32_envs.ini
@@ -8,7 +8,7 @@
 
 [esp32_common]
 extends                   = common
-platform                  = ${core_esp32_1_11_1.platform}
+platform                  = ${core_esp32_1_11_0.platform}
 lib_ignore                = AS_BH1750, ESP8266WiFi, ESP8266Ping, ESP8266WebServer, ESP8266HTTPUpdateServer, ESP8266mDNS, IRremoteESP8266, ESPEasy_ESP8266Ping, ESP32_ping, HeatpumpIR
 lib_deps                  = https://github.com/TD-er/ESPEasySerial.git
 board_build.f_flash       = 80000000L

--- a/platformio_esp82xx_base.ini
+++ b/platformio_esp82xx_base.ini
@@ -6,7 +6,7 @@
 
 [regular_platform]
 build_unflags             =
-build_flags               = ${core_2_6_2.build_flags} ${common.build_flags}
+build_flags               = ${core_2_6_2.build_flags}
 platform                  = ${core_2_6_2.platform}
 platform_packages         = ${core_2_6_2.platform_packages}
 

--- a/platformio_esp82xx_base.ini
+++ b/platformio_esp82xx_base.ini
@@ -6,13 +6,16 @@
 
 [regular_platform]
 build_unflags             =
-build_flags               = ${core_2_6_1.build_flags}
-platform                  = ${core_2_6_1.platform}
+build_flags               = ${core_2_6_2.build_flags} ${common.build_flags}
+platform                  = ${core_2_6_2.platform}
+platform_packages         = ${core_2_6_2.platform_packages}
 
-[core261_sdk3_platform]
+
+[core262_sdk3_platform]
 build_unflags             =
-build_flags               = ${core_2_6_1_sdk3.build_flags}
-platform                  = ${core_2_6_1_sdk3.platform}
+build_flags               = ${core_2_6_2_sdk3.build_flags}
+platform                  = ${core_2_6_2_sdk3.platform}
+platform_packages         = ${core_2_6_2_sdk3.platform_packages}
 
 [beta_platform]
 build_unflags             =
@@ -38,7 +41,9 @@ board                     = esp12e
 
 [normal]
 platform                  = ${regular_platform.platform}
+platform_packages         = ${regular_platform.platform_packages}
 build_flags               = ${regular_platform.build_flags}
+
 
 [normal_beta]
 platform                  = ${beta_platform.platform}
@@ -52,6 +57,7 @@ build_flags               = ${beta_platform.build_flags}
 
 [testing]
 platform                  = ${regular_platform.platform}
+platform_packages         = ${regular_platform.platform_packages}
 build_flags               = ${regular_platform.build_flags} -DPLUGIN_BUILD_TESTING
 
 [testing_beta]
@@ -66,6 +72,7 @@ build_flags               = ${beta_platform.build_flags} -DPLUGIN_BUILD_TESTING
 
 [dev]
 platform                  = ${regular_platform.platform}
+platform_packages         = ${regular_platform.platform_packages}
 build_flags               = ${regular_platform.build_flags} -DPLUGIN_BUILD_DEV
 
 
@@ -75,6 +82,7 @@ build_flags               = ${regular_platform.build_flags} -DPLUGIN_BUILD_DEV
 
 [ir]
 platform                  = ${regular_platform.platform}
+platform_packages         = ${regular_platform.platform_packages}
 build_flags               = ${regular_platform.build_flags}
 lib_ignore                = ESP32_ping, ESP32WebServer, SD(esp8266), SDFS
 

--- a/platformio_esp82xx_envs.ini
+++ b/platformio_esp82xx_envs.ini
@@ -6,6 +6,7 @@
 
 [hard_esp82xx]
 platform                  = ${regular_platform.platform}
+platform_packages         = ${regular_platform.platform_packages}
 build_flags               = ${regular_platform.build_flags}
                             -DBUILD_NO_DEBUG
                             -DPLUGIN_BUILD_CUSTOM
@@ -15,6 +16,7 @@ build_flags               = ${regular_platform.build_flags}
 [env:custom_ESP8266_4M1M]
 extends                   = esp8266_4M1M
 platform                  = ${regular_platform.platform}
+platform_packages         = ${regular_platform.platform_packages}
 build_flags               = ${regular_platform.build_flags} 
                             ${esp8266_4M1M.build_flags} 
                             -DPLUGIN_BUILD_CUSTOM
@@ -46,6 +48,7 @@ extra_scripts             = pre:pre_custom_esp82xx.py
 [env:custom_ESP8266_4M2M]
 extends                   = esp8266_4M2M
 platform                  = ${regular_platform.platform}
+platform_packages         = ${regular_platform.platform_packages}
 build_flags               = ${regular_platform.build_flags}
                             ${esp8266_4M1M.build_flags}
                             -DPLUGIN_BUILD_CUSTOM
@@ -63,6 +66,7 @@ extra_scripts             = pre:pre_custom_esp82xx.py
 [env:normal_ESP8266_1M]
 extends                   = esp8266_1M
 platform                  = ${regular_platform.platform}
+platform_packages         = ${regular_platform.platform_packages}
 build_flags               = ${regular_platform.build_flags}
                             ${esp8266_1M.build_flags}
 
@@ -77,6 +81,7 @@ build_flags               = ${core261_sdk3_platform.build_flags}
 [env:normal_ESP8266_1M_VCC]
 extends                   = esp8266_1M
 platform                  = ${regular_platform.platform}
+platform_packages         = ${regular_platform.platform_packages}
 build_flags               = ${regular_platform.build_flags}
                             ${esp8266_1M.build_flags}
                             -D FEATURE_ADC_VCC=true
@@ -86,6 +91,7 @@ build_flags               = ${regular_platform.build_flags}
 [env:normal_ESP8285_1M]
 extends                   = esp8285_1M
 platform                  = ${regular_platform.platform}
+platform_packages         = ${regular_platform.platform_packages}
 build_flags               = ${regular_platform.build_flags}
                             ${esp8285_1M.build_flags}
 
@@ -94,6 +100,7 @@ build_flags               = ${regular_platform.build_flags}
 [env:normal_WROOM02_2M]
 extends                   = espWroom2M
 platform                  = ${regular_platform.platform}
+platform_packages         = ${regular_platform.platform_packages}
 build_flags               = ${regular_platform.build_flags}
                             ${espWroom2M.build_flags}
 
@@ -102,6 +109,7 @@ build_flags               = ${regular_platform.build_flags}
 [env:normal_WROOM02_2M256]
 extends                   = espWroom2M256
 platform                  = ${regular_platform.platform}
+platform_packages         = ${regular_platform.platform_packages}
 build_flags               = ${regular_platform.build_flags}
                             ${espWroom2M256.build_flags}
 
@@ -110,6 +118,7 @@ build_flags               = ${regular_platform.build_flags}
 [env:normal_ESP8266_4M1M]
 extends                   = esp8266_4M1M
 platform                  = ${regular_platform.platform}
+platform_packages         = ${regular_platform.platform_packages}
 build_flags               = ${regular_platform.build_flags}
                             ${esp8266_4M1M.build_flags}
 
@@ -117,6 +126,7 @@ build_flags               = ${regular_platform.build_flags}
 [env:normal_ESP8266_16M]
 extends                   = esp8266_16M
 platform                  = ${regular_platform.platform}
+platform_packages         = ${regular_platform.platform_packages}
 build_flags               = ${regular_platform.build_flags}
                             ${esp8266_16M.build_flags}
 
@@ -140,12 +150,14 @@ build_flags               = ${core_2_4_2.build_flags}
 [env:minimal_core_261_ESP8266_1M_OTA]
 extends                   = esp8266_1M_OTA
 platform                  = ${regular_platform.platform}
+platform_packages         = ${regular_platform.platform_packages}
 build_flags               = ${regular_platform.build_flags} 
                             ${esp8266_1M_OTA.build_flags}
 
 [env:minimal_core_261_ESP8285_1M_OTA]
 extends                   = esp8285_1M_OTA
 platform                  = ${regular_platform.platform}
+platform_packages         = ${regular_platform.platform_packages}
 build_flags               = ${regular_platform.build_flags} 
                             ${esp8285_1M_OTA.build_flags}
 
@@ -272,6 +284,7 @@ build_flags               = ${dev.build_flags}
 ;[env:hard_SONOFF_BASIC]
 ;extends                   = esp8266_1M, hard_esp82xx
 ;platform                  = ${hard_esp82xx.platform}
+;platform_packages         = ${hard_esp82xx.platform_packages}
 ;build_flags               = ${hard_esp82xx.build_flags} ${esp8266_1M.build_flags} -D PLUGIN_SET_SONOFF_BASIC
 
 
@@ -279,6 +292,7 @@ build_flags               = ${dev.build_flags}
 ;[env:hard_SONOFF_TH1x]
 ;extends                   = esp8266_1M, hard_esp82xx
 ;platform                  = ${hard_esp82xx.platform}
+;platform_packages         = ${hard_esp82xx.platform_packages}
 ;build_flags               = ${hard_esp82xx.build_flags} ${esp8266_1M.build_flags} -D PLUGIN_SET_SONOFF_TH1x
 
 ; ITEAD / SONOFF POW & POW R2 version --------------------
@@ -299,6 +313,7 @@ build_flags               = ${dev.build_flags}
 [env:hard_SONOFF_POW_4M1M]
 extends                   = esp8266_4M1M, hard_esp82xx
 platform                  = ${hard_esp82xx.platform}
+platform_packages         = ${hard_esp82xx.platform_packages}
 build_flags               = ${hard_esp82xx.build_flags} 
                             ${esp8266_4M1M.build_flags}
                             -D PLUGIN_SET_SONOFF_POW
@@ -309,6 +324,7 @@ build_flags               = ${hard_esp82xx.build_flags}
 [env:hard_other_POW_ESP8285_1M]
 extends                   = esp8266_1M_OTA, hard_esp82xx
 platform                  = ${hard_esp82xx.platform}
+platform_packages         = ${hard_esp82xx.platform_packages}
 build_flags               = ${hard_esp82xx.build_flags} 
                             ${esp8266_1M_OTA.build_flags}
                             -D PLUGIN_SET_SONOFF_POW
@@ -318,6 +334,7 @@ build_flags               = ${hard_esp82xx.build_flags}
 ;[env:hard_SONOFF_S20]
 ;extends                   = esp8266_1M_OTA, hard_esp82xx
 ;platform                  = ${hard_esp82xx.platform}
+;platform_packages         = ${hard_esp82xx.platform_packages}
 ;build_flags               = ${hard_esp82xx.build_flags} ${esp8266_1M_OTA.build_flags} -D PLUGIN_SET_SONOFF_S2x
 
 
@@ -325,6 +342,7 @@ build_flags               = ${hard_esp82xx.build_flags}
 ;[env:hard_SONOFF_4CH]
 ;extends                   = esp8285_1M_OTA, hard_esp82xx
 ;platform                  = ${hard_esp82xx.platform}
+;platform_packages         = ${hard_esp82xx.platform_packages}
 ;build_flags               = ${hard_esp82xx.build_flags} ${esp8285_1M_OTA.build_flags} -D PLUGIN_SET_SONOFF_4CH
 
 
@@ -333,6 +351,7 @@ build_flags               = ${hard_esp82xx.build_flags}
 ;[env:hard_SONOFF_TOUCH]
 ;extends                   = esp8285_1M_OTA, hard_esp82xx
 ;platform                  = ${hard_esp82xx.platform}
+;platform_packages         = ${hard_esp82xx.platform_packages}
 ;build_flags               = ${hard_esp82xx.build_flags} ${esp8285_1M_OTA.build_flags} -D PLUGIN_SET_SONOFF_TOUCH
 
 
@@ -343,6 +362,7 @@ build_flags               = ${hard_esp82xx.build_flags}
 [env:hard_Shelly_1_2M256]
 extends                   = esp8266_2M256, hard_esp82xx
 platform                  = ${hard_esp82xx.platform}
+platform_packages         = ${hard_esp82xx.platform_packages}
 build_flags               = ${hard_esp82xx.build_flags} 
                             ${esp8266_2M256.build_flags}
                             -D PLUGIN_SET_SHELLY_1
@@ -352,6 +372,7 @@ build_flags               = ${hard_esp82xx.build_flags}
 [env:hard_Ventus_W266]
 extends                   = esp8266_1M, hard_esp82xx
 platform                  = ${hard_esp82xx.platform}
+platform_packages         = ${hard_esp82xx.platform_packages}
 build_flags               = ${hard_esp82xx.build_flags}
                             ${esp8266_1M_OTA.build_flags}
                             -D PLUGIN_SET_VENTUS_W266

--- a/platformio_esp82xx_envs.ini
+++ b/platformio_esp82xx_envs.ini
@@ -26,8 +26,8 @@ extra_scripts             = pre:pre_custom_esp82xx.py
 
 [env:custom_sdk3_ESP8266_4M1M]
 extends                   = esp8266_4M1M
-platform                  = ${core261_sdk3_platform.platform}
-build_flags               = ${core261_sdk3_platform.build_flags}
+platform                  = ${core_2_6_2_sdk3.platform}
+build_flags               = ${core_2_6_2_sdk3.build_flags}
                             ${esp8266_4M1M.build_flags} 
                             -DPLUGIN_BUILD_CUSTOM
 lib_ignore                = ESP32_ping, ESP32WebServer
@@ -73,8 +73,8 @@ build_flags               = ${regular_platform.build_flags}
 
 [env:normal_sdk3_ESP8266_1M]
 extends                   = esp8266_1M
-platform                  = ${core261_sdk3_platform.platform}
-build_flags               = ${core261_sdk3_platform.build_flags}
+platform                  = ${core_2_6_2_sdk3.platform}
+build_flags               = ${core_2_6_2_sdk3.build_flags}
                             ${esp8266_1M.build_flags}
 
 
@@ -163,14 +163,14 @@ build_flags               = ${regular_platform.build_flags}
 
 [env:minimal_core_261_sdk3_ESP8266_1M_OTA]
 extends                   = esp8266_1M_OTA
-platform                  = ${core261_sdk3_platform.platform}
-build_flags               = ${core261_sdk3_platform.build_flags} 
+platform                  = ${core_2_6_2_sdk3.platform}
+build_flags               = ${core_2_6_2_sdk3.build_flags} 
                             ${esp8266_1M_OTA.build_flags}
 
 [env:minimal_core_261_sdk3_ESP8285_1M_OTA]
 extends                   = esp8285_1M_OTA
-platform                  = ${core261_sdk3_platform.platform}
-build_flags               = ${core261_sdk3_platform.build_flags} 
+platform                  = ${core_2_6_2_sdk3.platform}
+build_flags               = ${core_2_6_2_sdk3.build_flags} 
                             ${esp8285_1M_OTA.build_flags}
 
 

--- a/platformio_special_envs.ini
+++ b/platformio_special_envs.ini
@@ -12,6 +12,7 @@ build_flags               = ${compiler_warnings.build_flags}
 [env:spec_debug_custom_ESP8266_4M1M]
 extends                   = esp8266_4M1M, debug_pio
 platform                  = ${regular_platform.platform}
+platform_packages         = ${regular_platform.platform_packages}
 build_flags               = ${regular_platform.build_flags}
                             ${debug_pio.build_flags}
                             ${esp8266_4M1M.build_flags}
@@ -46,6 +47,7 @@ extra_scripts             = pre:pre_custom_esp32.py
 [env:spec_memanalyze_ESP8266]
 extends                   = esp8266_4M1M
 platform                  = ${regular_platform.platform}
+platform_packages         = ${regular_platform.platform_packages}
 lib_ignore                = ESP32_ping, ESP32WebServer
 build_flags               = ${esp8266_4M1M.build_flags} -DMEMORY_ANALYSIS -DPLUGIN_BUILD_CUSTOM -w -DUSE_NON_STANDARD_24_TASKS -DTASKS_MAX=24
 extra_scripts             = pre:pre_memanalyze.py

--- a/pre_custom_esp32.py
+++ b/pre_custom_esp32.py
@@ -16,9 +16,9 @@ env.Append(CPPDEFINES=[
 #  ("WEBSERVER_RULES_DEBUG", "1")
 ])
 if os.path.isfile('src/Custom.h'):
-  env['CPPDEFINES'].append("USE_CUSTOM_H")
+  env.Append(CPPDEFINES=["USE_CUSTOM_H"])
 else:
-  env['CPPDEFINES'].extend([
+  env.Append(CPPDEFINES=[
     "CONTROLLER_SET_ALL",
     "NOTIFIER_SET_NONE",
     "PLUGIN_SET_ONLY_SWITCH",

--- a/pre_custom_esp82xx.py
+++ b/pre_custom_esp82xx.py
@@ -17,9 +17,9 @@ env.Append(CPPDEFINES=[
   # ,("WEBSERVER_RULES_DEBUG", "0")
 ])
 if os.path.isfile('src/Custom.h'):
-  env['CPPDEFINES'].append("USE_CUSTOM_H")
+  env.Append(CPPDEFINES=["USE_CUSTOM_H"])
 else:
-  env['CPPDEFINES'].extend([
+  env.Append(CPPDEFINES=[
     "CONTROLLER_SET_ALL",
     "NOTIFIER_SET_NONE",
     "PLUGIN_SET_ONLY_SWITCH",

--- a/pre_custom_esp82xx.py
+++ b/pre_custom_esp82xx.py
@@ -39,6 +39,8 @@ else:
     "USES_C016",  # Cache Controller
     "USES_C018",  # TTN/RN2483
 
+    "FEATURE_MDNS",
+
     "USE_SETTINGS_ARCHIVE"
   ])
 

--- a/pre_custom_esp82xx.py
+++ b/pre_custom_esp82xx.py
@@ -44,4 +44,22 @@ else:
     "USE_SETTINGS_ARCHIVE"
   ])
 
-print(env['CPPDEFINES'])
+
+
+my_flags = env.ParseFlags(env['BUILD_FLAGS'])
+my_defines = my_flags.get("CPPDEFINES")
+#defines = {k: v for (k, v) in my_defines}
+
+print("\u001b[32m Custom PIO configuration check \u001b[0m", flush=True)
+# print the defines
+print("\u001b[33m CPPDEFINES: \u001b[0m  {}".format(my_defines), flush=True)
+print("\u001b[33m Custom CPPDEFINES: \u001b[0m  {}".format(env['CPPDEFINES']), flush=True)
+print("\u001b[32m ------------------------------- \u001b[0m", flush=True)
+
+
+if (len(my_defines) == 0):
+  print("\u001b[31m No defines are set, probably configuration error. \u001b[0m", flush=True)
+  raise ValueError
+
+
+

--- a/pre_custom_esp82xx.py
+++ b/pre_custom_esp82xx.py
@@ -50,15 +50,15 @@ my_flags = env.ParseFlags(env['BUILD_FLAGS'])
 my_defines = my_flags.get("CPPDEFINES")
 #defines = {k: v for (k, v) in my_defines}
 
-print("\u001b[32m Custom PIO configuration check \u001b[0m", flush=True)
+print("\u001b[32m Custom PIO configuration check \u001b[0m")
 # print the defines
-print("\u001b[33m CPPDEFINES: \u001b[0m  {}".format(my_defines), flush=True)
-print("\u001b[33m Custom CPPDEFINES: \u001b[0m  {}".format(env['CPPDEFINES']), flush=True)
-print("\u001b[32m ------------------------------- \u001b[0m", flush=True)
+print("\u001b[33m CPPDEFINES: \u001b[0m  {}".format(my_defines))
+print("\u001b[33m Custom CPPDEFINES: \u001b[0m  {}".format(env['CPPDEFINES']))
+print("\u001b[32m ------------------------------- \u001b[0m")
 
 
 if (len(my_defines) == 0):
-  print("\u001b[31m No defines are set, probably configuration error. \u001b[0m", flush=True)
+  print("\u001b[31m No defines are set, probably configuration error. \u001b[0m")
   raise ValueError
 
 

--- a/pre_default_check.py
+++ b/pre_default_check.py
@@ -1,23 +1,26 @@
-# Simple check for the configuration of an environment.
-
-
 Import("env")
 import os
 
+# Simple check for the configuration of an environment.
+
 # access to global construction environment
-#print env
+#print(env)
 
 # Dump construction environment (for debug purpose)
-#print env.Dump()
+#print(env.Dump())
+
 
 my_flags = env.ParseFlags(env['BUILD_FLAGS'])
+my_defines = my_flags.get("CPPDEFINES")
+#defines = {k: v for (k, v) in my_defines}
 
-
+print("\u001b[32m Default PIO configuration check \u001b[0m", flush=True)
 # print the defines
-print("CPPDEFINES: {}".format(my_flags.get("CPPDEFINES")))
-print("LINKFLAGS: {}".format(my_flags.get("LINKFLAGS")))
-#print(my_flags)
+print("\u001b[33m CPPDEFINES: \u001b[0m  {}".format(my_defines), flush=True)
+print("\u001b[32m ------------------------------- \u001b[0m", flush=True)
 
 
-if (len(my_flags.get("CPPDEFINES")) == 0):
+if (len(my_defines) == 0):
+  print("\u001b[31m No defines are set, probably configuration error. \u001b[0m", flush=True)
   raise ValueError
+

--- a/pre_default_check.py
+++ b/pre_default_check.py
@@ -14,13 +14,13 @@ my_flags = env.ParseFlags(env['BUILD_FLAGS'])
 my_defines = my_flags.get("CPPDEFINES")
 #defines = {k: v for (k, v) in my_defines}
 
-print("\u001b[32m Default PIO configuration check \u001b[0m", flush=True)
+print("\u001b[32m Default PIO configuration check \u001b[0m")
 # print the defines
-print("\u001b[33m CPPDEFINES: \u001b[0m  {}".format(my_defines), flush=True)
-print("\u001b[32m ------------------------------- \u001b[0m", flush=True)
+print("\u001b[33m CPPDEFINES: \u001b[0m  {}".format(my_defines))
+print("\u001b[32m ------------------------------- \u001b[0m")
 
 
 if (len(my_defines) == 0):
-  print("\u001b[31m No defines are set, probably configuration error. \u001b[0m", flush=True)
+  print("\u001b[31m No defines are set, probably configuration error. \u001b[0m")
   raise ValueError
 

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -287,6 +287,13 @@ void setup()
       toDisable = disableNotification(toDisable);
     }
   }
+  if (!selectValidWiFiSettings()) {
+    wifiSetup = true;
+    RTC.lastWiFiChannel = 0; // Must scan all channels
+    // Wait until scan has finished to make sure as many as possible are found
+    // We're still in the setup phase, so nothing else is taking resources of the ESP.
+    WifiScan(false); 
+  }
 
 //  setWifiMode(WIFI_STA);
   checkRuleSets();
@@ -357,17 +364,6 @@ void setup()
     rulesProcessing(event);
   }
 
-  if (!selectValidWiFiSettings()) {
-    wifiSetup = true;
-  }
-/*
-  // FIXME TD-er:
-  // Async scanning for wifi doesn't work yet like it should.
-  // So no selection of strongest network yet.
-  if (selectValidWiFiSettings()) {
-    WifiScanAsync();
-  }
-*/
   WiFiConnectRelaxed();
 
   #ifdef FEATURE_REPORTING

--- a/src/ESPEasyStorage.ino
+++ b/src/ESPEasyStorage.ino
@@ -297,6 +297,7 @@ void afterloadSettings() {
     ResetFactoryDefaultPreference = Settings.ResetFactoryDefaultPreference;
   }
   msecTimerHandler.setEcoMode(Settings.EcoPowerMode());
+  set_mDNS(); // To update changes in hostname.
 }
 
 /********************************************************************************************\

--- a/src/ESPEasyWiFiEvent.h
+++ b/src/ESPEasyWiFiEvent.h
@@ -58,8 +58,6 @@ void onConnectedAPmode(const WiFiEventSoftAPModeStationConnected& event);
 
 void onDisonnectedAPmode(const WiFiEventSoftAPModeStationDisconnected& event);
 
-void onScanFinished(int networksFound);
-
 #endif // ifdef ESP32
 
 

--- a/src/ESPEasyWiFi_credentials.ino
+++ b/src/ESPEasyWiFi_credentials.ino
@@ -2,21 +2,21 @@
 // Manage WiFi credentials
 // ********************************************************************************
 const char* getLastWiFiSettingsSSID() {
-  return lastWiFiSettings == 0 ? SecuritySettings.WifiSSID : SecuritySettings.WifiSSID2;
+  return RTC.lastWiFiSettingsIndex == 0 ? SecuritySettings.WifiSSID : SecuritySettings.WifiSSID2;
 }
 
 const char* getLastWiFiSettingsPassphrase() {
-  return lastWiFiSettings == 0 ? SecuritySettings.WifiKey : SecuritySettings.WifiKey2;
+  return RTC.lastWiFiSettingsIndex == 0 ? SecuritySettings.WifiKey : SecuritySettings.WifiKey2;
 }
 
 bool selectNextWiFiSettings() {
-  uint8_t tmp = lastWiFiSettings;
+  uint8_t tmp = RTC.lastWiFiSettingsIndex;
 
-  lastWiFiSettings = (lastWiFiSettings + 1) % 2;
+  RTC.lastWiFiSettingsIndex = (RTC.lastWiFiSettingsIndex + 1) % 2;
 
   if (!wifiSettingsValid(getLastWiFiSettingsSSID(), getLastWiFiSettingsPassphrase())) {
     // other settings are not correct, switch back.
-    lastWiFiSettings = tmp;
+    RTC.lastWiFiSettingsIndex = tmp;
     return false; // Nothing changed.
   }
   return true;

--- a/src/ESPEasyWifi.ino
+++ b/src/ESPEasyWifi.ino
@@ -88,8 +88,7 @@ bool WiFiConnected() {
   if (wifiStatus != ESPEASY_WIFI_SERVICES_INITIALIZED) {
     if (validWiFi) {
       // Set internal wifiStatus and reset timer to disable AP mode
-      wifiStatus            = ESPEASY_WIFI_SERVICES_INITIALIZED;
-      wifiConnectInProgress = false;
+      markWiFi_services_initialized();
     }
   }
 
@@ -217,6 +216,7 @@ bool prepareWiFi() {
   #endif // if defined(ESP8266)
   #if defined(ESP32)
   WiFi.setHostname(hostname);
+  WiFi.config(INADDR_NONE, INADDR_NONE, INADDR_NONE);
   #endif // if defined(ESP32)
 
   if (RTC.lastWiFiChannel == 0 && wifi_connect_attempt <= 1) {
@@ -485,6 +485,9 @@ void setWifiMode(WiFiMode_t wifimode) {
     // Mode has changed
     setAPinternal(new_mode_AP_enabled);
   }
+  #ifdef FEATURE_MDNS
+  MDNS.notifyAPChange();
+  #endif
 }
 
 bool WifiIsAP(WiFiMode_t wifimode)
@@ -584,6 +587,7 @@ void setConnectionSpeed() {
 
   // Does not (yet) work, so commented out.
   #ifdef ESP32
+  /*
   uint8_t protocol = WIFI_PROTOCOL_11B | WIFI_PROTOCOL_11G; // Default to BG
 
   if (!Settings.ForceWiFi_bg_mode() || (wifi_connect_attempt > 10)) {
@@ -598,6 +602,7 @@ void setConnectionSpeed() {
   if (WifiIsAP(WiFi.getMode())) {
     esp_wifi_set_protocol(WIFI_IF_AP, protocol);
   }
+  */
   #endif // ifdef ESP32
 }
 

--- a/src/ESPEasy_checks.ino
+++ b/src/ESPEasy_checks.ino
@@ -37,7 +37,7 @@ void run_compiletime_checks() {
   check_size<NotificationStruct,                    3u>();
   check_size<NodeStruct,                            24u>();
   check_size<systemTimerStruct,                     28u>();
-  check_size<RTCStruct,                             20u>();
+  check_size<RTCStruct,                             28u>();
   check_size<rulesTimerStatus,                      12u>();
   check_size<portStatusStruct,                      4u>();
   check_size<ResetFactoryDefaultPreference_struct,  4u>();

--- a/src/ESPEasy_fdwdecl.h
+++ b/src/ESPEasy_fdwdecl.h
@@ -167,6 +167,7 @@ String rulesProcessingFile(const String& fileName, String& event);
 int Calculate(const char *input, float* result);
 
 
+void WifiScan(bool async, bool quick = false);
 void WifiScan();
 void WiFiConnectRelaxed();
 void WifiDisconnect();

--- a/src/Networking.ino
+++ b/src/Networking.ino
@@ -790,7 +790,7 @@ bool hasIPaddr() {
   bool configured = false;
 
   for (auto addr : addrList) {
-    if ((configured = !addr.isLocal() && (addr.ifnumber() == STATION_IF))) {
+    if ((configured = (!addr.isLocal() && (addr.ifnumber() == STATION_IF)))) {
       /*
          Serial.printf("STA: IF='%s' hostname='%s' addr= %s\n",
                     addr.ifname().c_str(),

--- a/src/StringProvider.ino
+++ b/src/StringProvider.ino
@@ -41,6 +41,9 @@ String getLabel(LabelType::Enum label) {
     case LabelType::IP_ADDRESS_SUBNET:      return F("IP / Subnet");
     case LabelType::GATEWAY:                return F("Gateway");
     case LabelType::CLIENT_IP:              return F("Client IP");
+    #ifdef FEATURE_MDNS
+    case LabelType::M_DNS:                  return F("mDNS");
+    #endif
     case LabelType::DNS:                    return F("DNS");
     case LabelType::DNS_1:                  return F("DNS 1");
     case LabelType::DNS_2:                  return F("DNS 2");
@@ -142,6 +145,9 @@ String getValue(LabelType::Enum label) {
     case LabelType::IP_ADDRESS_SUBNET:      return String(getValue(LabelType::IP_ADDRESS) + F(" / ") + getValue(LabelType::IP_SUBNET));
     case LabelType::GATEWAY:                return WiFi.gatewayIP().toString();
     case LabelType::CLIENT_IP:              return formatIP(WebServer.client().remoteIP());
+    #ifdef FEATURE_MDNS
+    case LabelType::M_DNS:                  return String(WifiGetHostname()) + F(".local");
+    #endif
     case LabelType::DNS:                    return String(getValue(LabelType::DNS_1) + F(" / ") + getValue(LabelType::DNS_2));
     case LabelType::DNS_1:                  return WiFi.dnsIP(0).toString();
     case LabelType::DNS_2:                  return WiFi.dnsIP(1).toString();

--- a/src/StringProviderTypes.h
+++ b/src/StringProviderTypes.h
@@ -41,6 +41,9 @@ enum Enum : short {
   IP_ADDRESS_SUBNET,           // 192.168.1.123 / 255.255.255.0
   GATEWAY,                     // 192.168.1.1
   CLIENT_IP,                   // 192.168.1.67
+  #ifdef FEATURE_MDNS
+  M_DNS,                       // breadboard.local
+  #endif
   DNS,                         // 192.168.1.1 / (IP unset)
   DNS_1,
   DNS_2,

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -566,6 +566,32 @@ void WebServerInit()
   #endif  // if defined(ESP8266)
 }
 
+void set_mDNS() {
+  #ifdef FEATURE_MDNS
+  if (webserverRunning) {
+    addLog(LOG_LEVEL_INFO, F("WIFI : Starting mDNS..."));
+    bool mdns_started = MDNS.begin(WifiGetHostname().c_str());
+    MDNS.setInstanceName(WifiGetHostname()); // Needed for when the hostname has changed.
+
+    if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+      String log = F("WIFI : ");
+
+      if (mdns_started) {
+        log += F("mDNS started, with name: ");
+        log += getValue(LabelType::M_DNS);
+      }
+      else {
+        log += F("mDNS failed");
+      }
+      addLog(LOG_LEVEL_INFO, log);
+    }
+    if (mdns_started) {
+      MDNS.addService("http", "tcp", 80);
+    }
+  }
+  #endif // ifdef FEATURE_MDNS
+}
+
 void setWebserverRunning(bool state) {
   if (webserverRunning == state) {
     return;
@@ -580,6 +606,7 @@ void setWebserverRunning(bool state) {
     addLog(LOG_LEVEL_INFO, F("Webserver: stop"));
   }
   webserverRunning = state;
+  set_mDNS(); // Uses webserverRunning state.
 }
 
 void getWebPageTemplateDefault(const String& tmplName, String& tmpl)

--- a/src/WebServer_JSON.ino
+++ b/src/WebServer_JSON.ino
@@ -70,6 +70,9 @@ void handle_json()
       #if defined(ESP8266)
       stream_next_json_object_value(LabelType::HOST_NAME);
       #endif // if defined(ESP8266)
+      #ifdef FEATURE_MDNS
+      stream_next_json_object_value(LabelType::M_DNS);
+      #endif
       stream_next_json_object_value(LabelType::IP_CONFIG);
       stream_next_json_object_value(LabelType::IP_ADDRESS);
       stream_next_json_object_value(LabelType::IP_SUBNET);

--- a/src/WebServer_RootPage.ino
+++ b/src/WebServer_RootPage.ino
@@ -106,13 +106,12 @@ void handle_root() {
     }
 
     #ifdef FEATURE_MDNS
-    html_TR_TD();
-    TXBuffer += F("mDNS:<TD><a href='http://");
-    TXBuffer += WifiGetHostname();
-    TXBuffer += F(".local'>");
-    TXBuffer += WifiGetHostname();
-    TXBuffer += F(".local</a>");
-    html_TD(3);
+    addRowLabel(getLabel(LabelType::M_DNS));
+    TXBuffer += F("<a href='http://");
+    TXBuffer += getValue(LabelType::M_DNS);
+    TXBuffer += F("'>");
+    TXBuffer += getValue(LabelType::M_DNS);
+    TXBuffer += F("</a>");
     #endif // ifdef FEATURE_MDNS
     html_TR_TD();
     html_TD();

--- a/src/WebServer_SetupPage.ino
+++ b/src/WebServer_SetupPage.ino
@@ -76,16 +76,14 @@ void handle_setup() {
 }
 
 void handle_setup_scan_and_show(const String& ssid, const String& other, const String& password) {
-  static int n            = 0;
-  WiFiMode_t cur_wifimode = WiFi.getMode();
-
-  if (n == 0) {
-    addLog(LOG_LEVEL_INFO, F("Start scan for WiFi APs"));
-    n = WiFi.scanNetworks(false, true);
+  if (WiFi.scanComplete() <= 0) {
+    WiFiMode_t cur_wifimode = WiFi.getMode();
+    WifiScan(false); 
+    setWifiMode(cur_wifimode);
   }
-  setWifiMode(cur_wifimode);
 
-  if (n == 0) {
+  const int8_t scanCompleteStatus = WiFi.scanComplete();
+  if (scanCompleteStatus <= 0) {
     TXBuffer += F("No Access Points found");
   }
   else
@@ -96,7 +94,7 @@ void handle_setup_scan_and_show(const String& ssid, const String& other, const S
     html_table_header(F("Network info"));
     html_table_header(F("RSSI"), 50);
 
-    for (int i = 0; i < n; ++i)
+    for (int i = 0; i < scanCompleteStatus; ++i)
     {
       html_TR_TD(); TXBuffer += F("<label class='container2'>");
       TXBuffer               += F("<input type='radio' name='ssid' value='");

--- a/src/WebServer_WiFiScanner.ino
+++ b/src/WebServer_WiFiScanner.ino
@@ -61,6 +61,11 @@ void handle_wifiscanner() {
   checkRAM(F("handle_wifiscanner"));
 
   if (!isLoggedIn()) { return; }
+
+  WiFiMode_t cur_wifimode = WiFi.getMode();
+  WifiScan(false); 
+  setWifiMode(cur_wifimode);
+
   navMenuIndex = MENU_INDEX_TOOLS;
   TXBuffer.startStream();
   sendHeadandTail_stdtemplate(_HEAD);
@@ -68,19 +73,22 @@ void handle_wifiscanner() {
   html_TR();
   html_table_header(getLabel(LabelType::SSID));
   html_table_header(getLabel(LabelType::BSSID));
-  html_table_header("info");
+  html_table_header(F("Network info"));
+  html_table_header(F("RSSI"), 50);
 
-  int n = WiFi.scanNetworks(false, true);
-
-  if (n == 0) {
+  const int8_t scanCompleteStatus = WiFi.scanComplete();
+  if (scanCompleteStatus <= 0) {
     TXBuffer += F("No Access Points found");
   }
   else
   {
-    for (int i = 0; i < n; ++i)
+    for (int i = 0; i < scanCompleteStatus; ++i)
     {
       html_TR_TD();
-      TXBuffer += formatScanResult(i, "<TD>");
+      int32_t rssi = 0;
+      TXBuffer += formatScanResult(i, "<TD>", rssi);
+      html_TD();
+      getWiFi_RSSI_icon(rssi, 45);
     }
   }
 

--- a/src/src/ControllerQueue/ControllerDelayHandlerStruct.h
+++ b/src/src/ControllerQueue/ControllerDelayHandlerStruct.h
@@ -85,7 +85,10 @@ struct ControllerDelayHandlerStruct {
 #ifndef BUILD_NO_DEBUG
 
     if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
-      String log = get_formatted_Controller_number(element.controller_idx);
+      // FIXME TD-er: Must convert it to controller number, but need Settings for that.
+      // int controllernummer = Settings.Protocol[element.controller_idx];
+      int controllernummer = element.controller_idx + 1;
+      String log = get_formatted_Controller_number(controllernummer);
       log += " : queue full";
       addLog(LOG_LEVEL_DEBUG, log);
     }
@@ -116,10 +119,10 @@ struct ControllerDelayHandlerStruct {
     if (remove_from_queue) {
       sendQueue.pop_front();
       attempt = 0;
+      lastSend = millis();
     } else {
       ++attempt;
     }
-    lastSend = millis();
     return getNextScheduleTime();
   }
 

--- a/src/src/DataStructs/RTCStruct.h
+++ b/src/src/DataStructs/RTCStruct.h
@@ -17,19 +17,24 @@
 //max 40 bytes: ( 74 - 64 ) * 4
 struct RTCStruct
 {
-  RTCStruct() : ID1(0), ID2(0), unused1(false), factoryResetCounter(0),
+  RTCStruct() : ID1(0), ID2(0), lastWiFiChannel(0), factoryResetCounter(0),
                 deepSleepState(0), bootFailedCount(0), flashDayCounter(0),
+                lastWiFiSettingsIndex(0),
                 flashCounter(0), bootCounter(0), lastMixedSchedulerId(0) {}
   byte ID1;
   byte ID2;
-  boolean unused1;
+  byte lastWiFiChannel;
   byte factoryResetCounter;
   byte deepSleepState;
   byte bootFailedCount;
   byte flashDayCounter;
+  byte lastWiFiSettingsIndex;
   unsigned long flashCounter;
   unsigned long bootCounter;
   unsigned long lastMixedSchedulerId;
+  uint8_t lastBSSID[6] = { 0 };
+  byte unused1;  // Force alignment to 4 bytes
+  byte unused2;
 };
 
 

--- a/src/src/Globals/ESPEasyWiFiEvent.cpp
+++ b/src/src/Globals/ESPEasyWiFiEvent.cpp
@@ -18,16 +18,14 @@ WiFiEventHandler APModeStationDisconnectedHandler;
 // WiFi related data
 bool wifiSetup                                 = false;
 bool wifiSetupConnect                          = false;
-uint8_t lastBSSID[6]                           = { 0 };
 uint8_t wifiStatus                             = ESPEASY_WIFI_DISCONNECTED;
 unsigned long last_wifi_connect_attempt_moment = 0;
 unsigned int  wifi_connect_attempt             = 0;
 int wifi_reconnects                            = -1; // First connection attempt is not a reconnect.
-uint8_t lastWiFiSettings                       = 0;
 String  last_ssid;
 bool    bssid_changed                     = false;
 bool    channel_changed                   = false;
-uint8_t last_channel                      = 0;
+
 WiFiDisconnectReason lastDisconnectReason = WIFI_DISCONNECT_REASON_UNSPECIFIED;
 unsigned long lastConnectMoment           = 0;
 unsigned long lastDisconnectMoment        = 0;
@@ -38,9 +36,6 @@ bool intent_to_reboot                     = false;
 uint8_t lastMacConnectedAPmode[6]         = { 0 };
 uint8_t lastMacDisconnectedAPmode[6]      = { 0 };
 
-// uint32_t scan_done_status = 0;
-// uint8_t  scan_done_scan_id = 0;
-uint8_t scan_done_number = 0;
 
 // Semaphore like bools for processing data gathered from WiFi events.
 volatile bool processedConnect          = true;

--- a/src/src/Globals/ESPEasyWiFiEvent.h
+++ b/src/src/Globals/ESPEasyWiFiEvent.h
@@ -73,16 +73,14 @@ extern WiFiEventHandler APModeStationDisconnectedHandler;
 // WiFi related data
 extern bool wifiSetup;
 extern bool wifiSetupConnect;
-extern uint8_t lastBSSID[6];
 extern uint8_t wifiStatus;
 extern unsigned long last_wifi_connect_attempt_moment;
 extern unsigned int  wifi_connect_attempt;
 extern int wifi_reconnects; // First connection attempt is not a reconnect.
-extern uint8_t lastWiFiSettings;
 extern String  last_ssid;
 extern bool    bssid_changed;
 extern bool    channel_changed;
-extern uint8_t last_channel;
+
 extern WiFiDisconnectReason lastDisconnectReason;
 extern unsigned long lastConnectMoment;
 extern unsigned long lastDisconnectMoment;
@@ -93,10 +91,6 @@ extern bool intent_to_reboot;
 extern uint8_t lastMacConnectedAPmode[6];
 extern uint8_t lastMacDisconnectedAPmode[6];
 
-// uint32_t scan_done_status = 0;
-extern uint8_t scan_done_number;
-
-// uint8_t  scan_done_scan_id = 0;
 
 // Semaphore like bools for processing data gathered from WiFi events.
 extern volatile bool processedConnect;


### PR DESCRIPTION
Store the last used BSSID and channel in the RTC and use it for initial WiFi connect attempt.
This does speed up the WiFI connection to about 1.8 sec after boot.
Old situation was connected at about 3.9 sec after boot.

When booting from cold boot, the strongest known RSSI is chosen first.

MQTT controller queue handling is now more aggressive in trying to get rid of buffered packets.
It also now accepts the MQTT messages before it is connected to WiFi (or when not yet reconnected)