### PR TITLE
[Events] Run events from rules immediately + add AsyncEvent command

### DIFF
--- a/docs/source/Plugin/P000_commands.repl
+++ b/docs/source/Plugin/P000_commands.repl
@@ -211,6 +211,19 @@
     Create an event, it's possible to send a float value along as well.
 
     See event syntax below..."
+    "
+    AsyncEvent","
+    :blue:`Special`","
+    Schedule an event, it's possible to send a float value along as well.
+
+    This is the same as a regular event, but it will not be executed immediately.
+    Instead it will be added to an event queue.
+    
+    Use this to keep rules execution times as short as possible.
+
+    N.B. New values sent by a task will also be of this type.
+
+    See event syntax below..."
 
 
 Event command
@@ -218,6 +231,12 @@ Event command
 
 The event command is a special command used to trigger an event. This event can then be acted upon from the rules.
 You can send 0..4 event values along with the event.
+
+An event will be executed immediately if its origin demands a state update.
+For events which do not need to be executed immediately, we have the AsyncEvent, which is added to an event queue.
+This queue is processed 10 times per second, one event at a time.
+
+Try to use AsyncEvents where possible, to keep rules processing times low.
 
 
 .. csv-table::

--- a/src/Command.ino
+++ b/src/Command.ino
@@ -117,6 +117,7 @@ bool executeInternalCommand(const char *cmd, struct EventStruct *event, const ch
   switch (cmd_lc[0]) {
     case 'a': {
       COMMAND_CASE("accessinfo", Command_AccessInfo_Ls, 0); // Network Command
+      COMMAND_CASE("asyncevent", Command_Rules_Async_Events,  -1); // Rule.h
       break;
     }
     case 'b': {

--- a/src/ESPEasyRules.ino
+++ b/src/ESPEasyRules.ino
@@ -566,7 +566,7 @@ void processMatchedRule(String& action, String& event,
       addLog(LOG_LEVEL_INFO, log);
     }
 
-    ExecuteCommand_all(VALUE_SOURCE_SYSTEM, action.c_str());
+    ExecuteCommand_all(VALUE_SOURCE_RULES, action.c_str());
     delay(0);
   }
 }

--- a/src/WebServer_ControlPage.ino
+++ b/src/WebServer_ControlPage.ino
@@ -12,9 +12,6 @@ void handle_control() {
   // TXBuffer.startStream(true); // true= json
   // sendHeadandTail_stdtemplate(_HEAD);
   String webrequest = WebServer.arg(F("cmd"));
-
-  // in case of event, store to buffer and return...
-  String command = parseString(webrequest, 1);
   addLog(LOG_LEVEL_INFO,  String(F("HTTP: ")) + webrequest);
   webrequest = parseTemplate(webrequest, webrequest.length());
 #ifndef BUILD_NO_DEBUG
@@ -22,10 +19,11 @@ void handle_control() {
 #endif // ifndef BUILD_NO_DEBUG
 
   bool handledCmd = false;
-
-  if (command == F("event"))
+  // in case of event, store to buffer and return...
+  String command = parseString(webrequest, 1);
+  if (command == F("event") || command == F("asyncevent")) 
   {
-    eventQueue.add(webrequest.substring(6));
+    eventQueue.add(parseStringToEnd(webrequest, 2));
     handledCmd  = true;
   }
   else if (command.equalsIgnoreCase(F("taskrun")) ||

--- a/src/_C005.ino
+++ b/src/_C005.ino
@@ -81,8 +81,8 @@ bool CPlugin_005(byte function, struct EventStruct *event, String& string)
           if (validTopic) {
             // in case of event, store to buffer and return...
             String command = parseString(cmd, 1);
-            if (command == F("event")) {
-            eventQueue.add(cmd.substring(6));
+            if (command == F("event") || command == F("asyncevent")) {
+              eventQueue.add(parseStringToEnd(cmd, 2));
             } else if (!PluginCall(PLUGIN_WRITE, &TempEvent, cmd)) {
               remoteConfig(&TempEvent, cmd);
             }

--- a/src/_C014.ino
+++ b/src/_C014.ino
@@ -636,10 +636,10 @@ bool CPlugin_014(byte function, struct EventStruct *event, String& string)
           if (validTopic) {
             // in case of event, store to buffer and return...
             String command = parseString(cmd, 1);
-            if (command == F("event"))
+            if (command == F("event") || command == F("asyncevent"))
             {
               if (Settings.UseRules) {
-                String newEvent = cmd.substring(6); 
+                String newEvent = parseStringToEnd(cmd, 2); 
                 eventQueue.add(newEvent);
                 if (loglevelActiveFor(LOG_LEVEL_INFO)) {
                   log=F("C014 : taskIndex:");

--- a/src/src/Commands/Rules.cpp
+++ b/src/src/Commands/Rules.cpp
@@ -2,10 +2,9 @@
 
 #include "../../ESPEasy_common.h"
 #include "../Commands/Common.h"
+#include "../DataStructs/EventValueSource.h"
 #include "../Globals/Settings.h"
 #include "../../ESPEasy-Globals.h"
-
-
 #include "../../ESPEasy_fdwdecl.h"
 
 
@@ -28,15 +27,28 @@ String Command_Rules_UseRules(struct EventStruct *event, const char *Line)
                               1);
 }
 
-String Command_Rules_Events(struct EventStruct *event, const char *Line)
+String Command_Rules_Async_Events(struct EventStruct *event, const char *Line)
 {
-  String eventName = Line;
-
-  eventName = eventName.substring(6);
+  String eventName = parseStringToEndKeepCase(Line, 2);
   eventName.replace('$', '#');
 
   if (Settings.UseRules) {
-    if (SourceNeedsStatusUpdate(event->Source)) {
+    eventQueue.add(eventName);
+  }
+  return return_command_success();
+}
+
+
+String Command_Rules_Events(struct EventStruct *event, const char *Line)
+{
+  String eventName = parseStringToEndKeepCase(Line, 2);
+  eventName.replace('$', '#');
+
+  if (Settings.UseRules) {
+    const bool executeImmediately = 
+        SourceNeedsStatusUpdate(event->Source) ||
+        event->Source == VALUE_SOURCE_RULES;
+    if (executeImmediately) {
       rulesProcessing(eventName); // TD-er: Process right now 
     } else {
       eventQueue.add(eventName);

--- a/src/src/Commands/Rules.h
+++ b/src/src/Commands/Rules.h
@@ -5,6 +5,7 @@ class String;
 
 String Command_Rules_Execute(struct EventStruct *event, const char *Line);
 String Command_Rules_UseRules(struct EventStruct *event, const char *Line);
+String Command_Rules_Async_Events(struct EventStruct *event, const char *Line);
 String Command_Rules_Events(struct EventStruct *event, const char *Line);
 String Command_Rules_Let(struct EventStruct *event, const char *Line);
 

--- a/src/src/DataStructs/EventValueSource.h
+++ b/src/src/DataStructs/EventValueSource.h
@@ -7,5 +7,6 @@
 #define VALUE_SOURCE_MQTT                   4
 #define VALUE_SOURCE_UDP                    5
 #define VALUE_SOURCE_WEB_FRONTEND           6
+#define VALUE_SOURCE_RULES                  7
 
 #endif // DATASTRUCTS_EVENT_VALUE_SOURCE_H


### PR DESCRIPTION
It appears the events called from rules must be run immediately, but there are some use cases where it can be useful to have async events.
So changed back the behavior for events called from rules, to be executed immediately.
Added the new command AsyncEvent.