### PR TITLE
[Rules] Add some checks for rules consistency before saving

### DIFF
--- a/src/StringConverter.ino
+++ b/src/StringConverter.ino
@@ -445,14 +445,36 @@ String tolerantParseStringKeepCase(const String& string, byte indexFind)
 }
 
 // escapes special characters in strings for use in html-forms
+bool htmlEscapeChar(char c, String& escaped)
+{
+  switch (c)
+  {
+    case '&':  escaped = F("&amp;");  return true;
+    case '\"': escaped = F("&quot;"); return true;
+    case '\'': escaped = F("&#039;"); return true;
+    case '<':  escaped = F("&lt;");   return true;
+    case '>':  escaped = F("&gt;");   return true;
+    case '/':  escaped = F("&#047;"); return true;
+  }
+  return false;
+}
+
+void htmlEscape(String& html, char c)
+{
+  String repl;
+  if (htmlEscapeChar(c, repl)) {
+    html.replace(String(c), repl);
+  }
+}
+
 void htmlEscape(String& html)
 {
-  html.replace("&",  F("&amp;"));
-  html.replace("\"", F("&quot;"));
-  html.replace("'",  F("&#039;"));
-  html.replace("<",  F("&lt;"));
-  html.replace(">",  F("&gt;"));
-  html.replace("/",  F("&#047;"));
+  htmlEscape(html, '&');
+  htmlEscape(html, '\"');
+  htmlEscape(html, '\'');
+  htmlEscape(html, '<');
+  htmlEscape(html, '>');
+  htmlEscape(html, '/');
 }
 
 void htmlStrongEscape(String& html)

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -405,8 +405,46 @@ void sendHeadandTail_stdtemplate(boolean Tail = false, boolean rebooting = false
     if (!clientIPinSubnet() && WifiIsAP(WiFi.getMode()) && (WiFi.softAPgetStationNum() > 0)) {
       addHtmlError(F("Warning: Connected via AP"));
     }
+    if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+      const int nrArgs = WebServer.args();
+      if (nrArgs > 0) {
+        String log = F(" Webserver args:");
+
+        for (int i = 0; i < nrArgs; ++i) {
+          log += ' ';
+          log += i;
+          log += F(": '");
+          log += WebServer.argName(i);
+          log += F("' length: ");
+          log += WebServer.arg(i).length();
+        }
+        addLog(LOG_LEVEL_INFO, log);
+      }
+    }
   }
 }
+
+size_t streamFile_htmlEscape(const String& fileName)
+{
+  fs::File f = tryOpenFile(fileName, "r");
+  size_t size = 0;
+  if (f)
+  {
+    String escaped;
+    while (f.available())
+    {
+      char c = (char)f.read();
+      if (htmlEscapeChar(c, escaped)) {
+        TXBuffer += escaped;
+      } else {
+        TXBuffer += c;
+      }
+    }
+    f.close();
+  }
+  return size;
+}
+
 
 // ********************************************************************************
 // Web Interface init

--- a/src/WebServer.ino
+++ b/src/WebServer.ino
@@ -439,6 +439,7 @@ size_t streamFile_htmlEscape(const String& fileName)
       } else {
         TXBuffer += c;
       }
+      ++size;
     }
     f.close();
   }

--- a/src/WebServer_Rules.ino
+++ b/src/WebServer_Rules.ino
@@ -10,8 +10,6 @@ void handle_rules() {
 
   if (!isLoggedIn() || !Settings.UseRules) { return; }
   navMenuIndex = MENU_INDEX_RULES;
-  TXBuffer.startStream();
-  sendHeadandTail_stdtemplate();
   static byte currentSet = 1;
 
   const byte rulesSet = getFormItemInt(F("set"), 1);
@@ -25,42 +23,25 @@ void handle_rules() {
   fileName += rulesSet;
   fileName += F(".txt");
 
-
-  checkRAM(F("handle_rules"));
-
-
-  if (WebServer.args() > 0)
-  {
+  String error;
+  if (WebServer.args() > 0) {
     String log = F("Rules : Save rulesSet: ");
     log += rulesSet;
     log += F(" currentSet: ");
     log += currentSet;
 
-    if (currentSet == rulesSet) // only save when the dropbox was not used to change set
-    {
-      size_t rulesLength = WebServer.arg(F("rules")).length();
-      log += F(" rules.length(): ");
-      log += rulesLength;
-
-      if (rulesLength > RULES_MAX_SIZE) {
-        TXBuffer += F("<span style=\"color:red\">Data was not saved, exceeds web editor limit!</span>");
-      }
-      else
-      {
-        // if (RTC.flashDayCounter > MAX_FLASHWRITES_PER_DAY)
-        // {
-        //   String log = F("FS   : Daily flash write rate exceeded! (powercyle to reset this)");
-        //   addLog(LOG_LEVEL_ERROR, log);
-        //   TXBuffer += F("<span style=\"color:red\">Error saving to flash!</span>");
-        // }
-        // else
-        // {
-        const byte *memAddress = reinterpret_cast<const byte *>(WebServer.arg(F("rules")).c_str());
-        addHtmlError(SaveToFile(fileName.c_str(), 0, memAddress, rulesLength, "w"));
-
-        // flashCount();
-
-        // }
+    if (currentSet == rulesSet) {
+      if (WebServer.hasArg(F("rules"))) {
+        size_t rulesLength = WebServer.arg(F("rules")).length();
+        if (rulesLength > RULES_MAX_SIZE) {
+          error = F("Error: Data was not saved, exceeds web editor limit!");
+        } else {
+          // Save as soon as possible, as the webserver may already overwrite the args.
+          const byte *memAddress = reinterpret_cast<const byte *>(WebServer.arg(F("rules")).c_str());
+          error = SaveToFile(fileName.c_str(), 0, memAddress, rulesLength, "w");
+        }
+      } else {
+        error = F("Error: Data was not saved, rules argument missing or corrupted");
       }
     }
     else // changed set, check if file exists and create new
@@ -75,19 +56,10 @@ void handle_rules() {
       }
     }
     addLog(LOG_LEVEL_INFO, log);
-
-    log = F(" Webserver args:");
-
-    for (int i = 0; i < WebServer.args(); ++i) {
-      log += ' ';
-      log += i;
-      log += F(": '");
-      log += WebServer.argName(i);
-      log += F("' length: ");
-      log += WebServer.arg(i).length();
-    }
-    addLog(LOG_LEVEL_INFO, log);
   }
+  TXBuffer.startStream();
+  sendHeadandTail_stdtemplate();
+  addHtmlError(error);
 
   if (rulesSet != currentSet) {
     currentSet = rulesSet;
@@ -113,38 +85,7 @@ void handle_rules() {
   addSelector(F("set"), RULESETS_MAX, options, optionValues, NULL, choice, true);
   addHelpButton(F("Tutorial_Rules"));
 
-  // load form data from flash
-
-  int size   = 0;
-  fs::File f = tryOpenFile(fileName, "r");
-
-  if (f)
-  {
-    size = f.size();
-
-    if (size > RULES_MAX_SIZE) {
-      TXBuffer += F("<span style=\"color:red\">Filesize exceeds web editor limit!</span>");
-    }
-    else
-    {
-      html_TR_TD(); TXBuffer += F("<textarea name='rules' rows='30' wrap='off'>");
-
-      while (f.available())
-      {
-        String c((char)f.read());
-        htmlEscape(c);
-        TXBuffer += c;
-      }
-      TXBuffer += F("</textarea>");
-    }
-    f.close();
-  }
-
-  html_TR_TD(); TXBuffer += F("Current size: ");
-  TXBuffer               += size;
-  TXBuffer               += F(" characters (Max ");
-  TXBuffer               += RULES_MAX_SIZE;
-  TXBuffer               += ')';
+  Rule_showRuleTextArea(fileName);
 
   addFormSeparator(2);
 
@@ -439,7 +380,6 @@ bool handle_rules_edit(String originalUri, bool isAddNew) {
     String fileName;
     bool   isOverwrite = false;
     bool   isNew       = false;
-    String rules;
     String error;
 
 
@@ -467,16 +407,21 @@ bool handle_rules_edit(String originalUri, bool isAddNew) {
 
     if (WebServer.args() > 0)
     {
-      rules = WebServer.arg(F("rules"));
+      const String& rules = WebServer.arg(F("rules"));
       isNew = WebServer.arg(F("IsNew")) == F("yes");
 
       // Overwrite verification
       if (isEdit && isNew) {
-        error = String(F("There is another rule with the same name."))
+        error = String(F("There is another rule with the same name: "))
                 + fileName;
         addLog(LOG_LEVEL_ERROR, error);
         isAddNew    = true;
         isOverwrite = true;
+      }
+      else if (!WebServer.hasArg(F("rules")))
+      {
+        error = F("Data was not saved, rules argument missing or corrupted");
+        addLog(LOG_LEVEL_ERROR, error);
       }
 
       // Check rules size
@@ -548,49 +493,9 @@ bool handle_rules_edit(String originalUri, bool isAddNew) {
 
     // load form data from flash
     TXBuffer += F("<TR><TD colspan='2'>");
-    int size = 0;
 
-    if (!isOverwrite)
-    {
-      rules = "";
-      fs::File f = tryOpenFile(fileName, "r");
+    Rule_showRuleTextArea(fileName);
 
-      if (f)
-      {
-        size = f.size();
-
-        if (size < RULES_MAX_SIZE)
-        {
-          rules.reserve(size);
-
-          while (f.available())
-          {
-            rules += (char)f.read();
-          }
-        }
-        f.close();
-      }
-    }
-
-    if (size > RULES_MAX_SIZE) {
-      TXBuffer += F("<span style=\"color:red\">Filesize exceeds web editor limit!</span>");
-    }
-    else
-    {
-      TXBuffer += F("<textarea name='rules' rows='30' wrap='off'>");
-      String c(rules);
-      htmlEscape(c);
-      TXBuffer += c;
-      TXBuffer += F("</textarea>");
-    }
-
-    TXBuffer += F("<TR><TD colspan='2'>");
-
-    html_TR_TD(); TXBuffer += F("Current size: ");
-    TXBuffer               += size;
-    TXBuffer               += F(" characters (Max ");
-    TXBuffer               += RULES_MAX_SIZE;
-    TXBuffer               += F(")");
     addFormSeparator(2);
     html_TR_TD();
     addSubmitButton();
@@ -604,6 +509,26 @@ bool handle_rules_edit(String originalUri, bool isAddNew) {
   checkRAM(F("handle_rules"));
   return handle;
 }
+
+void Rule_showRuleTextArea(const String& fileName) {
+  // Read rules from file and stream directly into the textarea
+  
+  size_t size = 0;
+  TXBuffer += F("<textarea name='rules' rows='30' wrap='off'>");
+  size = streamFile_htmlEscape(fileName);
+  TXBuffer += F("</textarea>");
+  TXBuffer += F("<TR><TD colspan='2'>");
+
+  html_TR_TD(); TXBuffer += F("Current size: ");
+  TXBuffer               += size;
+  TXBuffer               += F(" characters (Max ");
+  TXBuffer               += RULES_MAX_SIZE;
+  TXBuffer               += F(")");
+  if (size > RULES_MAX_SIZE) {
+    TXBuffer += F("<span style=\"color:red\">Filesize exceeds web editor limit!</span>");
+  }
+}
+
 
 bool Rule_Download(const String& path)
 {


### PR DESCRIPTION
The web arguments may get corrupted sometimes.
This can be due to another request mangling the already parsed arguments, or lack of memory to split the sent arguments into parsed ones.

I  added a very basic JavaScript line to the rules page, where it appends the length of the rules.
Only problem is that the length in JavaScript is with a newline counted as `\n` and it outputs to the node with a newline as `\r\n`, so there is an offset of 1 byte per line.
But still gives me a good indication whether data is lost, which happens quite a lot when you cross the 1600 bytes

Known issue:
If you try to save and it fails, then the stored rules will be shown (not the one you just tried to submit)