### PR TITLE
[LCD] Fix incorrect convert to lower case for LCD texts

### DIFF
--- a/src/_P012_LCD.ino
+++ b/src/_P012_LCD.ino
@@ -226,7 +226,7 @@ boolean Plugin_012(byte function, struct EventStruct *event, String& string)
           success = true;
           int colPos = event->Par2 - 1;
           int rowPos = event->Par1 - 1;
-          String text = parseString(string, 4);
+          String text = parseStringKeepCase(string, 4);
           text = P012_parseTemplate(text, Plugin_012_cols);
 
           //clear line before writing new string

--- a/src/_P033_Dummy.ino
+++ b/src/_P033_Dummy.ino
@@ -110,7 +110,7 @@ boolean Plugin_033(byte function, struct EventStruct *event, String& string)
                 log += F(" value ");
                 log += event->Par2;
                 log += F(" parameter3: ");
-                log += parseString(string, 4);
+                log += parseStringKeepCase(string, 4);
                 log += F(" not a float value!");
                 addLog(LOG_LEVEL_ERROR,log);
               }


### PR DESCRIPTION
As reported on [the forum](https://www.letscontrolit.com/forum/viewtopic.php?p=41490#p41490)