### PR TITLE
[Build Size] Replace all TXBuffer += calls where possible

### DIFF
--- a/lib/ccronexpr/ccronexpr_test.c
+++ b/lib/ccronexpr/ccronexpr_test.c
@@ -1,0 +1,409 @@
+/*
+ * Copyright 2015, alex at staticlibs.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* 
+ * File:   CronExprParser_test.cpp
+ * Author: alex
+ *
+ * Created on February 24, 2015, 9:36 AM
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <limits.h>
+
+#include "ccronexpr.h"
+
+#define MAX_SECONDS 60
+#define CRON_MAX_MINUTES 60
+#define CRON_MAX_HOURS 24
+#define CRON_MAX_DAYS_OF_WEEK 8
+#define CRON_MAX_DAYS_OF_MONTH 32
+#define CRON_MAX_MONTHS 12
+
+#define INVALID_INSTANT ((time_t) -1)
+
+#define DATE_FORMAT "%Y-%m-%d_%H:%M:%S"
+
+#ifndef ARRAY_LEN
+#define ARRAY_LEN(x) sizeof(x)/sizeof(x[0])
+#endif
+
+#ifdef CRON_TEST_MALLOC
+static int cronAllocations = 0;
+static int cronTotalAllocations = 0;
+static int maxAlloc = 0;
+void* cron_malloc(size_t n) {
+    cronAllocations++;
+    cronTotalAllocations++;
+    if (cronAllocations > maxAlloc) {
+        maxAlloc = cronAllocations;
+    }
+    return malloc(n);
+}
+
+void cron_free(void* p) {
+    cronAllocations--;
+    free(p);
+}
+#endif
+
+#ifndef ANDROID
+#ifndef _WIN32
+time_t timegm(struct tm* __tp);
+#else /* _WIN32 */
+static time_t timegm(struct tm* tm) {
+    return _mkgmtime(tm);
+}
+#endif /* _WIN32 */
+#else /* ANDROID */
+static time_t timegm(struct tm * const t) {
+    /* time_t is signed on Android. */
+    static const time_t kTimeMax = ~(1L << (sizeof (time_t) * CHAR_BIT - 1));
+    static const time_t kTimeMin = (1L << (sizeof (time_t) * CHAR_BIT - 1));
+    time64_t result = timegm64(t);
+    if (result < kTimeMin || result > kTimeMax)
+    return -1;
+    return result;
+}
+#endif
+
+/**
+ * uint8_t* replace char* for storing hit dates, set_bit and get_bit are used as handlers
+ */
+uint8_t cron_get_bit(uint8_t* rbyte, int idx);
+void cron_set_bit(uint8_t* rbyte, int idx);
+void cron_del_bit(uint8_t* rbyte, int idx);
+
+static int crons_equal(cron_expr* cr1, cron_expr* cr2) {
+    unsigned int i;
+    for (i = 0; i < ARRAY_LEN(cr1->seconds); i++) {
+        if (cr1->seconds[i] != cr2->seconds[i]) {
+            printf("seconds not equal @%d %02x != %02x", i, cr1->seconds[i], cr2->seconds[i]);
+            return 0;
+        }
+    }
+    for (i = 0; i < ARRAY_LEN(cr1->minutes); i++) {
+        if (cr1->minutes[i] != cr2->minutes[i]) {
+            printf("minutes not equal @%d %02x != %02x", i, cr1->minutes[i], cr2->minutes[i]);
+            return 0;
+        }
+    }
+    for (i = 0; i < ARRAY_LEN(cr1->hours); i++) {
+        if (cr1->hours[i] != cr2->hours[i]) {
+            printf("hours not equal @%d %02x != %02x", i, cr1->hours[i], cr2->hours[i]);
+            return 0;
+        }
+    }
+    for (i = 0; i < ARRAY_LEN(cr1->days_of_week); i++) {
+        if (cr1->days_of_week[i] != cr2->days_of_week[i]) {
+            printf("days_of_week not equal @%d %02x != %02x", i, cr1->days_of_week[i], cr2->days_of_week[i]);
+            return 0;
+        }
+    }
+    for (i = 0; i < ARRAY_LEN(cr1->days_of_month); i++) {
+        if (cr1->days_of_month[i] != cr2->days_of_month[i]) {
+            printf("days_of_month not equal @%d %02x != %02x", i, cr1->days_of_month[i], cr2->days_of_month[i]);
+            return 0;
+        }
+    }
+    for (i = 0; i < ARRAY_LEN(cr1->months); i++) {
+        if (cr1->months[i] != cr2->months[i]) {
+            printf("months not equal @%d %02x != %02x", i, cr1->months[i], cr2->months[i]);
+            return 0;
+        }
+    }
+    return 1;
+}
+
+int one_dec_num(const char ch) {
+    switch (ch) {
+    case '0':
+        return 0;
+    case '1':
+        return 1;
+    case '2':
+        return 2;
+    case '3':
+        return 3;
+    case '4':
+        return 4;
+    case '5':
+        return 5;
+    case '6':
+        return 6;
+    case '7':
+        return 7;
+    case '8':
+        return 8;
+    case '9':
+        return 9;
+    default:
+        return -1;
+    }
+}
+
+int two_dec_num(const char* first) {
+    return one_dec_num(first[0]) * 10 + one_dec_num(first[1]);
+}
+
+int four_dec_num(const char *first) {
+    return ((one_dec_num(first[0]) * 1000)
+          + (one_dec_num(first[1]) * 100)
+          + (one_dec_num(first[2]) * 10)
+          + (one_dec_num(first[3]) * 1));
+}
+
+/* strptime is not available in msvc */
+/* 2012-07-01_09:53:50 */
+/* 0123456789012345678 */
+struct tm* poors_mans_strptime(const char* str) {
+    struct tm* cal = (struct tm*) malloc(sizeof(struct tm));
+    assert(cal != NULL);
+    memset(cal, 0, sizeof(struct tm));
+    cal->tm_year = four_dec_num(str) - 1900;
+    cal->tm_mon = two_dec_num(str + 5) - 1;
+    cal->tm_mday = two_dec_num(str + 8);
+    cal->tm_wday = 0;
+    cal->tm_yday = 0;
+    cal->tm_hour = two_dec_num(str + 11);
+    cal->tm_min = two_dec_num(str + 14);
+    cal->tm_sec = two_dec_num(str + 17);
+    return cal;
+}
+
+void check_next(const char* pattern, const char* initial, const char* expected) {
+    const char* err = NULL;
+    cron_expr parsed;
+    cron_parse_expr(pattern, &parsed, &err);
+
+    struct tm* calinit = poors_mans_strptime(initial);
+#ifdef CRON_USE_LOCAL_TIME
+    time_t dateinit = mktime(calinit);
+#else
+    time_t dateinit = timegm(calinit);
+#endif
+    assert(-1 != dateinit);
+    time_t datenext = cron_next(&parsed, dateinit);
+#ifdef CRON_USE_LOCAL_TIME
+    struct tm* calnext = localtime(&datenext);
+#else
+    struct tm* calnext = gmtime(&datenext);
+#endif
+    assert(calnext);
+    char* buffer = (char*) malloc(21);
+    memset(buffer, 0, 21);
+    strftime(buffer, 20, DATE_FORMAT, calnext);
+    if (0 != strcmp(expected, buffer)) {
+        printf("Pattern: %s\n", pattern);
+        printf("Initial: %s\n", initial);
+        printf("Expected: %s\n", expected);
+        printf("Actual: %s\n", buffer);
+        assert(0);
+    }
+    free(buffer);
+    free(calinit);
+}
+
+void check_same(const char* expr1, const char* expr2) {
+    cron_expr parsed1;
+    cron_parse_expr(expr1, &parsed1, NULL);
+    cron_expr parsed2;
+    cron_parse_expr(expr2, &parsed2, NULL);
+    assert(crons_equal(&parsed1, &parsed2));
+}
+
+void check_calc_invalid() {
+    cron_expr parsed;
+    cron_parse_expr("0 0 0 31 6 *", &parsed, NULL);
+    struct tm * calinit = poors_mans_strptime("2012-07-01_09:53:50");
+    time_t dateinit = timegm(calinit);
+    time_t res = cron_next(&parsed, dateinit);
+    assert(INVALID_INSTANT == res);
+    free(calinit);
+}
+
+void check_expr_invalid(const char* expr) {
+    const char* err = NULL;
+    cron_expr test;
+    cron_parse_expr(expr, &test, &err);
+    assert(err);
+}
+
+void test_expr() {
+#ifdef CRON_USE_LOCAL_TIME
+    check_next("* 15 11 * * *",     "2019-03-09_11:43:00", "2019-03-10_11:15:00");
+#else
+    check_next("*/15 * 1-4 * * *",  "2012-07-01_09:53:50", "2012-07-02_01:00:00");
+    check_next("*/15 * 1-4 * * *",  "2012-07-01_09:53:00", "2012-07-02_01:00:00");
+    check_next("0 */2 1-4 * * *",   "2012-07-01_09:00:00", "2012-07-02_01:00:00");
+    check_next("0 */2 * * * *",     "2012-07-01_09:00:00", "2012-07-01_09:02:00");
+    check_next("0 */2 * * * *",     "2013-07-01_09:00:00", "2013-07-01_09:02:00");
+    check_next("0 */2 * * * *",     "2018-09-14_14:24:00", "2018-09-14_14:26:00");
+    check_next("0 */2 * * * *",     "2018-09-14_14:25:00", "2018-09-14_14:26:00");
+    check_next("0 */20 * * * *",    "2018-09-14_14:24:00", "2018-09-14_14:40:00");
+    check_next("* * * * * *",       "2012-07-01_09:00:00", "2012-07-01_09:00:01");
+    check_next("* * * * * *",       "2012-12-01_09:00:58", "2012-12-01_09:00:59");
+    check_next("10 * * * * *",      "2012-12-01_09:42:09", "2012-12-01_09:42:10");
+    check_next("11 * * * * *",      "2012-12-01_09:42:10", "2012-12-01_09:42:11");
+    check_next("10 * * * * *",      "2012-12-01_09:42:10", "2012-12-01_09:43:10");
+    check_next("10-15 * * * * *",   "2012-12-01_09:42:09", "2012-12-01_09:42:10");
+    check_next("10-15 * * * * *",   "2012-12-01_21:42:14", "2012-12-01_21:42:15");
+    check_next("0 * * * * *",       "2012-12-01_21:10:42", "2012-12-01_21:11:00");
+    check_next("0 * * * * *",       "2012-12-01_21:11:00", "2012-12-01_21:12:00");
+    check_next("0 11 * * * *",      "2012-12-01_21:10:42", "2012-12-01_21:11:00");
+    check_next("0 10 * * * *",      "2012-12-01_21:11:00", "2012-12-01_22:10:00");
+    check_next("0 0 * * * *",       "2012-09-30_11:01:00", "2012-09-30_12:00:00");
+    check_next("0 0 * * * *",       "2012-09-30_12:00:00", "2012-09-30_13:00:00");
+    check_next("0 0 * * * *",       "2012-09-10_23:01:00", "2012-09-11_00:00:00");
+    check_next("0 0 * * * *",       "2012-09-11_00:00:00", "2012-09-11_01:00:00");
+    check_next("0 0 0 * * *",       "2012-09-01_14:42:43", "2012-09-02_00:00:00");
+    check_next("0 0 0 * * *",       "2012-09-02_00:00:00", "2012-09-03_00:00:00");
+    check_next("* * * 10 * *",      "2012-10-09_15:12:42", "2012-10-10_00:00:00");
+    check_next("* * * 10 * *",      "2012-10-11_15:12:42", "2012-11-10_00:00:00");
+    check_next("0 0 0 * * *",       "2012-09-30_15:12:42", "2012-10-01_00:00:00");
+    check_next("0 0 0 * * *",       "2012-10-01_00:00:00", "2012-10-02_00:00:00");
+    check_next("0 0 0 * * *",       "2012-08-30_15:12:42", "2012-08-31_00:00:00");
+    check_next("0 0 0 * * *",       "2012-08-31_00:00:00", "2012-09-01_00:00:00");
+    check_next("0 0 0 * * *",       "2012-10-30_15:12:42", "2012-10-31_00:00:00");
+    check_next("0 0 0 * * *",       "2012-10-31_00:00:00", "2012-11-01_00:00:00");
+    check_next("0 0 0 1 * *",       "2012-10-30_15:12:42", "2012-11-01_00:00:00");
+    check_next("0 0 0 1 * *",       "2012-11-01_00:00:00", "2012-12-01_00:00:00");
+    check_next("0 0 0 1 * *",       "2010-12-31_15:12:42", "2011-01-01_00:00:00");
+    check_next("0 0 0 1 * *",       "2011-01-01_00:00:00", "2011-02-01_00:00:00");
+    check_next("0 0 0 31 * *",      "2011-10-30_15:12:42", "2011-10-31_00:00:00");
+    check_next("0 0 0 1 * *",       "2011-10-30_15:12:42", "2011-11-01_00:00:00");
+    check_next("* * * * * 2",       "2010-10-25_15:12:42", "2010-10-26_00:00:00");
+    check_next("* * * * * 2",       "2010-10-20_15:12:42", "2010-10-26_00:00:00");
+    check_next("* * * * * 2",       "2010-10-27_15:12:42", "2010-11-02_00:00:00");
+    check_next("55 5 * * * *",      "2010-10-27_15:04:54", "2010-10-27_15:05:55");
+    check_next("55 5 * * * *",      "2010-10-27_15:05:55", "2010-10-27_16:05:55");
+    check_next("55 * 10 * * *",     "2010-10-27_09:04:54", "2010-10-27_10:00:55");
+    check_next("55 * 10 * * *",     "2010-10-27_10:00:55", "2010-10-27_10:01:55");
+    check_next("* 5 10 * * *",      "2010-10-27_09:04:55", "2010-10-27_10:05:00");
+    check_next("* 5 10 * * *",      "2010-10-27_10:05:00", "2010-10-27_10:05:01");
+    check_next("55 * * 3 * *",      "2010-10-02_10:05:54", "2010-10-03_00:00:55");
+    check_next("55 * * 3 * *",      "2010-10-03_00:00:55", "2010-10-03_00:01:55");
+    check_next("* * * 3 11 *",      "2010-10-02_14:42:55", "2010-11-03_00:00:00");
+    check_next("* * * 3 11 *",      "2010-11-03_00:00:00", "2010-11-03_00:00:01");
+    check_next("0 0 0 29 2 *",      "2007-02-10_14:42:55", "2008-02-29_00:00:00");
+    check_next("0 0 0 29 2 *",      "2008-02-29_00:00:00", "2012-02-29_00:00:00");
+    check_next("0 0 7 ? * MON-FRI", "2009-09-26_00:42:55", "2009-09-28_07:00:00");
+    check_next("0 0 7 ? * MON-FRI", "2009-09-28_07:00:00", "2009-09-29_07:00:00");
+    check_next("0 30 23 30 1/3 ?",  "2010-12-30_00:00:00", "2011-01-30_23:30:00");
+    check_next("0 30 23 30 1/3 ?",  "2011-01-30_23:30:00", "2011-04-30_23:30:00");
+    check_next("0 30 23 30 1/3 ?",  "2011-04-30_23:30:00", "2011-07-30_23:30:00");    
+#endif
+}
+
+void test_parse() {
+
+    check_same("* * * 2 * *", "* * * 2 * ?");
+    check_same("57,59 * * * * *", "57/2 * * * * *");
+    check_same("1,3,5 * * * * *", "1-6/2 * * * * *");
+    check_same("* * 4,8,12,16,20 * * *", "* * 4/4 * * *");
+    check_same("* * * * * 0-6", "* * * * * TUE,WED,THU,FRI,SAT,SUN,MON");
+    check_same("* * * * * 0", "* * * * * SUN");
+    check_same("* * * * * 0", "* * * * * 7");
+    check_same("* * * * 1-12 *", "* * * * FEB,JAN,MAR,APR,MAY,JUN,JUL,AUG,SEP,OCT,NOV,DEC *");
+    check_same("* * * * 2 *", "* * * * Feb *");
+    check_same("*  *  * *  1 *", "* * * * 1 *");
+
+    check_expr_invalid("77 * * * * *");
+    check_expr_invalid("44-77 * * * * *");
+    check_expr_invalid("* 77 * * * *");
+    check_expr_invalid("* 44-77 * * * *");
+    check_expr_invalid("* * 27 * * *");
+    check_expr_invalid("* * 23-28 * * *");
+    check_expr_invalid("* * * 45 * *");
+    check_expr_invalid("* * * 28-45 * *");
+    check_expr_invalid("0 0 0 25 13 ?");
+    check_expr_invalid("0 0 0 25 0 ?");
+    check_expr_invalid("0 0 0 32 12 ?");
+    check_expr_invalid("* * * * 11-13 *");
+    check_expr_invalid("-5 * * * * *");
+    check_expr_invalid("3-2 */5 * * * *");
+    check_expr_invalid("/5 * * * * *");
+    check_expr_invalid("*/0 * * * * *");
+    check_expr_invalid("*/-0 * * * * *");
+    check_expr_invalid("* 1 1 0 * *");
+}
+
+void test_bits() {
+
+    uint8_t testbyte[8];
+    memset(testbyte, 0, 8);
+    int err = 0;
+    int i;
+
+    for (i = 0; i <= 63; i++) {
+        cron_set_bit(testbyte, i);
+        if (!cron_get_bit(testbyte, i)) {
+            printf("Bit set error! Bit: %d!\n", i);
+            err = 1;
+        }
+        cron_del_bit(testbyte, i);
+        if (cron_get_bit(testbyte, i)) {
+            printf("Bit clear error! Bit: %d!\n", i);
+            err = 1;
+        }
+        assert(!err);
+    }
+
+    for (i = 0; i < 12; i++) {
+        cron_set_bit(testbyte, i);
+    }
+    if (testbyte[0] != 0xff) {
+        err = 1;
+    }
+    if (testbyte[1] != 0x0f) {
+        err = 1;
+    }
+
+    assert(!err);
+}
+
+/* For this test to work you need to set "-DCRON_TEST_MALLOC=1"*/
+#ifdef CRON_TEST_MALLOC
+void test_memory() {
+    cron_expr cron;
+    const char* err;
+
+    cron_parse_expr("* * * * * *", &cron, &err);
+    if (cronAllocations != 0) {
+        printf("Allocations != 0 but %d", cronAllocations);
+        assert(0);
+    }
+    printf("Allocations: total: %d, max: %d", cronTotalAllocations, maxAlloc);
+}
+#endif
+
+int main() {
+
+    test_bits();
+
+    test_expr();
+    test_parse();
+    check_calc_invalid();
+    #ifdef CRON_TEST_MALLOC
+    test_memory(); /* For this test to work you need to set "-DCRON_TEST_MALLOC=1"*/
+    #endif
+    printf("\nAll OK!");
+    return 0;
+}
+

--- a/src/WebServer_AdvancedConfigPage.ino
+++ b/src/WebServer_AdvancedConfigPage.ino
@@ -82,7 +82,7 @@ void handle_advanced() {
     }
   }
 
-  TXBuffer += F("<form  method='post'>");
+  addHtml(F("<form  method='post'>"));
   html_table_class_normal();
 
   addFormHeader(F("Advanced Settings"), F("RTDTools/Tools.html#advanced"));
@@ -150,10 +150,10 @@ void handle_advanced() {
   // TODO sort settings in groups or move to other pages/groups
   addFormSubHeader(F("Special and Experimental Settings"));
 
-  addFormNumericBox(F("Fixed IP Octet"),        F("ip"),                    Settings.IP_Octet,     0, 255);
+  addFormNumericBox(F("Fixed IP Octet"), F("ip"),           Settings.IP_Octet,     0, 255);
 
-  addFormNumericBox(F("WD I2C Address"),        F("wdi2caddress"),          Settings.WDI2CAddress, 0, 127);
-  TXBuffer += F(" (decimal)");
+  addFormNumericBox(F("WD I2C Address"), F("wdi2caddress"), Settings.WDI2CAddress, 0, 127);
+  addHtml(F(" (decimal)"));
 
   addFormNumericBox(F("I2C ClockStretchLimit"), F("wireclockstretchlimit"), Settings.WireClockStretchLimit); // TODO define limits
   #if defined(FEATURE_ARDUINO_OTA)
@@ -164,8 +164,8 @@ void handle_advanced() {
   #endif // if defined(ESP32)
 
   #ifdef USES_SSDP
-  addFormCheckBox_disabled(F("Use SSDP"),                 F("usessdp"),             Settings.UseSSDP);
-  #endif
+  addFormCheckBox_disabled(F("Use SSDP"), F("usessdp"), Settings.UseSSDP);
+  #endif // ifdef USES_SSDP
 
   addFormNumericBox(getLabel(LabelType::CONNECTION_FAIL_THRESH), F("cft"), Settings.ConnectionFailuresThreshold, 0, 100);
 #ifdef ESP8266
@@ -192,7 +192,7 @@ void handle_advanced() {
   html_TR_TD();
   html_TD();
   addSubmitButton();
-  TXBuffer += F("<input type='hidden' name='edit' value='1'>");
+  addHtml(F("<input type='hidden' name='edit' value='1'>"));
   html_end_table();
   html_end_form();
   sendHeadandTail_stdtemplate(true);
@@ -224,10 +224,10 @@ void addFormDstSelect(bool isStart, uint16_t choice) {
   }
   TimeChangeRule rule(isStart ? tmpstart : tmpend, 0);
   addRowLabel(weeklabel);
-  addSelector(weekid,  5,  week,   weekValues, NULL, rule.week,  false);
-  TXBuffer += F("<BR>");
-  addSelector(dowid,   7,  dow,     dowValues, NULL, rule.dow,   false);
-  TXBuffer += F("<BR>");
+  addSelector(weekid, 5, week, weekValues, NULL, rule.week, false);
+  html_BR();
+  addSelector(dowid, 7, dow, dowValues, NULL, rule.dow, false);
+  html_BR();
   addSelector(monthid, 12, month, monthValues, NULL, rule.month, false);
 
   addFormNumericBox(hourlabel, hourid, rule.hour, 0, 23);
@@ -263,8 +263,8 @@ void addFormLogFacilitySelect(const String& label, const String& id, int choice)
 void addLogFacilitySelect(const String& name, int choice)
 {
   String options[12] =
-  { F("Kernel"), F("User"),   F("Daemon"), F("Message"), F("Local0"), F("Local1"),
-    F("Local2"), F("Local3"), F("Local4"), F("Local5"),  F("Local6"), F("Local7") };
+  { F("Kernel"), F("User"),   F("Daemon"),   F("Message"), F("Local0"),  F("Local1"),
+    F("Local2"), F("Local3"), F("Local4"),   F("Local5"),  F("Local6"),  F("Local7") };
   int optionValues[12] = { 0, 1, 3, 5, 16, 17, 18, 19, 20, 21, 22, 23 };
 
   addSelector(name, 12, options, optionValues, NULL, choice, false);

--- a/src/WebServer_ConfigPage.ino
+++ b/src/WebServer_ConfigPage.ino
@@ -38,7 +38,7 @@ void handle_config() {
 
       if (CPluginCall(CPlugin::Function::CPLUGIN_GOT_INVALID, 0)) { // inform controllers that the old name will be invalid from now on.
 #ifdef USES_MQTT
-        MQTTDisconnect();                        // disconnect form MQTT Server if invalid message was sent succesfull.
+        MQTTDisconnect();                                           // disconnect form MQTT Server if invalid message was sent succesfull.
 #endif // USES_MQTT
       }
 #ifdef USES_MQTT

--- a/src/WebServer_ControlPage.ino
+++ b/src/WebServer_ControlPage.ino
@@ -19,12 +19,14 @@ void handle_control() {
 #endif // ifndef BUILD_NO_DEBUG
 
   bool handledCmd = false;
+
   // in case of event, store to buffer and return...
   String command = parseString(webrequest, 1);
-  if (command == F("event") || command == F("asyncevent")) 
+
+  if ((command == F("event")) || (command == F("asyncevent")))
   {
     eventQueue.add(parseStringToEnd(webrequest, 2));
-    handledCmd  = true;
+    handledCmd = true;
   }
   else if (command.equalsIgnoreCase(F("taskrun")) ||
            command.equalsIgnoreCase(F("taskvalueset")) ||
@@ -39,7 +41,7 @@ void handle_control() {
 
   if (handledCmd) {
     TXBuffer.startStream("*");
-    TXBuffer += "OK";
+    addHtml(F("OK"));
     TXBuffer.endStream();
     return;
   }
@@ -55,10 +57,10 @@ void handle_control() {
   }
 
   if (unknownCmd) {
-    TXBuffer += F("Unknown or restricted command!");
+    addHtml(F("Unknown or restricted command!"));
   }
   else {
-    TXBuffer += printWebString;
+    addHtml(printWebString);
   }
 
   TXBuffer.endStream();

--- a/src/WebServer_ControllerPage.ino
+++ b/src/WebServer_ControllerPage.ino
@@ -54,11 +54,12 @@ void handle_controllers() {
     if (mustInit) {
       // Init controller plugin using the new settings.
       protocolIndex_t ProtocolIndex = getProtocolIndex_from_ControllerIndex(controllerindex);
+
       if (validProtocolIndex(ProtocolIndex)) {
         struct EventStruct TempEvent;
         TempEvent.ControllerIndex = controllerindex;
         String dummy;
-        byte cfunction = Settings.ControllerEnabled[controllerindex] ? CPlugin::Function::CPLUGIN_INIT : CPlugin::Function::CPLUGIN_EXIT;
+        byte   cfunction = Settings.ControllerEnabled[controllerindex] ? CPlugin::Function::CPLUGIN_INIT : CPlugin::Function::CPLUGIN_EXIT;
         CPluginCall(ProtocolIndex, static_cast<CPlugin::Function>(cfunction), &TempEvent, dummy);
       }
     }
@@ -88,6 +89,7 @@ void handle_controllers_clearLoadDefaults(byte controllerindex, ControllerSettin
   // Protocol has changed and it was not an empty one.
   // reset (some) default-settings
   protocolIndex_t ProtocolIndex = getProtocolIndex(Settings.Protocol[controllerindex]);
+
   if (!validProtocolIndex(ProtocolIndex)) {
     return;
   }
@@ -129,6 +131,7 @@ void handle_controllers_CopySubmittedSettings(byte controllerindex, ControllerSe
   }
 
   protocolIndex_t ProtocolIndex = getProtocolIndex_from_ControllerIndex(controllerindex);
+
   if (validProtocolIndex(ProtocolIndex)) {
     struct EventStruct TempEvent;
     TempEvent.ControllerIndex = controllerindex;
@@ -160,25 +163,30 @@ void handle_controllers_ShowAllControllersTable()
     const bool cplugin_set = Settings.Protocol[x] != INVALID_C_PLUGIN_ID;
 
 
-
     LoadControllerSettings(x, ControllerSettings);
     html_TR_TD();
+
     if (cplugin_set && !supportedCPluginID(Settings.Protocol[x])) {
       html_add_button_prefix(F("red"), true);
     } else {
       html_add_button_prefix();
-    }    
-    TXBuffer += F("controllers?index=");
-    TXBuffer += x + 1;
-    TXBuffer += F("'>");
-    if (cplugin_set) {
-      TXBuffer += F("Edit");
-    } else {
-      TXBuffer += F("Add");
     }
-    TXBuffer += F("</a>");
-    html_TD();
-    TXBuffer += getControllerSymbol(x);
+    {
+      String html;
+      html.reserve(32);
+      html += F("controllers?index=");
+      html += x + 1;
+      html += F("'>");
+
+      if (cplugin_set) {
+        html += F("Edit");
+      } else {
+        html += F("Add");
+      }
+      html += F("</a><TD>");
+      html += getControllerSymbol(x);
+      addHtml(html);
+    }
     html_TD();
 
     if (cplugin_set)
@@ -186,7 +194,7 @@ void handle_controllers_ShowAllControllersTable()
       addEnabled(Settings.ControllerEnabled[x]);
 
       html_TD();
-      TXBuffer += getCPluginNameFromCPluginID(Settings.Protocol[x]);
+      addHtml(getCPluginNameFromCPluginID(Settings.Protocol[x]));
       html_TD();
       {
         const protocolIndex_t ProtocolIndex = getProtocolIndex_from_ControllerIndex(x);
@@ -194,14 +202,14 @@ void handle_controllers_ShowAllControllersTable()
         CPluginCall(ProtocolIndex, CPlugin::Function::CPLUGIN_WEBFORM_SHOW_HOST_CONFIG, 0, hostDescription);
 
         if (hostDescription.length() != 0) {
-          TXBuffer += hostDescription;
+          addHtml(hostDescription);
         } else {
-          TXBuffer += ControllerSettings.getHost();
+          addHtml(ControllerSettings.getHost());
         }
       }
 
       html_TD();
-      TXBuffer += ControllerSettings.Port;
+      addHtml(String(ControllerSettings.Port));
     }
     else {
       html_TD(3);
@@ -271,9 +279,11 @@ void handle_controllers_ControllerSettingsPage(controllerIndex_t controllerindex
         addControllerParameterForm(ControllerSettings, controllerindex, CONTROLLER_MAX_RETRIES);
         addControllerParameterForm(ControllerSettings, controllerindex, CONTROLLER_FULL_QUEUE_ACTION);
       }
+
       if (Protocol[ProtocolIndex].usesCheckReply) {
         addControllerParameterForm(ControllerSettings, controllerindex, CONTROLLER_CHECK_REPLY);
       }
+
       if (Protocol[ProtocolIndex].usesTimeout) {
         addControllerParameterForm(ControllerSettings, controllerindex, CONTROLLER_TIMEOUT);
       }

--- a/src/WebServer_CustomPage.ino
+++ b/src/WebServer_CustomPage.ino
@@ -39,9 +39,9 @@ boolean handle_custom(String path) {
       if (it != Nodes.end()) {
         TXBuffer.startStream();
         sendHeadandTail(F("TmplDsh"), _HEAD);
-        TXBuffer += F("<meta http-equiv=\"refresh\" content=\"0; URL=http://");
-        TXBuffer += it->second.ip.toString();
-        TXBuffer += F("/dashboard.esp\">");
+        addHtml(F("<meta http-equiv=\"refresh\" content=\"0; URL=http://"));
+        addHtml(it->second.ip.toString());
+        addHtml(F("/dashboard.esp\">"));
         sendHeadandTail(F("TmplDsh"), _TAIL);
         TXBuffer.endStream();
         return true;
@@ -96,15 +96,15 @@ boolean handle_custom(String path) {
     }
 
     html_add_button_prefix();
-    TXBuffer += path;
-    TXBuffer += F("?btnunit=");
-    TXBuffer += prev;
-    TXBuffer += F("'>&lt;</a>");
+    addHtml(path);
+    addHtml(F("?btnunit="));
+    addHtml(String(prev));
+    addHtml(F("'>&lt;</a>"));
     html_add_button_prefix();
-    TXBuffer += path;
-    TXBuffer += F("?btnunit=");
-    TXBuffer += next;
-    TXBuffer += F("'>&gt;</a>");
+    addHtml(path);
+    addHtml(F("?btnunit="));
+    addHtml(String(next));
+    addHtml(F("'>&gt;</a>"));
   }
 
   // handle commands from a custom page
@@ -128,7 +128,7 @@ boolean handle_custom(String path) {
       page += ((char)dataFile.read());
     }
 
-    TXBuffer += parseTemplate(page);
+    addHtml(parseTemplate(page));
     dataFile.close();
   }
   else // if the requestef file does not exist, create a default action in case the page is named "dashboard*"
@@ -136,8 +136,8 @@ boolean handle_custom(String path) {
     if (dashboardPage)
     {
       // if the custom page does not exist, create a basic task value overview page in case of dashboard request...
-      TXBuffer += F(
-        "<meta name='viewport' content='width=width=device-width, initial-scale=1'><STYLE>* {font-family:sans-serif; font-size:16pt;}.button {margin:4px; padding:4px 16px; background-color:#07D; color:#FFF; text-decoration:none; border-radius:4px}</STYLE>");
+      addHtml(F(
+                "<meta name='viewport' content='width=width=device-width, initial-scale=1'><STYLE>* {font-family:sans-serif; font-size:16pt;}.button {margin:4px; padding:4px 16px; background-color:#07D; color:#FFF; text-decoration:none; border-radius:4px}</STYLE>"));
       html_table_class_normal();
 
       for (taskIndex_t x = 0; x < TASKS_MAX; x++)
@@ -145,10 +145,11 @@ boolean handle_custom(String path) {
         if (validPluginID_fullcheck(Settings.TaskDeviceNumber[x]))
         {
           const deviceIndex_t DeviceIndex = getDeviceIndex_from_TaskIndex(x);
+
           if (validDeviceIndex(DeviceIndex)) {
             LoadTaskSettings(x);
             html_TR_TD();
-            TXBuffer += ExtraTaskSettings.TaskDeviceName;
+            addHtml(ExtraTaskSettings.TaskDeviceName);
 
             for (byte varNr = 0; varNr < VARS_PER_TASK; varNr++)
             {
@@ -159,9 +160,9 @@ boolean handle_custom(String path) {
                   html_TR_TD();
                 }
                 html_TD();
-                TXBuffer += ExtraTaskSettings.TaskDeviceValueNames[varNr];
+                addHtml(ExtraTaskSettings.TaskDeviceValueNames[varNr]);
                 html_TD();
-                TXBuffer += String(UserVar[x * VARS_PER_TASK + varNr], ExtraTaskSettings.TaskDeviceValueDecimals[varNr]);
+                addHtml(String(UserVar[x * VARS_PER_TASK + varNr], ExtraTaskSettings.TaskDeviceValueDecimals[varNr]));
               }
             }
           }

--- a/src/WebServer_DevicesPage.ino
+++ b/src/WebServer_DevicesPage.ino
@@ -1,10 +1,10 @@
 #ifdef WEBSERVER_DEVICES
 
-#include "src/Globals/Nodes.h"
-#include "src/Globals/Device.h"
-#include "src/Globals/CPlugins.h"
-#include "src/Globals/Plugins.h"
-#include "src/Static/WebStaticData.h"
+# include "src/Globals/Nodes.h"
+# include "src/Globals/Device.h"
+# include "src/Globals/CPlugins.h"
+# include "src/Globals/Plugins.h"
+# include "src/Static/WebStaticData.h"
 
 
 void handle_devices() {
@@ -105,7 +105,7 @@ void handle_devices() {
 
   if (!taskIndexNotSet) {
     --taskIndex;
-    LoadTaskSettings(taskIndex);       // Make sure ExtraTaskSettings are up-to-date
+    LoadTaskSettings(taskIndex); // Make sure ExtraTaskSettings are up-to-date
   }
 
   // FIXME TD-er: Might have to clear any caches here.
@@ -149,14 +149,14 @@ void handle_devices() {
   }
 
   checkRAM(F("handle_devices"));
-#ifndef BUILD_NO_DEBUG
+# ifndef BUILD_NO_DEBUG
 
   if (loglevelActiveFor(LOG_LEVEL_DEBUG_DEV)) {
     String log = F("DEBUG: String size:");
     log += String(TXBuffer.sentBytes);
     addLog(LOG_LEVEL_DEBUG_DEV, log);
   }
-#endif // ifndef BUILD_NO_DEBUG
+# endif // ifndef BUILD_NO_DEBUG
   sendHeadandTail_stdtemplate(_TAIL);
   TXBuffer.endStream();
 }
@@ -176,15 +176,16 @@ void addDeviceSelect(const String& name,  int choice)
   for (byte x = 0; x <= deviceCount; x++)
   {
     const deviceIndex_t deviceIndex = DeviceIndex_sorted[x];
+
     if (validDeviceIndex(deviceIndex)) {
-      const pluginID_t    pluginID    = DeviceIndex_to_Plugin_id[deviceIndex];
+      const pluginID_t pluginID = DeviceIndex_to_Plugin_id[deviceIndex];
 
       if (validPluginID(pluginID)) {
         deviceName = getPluginNameFromDeviceIndex(deviceIndex);
 
 
-  #ifdef PLUGIN_BUILD_DEV
-        String     plugin = "P";
+  # ifdef PLUGIN_BUILD_DEV
+        String plugin = "P";
 
         if (pluginID < 10) { plugin += '0'; }
 
@@ -192,19 +193,18 @@ void addDeviceSelect(const String& name,  int choice)
         plugin    += pluginID;
         plugin    += F(" - ");
         deviceName = plugin + deviceName;
-  #endif // ifdef PLUGIN_BUILD_DEV
+  # endif // ifdef PLUGIN_BUILD_DEV
 
         addSelector_Item(deviceName,
-                        Device[deviceIndex].Number,
-                        choice == Device[deviceIndex].Number,
-                        false,
-                        "");
+                         Device[deviceIndex].Number,
+                         choice == Device[deviceIndex].Number,
+                         false,
+                         "");
       }
     }
   }
   addSelector_Foot();
 }
-
 
 // ********************************************************************************
 // Collect all submitted form data and store the task settings
@@ -309,25 +309,38 @@ void handle_devicess_ShowAllTasksTable(byte page)
   if (TASKS_MAX != TASKS_PER_PAGE)
   {
     html_add_button_prefix();
-    TXBuffer += F("devices?setpage=");
 
-    if (page > 1) {
-      TXBuffer += page - 1;
+    {
+      String html;
+      html.reserve(30);
+
+      html += F("devices?setpage=");
+
+      if (page > 1) {
+        html += page - 1;
+      }
+      else {
+        html += page;
+      }
+      html += F("'>&lt;</a>");
+      addHtml(html);
     }
-    else {
-      TXBuffer += page;
-    }
-    TXBuffer += F("'>&lt;</a>");
     html_add_button_prefix();
-    TXBuffer += F("devices?setpage=");
+    {
+      String html;
+      html.reserve(30);
 
-    if (page < (TASKS_MAX / TASKS_PER_PAGE)) {
-      TXBuffer += page + 1;
+      html += F("devices?setpage=");
+
+      if (page < (TASKS_MAX / TASKS_PER_PAGE)) {
+        html += page + 1;
+      }
+      else {
+        html += page;
+      }
+      html += F("'>&gt;</a>");
+      addHtml(html);
     }
-    else {
-      TXBuffer += page;
-    }
-    TXBuffer += F("'>&gt;</a>");
   }
 
   html_table_header("Task",       50);
@@ -343,8 +356,8 @@ void handle_devicess_ShowAllTasksTable(byte page)
 
   for (byte x = (page - 1) * TASKS_PER_PAGE; x < ((page) * TASKS_PER_PAGE) && validTaskIndex(x); x++)
   {
-    const deviceIndex_t DeviceIndex      = getDeviceIndex_from_TaskIndex(x);
-    const bool pluginID_set              = INVALID_PLUGIN_ID != Settings.TaskDeviceNumber[x];
+    const deviceIndex_t DeviceIndex = getDeviceIndex_from_TaskIndex(x);
+    const bool pluginID_set         = INVALID_PLUGIN_ID != Settings.TaskDeviceNumber[x];
 
     html_TR_TD();
 
@@ -353,21 +366,26 @@ void handle_devicess_ShowAllTasksTable(byte page)
     } else {
       html_add_button_prefix();
     }
-    TXBuffer += F("devices?index=");
-    TXBuffer += x + 1;
-    TXBuffer += F("&page=");
-    TXBuffer += page;
-    TXBuffer += F("'>");
+    {
+      String html;
+      html.reserve(30);
 
-    if (pluginID_set) {
-      TXBuffer += F("Edit");
-    } else {
-      TXBuffer += F("Add");
+      html += F("devices?index=");
+      html += x + 1;
+      html += F("&page=");
+      html += page;
+      html += F("'>");
+
+      if (pluginID_set) {
+        html += F("Edit");
+      } else {
+        html += F("Add");
+      }
+      html += F("</a><TD>");
+      html += x + 1;
+      addHtml(html);
+      html_TD();
     }
-    TXBuffer += F("</a>");
-    html_TD();
-    TXBuffer += x + 1;
-    html_TD();
 
     // Show table of all configured tasks
     // A task may also refer to a non supported plugin.
@@ -381,38 +399,38 @@ void handle_devicess_ShowAllTasksTable(byte page)
       addEnabled(Settings.TaskDeviceEnabled[x]  && validDeviceIndex(DeviceIndex));
 
       html_TD();
-      TXBuffer += getPluginNameFromPluginID(Settings.TaskDeviceNumber[x]);
+      addHtml(getPluginNameFromPluginID(Settings.TaskDeviceNumber[x]));
       html_TD();
-      TXBuffer += ExtraTaskSettings.TaskDeviceName;
+      addHtml(ExtraTaskSettings.TaskDeviceName);
       html_TD();
 
       if (validDeviceIndex(DeviceIndex)) {
         if (Settings.TaskDeviceDataFeed[x] != 0) {
           // Show originating node number
           byte remoteUnit = Settings.TaskDeviceDataFeed[x];
-          TXBuffer += F("Unit ");
-          TXBuffer += remoteUnit;
+          addHtml(F("Unit "));
+          addHtml(String(remoteUnit));
 
           if (remoteUnit != 255) {
             NodesMap::iterator it = Nodes.find(remoteUnit);
 
             if (it != Nodes.end()) {
-              TXBuffer += F(" - ");
-              TXBuffer += it->second.nodeName;
+              addHtml(F(" - "));
+              addHtml(it->second.nodeName);
             } else {
-              TXBuffer += F(" - Not Seen recently");
+              addHtml(F(" - Not Seen recently"));
             }
           }
         } else {
           String portDescr;
 
           if (PluginCall(PLUGIN_WEBFORM_SHOW_CONFIG, &TempEvent, portDescr)) {
-            TXBuffer += portDescr;
+            addHtml(portDescr);
           } else {
             // Plugin has no custom port formatting, show default one.
             if (Device[DeviceIndex].Ports != 0)
             {
-              TXBuffer += formatToHex_decimal(Settings.TaskDevicePort[x]);
+              addHtml(formatToHex_decimal(Settings.TaskDevicePort[x]));
             }
           }
         }
@@ -430,20 +448,25 @@ void handle_devicess_ShowAllTasksTable(byte page)
             if (Settings.TaskDeviceSendData[controllerNr][x])
             {
               if (doBR) {
-                TXBuffer += F("<BR>");
+                html_BR();
               }
-              TXBuffer += getControllerSymbol(controllerNr);
+              addHtml(getControllerSymbol(controllerNr));
               protocolIndex_t ProtocolIndex = getProtocolIndex_from_ControllerIndex(controllerNr);
+
               if (validProtocolIndex(ProtocolIndex)) {
                 if (Protocol[ProtocolIndex].usesID && (Settings.Protocol[controllerNr] != 0))
                 {
-                  TXBuffer += " (";
-                  TXBuffer += Settings.TaskDeviceID[controllerNr][x];
-                  TXBuffer += ')';
+                  String html;
+                  html.reserve(16);
+                  html += " (";
+                  html += Settings.TaskDeviceID[controllerNr][x];
+                  html += ')';
 
                   if (Settings.TaskDeviceID[controllerNr][x] == 0) {
-                    TXBuffer += F(" " HTML_SYMBOL_WARNING);
+                    html += " ";
+                    html += F(HTML_SYMBOL_WARNING);
                   }
+                  addHtml(html);
                 }
                 doBR = true;
               }
@@ -459,32 +482,42 @@ void handle_devicess_ShowAllTasksTable(byte page)
         {
           if (Device[DeviceIndex].Type == DEVICE_TYPE_I2C)
           {
-            TXBuffer += F("GPIO-");
-            TXBuffer += Settings.Pin_i2c_sda;
-            TXBuffer += F("<BR>GPIO-");
-            TXBuffer += Settings.Pin_i2c_scl;
+            String html;
+            html.reserve(20);
+            html += F("GPIO-");
+            html += Settings.Pin_i2c_sda;
+            html += F("<BR>GPIO-");
+            html += Settings.Pin_i2c_scl;
+
+            addHtml(html);
           }
 
           if (Device[DeviceIndex].Type == DEVICE_TYPE_ANALOG) {
-            TXBuffer += F("ADC (TOUT)");
+            addHtml(F("ADC (TOUT)"));
           }
 
           if (Settings.TaskDevicePin1[x] != -1)
           {
-            TXBuffer += F("GPIO-");
-            TXBuffer += Settings.TaskDevicePin1[x];
+            String html;
+            html += F("GPIO-");
+            html += Settings.TaskDevicePin1[x];
+            addHtml(html);
           }
 
           if (Settings.TaskDevicePin2[x] != -1)
           {
-            TXBuffer += F("<BR>GPIO-");
-            TXBuffer += Settings.TaskDevicePin2[x];
+            String html;
+            html += F("<BR>GPIO-");
+            html += Settings.TaskDevicePin2[x];
+            addHtml(html);
           }
 
           if (Settings.TaskDevicePin3[x] != -1)
           {
-            TXBuffer += F("<BR>GPIO-");
-            TXBuffer += Settings.TaskDevicePin3[x];
+            String html;
+            html += F("<BR>GPIO-");
+            html += Settings.TaskDevicePin3[x];
+            addHtml(html);
           }
         }
       }
@@ -502,7 +535,7 @@ void handle_devicess_ShowAllTasksTable(byte page)
           {
             if (validPluginID_fullcheck(Settings.TaskDeviceNumber[x]))
             {
-              TXBuffer += pluginWebformShowValue(x, varNr, ExtraTaskSettings.TaskDeviceValueNames[varNr], formatUserVarNoCheck(x, varNr));
+              addHtml(pluginWebformShowValue(x, varNr, ExtraTaskSettings.TaskDeviceValueNames[varNr], formatUserVarNoCheck(x, varNr)));
             }
           }
         }
@@ -533,7 +566,7 @@ void handle_devices_TaskSettingsPage(taskIndex_t taskIndex, byte page)
   addFormHeader(F("Task Settings"));
 
 
-  TXBuffer += F("<TR><TD style='width:150px;' align='left'>Device:<TD>");
+  addHtml(F("<TR><TD style='width:150px;' align='left'>Device:<TD>"));
 
   // no (supported) device selected, this effectively checks for validDeviceIndex
   if (!supportedPluginID(Settings.TaskDeviceNumber[taskIndex]))
@@ -546,12 +579,16 @@ void handle_devices_TaskSettingsPage(taskIndex_t taskIndex, byte page)
   else
   {
     // remember selected device number
-    TXBuffer += F("<input type='hidden' name='TDNUM' value='");
-    TXBuffer += Settings.TaskDeviceNumber[taskIndex];
-    TXBuffer += "'>";
+    addHtml(F("<input type='hidden' name='TDNUM' value='"));
+    {
+      String html;
+      html += Settings.TaskDeviceNumber[taskIndex];
+      html += "'>";
+      addHtml(html);
+    }
 
     // show selected device name and delete button
-    TXBuffer += getPluginNameFromDeviceIndex(DeviceIndex);
+    addHtml(getPluginNameFromDeviceIndex(DeviceIndex));
 
     addHelpButton(String(F("Plugin")) + Settings.TaskDeviceNumber[taskIndex]);
     addRTDPluginButton(Settings.TaskDeviceNumber[taskIndex]);
@@ -582,13 +619,13 @@ void handle_devices_TaskSettingsPage(taskIndex_t taskIndex, byte page)
       if (Device[DeviceIndex].PullUpOption)
       {
         addFormCheckBox(F("Internal PullUp"), F("TDPPU"), Settings.TaskDevicePin1PullUp[taskIndex]); // ="taskdevicepin1pullup"
-          #if defined(ESP8266)
+          # if defined(ESP8266)
 
         if ((Settings.TaskDevicePin1[taskIndex] == 16) || (Settings.TaskDevicePin2[taskIndex] == 16) ||
             (Settings.TaskDevicePin3[taskIndex] == 16)) {
           addFormNote(F("PullDown for GPIO-16 (D0)"));
         }
-          #endif // if defined(ESP8266)
+          # endif // if defined(ESP8266)
       }
 
       if (Device[DeviceIndex].InverseLogicOption)
@@ -662,12 +699,14 @@ void handle_devices_TaskSettingsPage(taskIndex_t taskIndex, byte page)
           String id = F("TDSD"); // ="taskdevicesenddata"
           id += controllerNr + 1;
 
-          html_TR_TD(); TXBuffer += F("Send to Controller ");
-          TXBuffer               += getControllerSymbol(controllerNr);
+          html_TR_TD();
+          addHtml(F("Send to Controller "));
+          addHtml(getControllerSymbol(controllerNr));
           html_TD();
           addCheckBox(id, Settings.TaskDeviceSendData[controllerNr][taskIndex]);
 
           protocolIndex_t ProtocolIndex = getProtocolIndex_from_ControllerIndex(controllerNr);
+
           if (validProtocolIndex(ProtocolIndex)) {
             if (Protocol[ProtocolIndex].usesID && (Settings.Protocol[controllerNr] != 0))
             {
@@ -691,7 +730,7 @@ void handle_devices_TaskSettingsPage(taskIndex_t taskIndex, byte page)
       addUnit(F("sec"));
 
       if (Device[DeviceIndex].TimerOptional) {
-        TXBuffer += F(" (Optional for this Device)");
+        addHtml(F(" (Optional for this Device)"));
       }
     }
 
@@ -703,7 +742,7 @@ void handle_devices_TaskSettingsPage(taskIndex_t taskIndex, byte page)
       html_table_class_normal();
 
       // table header
-      TXBuffer += F("<TR><TH style='width:30px;' align='center'>#");
+      addHtml(F("<TR><TH style='width:30px;' align='center'>#"));
       html_table_header("Name");
 
       if (Device[DeviceIndex].FormulaOption)
@@ -720,7 +759,7 @@ void handle_devices_TaskSettingsPage(taskIndex_t taskIndex, byte page)
       for (byte varNr = 0; varNr < Device[DeviceIndex].ValueCount; varNr++)
       {
         html_TR_TD();
-        TXBuffer += varNr + 1;
+        addHtml(String(varNr + 1));
         html_TD();
         String id = F("TDVN"); // ="taskdevicevaluename"
         id += (varNr + 1);
@@ -748,14 +787,20 @@ void handle_devices_TaskSettingsPage(taskIndex_t taskIndex, byte page)
   addFormSeparator(4);
 
   html_TR_TD();
-  TXBuffer += F("<TD colspan='3'>");
+  addHtml(F("<TD colspan='3'>"));
   html_add_button_prefix();
-  TXBuffer += F("devices?setpage=");
-  TXBuffer += page;
-  TXBuffer += F("'>Close</a>");
+  {
+    String html;
+    html.reserve(32);
+
+    html += F("devices?setpage=");
+    html += page;
+    html += F("'>Close</a>");
+    addHtml(html);
+  }
   addSubmitButton();
-  TXBuffer += F("<input type='hidden' name='edit' value='1'>");
-  TXBuffer += F("<input type='hidden' name='page' value='1'>");
+  addHtml(F("<input type='hidden' name='edit' value='1'>"));
+  addHtml(F("<input type='hidden' name='page' value='1'>"));
 
   // if user selected a device, add the delete button
   if (validPluginID_fullcheck(Settings.TaskDeviceNumber[taskIndex])) {
@@ -767,7 +812,6 @@ void handle_devices_TaskSettingsPage(taskIndex_t taskIndex, byte page)
 }
 
 #endif // ifdef WEBSERVER_DEVICES
-
 
 
 // ********************************************************************************
@@ -825,6 +869,6 @@ void setBasicTaskValues(taskIndex_t taskIndex, unsigned long taskdevicetimer,
   // FIXME TD-er: Check for valid GPIO pin (and  -1 for "not set")
   Settings.TaskDevicePin1[taskIndex] = pin1;
   Settings.TaskDevicePin2[taskIndex] = pin2;
-  Settings.TaskDevicePin3[taskIndex] = pin3; 
+  Settings.TaskDevicePin3[taskIndex] = pin3;
   SaveTaskSettings(taskIndex);
 }

--- a/src/WebServer_FactoryResetPage.ino
+++ b/src/WebServer_FactoryResetPage.ino
@@ -109,7 +109,7 @@ void addPreDefinedConfigSelector() {
 void handle_factoryreset_json() {
   if (!isLoggedIn()) { return; }
   TXBuffer.startJsonStream();
-  TXBuffer += "{";
+  addHtml("{");
 
   if (WebServer.hasArg("fdm")) {
     DeviceModel model = static_cast<DeviceModel>(getFormItemInt("fdm"));
@@ -139,8 +139,9 @@ void handle_factoryreset_json() {
     ResetFactoryDefaultPreference.keepLogSettings(isFormItemChecked("klog"));
   }
   String error;
-  bool performReset = false;
-  bool savePref = false;
+  bool   performReset = false;
+  bool   savePref     = false;
+
   if (WebServer.hasArg(F("savepref"))) {
     // User choose a pre-defined config and wants to save it as the new default.
     savePref = true;
@@ -149,10 +150,11 @@ void handle_factoryreset_json() {
   if (WebServer.hasArg(F("performfactoryreset"))) {
     // User confirmed to really perform the reset.
     performReset = true;
-    savePref = true;
+    savePref     = true;
   } else {
     error = F("no reset");
   }
+
   if (savePref) {
     applyFactoryDefaultPref();
     error = SaveSettings();
@@ -163,7 +165,7 @@ void handle_factoryreset_json() {
   }
 
   stream_last_json_object_value(F("status"), error);
-  TXBuffer += "}";
+  addHtml("}");
   TXBuffer.endStream();
 
   if (performReset) {

--- a/src/WebServer_FileList.ino
+++ b/src/WebServer_FileList.ino
@@ -384,10 +384,11 @@ void handle_SDfilelist() {
 
   while (entry)
   {
+    html_TR_TD();
+    size_t entrynameLength = strlen(entry.name());
     if (entry.isDirectory())
     {
       char SDcardChildDir[80];
-      html_TR_TD();
 
       // take a look in the directory for entries
       String child_dir = current_dir + entry.name();
@@ -400,7 +401,7 @@ void handle_SDfilelist() {
       {
         addHtml(F("<a class='button link' onclick=\"return confirm('Delete this directory?')\" href=\"SDfilelist?deletedir="));
         String html;
-        html.reserve(20 + 2 * current_dir.length() + entry.name().length());
+        html.reserve(20 + 2 * current_dir.length() + entrynameLength);
         html += current_dir;
         html += entry.name();
         html += '/';
@@ -411,7 +412,7 @@ void handle_SDfilelist() {
       }
       {
         String html;
-        html.reserve(48 + current_dir.length() + 2 * entry.name().length());
+        html.reserve(48 + current_dir.length() + 2 * entrynameLength);
 
         html += F("<TD><a href=\"SDfilelist?chgto=");
         html += current_dir;
@@ -427,13 +428,12 @@ void handle_SDfilelist() {
     }
     else
     {
-      html_TR_TD();
 
       if ((entry.name() != String(F(FILE_CONFIG)).c_str()) && (entry.name() != String(F(FILE_SECURITY)).c_str()))
       {
         addHtml(F("<a class='button link' onclick=\"return confirm('Delete this file?')\" href=\"SDfilelist?delete="));
         String html;
-        html.reserve(20 + 2 * current_dir.length() + entry.name().length());
+        html.reserve(20 + 2 * current_dir.length() + entrynameLength);
 
         html += current_dir;
         html += entry.name();
@@ -444,7 +444,7 @@ void handle_SDfilelist() {
       }
       {
         String html;
-        html.reserve(48 + current_dir.length() + 2 * entry.name().length());
+        html.reserve(48 + current_dir.length() + 2 * entrynameLength);
         html += F("<TD><a href=\"");
         html += current_dir;
         html += entry.name();

--- a/src/WebServer_FileList.ino
+++ b/src/WebServer_FileList.ino
@@ -34,7 +34,7 @@ void handle_filelist_json() {
   }
   int endIdx = startIdx + pageSize - 1;
 
-  TXBuffer += "[{";
+  addHtml("[{");
   bool firstentry = true;
   # if defined(ESP32)
   File root  = SPIFFS.open("/");
@@ -51,7 +51,7 @@ void handle_filelist_json() {
         if (firstentry) {
           firstentry = false;
         } else {
-          TXBuffer += ",{";
+          addHtml(",{");
         }
         stream_next_json_object_value(F("fileName"), String(file.name()));
         stream_next_json_object_value(F("index"),    String(startIdx));
@@ -78,7 +78,7 @@ void handle_filelist_json() {
     if (firstentry) {
       firstentry = false;
     } else {
-      TXBuffer += ",{";
+      addHtml(",{");
     }
 
     stream_next_json_object_value(F("fileName"), String(dir.fileName()));
@@ -97,12 +97,13 @@ void handle_filelist_json() {
       break;
     }
   }
+
   if (firstentry) {
-    TXBuffer += "}";
+    addHtml("}");
   }
 
   # endif // if defined(ESP8266)
-  TXBuffer += "]";
+  addHtml("]");
   TXBuffer.endStream();
 }
 
@@ -123,7 +124,7 @@ void handle_filelist() {
   {
     checkRuleSets();
   }
-  #ifdef USES_C016
+  # ifdef USES_C016
 
   if (WebServer.hasArg(F("delcache"))) {
     while (C016_deleteOldestCacheBlock()) {
@@ -134,7 +135,7 @@ void handle_filelist() {
       delay(1);
     }
   }
-  #endif // ifdef USES_C016
+  # endif // ifdef USES_C016
   const int pageSize = 25;
   int startIdx       = 0;
   String fstart      = WebServer.arg(F("start"));
@@ -153,7 +154,7 @@ void handle_filelist() {
   bool moreFilesPresent  = false;
   bool cacheFilesPresent = false;
 
-#if defined(ESP8266)
+# if defined(ESP8266)
 
   fs::Dir dir = SPIFFS.openDir("");
 
@@ -178,8 +179,8 @@ void handle_filelist() {
     }
   }
   moreFilesPresent = dir.next();
-#endif // if defined(ESP8266)
-#if defined(ESP32)
+# endif // if defined(ESP8266)
+# if defined(ESP32)
   File root = SPIFFS.open("/");
   File file = root.openNextFile();
 
@@ -200,7 +201,7 @@ void handle_filelist() {
     file = root.openNextFile();
   }
   moreFilesPresent = file;
-#endif // if defined(ESP32)
+# endif // if defined(ESP32)
 
   int start_prev = -1;
 
@@ -222,26 +223,30 @@ void handle_filelist_add_file(const String& filename, int filesize, int startIdx
   if ((filename != F(FILE_CONFIG)) && (filename != F(FILE_SECURITY)) && (filename != F(FILE_NOTIFICATION)))
   {
     html_add_button_prefix();
-    TXBuffer += F("filelist?delete=");
-    TXBuffer += filename;
+    addHtml(F("filelist?delete="));
+    addHtml(filename);
 
     if (startIdx > 0)
     {
-      TXBuffer += F("&start=");
-      TXBuffer += startIdx;
+      addHtml(F("&start="));
+      addHtml(String(startIdx));
     }
-    TXBuffer += F("'>Del</a>");
+    addHtml(F("'>Del</a>"));
   }
+  {
+    String html;
+    html.reserve(30 + 2 * filename.length());
 
-  TXBuffer += F("<TD><a href=\"");
-  TXBuffer += filename;
-  TXBuffer += "\">";
-  TXBuffer += filename;
-  TXBuffer += F("</a>");
-  html_TD();
+    html += F("<TD><a href=\"");
+    html += filename;
+    html += "\">";
+    html += filename;
+    html += F("</a><TD>");
 
-  if (filesize >= 0) {
-    TXBuffer += String(filesize);
+    if (filesize >= 0) {
+      html += String(filesize);
+    }
+    addHtml(html);
   }
 }
 
@@ -254,28 +259,35 @@ void handle_filelist_buttons(int start_prev, int start_next, bool cacheFilesPres
   if (start_prev >= 0)
   {
     html_add_button_prefix();
-    TXBuffer += F("/filelist?start=");
-    TXBuffer += start_prev;
-    TXBuffer += F("'>Previous</a>");
+    String html;
+    html.reserve(36);
+    html += F("/filelist?start=");
+    html += start_prev;
+    html += F("'>Previous</a>");
+    addHtml(html);
   }
 
   if (start_next >= 0)
   {
     html_add_button_prefix();
-    TXBuffer += F("/filelist?start=");
-    TXBuffer += start_next;
-    TXBuffer += F("'>Next</a>");
+    String html;
+    html.reserve(36);
+
+    html += F("/filelist?start=");
+    html += start_next;
+    html += F("'>Next</a>");
+    addHtml(html);
   }
 
   if (cacheFilesPresent) {
     html_add_button_prefix(F("red"), true);
-    TXBuffer += F("filelist?delcache");
-    TXBuffer += F("'>Delete Cache Files</a>");
+    addHtml(F("filelist?delcache'>Delete Cache Files</a>"));
   }
-  TXBuffer += F("<BR><BR>");
+  addHtml(F("<BR><BR>"));
   sendHeadandTail_stdtemplate(true);
   TXBuffer.endStream();
 }
+
 #endif // ifdef WEBSERVER_FILELIST
 
 // ********************************************************************************
@@ -360,11 +372,15 @@ void handle_SDfilelist() {
   html_table_header("Name");
   html_table_header("Size");
   html_TR_TD();
-  TXBuffer += F("<TD><a href=\"SDfilelist?chgto=");
-  TXBuffer += parent_dir;
-  TXBuffer += F("\">..");
-  TXBuffer += F("</a>");
-  html_TD();
+  {
+    String html;
+    html.reserve(50 + parent_dir.length());
+    html += F("<TD><a href=\"SDfilelist?chgto=");
+    html += parent_dir;
+    html += F("\">..");
+    html += F("</a><TD>");
+    addHtml(html);
+  }
 
   while (entry)
   {
@@ -382,23 +398,31 @@ void handle_SDfilelist() {
       // when the directory is empty, display the button to delete them
       if (!dir_has_entry)
       {
-        TXBuffer += F("<a class='button link' onclick=\"return confirm('Delete this directory?')\" href=\"SDfilelist?deletedir=");
-        TXBuffer += current_dir;
-        TXBuffer += entry.name();
-        TXBuffer += '/';
-        TXBuffer += F("&chgto=");
-        TXBuffer += current_dir;
-        TXBuffer += F("\">Del</a>");
+        addHtml(F("<a class='button link' onclick=\"return confirm('Delete this directory?')\" href=\"SDfilelist?deletedir="));
+        String html;
+        html.reserve(20 + 2 * current_dir.length() + entry.name().length());
+        html += current_dir;
+        html += entry.name();
+        html += '/';
+        html += F("&chgto=");
+        html += current_dir;
+        html += F("\">Del</a>");
+        addHtml(html);
       }
-      TXBuffer += F("<TD><a href=\"SDfilelist?chgto=");
-      TXBuffer += current_dir;
-      TXBuffer += entry.name();
-      TXBuffer += '/';
-      TXBuffer += "\">";
-      TXBuffer += entry.name();
-      TXBuffer += F("</a>");
-      html_TD();
-      TXBuffer += F("dir");
+      {
+        String html;
+        html.reserve(48 + current_dir.length() + 2 * entry.name().length());
+
+        html += F("<TD><a href=\"SDfilelist?chgto=");
+        html += current_dir;
+        html += entry.name();
+        html += '/';
+        html += "\">";
+        html += entry.name();
+        html += F("</a><TD>");
+        html += F("dir");
+        addHtml(html);
+      }
       dir_has_entry.close();
     }
     else
@@ -407,21 +431,29 @@ void handle_SDfilelist() {
 
       if ((entry.name() != String(F(FILE_CONFIG)).c_str()) && (entry.name() != String(F(FILE_SECURITY)).c_str()))
       {
-        TXBuffer += F("<a class='button link' onclick=\"return confirm('Delete this file?')\" href=\"SDfilelist?delete=");
-        TXBuffer += current_dir;
-        TXBuffer += entry.name();
-        TXBuffer += F("&chgto=");
-        TXBuffer += current_dir;
-        TXBuffer += F("\">Del</a>");
+        addHtml(F("<a class='button link' onclick=\"return confirm('Delete this file?')\" href=\"SDfilelist?delete="));
+        String html;
+        html.reserve(20 + 2 * current_dir.length() + entry.name().length());
+
+        html += current_dir;
+        html += entry.name();
+        html += F("&chgto=");
+        html += current_dir;
+        html += F("\">Del</a>");
+        addHtml(html);
       }
-      TXBuffer += F("<TD><a href=\"");
-      TXBuffer += current_dir;
-      TXBuffer += entry.name();
-      TXBuffer += "\">";
-      TXBuffer += entry.name();
-      TXBuffer += F("</a>");
-      html_TD();
-      TXBuffer += entry.size();
+      {
+        String html;
+        html.reserve(48 + current_dir.length() + 2 * entry.name().length());
+        html += F("<TD><a href=\"");
+        html += current_dir;
+        html += entry.name();
+        html += "\">";
+        html += entry.name();
+        html += F("</a><TD>");
+        html += entry.size();
+        addHtml(html);
+      }
     }
     entry.close();
     entry = root.openNextFile();
@@ -430,10 +462,9 @@ void handle_SDfilelist() {
   html_end_table();
   html_end_form();
 
-  // TXBuffer += F("<BR><a class='button link' href=\"/upload\">Upload</a>");
+  // addHtml(F("<BR><a class='button link' href=\"/upload\">Upload</a>"));
   sendHeadandTail_stdtemplate(true);
   TXBuffer.endStream();
 }
 
 #endif // ifdef FEATURE_SD
-

--- a/src/WebServer_HTML_wrappers.ino
+++ b/src/WebServer_HTML_wrappers.ino
@@ -6,13 +6,18 @@
 // Flash strings are not checked for duplication.
 // ********************************************************************************
 void wrap_html_tag(const String& tag, const String& text) {
-  TXBuffer += '<';
-  TXBuffer += tag;
-  TXBuffer += '>';
-  TXBuffer += text;
-  TXBuffer += "</";
-  TXBuffer += tag;
-  TXBuffer += '>';
+  String html;
+
+  html.reserve(6 + (2 * tag.length()) + text.length());
+
+  html += '<';
+  html += tag;
+  html += '>';
+  html += text;
+  html += "</";
+  html += tag;
+  html += '>';
+  addHtml(html);
 }
 
 void html_B(const String& text) {
@@ -28,7 +33,7 @@ void html_U(const String& text) {
 }
 
 void html_TR_TD_highlight() {
-  TXBuffer += F("<TR class=\"highlight\">");
+  addHtml(F("<TR class=\"highlight\">"));
   html_TD();
 }
 
@@ -38,18 +43,23 @@ void html_TR_TD() {
 }
 
 void html_BR() {
-  TXBuffer += F("<BR>");
+  addHtml(F("<BR>"));
 }
 
 void html_TR() {
-  TXBuffer += F("<TR>");
+  addHtml(F("<TR>"));
 }
 
 void html_TR_TD_height(int height) {
   html_TR();
-  TXBuffer += F("<TD HEIGHT=\"");
-  TXBuffer += height;
-  TXBuffer += "\">";
+
+  String html;
+  html.reserve(20);
+
+  html += F("<TD HEIGHT=\"");
+  html += height;
+  html += "\">";
+  addHtml(html);
 }
 
 void html_TD() {
@@ -58,7 +68,7 @@ void html_TD() {
 
 void html_TD(int td_cnt) {
   for (int i = 0; i < td_cnt; ++i) {
-    TXBuffer += F("<TD>");
+    addHtml(F("<TD>"));
   }
 }
 
@@ -70,18 +80,23 @@ void html_reset_copyTextCounter() {
 
 void html_copyText_TD() {
   ++copyTextCounter;
-  TXBuffer += F("<TD id='copyText_");
-  TXBuffer += copyTextCounter;
-  TXBuffer += "'>";
+
+  String html;
+  html.reserve(24);
+
+  html += F("<TD id='copyText_");
+  html += copyTextCounter;
+  html += "'>";
+  addHtml(html);
 }
 
 // Add some recognizable token to show which parts will be copied.
 void html_copyText_marker() {
-  TXBuffer += F("&#x022C4;"); //   &diam; &diamond; &Diamond; &#x022C4; &#8900;
+  addHtml(F("&#x022C4;")); //   &diam; &diamond; &Diamond; &#x022C4; &#8900;
 }
 
 void html_add_estimate_symbol() {
-  TXBuffer += F(" &#8793; "); //   &#8793;  &#x2259;  &wedgeq;
+  addHtml(F(" &#8793; ")); //   &#8793;  &#x2259;  &wedgeq;
 }
 
 void html_table_class_normal() {
@@ -101,14 +116,19 @@ void html_table(const String& tableclass) {
 }
 
 void html_table(const String& tableclass, bool boxed) {
-  TXBuffer += F("<table class='");
-  TXBuffer += tableclass;
-  TXBuffer += '\'';
+  String html;
+
+  html.reserve(16 + tableclass.length());
+
+  html += F("<table class='");
+  html += tableclass;
+  html += '\'';
+  addHtml(html);
 
   if (boxed) {
-    TXBuffer += F("' border=1px frame='box' rules='all'");
+    addHtml(F("' border=1px frame='box' rules='all'"));
   }
-  TXBuffer += '>';
+  addHtml(">");
 }
 
 void html_table_header(const String& label) {
@@ -120,28 +140,33 @@ void html_table_header(const String& label, int width) {
 }
 
 void html_table_header(const String& label, const String& helpButton, int width) {
-  TXBuffer += F("<TH");
+  String html;
+
+  html.reserve(25 + label.length());
+
+  html += F("<TH");
 
   if (width > 0) {
-    TXBuffer += F(" style='width:");
-    TXBuffer += String(width);
-    TXBuffer += F("px;'");
+    html += F(" style='width:");
+    html += String(width);
+    html += F("px;'");
   }
-  TXBuffer += '>';
-  TXBuffer += label;
+  html += '>';
+  html += label;
+  addHtml(html);
 
   if (helpButton.length() > 0) {
     addHelpButton(helpButton);
   }
-  TXBuffer += F("</TH>");
+  addHtml(F("</TH>"));
 }
 
 void html_end_table() {
-  TXBuffer += F("</table>");
+  addHtml(F("</table>"));
 }
 
 void html_end_form() {
-  TXBuffer += F("</form>");
+  addHtml(F("</form>"));
 }
 
 void html_add_button_prefix() {
@@ -149,22 +174,25 @@ void html_add_button_prefix() {
 }
 
 void html_add_button_prefix(const String& classes, bool enabled) {
-  TXBuffer += F(" <a class='button link");
+  addHtml(F(" <a class='button link"));
 
   if (classes.length() > 0) {
-    TXBuffer += ' ';
-    TXBuffer += classes;
+    String html;
+    html.reserve(classes.length() + 1);
+    html += ' ';
+    html += classes;
+    addHtml(html);
   }
 
   if (!enabled) {
     addDisabled();
   }
-  TXBuffer += '\'';
+  addHtml("'");
 
   if (!enabled) {
     addDisabled();
   }
-  TXBuffer += F(" href='");
+  addHtml(F(" href='"));
 }
 
 void html_add_wide_button_prefix() {
@@ -181,13 +209,13 @@ void html_add_wide_button_prefix(const String& classes, bool enabled) {
 }
 
 void html_add_form() {
-  TXBuffer += F("<form name='frmselect' method='post'>");
+  addHtml(F("<form name='frmselect' method='post'>"));
 }
 
 void html_add_autosubmit_form() {
-  TXBuffer += F("<script><!--\n"
-                "function dept_onchange(frmselect) {frmselect.submit();}"
-                "\n//--></script>");
+  addHtml(F("<script><!--\n"
+            "function dept_onchange(frmselect) {frmselect.submit();}"
+            "\n//--></script>"));
 }
 
 void html_add_script(const String& script, bool defer) {
@@ -197,39 +225,42 @@ void html_add_script(const String& script, bool defer) {
 }
 
 void html_add_script(bool defer) {
-  TXBuffer += F("<script");
+  addHtml(F("<script"));
 
   if (defer) {
-    TXBuffer += F(" defer");
+    addHtml(F(" defer"));
   }
-  TXBuffer += F(" type='text/JavaScript'>");
+  addHtml(F(" type='text/JavaScript'>"));
 }
 
 void html_add_script_end() {
-  TXBuffer += F("</script>");
+  addHtml(F("</script>"));
 }
 
 // if there is an error-string, add it to the html code with correct formatting
 void addHtmlError(const String& error) {
   if (error.length() > 0)
   {
-    TXBuffer += F("<div class=\"");
+    String html;
+    html.reserve(20);
+    html += F("<div class=\"");
 
     if (error.startsWith(F("Warn"))) {
-      TXBuffer += F("warning");
+      html += F("warning");
     } else {
-      TXBuffer += F("alert");
+      html += F("alert");
     }
-    TXBuffer += F("\"><span class=\"closebtn\" onclick=\"this.parentElement.style.display='none';\">&times;</span>");
-    TXBuffer += error;
-    TXBuffer += F("</div>");
+    addHtml( html);
+    addHtml(    F("\"><span class=\"closebtn\" onclick=\"this.parentElement.style.display='none';\">&times;</span>"));
+    addHtml(error);
+    addHtml(    F("</div>"));
   }
   else
   {
     TXBuffer += jsToastMessageBegin;
 
     // we can push custom messages here in future releases...
-    TXBuffer += F("Submitted");
+    addHtml(F("Submitted"));
     TXBuffer += jsToastMessageEnd;
   }
 }
@@ -239,28 +270,37 @@ void addHtml(const String& html) {
 }
 
 void addDisabled() {
-  TXBuffer += F(" disabled");
+  addHtml(F(" disabled"));
 }
 
 void addHtmlLink(const String& htmlclass, const String& url, const String& label) {
-  TXBuffer += F(" <a class='");
-  TXBuffer += htmlclass;
-  TXBuffer += F("' href='");
-  TXBuffer += url;
-  TXBuffer += F("' target='_blank'>");
-  TXBuffer += label;
-  TXBuffer += F("</a>");
+  String html;
+
+  html.reserve(44 + htmlclass.length() + url.length() + label.length());
+
+  html += F(" <a class='");
+  html += htmlclass;
+  html += F("' href='");
+  html += url;
+  html += F("' target='_blank'>");
+  html += label;
+  html += F("</a>");
+  addHtml(html);
 }
 
 void addEnabled(boolean enabled)
 {
-  TXBuffer += F("<span class='enabled ");
+  String html;
+
+  html.reserve(40);
+  html += F("<span class='enabled ");
 
   if (enabled) {
-    TXBuffer += F("on'>&#10004;");
+    html += F("on'>&#10004;");
   }
   else {
-    TXBuffer += F("off'>&#10060;");
+    html += F("off'>&#10060;");
   }
-  TXBuffer += F("</span>");
+  html += F("</span>");
+  addHtml(html);
 }

--- a/src/WebServer_HardwarePage.ino
+++ b/src/WebServer_HardwarePage.ino
@@ -41,7 +41,7 @@ void handle_hardware() {
     addHtmlError(SaveSettings());
   }
 
-  TXBuffer += F("<form  method='post'>");
+  addHtml(F("<form  method='post'>"));
   html_table_class_normal();
   addFormHeader(F("Hardware Settings"), F("ESPEasy#Hardware_page"));
 

--- a/src/WebServer_I2C_Scanner.ino
+++ b/src/WebServer_I2C_Scanner.ino
@@ -16,33 +16,41 @@ void handle_i2cscanner_json() {
 
   byte error, address;
   int  nDevices = 0;
+
   for (address = 1; address <= 127; address++)
   {
     Wire.beginTransmission(address);
     error = Wire.endTransmission();
-    if (error == 0 || error == 4)
+
+    if ((error == 0) || (error == 4))
     {
       json_open();
       json_prop(F("addr"), String(formatToHex(address)));
       json_number(F("status"), String(error));
+
       if (error == 4) {
         json_prop(F("error"), F("Unknown error at address "));
       } else {
         String description = getKnownI2Cdevice(address);
+
         if (description.length() > 0) {
           json_open(true, F("known devices"));
           int pos = 0;
+
           while (pos >= 0) {
             int newpos = description.indexOf(',', pos);
+
             if (pos != 0) {
-              TXBuffer += ',';
+              addHtml(",");
             }
+
             if (newpos == -1) {
               json_quote_val(description.substring(pos));
             } else {
               json_quote_val(description.substring(pos, newpos));
             }
             pos = newpos;
+
             if (newpos != -1)
             {
               ++pos;
@@ -65,6 +73,7 @@ void handle_i2cscanner_json() {
 // FIXME TD-er: Query all included plugins for their supported addresses (return name of plugin)
 String getKnownI2Cdevice(byte address) {
   String result;
+
   switch (address)
   {
     case 0x20:
@@ -189,25 +198,27 @@ void handle_i2cscanner() {
 
     if (error == 0)
     {
-      TXBuffer += "<TR><TD>";
-      TXBuffer += formatToHex(address);
-      TXBuffer += "<TD>";
+      html_TR_TD();
+      addHtml(formatToHex(address));
+      html_TD();
       String description = getKnownI2Cdevice(address);
+
       if (description.length() > 0) {
         description.replace(",", "<BR>");
-        TXBuffer += description;
+        addHtml(description);
       }
       nDevices++;
     }
     else if (error == 4)
     {
-      html_TR_TD(); TXBuffer += F("Unknown error at address ");
-      TXBuffer               += formatToHex(address);
+      html_TR_TD();
+      addHtml(F("Unknown error at address "));
+      addHtml(formatToHex(address));
     }
   }
 
   if (nDevices == 0) {
-    TXBuffer += F("<TR>No I2C devices found");
+    addHtml(F("<TR>No I2C devices found"));
   }
 
   html_end_table();

--- a/src/WebServer_JSON.ino
+++ b/src/WebServer_JSON.ino
@@ -34,10 +34,10 @@ void handle_json()
 
   if (!showSpecificTask)
   {
-    TXBuffer += '{';
+    addHtml("{");
 
     if (showSystem) {
-      TXBuffer += F("\"System\":{\n");
+      addHtml(F("\"System\":{\n"));
       stream_next_json_object_value(LabelType::BUILD_DESC);
       stream_next_json_object_value(LabelType::GIT_BUILD);
       stream_next_json_object_value(LabelType::SYSTEM_LIBRARIES);
@@ -62,17 +62,17 @@ void handle_json()
       stream_next_json_object_value(LabelType::HEAP_FRAGMENTATION);
       #endif // ifdef CORE_POST_2_5_0
       stream_last_json_object_value(LabelType::FREE_MEM);
-      TXBuffer += ",\n";
+      addHtml(F(",\n"));
     }
 
     if (showWifi) {
-      TXBuffer += F("\"WiFi\":{\n");
+      addHtml(F("\"WiFi\":{\n"));
       #if defined(ESP8266)
       stream_next_json_object_value(LabelType::HOST_NAME);
       #endif // if defined(ESP8266)
       #ifdef FEATURE_MDNS
       stream_next_json_object_value(LabelType::M_DNS);
-      #endif
+      #endif // ifdef FEATURE_MDNS
       stream_next_json_object_value(LabelType::IP_CONFIG);
       stream_next_json_object_value(LabelType::IP_ADDRESS);
       stream_next_json_object_value(LabelType::IP_SUBNET);
@@ -97,7 +97,7 @@ void handle_json()
 #endif // ifdef SUPPORT_ARP
       stream_next_json_object_value(LabelType::CONNECTION_FAIL_THRESH);
       stream_last_json_object_value(LabelType::WIFI_RSSI);
-      TXBuffer += ",\n";
+      addHtml(F(",\n"));
     }
 
     if (showNodes) {
@@ -108,13 +108,13 @@ void handle_json()
         if (it->second.ip[0] != 0)
         {
           if (comma_between) {
-            TXBuffer += ',';
+            addHtml(",");
           } else {
             comma_between = true;
-            TXBuffer     += F("\"nodes\":[\n"); // open json array if >0 nodes
+            addHtml(F("\"nodes\":[\n")); // open json array if >0 nodes
           }
 
-          TXBuffer += '{';
+          addHtml("{");
           stream_next_json_object_value(F("nr"), String(it->first));
           stream_next_json_object_value(F("name"),
                                         (it->first != Settings.Unit) ? it->second.nodeName : Settings.Name);
@@ -136,7 +136,7 @@ void handle_json()
       }   // for loop
 
       if (comma_between) {
-        TXBuffer += F("],\n"); // close array if >0 nodes
+        addHtml(F("],\n")); // close array if >0 nodes
       }
     }
   }
@@ -157,7 +157,10 @@ void handle_json()
     }
   }
 
-  if (!showSpecificTask) { TXBuffer += F("\"Sensors\":[\n"); }
+  if (!showSpecificTask) {
+    addHtml(F("\"Sensors\":[\n"));
+  }
+
   // Keep track of the lowest reported TTL and use that as refresh interval.
   unsigned long lowest_ttl_json = 60;
 
@@ -169,7 +172,7 @@ void handle_json()
     {
       const unsigned long taskInterval = Settings.TaskDeviceTimer[TaskIndex];
       LoadTaskSettings(TaskIndex);
-      TXBuffer += F("{\n");
+      addHtml(F("{\n"));
 
       unsigned long ttl_json = 60; // Default value
 
@@ -177,25 +180,26 @@ void handle_json()
       if (Device[DeviceIndex].ValueCount != 0) {
         if ((taskInterval > 0) && Settings.TaskDeviceEnabled[TaskIndex]) {
           ttl_json = taskInterval;
+
           if (ttl_json < lowest_ttl_json) {
             lowest_ttl_json = ttl_json;
           }
         }
-        TXBuffer += F("\"TaskValues\": [\n");
+        addHtml(F("\"TaskValues\": [\n"));
 
         for (byte x = 0; x < Device[DeviceIndex].ValueCount; x++)
         {
-          TXBuffer += '{';
+          addHtml("{");
           stream_next_json_object_value(F("ValueNumber"), String(x + 1));
           stream_next_json_object_value(F("Name"),        String(ExtraTaskSettings.TaskDeviceValueNames[x]));
           stream_next_json_object_value(F("NrDecimals"),  String(ExtraTaskSettings.TaskDeviceValueDecimals[x]));
           stream_last_json_object_value(F("Value"), formatUserVarNoCheck(TaskIndex, x));
 
           if (x < (Device[DeviceIndex].ValueCount - 1)) {
-            TXBuffer += ",\n";
+            addHtml(F(",\n"));
           }
         }
-        TXBuffer += F("],\n");
+        addHtml(F("],\n"));
       }
 
       if (showSpecificTask) {
@@ -203,20 +207,20 @@ void handle_json()
       }
 
       if (showDataAcquisition) {
-        TXBuffer += F("\"DataAcquisition\": [\n");
+        addHtml(F("\"DataAcquisition\": [\n"));
 
         for (controllerIndex_t x = 0; x < CONTROLLER_MAX; x++)
         {
-          TXBuffer += '{';
+          addHtml("{");
           stream_next_json_object_value(F("Controller"), String(x + 1));
           stream_next_json_object_value(F("IDX"),        String(Settings.TaskDeviceID[x][TaskIndex]));
           stream_last_json_object_value(F("Enabled"), jsonBool(Settings.TaskDeviceSendData[x][TaskIndex]));
 
           if (x < (CONTROLLER_MAX - 1)) {
-            TXBuffer += ",\n";
+            addHtml(F(",\n"));
           }
         }
-        TXBuffer += F("],\n");
+        addHtml(F("],\n"));
       }
 
       if (showTaskDetails) {
@@ -229,14 +233,14 @@ void handle_json()
       stream_last_json_object_value(F("TaskNumber"), String(TaskIndex + 1));
 
       if (TaskIndex != lastActiveTaskIndex) {
-        TXBuffer += ',';
+        addHtml(",");
       }
-      TXBuffer += '\n';
+      addHtml("\n");
     }
   }
 
   if (!showSpecificTask) {
-    TXBuffer += F("],\n");
+    addHtml(F("],\n"));
   }
   stream_last_json_object_value(F("TTL"), String(lowest_ttl_json * 1000));
 
@@ -354,18 +358,26 @@ void handle_buildinfo() {
 \*********************************************************************************************/
 void stream_to_json_value(const String& value) {
   if ((value.length() == 0) || !isFloat(value)) {
-    TXBuffer += '\"';
-    TXBuffer += value;
-    TXBuffer += '\"';
+    String html;
+    html.reserve(value.length() + 2);
+    html += '\"';
+    html += value;
+    html += '\"';
+    addHtml(html);
   } else {
-    TXBuffer += value;
+    addHtml(value);
   }
 }
 
 void stream_to_json_object_value(const String& object, const String& value) {
-  TXBuffer += '\"';
-  TXBuffer += object;
-  TXBuffer += "\":";
+  String html;
+
+  html.reserve(object.length() + 4);
+
+  html += '\"';
+  html += object;
+  html += "\":";
+  addHtml(html);
   stream_to_json_value(value);
 }
 
@@ -375,14 +387,14 @@ String jsonBool(bool value) {
 
 // Add JSON formatted data directly to the TXbuffer, including a trailing comma.
 void stream_next_json_object_value(const String& object, const String& value) {
-  TXBuffer += to_json_object_value(object, value);
-  TXBuffer += ",\n";
+  addHtml(to_json_object_value(object, value));
+  addHtml(F(",\n"));
 }
 
 // Add JSON formatted data directly to the TXbuffer, including a closing '}'
 void stream_last_json_object_value(const String& object, const String& value) {
-  TXBuffer += to_json_object_value(object, value);
-  TXBuffer += "\n}";
+  addHtml(to_json_object_value(object, value));
+  addHtml(F("\n}"));
 }
 
 void stream_next_json_object_value(LabelType::Enum label) {

--- a/src/WebServer_Log.ino
+++ b/src/WebServer_Log.ino
@@ -13,21 +13,21 @@ void handle_log() {
   html_table_class_normal();
 
   #ifdef WEBSERVER_LOG
-  TXBuffer += F("<TR><TH id=\"headline\" align=\"left\">Log");
+  addHtml(F("<TR><TH id=\"headline\" align=\"left\">Log"));
   addCopyButton(F("copyText"), "", F("Copy log to clipboard"));
-  TXBuffer += F(
-    "</TR></table><div  id='current_loglevel' style='font-weight: bold;'>Logging: </div><div class='logviewer' id='copyText_1'></div>");
-  TXBuffer += F("Autoscroll: ");
+  addHtml(F(
+            "</TR></table><div  id='current_loglevel' style='font-weight: bold;'>Logging: </div><div class='logviewer' id='copyText_1'></div>"));
+  addHtml(F("Autoscroll: "));
   addCheckBox(F("autoscroll"), true);
-  TXBuffer += F("<BR></body>");
+  addHtml(F("<BR></body>"));
 
   html_add_script(true);
   TXBuffer += DATA_FETCH_AND_PARSE_LOG_JS;
   html_add_script_end();
 
-  #else
-  TXBuffer += F("Not included in build");
-  #endif
+  #else // ifdef WEBSERVER_LOG
+  addHtml(F("Not included in build"));
+  #endif // ifdef WEBSERVER_LOG
   sendHeadandTail_stdtemplate(_TAIL);
   TXBuffer.endStream();
 }
@@ -40,23 +40,23 @@ void handle_log_JSON() {
   #ifdef WEBSERVER_LOG
   TXBuffer.startJsonStream();
   String webrequest = WebServer.arg(F("view"));
-  TXBuffer += F("{\"Log\": {");
+  addHtml(F("{\"Log\": {"));
 
   if (webrequest == F("legend")) {
-    TXBuffer += F("\"Legend\": [");
+    addHtml(F("\"Legend\": ["));
 
     for (byte i = 0; i < LOG_LEVEL_NRELEMENTS; ++i) {
       if (i != 0) {
-        TXBuffer += ',';
+        addHtml(",");
       }
-      TXBuffer += '{';
+      addHtml("{");
       int loglevel;
       stream_next_json_object_value(F("label"), getLogLevelDisplayStringFromIndex(i, loglevel));
       stream_last_json_object_value(F("loglevel"), String(loglevel));
     }
-    TXBuffer += F("],\n");
+    addHtml(F("],\n"));
   }
-  TXBuffer += F("\"Entries\": [");
+  addHtml(F("\"Entries\": ["));
   bool logLinesAvailable       = true;
   int  nrEntries               = 0;
   unsigned long firstTimeStamp = 0;
@@ -66,7 +66,7 @@ void handle_log_JSON() {
     String reply = Logging.get_logjson_formatted(logLinesAvailable, lastTimeStamp);
 
     if (reply.length() > 0) {
-      TXBuffer += reply;
+      addHtml(reply);
 
       if (nrEntries == 0) {
         firstTimeStamp = lastTimeStamp;
@@ -76,7 +76,7 @@ void handle_log_JSON() {
 
     // Do we need to do something here and maybe limit number of lines at once?
   }
-  TXBuffer += F("],\n");
+  addHtml(F("],\n"));
   long logTimeSpan       = timeDiff(firstTimeStamp, lastTimeStamp);
   long refreshSuggestion = 1000;
   long newOptimum        = 1000;
@@ -99,11 +99,11 @@ void handle_log_JSON() {
   stream_next_json_object_value(F("nrEntries"),           String(nrEntries));
   stream_next_json_object_value(F("SettingsWebLogLevel"), String(Settings.WebLogLevel));
   stream_last_json_object_value(F("logTimeSpan"), String(logTimeSpan));
-  TXBuffer += F("}\n");
+  addHtml(F("}\n"));
   TXBuffer.endStream();
   updateLogLevelCache();
 
-  #else 
+  #else // ifdef WEBSERVER_LOG
   handleNotFound();
-  #endif
+  #endif // ifdef WEBSERVER_LOG
 }

--- a/src/WebServer_Markup.ino
+++ b/src/WebServer_Markup.ino
@@ -1,4 +1,5 @@
 // ********************************************************************************
+
 // Add Selector
 // ********************************************************************************
 void addSelector(const String& id,
@@ -28,21 +29,24 @@ void addSelector_options(int optionCount, const String options[], const int indi
     else {
       index = x;
     }
-    TXBuffer += F("<option value=");
-    TXBuffer += index;
+    String html;
+    html.reserve(64);
+    html += F("<option value=");
+    html += index;
 
     if (selectedIndex == index) {
-      TXBuffer += F(" selected");
+      html += F(" selected");
     }
 
     if (attr)
     {
-      TXBuffer += ' ';
-      TXBuffer += attr[x];
+      addHtml(" ");
+      html += attr[x];
     }
-    TXBuffer += '>';
-    TXBuffer += options[x];
-    TXBuffer += F("</option>");
+    html += '>';
+    html += options[x];
+    html += F("</option>");
+    addHtml(html);
   }
 }
 
@@ -61,62 +65,80 @@ void addSelector_Head(const String& id, boolean reloadonchange, bool disabled)
 
 void addSelector_Head(const String& id, const String& onChangeCall, bool disabled)
 {
-  TXBuffer += F("<select class='wide' name='");
-  TXBuffer += id;
-  TXBuffer += F("' id='");
-  TXBuffer += id;
-  TXBuffer += '\'';
+  {
+    String html;
+    html.reserve(32 + id.length());
+    html += F("<select class='wide' name='");
+    html += id;
+    html += F("' id='");
+    html += id;
+    html += '\'';
+    addHtml(html);
+  }
 
   if (disabled) {
     addDisabled();
   }
 
-  if (onChangeCall.length() > 0) {
-    TXBuffer += F(" onchange='");
-    TXBuffer += onChangeCall;
-    TXBuffer += '\'';
+  {
+    String html;
+    html.reserve(16 + onChangeCall.length());
+
+    if (onChangeCall.length() > 0) {
+      html += F(" onchange='");
+      html += onChangeCall;
+      html += '\'';
+    }
+    html += '>';
+    addHtml(html);
   }
-  TXBuffer += '>';
 }
 
 void addSelector_Item(const String& option, int index, boolean selected, boolean disabled, const String& attr)
 {
-  TXBuffer += F("<option value=");
-  TXBuffer += index;
+  addHtml(F("<option value="));
+  addHtml(String(index));
 
   if (selected) {
-    TXBuffer += F(" selected");
+    addHtml(F(" selected"));
   }
 
   if (disabled) {
     addDisabled();
   }
+  String html;
+  html.reserve(48 + option.length() + attr.length());
 
   if (attr && (attr.length() > 0))
   {
-    TXBuffer += ' ';
-    TXBuffer += attr;
+    html += ' ';
+    html += attr;
   }
-  TXBuffer += '>';
-  TXBuffer += option;
-  TXBuffer += F("</option>");
+  html += '>';
+  html += option;
+  html += F("</option>");
+  addHtml(html);
 }
 
 void addSelector_Foot()
 {
-  TXBuffer += F("</select>");
+  addHtml(F("</select>"));
 }
 
 void addUnit(const String& unit)
 {
-  TXBuffer += F(" [");
-  TXBuffer += unit;
-  TXBuffer += "]";
+  String html;
+
+  html += F(" [");
+  html += unit;
+  html += "]";
+  addHtml(html);
 }
 
 void addRowLabel_tr_id(const String& label, const String& id)
 {
   String tr_id = F("tr_");
+
   tr_id += id;
   addRowLabel(label, tr_id);
 }
@@ -124,56 +146,73 @@ void addRowLabel_tr_id(const String& label, const String& id)
 void addRowLabel(const String& label, const String& id)
 {
   if (id.length() > 0) {
-    TXBuffer += F("<TR id='");
-    TXBuffer += id;
-    TXBuffer += F("'><TD>");
+    String html;
+    html += F("<TR id='");
+    html += id;
+    html += F("'><TD>");
+    addHtml(html);
   } else {
     html_TR_TD();
   }
+
   if (label.length() != 0) {
-    TXBuffer += label;
-    TXBuffer += ':';
+    String html;
+    html += label;
+    html += ':';
+    addHtml(html);
   }
   html_TD();
 }
 
 // Add a row label and mark it with copy markers to copy it to clipboard.
 void addRowLabel_copy(const String& label) {
-  TXBuffer += F("<TR>");
+  addHtml(F("<TR>"));
   html_copyText_TD();
-  TXBuffer += label;
-  TXBuffer += ':';
+  String html;
+  html += label;
+  html += ':';
+  addHtml(html);
   html_copyText_marker();
   html_copyText_TD();
 }
 
 void addRowLabelValue(LabelType::Enum label) {
   addRowLabel(getLabel(label));
-  TXBuffer += getValue(label);
+  addHtml(getValue(label));
 }
 
 void addRowLabelValue_copy(LabelType::Enum label) {
   addRowLabel_copy(getLabel(label));
-  TXBuffer += getValue(label);
+  addHtml(getValue(label));
 }
 
 // ********************************************************************************
 // Add a header
 // ********************************************************************************
 void addTableSeparator(const String& label, int colspan, int h_size, const String& helpButton) {
-  TXBuffer += F("<TR><TD colspan=");
-  TXBuffer += colspan;
-  TXBuffer += "><H";
-  TXBuffer += h_size;
-  TXBuffer += '>';
-  TXBuffer += label;
+  {
+    String html;
+    html.reserve(32 + label.length());
+    html += F("<TR><TD colspan=");
+    html += colspan;
+    html += "><H";
+    html += h_size;
+    html += '>';
+    html += label;
+    addHtml(html);
+  }
 
   if (helpButton.length() > 0) {
     addHelpButton(helpButton);
   }
-  TXBuffer += "</H";
-  TXBuffer += h_size;
-  TXBuffer += F("></TD></TR>");
+  {
+    String html;
+    html.reserve(16);
+    html += "</H";
+    html += h_size;
+    html += F("></TD></TR>");
+    addHtml(html);
+  }
 }
 
 void addFormHeader(const String& header, const String& helpButton)
@@ -182,7 +221,6 @@ void addFormHeader(const String& header, const String& helpButton)
   html_table_header(header, helpButton, 225);
   html_table_header("");
 }
-
 
 // ********************************************************************************
 // Add a sub header
@@ -197,22 +235,27 @@ void addFormSubHeader(const String& header)
 // ********************************************************************************
 void addCheckBox(const String& id, boolean checked, bool disabled)
 {
-  TXBuffer += F("<label class='container'>&nbsp;");
-  TXBuffer += F("<input type='checkbox' id='");
-  TXBuffer += id;
-  TXBuffer += F("' name='");
-  TXBuffer += id;
-  TXBuffer += '\'';
+  addHtml(F("<label class='container'>&nbsp;"));
+  addHtml(F("<input type='checkbox' id='"));
+  {
+    String html;
+    html.reserve(16 + 2 * id.length());
+    html += id;
+    html += F("' name='");
+    html += id;
+    html += '\'';
 
-  if (checked) {
-    TXBuffer += F(" checked");
+    if (checked) {
+      html += F(" checked");
+    }
+    addHtml(html);
   }
 
   if (disabled) { addDisabled(); }
-  TXBuffer += F("><span class='checkmark");
+  addHtml(F("><span class='checkmark"));
 
   if (disabled) { addDisabled(); }
-  TXBuffer += F("'></span></label>");
+  addHtml(F("'></span></label>"));
 }
 
 // ********************************************************************************
@@ -220,39 +263,48 @@ void addCheckBox(const String& id, boolean checked, bool disabled)
 // ********************************************************************************
 void addNumericBox(const String& id, int value, int min, int max)
 {
-  TXBuffer += F("<input class='widenumber' type='number' name='");
-  TXBuffer += id;
-  TXBuffer += '\'';
+  addHtml(F("<input class='widenumber' type='number' name='"));
+  String html;
+  html.reserve(32 + id.length());
+  html += id;
+  html += '\'';
 
   if (min != INT_MIN)
   {
-    TXBuffer += F(" min=");
-    TXBuffer += min;
+    html += F(" min=");
+    html += min;
   }
 
   if (max != INT_MAX)
   {
-    TXBuffer += F(" max=");
-    TXBuffer += max;
+    html += F(" max=");
+    html += max;
   }
-  TXBuffer += F(" value=");
-  TXBuffer += value;
-  TXBuffer += '>';
+  html += F(" value=");
+  html += value;
+  html += '>';
+  addHtml(html);
 }
 
 void addFloatNumberBox(const String& id, float value, float min, float max)
 {
-  TXBuffer += F("<input type='number' name='");
-  TXBuffer += id;
-  TXBuffer += '\'';
-  TXBuffer += F(" min=");
-  TXBuffer += min;
-  TXBuffer += F(" max=");
-  TXBuffer += max;
-  TXBuffer += F(" step=0.01");
-  TXBuffer += F(" style='width:5em;' value=");
-  TXBuffer += value;
-  TXBuffer += '>';
+  String html;
+
+  html.reserve(64 + id.length());
+
+  html += F("<input type='number' name='");
+  html += id;
+  html += '\'';
+  html += F(" min=");
+  html += min;
+  html += F(" max=");
+  html += max;
+  html += F(" step=0.01");
+  html += F(" style='width:5em;' value=");
+  html += value;
+  html += '>';
+
+  addHtml(html);
 }
 
 // ********************************************************************************
@@ -260,28 +312,34 @@ void addFloatNumberBox(const String& id, float value, float min, float max)
 // ********************************************************************************
 void addTextBox(const String& id, const String&  value, int maxlength, bool readonly, bool required, const String& pattern)
 {
-  TXBuffer += F("<input class='wide' type='text' name='");
-  TXBuffer += id;
-  TXBuffer += F("' maxlength=");
-  TXBuffer += maxlength;
-  TXBuffer += F(" value='");
-  TXBuffer += value;
-  TXBuffer += '\'';
+  String html;
+
+  html.reserve(96 + id.length() + value.length() + pattern.length());
+
+  html += F("<input class='wide' type='text' name='");
+  html += id;
+  html += F("' maxlength=");
+  html += maxlength;
+  html += F(" value='");
+  html += value;
+  html += '\'';
 
   if (readonly) {
-    TXBuffer += F(" readonly ");
+    html += F(" readonly ");
   }
 
   if (required) {
-    TXBuffer += F(" required ");
+    html += F(" required ");
   }
 
   if (pattern.length() > 0) {
-    TXBuffer += F("pattern = '");
-    TXBuffer += pattern;
-    TXBuffer += '\'';
+    html += F("pattern = '");
+    html += pattern;
+    html += '\'';
   }
-  TXBuffer += '>';
+  html += '>';
+
+  addHtml(html);
 }
 
 // ********************************************************************************
@@ -289,26 +347,32 @@ void addTextBox(const String& id, const String&  value, int maxlength, bool read
 // ********************************************************************************
 void addTextArea(const String& id, const String& value, int maxlength, int rows, int columns, bool readonly, bool required)
 {
-  TXBuffer += F("<textarea class='wide' type='text' name='");
-  TXBuffer += id;
-  TXBuffer += F("' maxlength=");
-  TXBuffer += maxlength;
-  TXBuffer += F("' rows=");
-  TXBuffer += rows;
-  TXBuffer += F("' cols=");
-  TXBuffer += columns;
-  TXBuffer += '\'';
+  String html;
+
+  html.reserve(96 + id.length() + value.length());
+
+  html += F("<textarea class='wide' type='text' name='");
+  html += id;
+  html += F("' maxlength=");
+  html += maxlength;
+  html += F("' rows=");
+  html += rows;
+  html += F("' cols=");
+  html += columns;
+  html += '\'';
 
   if (readonly) {
-    TXBuffer += F(" readonly ");
+    html += F(" readonly ");
   }
 
   if (required) {
-    TXBuffer += F(" required ");
+    html += F(" required ");
   }
-  TXBuffer += '>';
-  TXBuffer += value;
-  TXBuffer += F("</textarea>");
+  html += '>';
+  html += value;
+  html += F("</textarea>");
+
+  addHtml(html);
 }
 
 // ********************************************************************************

--- a/src/WebServer_Markup_Buttons.ino
+++ b/src/WebServer_Markup_Buttons.ino
@@ -10,10 +10,13 @@ void addButton(const String& url, const String& label, const String& classes) {
 void addButton(const String& url, const String& label, const String& classes, bool enabled)
 {
   html_add_button_prefix(classes, enabled);
-  TXBuffer += url;
-  TXBuffer += "'>";
-  TXBuffer += label;
-  TXBuffer += F("</a>");
+  String html;
+  html.reserve(8 + url.length() + label.length());
+  html += url;
+  html += "'>";
+  html += label;
+  html += F("</a>");
+  addHtml(html);
 }
 
 void addButton(class StreamingBuffer& buffer, const String& url, const String& label)
@@ -104,10 +107,13 @@ void addWideButton(const String& url, const String& label, const String& classes
 void addWideButton(const String& url, const String& label, const String& classes, bool enabled)
 {
   html_add_wide_button_prefix(classes, enabled);
-  TXBuffer += url;
-  TXBuffer += "'>";
-  TXBuffer += label;
-  TXBuffer += F("</a>");
+  String html;
+  html.reserve(8 + url.length() + label.length());
+  html += url;
+  html += "'>";
+  html += label;
+  html += F("</a>");
+  addHtml(html);
 }
 
 void addSubmitButton()
@@ -122,36 +128,35 @@ void addSubmitButton(const String& value, const String& name) {
 
 void addSubmitButton(const String& value, const String& name, const String& classes)
 {
-  TXBuffer += F("<input class='button link");
+  addHtml(F("<input class='button link"));
 
   if (classes.length() > 0) {
-    TXBuffer += ' ';
-    TXBuffer += classes;
+    addHtml(" ");
+    addHtml(classes);
   }
-  TXBuffer += F("' type='submit' value='");
-  TXBuffer += value;
+  addHtml(F("' type='submit' value='"));
+  addHtml(value);
 
   if (name.length() > 0) {
-    TXBuffer += F("' name='");
-    TXBuffer += name;
+    addHtml(F("' name='"));
+    addHtml(name);
   }
-  TXBuffer += F("'><div id='toastmessage'></div><script type='text/javascript'>toasting();</script>");
+  addHtml(F("'><div id='toastmessage'></div><script type='text/javascript'>toasting();</script>"));
 }
 
 // add copy to clipboard button
 void addCopyButton(const String& value, const String& delimiter, const String& name)
 {
   TXBuffer += jsClipboardCopyPart1;
-  TXBuffer += value;
+  addHtml(value);
   TXBuffer += jsClipboardCopyPart2;
-  TXBuffer += delimiter;
+  addHtml(delimiter);
   TXBuffer += jsClipboardCopyPart3;
 
   // Fix HTML
-  TXBuffer += F("<button class='button link' onclick='setClipboard()'>");
-  TXBuffer += name;
-  TXBuffer += " (";
+  addHtml(F("<button class='button link' onclick='setClipboard()'>"));
+  addHtml(name);
+  addHtml(" (");
   html_copyText_marker();
-  TXBuffer += ')';
-  TXBuffer += F("</button>");
+  addHtml(F(")</button>"));
 }

--- a/src/WebServer_Markup_Forms.ino
+++ b/src/WebServer_Markup_Forms.ino
@@ -4,9 +4,13 @@
 // ********************************************************************************
 void addFormSeparator(int clspan)
 {
-  TXBuffer += F("<TR><TD colspan='");
-  TXBuffer += clspan;
-  TXBuffer += F("'><hr>");
+  String html;
+
+  html.reserve(40);
+  html += F("<TR><TD colspan='");
+  html += clspan;
+  html += F("'><hr>");
+  addHtml(html);
 }
 
 // ********************************************************************************
@@ -15,9 +19,12 @@ void addFormSeparator(int clspan)
 void addFormNote(const String& text, const String& id)
 {
   addRowLabel_tr_id("", id);
-  TXBuffer += F("<div class='note'>Note: ");
-  TXBuffer += text;
-  TXBuffer += F("</div>");
+  String html;
+  html.reserve(40 + text.length());
+  html += F("<div class='note'>Note: ");
+  html += text;
+  html += F("</div>");
+  addHtml(html);
 }
 
 // ********************************************************************************
@@ -71,7 +78,6 @@ void addTaskSelectBox(const String& label, const String& id, taskIndex_t choice)
   addTaskSelect(id, choice);
 }
 
-
 // ********************************************************************************
 // Add a Text Box form
 // ********************************************************************************
@@ -88,13 +94,13 @@ void addFormTextBox(const String& label,
 }
 
 void addFormTextArea(const String& label,
-                    const String& id,
-                    const String& value,
-                    int           maxlength,
-                    int           rows, 
-                    int           columns,
-                    bool          readonly,
-                    bool          required)
+                     const String& id,
+                     const String& value,
+                     int           maxlength,
+                     int           rows,
+                     int           columns,
+                     bool          readonly,
+                     bool          required)
 {
   addRowLabel_tr_id(label, id);
   addTextArea(id, value, maxlength, rows, columns, readonly, required);
@@ -107,18 +113,23 @@ void addFormTextArea(const String& label,
 void addFormPasswordBox(const String& label, const String& id, const String& password, int maxlength)
 {
   addRowLabel_tr_id(label, id);
-  TXBuffer += F("<input class='wide' type='password' name='");
-  TXBuffer += id;
-  TXBuffer += F("' maxlength=");
-  TXBuffer += maxlength;
-  TXBuffer += F(" value='");
+
+  String html;
+  html.reserve(80 + id.length());
+
+  html += F("<input class='wide' type='password' name='");
+  html += id;
+  html += F("' maxlength=");
+  html += maxlength;
+  html += F(" value='");
 
   if (password != "") { // no password?
-    TXBuffer += F("*****");
+    html += F("*****");
   }
 
-  // TXBuffer += password;   //password will not published over HTTP
-  TXBuffer += "'>";
+  // html += password;   //password will not published over HTTP
+  html += "'>";
+  addHtml(html);
 }
 
 // ********************************************************************************
@@ -130,14 +141,19 @@ void addFormIPBox(const String& label, const String& id, const byte ip[4])
   bool empty_IP = (ip[0] == 0 && ip[1] == 0 && ip[2] == 0 && ip[3] == 0);
 
   addRowLabel_tr_id(label, id);
-  TXBuffer += F("<input class='wide' type='text' name='");
-  TXBuffer += id;
-  TXBuffer += F("' value='");
+
+  String html;
+  html.reserve(80 + id.length());
+
+  html += F("<input class='wide' type='text' name='");
+  html += id;
+  html += F("' value='");
 
   if (!empty_IP) {
-    TXBuffer += formatIP(ip);
+    html += formatIP(ip);
   }
-  TXBuffer += "'>";
+  html += "'>";
+  addHtml(html);
 }
 
 // ********************************************************************************
@@ -255,18 +271,20 @@ bool getCheckWebserverArg_int(const String& key, int& value) {
 }
 
 bool update_whenset_FormItemInt(const String& key, int& value) {
-  int tmpVal; 
+  int tmpVal;
+
   if (getCheckWebserverArg_int(key, tmpVal)) {
-    value = tmpVal; 
+    value = tmpVal;
     return true;
   }
   return false;
 }
 
 bool update_whenset_FormItemInt(const String& key, byte& value) {
-  int tmpVal; 
+  int tmpVal;
+
   if (getCheckWebserverArg_int(key, tmpVal)) {
-    value = tmpVal; 
+    value = tmpVal;
     return true;
   }
   return false;

--- a/src/WebServer_NotificationPage.ino
+++ b/src/WebServer_NotificationPage.ino
@@ -40,7 +40,7 @@ void handle_notifications() {
       {
         nprotocolIndex_t NotificationProtocolIndex = getNProtocolIndex_from_NotifierIndex(notificationindex);
 
-        if (validNProtocolIndex(NotificationProtocolIndex )) {
+        if (validNProtocolIndex(NotificationProtocolIndex)) {
           NPlugin_ptr[NotificationProtocolIndex](NPlugin::Function::NPLUGIN_WEBFORM_SAVE, 0, dummyString);
         }
         NotificationSettings.Port                       = getFormItemInt(F("port"), 0);
@@ -66,7 +66,7 @@ void handle_notifications() {
       // Perform tests with the settings in the form.
       nprotocolIndex_t NotificationProtocolIndex = getNProtocolIndex_from_NotifierIndex(notificationindex);
 
-      if (validNProtocolIndex(NotificationProtocolIndex ))
+      if (validNProtocolIndex(NotificationProtocolIndex))
       {
         // TempEvent.NotificationProtocolIndex = NotificationProtocolIndex;
         TempEvent.NotificationIndex = notificationindex;
@@ -96,11 +96,11 @@ void handle_notifications() {
       NotificationSettings.validate();
       html_TR_TD();
       html_add_button_prefix();
-      TXBuffer += F("notifications?index=");
-      TXBuffer += x + 1;
-      TXBuffer += F("'>Edit</a>");
+      addHtml(F("notifications?index="));
+      addHtml(String(x + 1));
+      addHtml(F("'>Edit</a>"));
       html_TD();
-      TXBuffer += x + 1;
+      addHtml(String(x + 1));
       html_TD();
 
       if (Settings.Notification[x] != 0)
@@ -111,15 +111,15 @@ void handle_notifications() {
         byte   NotificationProtocolIndex = getNProtocolIndex(Settings.Notification[x]);
         String NotificationName          = F("(plugin not found?)");
 
-        if (validNProtocolIndex(NotificationProtocolIndex ))
+        if (validNProtocolIndex(NotificationProtocolIndex))
         {
           NPlugin_ptr[NotificationProtocolIndex](NPlugin::Function::NPLUGIN_GET_DEVICENAME, 0, NotificationName);
         }
-        TXBuffer += NotificationName;
+        addHtml(NotificationName);
         html_TD();
-        TXBuffer += NotificationSettings.Server;
+        addHtml(NotificationSettings.Server);
         html_TD();
-        TXBuffer += NotificationSettings.Port;
+        addHtml(String(NotificationSettings.Port));
       }
       else {
         html_TD(3);
@@ -159,7 +159,7 @@ void handle_notifications() {
 
       nprotocolIndex_t NotificationProtocolIndex = getNProtocolIndex_from_NotifierIndex(notificationindex);
 
-      if (validNProtocolIndex(NotificationProtocolIndex ))
+      if (validNProtocolIndex(NotificationProtocolIndex))
       {
         if (Notification[NotificationProtocolIndex].usesMessaging)
         {
@@ -175,9 +175,9 @@ void handle_notifications() {
           addFormTextBox(F("Pass"),     F("pass"),     NotificationSettings.Pass,     sizeof(NotificationSettings.Pass) - 1);
 
           addRowLabel(F("Body"));
-          TXBuffer += F("<textarea name='body' rows='20' size=512 wrap='off'>");
-          TXBuffer += NotificationSettings.Body;
-          TXBuffer += F("</textarea>");
+          addHtml(F("<textarea name='body' rows='20' size=512 wrap='off'>"));
+          addHtml(NotificationSettings.Body);
+          addHtml(F("</textarea>"));
         }
 
         if (Notification[NotificationProtocolIndex].usesGPIO > 0)

--- a/src/WebServer_PinStates.ino
+++ b/src/WebServer_PinStates.ino
@@ -12,16 +12,16 @@ void handle_pinstates_json() {
   TXBuffer.startJsonStream();
 
   bool first = true;
-  TXBuffer += F("[");
+  addHtml(F("["));
 
   for (std::map<uint32_t, portStatusStruct>::iterator it = globalMapPortStatus.begin(); it != globalMapPortStatus.end(); ++it)
   {
     if (!first) {
-      TXBuffer += ',';
+      addHtml(",");
     } else {
       first = false;
     }
-    TXBuffer += '{';
+    addHtml("{");
 
 
     const uint16_t plugin = getPluginFromKey(it->first);
@@ -36,7 +36,7 @@ void handle_pinstates_json() {
     stream_last_json_object_value(F("init"), String(it->second.init));
   }
 
-  TXBuffer += F("]");
+  addHtml(F("]"));
 
 
   /*
@@ -50,11 +50,11 @@ void handle_pinstates_json() {
         html_TR_TD(); TXBuffer += "P";
         if (pinStates[x].plugin < 100)
         {
-          TXBuffer += '0';
+          addHtml("0");
         }
         if (pinStates[x].plugin < 10)
         {
-          TXBuffer += '0';
+          addHtml("0");
         }
         TXBuffer += pinStates[x].plugin;
         html_TD();
@@ -97,34 +97,35 @@ void handle_pinstates() {
 
   for (std::map<uint32_t, portStatusStruct>::iterator it = globalMapPortStatus.begin(); it != globalMapPortStatus.end(); ++it)
   {
-    html_TR_TD(); TXBuffer += "P";
+    html_TR_TD();
+    addHtml("P");
     const uint16_t plugin = getPluginFromKey(it->first);
     const uint16_t port   = getPortFromKey(it->first);
 
     if (plugin < 100)
     {
-      TXBuffer += '0';
+      addHtml("0");
     }
 
     if (plugin < 10)
     {
-      TXBuffer += '0';
+      addHtml("0");
     }
-    TXBuffer += plugin;
+    addHtml(String(plugin));
     html_TD();
-    TXBuffer += port;
+    addHtml(String(port));
     html_TD();
-    TXBuffer += getPinModeString(it->second.mode);
+    addHtml(getPinModeString(it->second.mode));
     html_TD();
-    TXBuffer += it->second.state;
+    addHtml(String(it->second.state));
     html_TD();
-    TXBuffer += it->second.task;
+    addHtml(String(it->second.task));
     html_TD();
-    TXBuffer += it->second.monitor;
+    addHtml(String(it->second.monitor));
     html_TD();
-    TXBuffer += it->second.command;
+    addHtml(String(it->second.command));
     html_TD();
-    TXBuffer += it->second.init;
+    addHtml(String(it->second.init));
   }
 
 
@@ -139,11 +140,11 @@ void handle_pinstates() {
         html_TR_TD(); TXBuffer += "P";
         if (pinStates[x].plugin < 100)
         {
-          TXBuffer += '0';
+          addHtml("0");
         }
         if (pinStates[x].plugin < 10)
         {
-          TXBuffer += '0';
+          addHtml("0");
         }
         TXBuffer += pinStates[x].plugin;
         html_TD();

--- a/src/WebServer_RootPage.ino
+++ b/src/WebServer_RootPage.ino
@@ -48,8 +48,8 @@ void handle_root() {
     // IPAddress ip = WiFi.localIP();
     // IPAddress gw = WiFi.gatewayIP();
 
-    TXBuffer += printWebString;
-    TXBuffer += F("<form>");
+    addHtml(printWebString);
+    addHtml(F("<form>"));
     html_table_class_normal();
     addFormHeader(F("System Info"));
 
@@ -59,59 +59,79 @@ void handle_root() {
 
     if (systemTimePresent())
     {
-      TXBuffer += getValue(LabelType::LOCAL_TIME);
+      addHtml(getValue(LabelType::LOCAL_TIME));
     }
     else {
-      TXBuffer += F("<font color='red'>No system time source</font>");
+      addHtml(F("<font color='red'>No system time source</font>"));
     }
 
     addRowLabel(getLabel(LabelType::UPTIME));
     {
-      TXBuffer += getExtendedValue(LabelType::UPTIME);
+      addHtml(getExtendedValue(LabelType::UPTIME));
     }
     addRowLabel(getLabel(LabelType::LOAD_PCT));
 
     if (wdcounter > 0)
     {
-      TXBuffer += String(getCPUload());
-      TXBuffer += F("% (LC=");
-      TXBuffer += String(getLoopCountPerSec());
-      TXBuffer += ')';
+      String html;
+      html.reserve(32);
+      html += getCPUload();
+      html += F("% (LC=");
+      html += getLoopCountPerSec();
+      html += ')';
+      addHtml(html);
     }
-
-    addRowLabel(F("Free Mem"));
-    TXBuffer += String(freeMem);
-    TXBuffer += " (";
-    TXBuffer += String(lowestRAM);
-    TXBuffer += F(" - ");
-    TXBuffer += String(lowestRAMfunction);
-    TXBuffer += ')';
-    addRowLabel(F("Free Stack"));
-    TXBuffer += String(getCurrentFreeStack());
-    TXBuffer += " (";
-    TXBuffer += String(lowestFreeStack);
-    TXBuffer += F(" - ");
-    TXBuffer += String(lowestFreeStackfunction);
-    TXBuffer += ')';
+    {
+      addRowLabel(F("Free Mem"));
+      String html;
+      html.reserve(64);
+      html += freeMem;
+      html += " (";
+      html += lowestRAM;
+      html += F(" - ");
+      html += lowestRAMfunction;
+      html += ')';
+      addHtml(html);
+    }
+    {
+      addRowLabel(F("Free Stack"));
+      String html;
+      html.reserve(64);
+      html += String(getCurrentFreeStack());
+      html += " (";
+      html += String(lowestFreeStack);
+      html += F(" - ");
+      html += String(lowestFreeStackfunction);
+      html += ')';
+      addHtml(html);
+    }
 
     addRowLabelValue(LabelType::IP_ADDRESS);
     addRowLabel(getLabel(LabelType::WIFI_RSSI));
 
     if (WiFiConnected())
     {
-      TXBuffer += String(WiFi.RSSI());
-      TXBuffer += F(" dB (");
-      TXBuffer += WiFi.SSID();
-      TXBuffer += ')';
+      String html;
+      html.reserve(32);
+      html += String(WiFi.RSSI());
+      html += F(" dB (");
+      html += WiFi.SSID();
+      html += ')';
+      addHtml(html);
     }
 
     #ifdef FEATURE_MDNS
-    addRowLabel(getLabel(LabelType::M_DNS));
-    TXBuffer += F("<a href='http://");
-    TXBuffer += getValue(LabelType::M_DNS);
-    TXBuffer += F("'>");
-    TXBuffer += getValue(LabelType::M_DNS);
-    TXBuffer += F("</a>");
+    {
+      addRowLabel(getLabel(LabelType::M_DNS));
+      String html;
+      html.reserve(64);
+      html += F("<a href='http://");
+      html += getValue(LabelType::M_DNS);
+      html += F("'>");
+      html += getValue(LabelType::M_DNS);
+      html += F("</a>");
+      addHtml(html);
+    }
     #endif // ifdef FEATURE_MDNS
     html_TR_TD();
     html_TD();
@@ -142,32 +162,38 @@ void handle_root() {
           html_TR_TD();
         }
 
-        TXBuffer += F("Unit ");
-        TXBuffer += String(it->first);
+        addHtml(F("Unit "));
+        addHtml(String(it->first));
         html_TD();
 
         if (isThisUnit) {
-          TXBuffer += Settings.Name;
+          addHtml(Settings.Name);
         }
         else {
-          TXBuffer += it->second.nodeName;
+          addHtml(it->second.nodeName);
         }
         html_TD();
 
         if (it->second.build) {
-          TXBuffer += String(it->second.build);
+          addHtml(String(it->second.build));
         }
         html_TD();
-        TXBuffer += getNodeTypeDisplayString(it->second.nodeType);
+        addHtml(getNodeTypeDisplayString(it->second.nodeType));
         html_TD();
         html_add_wide_button_prefix();
-        TXBuffer += F("http://");
-        TXBuffer += it->second.ip.toString();
-        TXBuffer += "'>";
-        TXBuffer += it->second.ip.toString();
-        TXBuffer += "</a>";
+        {
+          String html;
+          html.reserve(64);
+
+          html += F("http://");
+          html += it->second.ip.toString();
+          html += "'>";
+          html += it->second.ip.toString();
+          html += "</a>";
+          addHtml(html);
+        }
         html_TD();
-        TXBuffer += String(it->second.age);
+        addHtml(String(it->second.age));
       }
     }
 
@@ -202,13 +228,13 @@ void handle_root() {
     {
       addLog(LOG_LEVEL_INFO, F("     : factory reset..."));
       cmd_within_mainloop = CMD_REBOOT;
-      TXBuffer           += F(
-        "OK. Please wait > 1 min and connect to Acces point.<BR><BR>PW=configesp<BR>URL=<a href='http://192.168.4.1'>192.168.4.1</a>");
+      addHtml(F(
+                "OK. Please wait > 1 min and connect to Acces point.<BR><BR>PW=configesp<BR>URL=<a href='http://192.168.4.1'>192.168.4.1</a>"));
       TXBuffer.endStream();
       ExecuteCommand_internal(VALUE_SOURCE_HTTP, sCommand.c_str());
     }
 
-    TXBuffer += "OK";
+    addHtml(F("OK"));
     TXBuffer.endStream();
   }
 }

--- a/src/WebServer_Rules.ino
+++ b/src/WebServer_Rules.ino
@@ -24,6 +24,7 @@ void handle_rules() {
   fileName += F(".txt");
 
   String error;
+
   if (WebServer.args() > 0) {
     String log = F("Rules : Save rulesSet: ");
     log += rulesSet;
@@ -33,13 +34,17 @@ void handle_rules() {
     if (currentSet == rulesSet) {
       if (WebServer.hasArg(F("rules"))) {
         size_t rulesLength = WebServer.arg(F("rules")).length();
+
         // Reported length is with CRLF counted as a single byte.
         // So rulesLength > reported_length is a valid situation.
         size_t reported_length = getFormItemInt(F("rules_len"), 0);
+
         if (rulesLength > RULES_MAX_SIZE) {
           error = F("Error: Data was not saved, exceeds web editor limit!");
-        } if (reported_length > rulesLength) {
-          error = F("Error: Data was not saved, not received all. (");
+        }
+
+        if (reported_length > rulesLength) {
+          error  = F("Error: Data was not saved, not received all. (");
           error += rulesLength;
           error += '/';
           error += reported_length;
@@ -74,7 +79,7 @@ void handle_rules() {
     currentSet = rulesSet;
   }
 
-  TXBuffer += F("<form name = 'frmselect' method = 'post' onsubmit='addRulesLength()'>");
+  addHtml(F("<form name = 'frmselect' method = 'post' onsubmit='addRulesLength()'>"));
   html_table_class_normal();
   html_TR();
   html_table_header(F("Rules"));
@@ -103,7 +108,9 @@ void handle_rules() {
   addButton(fileName, F("Download to file"));
   html_end_table();
   html_end_form();
-  html_add_script(F("function addRulesLength() {    var r_len = document.getElementById('rules').value.length;	document.getElementById('rules_len').setAttribute('value', r_len);  };"), true);
+  html_add_script(F(
+                    "function addRulesLength() {    var r_len = document.getElementById('rules').value.length;	document.getElementById('rules_len').setAttribute('value', r_len);  };"),
+                  true);
   sendHeadandTail_stdtemplate(true);
   TXBuffer.endStream();
 
@@ -155,9 +162,9 @@ void handle_rules_new() {
   html_table_header(F("Event Name"));
   html_table_header(F("Filename"));
   html_table_header(F("Size"));
-  TXBuffer += F("<TH>Actions");
+  addHtml(F("<TH>Actions"));
   addSaveButton(TXBuffer, F("/rules/backup"), F("Backup"));
-  TXBuffer += F("</TH></TR>");
+  addHtml(F("</TH></TR>"));
 
   // class StreamingBuffer buffer = TXBuffer;
 
@@ -171,20 +178,20 @@ void handle_rules_new() {
 
                                    if (fi.isDirectory)
                                    {
-                                     TXBuffer += F("<TR><TD>");
+                                     html_TR_TD();
                                    }
                                    else
                                    {
                                      count++;
-                                     TXBuffer += F("<TR><TD style='text-align:right'>");
+                                     addHtml(F("<TR><TD style='text-align:right'>"));
                                    }
 
                                    // Event Name
-                                   TXBuffer += FileNameToEvent(fi.Name);
+                                   addHtml(FileNameToEvent(fi.Name));
 
                                    if (fi.isDirectory)
                                    {
-                                     TXBuffer += F("</TD><TD></TD><TD></TD><TD>");
+                                     addHtml(F("</TD><TD></TD><TD></TD><TD>"));
                                      addSaveButton(TXBuffer
                                                    , String(F("/rules/backup?directory=")) + URLEncode(fi.Name.c_str())
                                                    , F("Backup")
@@ -195,21 +202,27 @@ void handle_rules_new() {
                                      String encodedPath =  URLEncode((fi.Name + F(".txt")).c_str());
 
                                      // File Name
-                                     TXBuffer += F("</TD><TD><a href='");
-                                     TXBuffer += fi.Name;
-                                     TXBuffer += F(".txt");
-                                     TXBuffer += "'>";
-                                     TXBuffer += fi.Name;
-                                     TXBuffer += F(".txt");
-                                     TXBuffer += F("</a></TD>");
+                                     {
+                                       String html;
+                                       html.reserve(128);
 
-                                     // File size
-                                     TXBuffer += F("<TD>");
-                                     TXBuffer += fi.Size;
-                                     TXBuffer += F("</TD>");
+                                       html += F("</TD><TD><a href='");
+                                       html += fi.Name;
+                                       html += F(".txt");
+                                       html += "'>";
+                                       html += fi.Name;
+                                       html += F(".txt");
+                                       html += F("</a></TD>");
+
+                                       // File size
+                                       html += F("<TD>");
+                                       html += fi.Size;
+                                       html += F("</TD>");
+                                       addHtml(html);
+                                     }
 
                                      // Actions
-                                     TXBuffer += F("<TD>");
+                                     html_TD();
                                      addSaveButton(TXBuffer
                                                    , String(F("/rules/backup?fileName=")) + encodedPath
                                                    , F("Backup")
@@ -220,7 +233,7 @@ void handle_rules_new() {
                                                      , F("Delete")
                                                      );
                                    }
-                                   TXBuffer += F("</TD></TR>");
+                                   addHtml(F("</TD></TR>"));
     #ifdef WEBSERVER_RULES_DEBUG
                                    Serial.print(F("End generation of: "));
                                    Serial.println(fi.Name);
@@ -233,10 +246,10 @@ void handle_rules_new() {
   bool hasMore = EnumerateFileAndDirectory(rootPath
                                            , startIdx
                                            , renderDetail);
-  TXBuffer += F("<TR><TD>");
+  html_TR_TD();
   addButton(F("/rules/add"), F("Add"));
-  TXBuffer += F("</TD><TD></TD><TD></TD><TD></TD></TR>");
-  TXBuffer += F("</table>");
+  addHtml(F("</TD><TD></TD><TD></TD><TD></TD></TR>"));
+  addHtml(F("</table>"));
 
   if (startIdx > 0)
   {
@@ -468,14 +481,14 @@ bool handle_rules_edit(String originalUri, bool isAddNew) {
     if (error.length() > 0) {
       addHtmlError(error);
     }
-    TXBuffer += F("<form name = 'editRule' method = 'post'><table class='normal'><TR><TH align='left' colspan='2'>Edit Rule");
+    addHtml(F("<form name = 'editRule' method = 'post'><table class='normal'><TR><TH align='left' colspan='2'>Edit Rule"));
 
     // hidden field to check Overwrite
-    TXBuffer += F("<input type='hidden' id='IsNew' name='IsNew' value='");
-    TXBuffer += isAddNew
-                ? F("yes")
-                : F("no");
-    TXBuffer += F("'>");
+    addHtml(F("<input type='hidden' id='IsNew' name='IsNew' value='"));
+    addHtml(isAddNew
+            ? F("yes")
+            : F("no"));
+    addHtml(F("'>"));
 
     bool isReadOnly = !isOverwrite && ((isEdit && !isAddNew && !isNew) || (isAddNew && isNew));
       #ifdef WEBSERVER_RULES_DEBUG
@@ -502,7 +515,7 @@ bool handle_rules_edit(String originalUri, bool isAddNew) {
     addHelpButton(F("Tutorial_Rules"));
 
     // load form data from flash
-    TXBuffer += F("<TR><TD colspan='2'>");
+    addHtml(F("<TR><TD colspan='2'>"));
 
     Rule_showRuleTextArea(fileName);
 
@@ -510,7 +523,7 @@ bool handle_rules_edit(String originalUri, bool isAddNew) {
     html_TR_TD();
     addSubmitButton();
 
-    TXBuffer += F("</table></form>");
+    addHtml(F("</table></form>"));
 
     sendHeadandTail(F("TmplStd"), true);
     TXBuffer.endStream();
@@ -522,24 +535,32 @@ bool handle_rules_edit(String originalUri, bool isAddNew) {
 
 void Rule_showRuleTextArea(const String& fileName) {
   // Read rules from file and stream directly into the textarea
-  
+
   size_t size = 0;
-  TXBuffer += F("<textarea id='rules' name='rules' rows='30' wrap='off'>");
+
+  addHtml(F("<textarea id='rules' name='rules' rows='30' wrap='off'>"));
   size = streamFile_htmlEscape(fileName);
-  TXBuffer += F("</textarea>");
-  TXBuffer += F("<TR><TD colspan='2'>");
+  addHtml(F("</textarea>"));
+  addHtml(F("<TR><TD colspan='2'>"));
 
-  html_TR_TD(); TXBuffer += F("Current size: ");
-  TXBuffer               += size;
-  TXBuffer               += F(" characters (Max ");
-  TXBuffer               += RULES_MAX_SIZE;
-  TXBuffer               += F(")");
-  if (size > RULES_MAX_SIZE) {
-    TXBuffer += F("<span style=\"color:red\">Filesize exceeds web editor limit!</span>");
+  html_TR_TD();
+  {
+    String html;
+    html.reserve(64);
+
+    html += F("Current size: ");
+    html += size;
+    html += F(" characters (Max ");
+    html += RULES_MAX_SIZE;
+    html += F(")");
+    addHtml(html);
   }
-  TXBuffer += F("<p><input type='text' id='rules_len' name='rules_len' value='0'></p>");
-}
 
+  if (size > RULES_MAX_SIZE) {
+    addHtml(F("<span style=\"color:red\">Filesize exceeds web editor limit!</span>"));
+  }
+  addHtml(F("<p><input type='text' id='rules_len' name='rules_len' value='0'></p>"));
+}
 
 bool Rule_Download(const String& path)
 {

--- a/src/WebServer_SetupPage.ino
+++ b/src/WebServer_SetupPage.ino
@@ -78,13 +78,14 @@ void handle_setup() {
 void handle_setup_scan_and_show(const String& ssid, const String& other, const String& password) {
   if (WiFi.scanComplete() <= 0) {
     WiFiMode_t cur_wifimode = WiFi.getMode();
-    WifiScan(false); 
+    WifiScan(false);
     setWifiMode(cur_wifimode);
   }
 
   const int8_t scanCompleteStatus = WiFi.scanComplete();
+
   if (scanCompleteStatus <= 0) {
-    TXBuffer += F("No Access Points found");
+    addHtml(F("No Access Points found"));
   }
   else
   {
@@ -96,38 +97,39 @@ void handle_setup_scan_and_show(const String& ssid, const String& other, const S
 
     for (int i = 0; i < scanCompleteStatus; ++i)
     {
-      html_TR_TD(); TXBuffer += F("<label class='container2'>");
-      TXBuffer               += F("<input type='radio' name='ssid' value='");
+      html_TR_TD();
+      addHtml(F("<label class='container2'>"));
+      addHtml(F("<input type='radio' name='ssid' value='"));
       {
         String escapeBuffer = WiFi.SSID(i);
         htmlStrongEscape(escapeBuffer);
-        TXBuffer += escapeBuffer;
+        addHtml(escapeBuffer);
       }
-      TXBuffer += '\'';
+      addHtml("'");
 
       if (WiFi.SSID(i) == ssid) {
-        TXBuffer += F(" checked ");
+        addHtml(F(" checked "));
       }
-      TXBuffer += F("><span class='dotmark'></span></label><TD>");
+      addHtml(F("><span class='dotmark'></span></label><TD>"));
       int32_t rssi = 0;
-      TXBuffer +=  formatScanResult(i, "<BR>", rssi);
+      addHtml(formatScanResult(i, "<BR>", rssi));
       html_TD();
       getWiFi_RSSI_icon(rssi, 45);
     }
     html_end_table();
   }
 
-  TXBuffer += F(
-    "<BR><label class='container2'>other SSID:<input type='radio' name='ssid' id='other_ssid' value='other' ><span class='dotmark'></span></label>");
-  TXBuffer += F("<input class='wide' type ='text' name='other' value='");
-  TXBuffer += other;
-  TXBuffer += F("'><BR><BR>");
+  addHtml(F(
+            "<BR><label class='container2'>other SSID:<input type='radio' name='ssid' id='other_ssid' value='other' ><span class='dotmark'></span></label>"));
+  addHtml(F("<input class='wide' type ='text' name='other' value='"));
+  addHtml(other);
+  addHtml(F("'><BR><BR>"));
 
   addFormSeparator(2);
 
-  TXBuffer += F("<BR>Password:<BR><input class='wide' type ='text' name='pass' value='");
-  TXBuffer += password;
-  TXBuffer += F("'><BR><BR>");
+  addHtml(F("<BR>Password:<BR><input class='wide' type ='text' name='pass' value='"));
+  addHtml(password);
+  addHtml(F("'><BR><BR>"));
 
   addSubmitButton(F("Connect"), "");
 }
@@ -147,24 +149,24 @@ bool handle_setup_connectingStage(byte& refreshCount) {
   if (refreshCount != 0) {
     wait = 3;
   }
-  TXBuffer += F("Please wait for <h1 id='countdown'>20..</h1>");
-  TXBuffer += F("<script type='text/JavaScript'>");
-  TXBuffer += F("function timedRefresh(timeoutPeriod) {");
-  TXBuffer += F("var timer = setInterval(function() {");
-  TXBuffer += F("if (timeoutPeriod > 0) {");
-  TXBuffer += F("timeoutPeriod -= 1;");
-  TXBuffer += F("document.getElementById('countdown').innerHTML = timeoutPeriod + '..' + '<br />';");
-  TXBuffer += F("} else {");
-  TXBuffer += F("clearInterval(timer);");
-  TXBuffer += F("window.location.href = window.location.href;");
-  TXBuffer += F("};");
-  TXBuffer += F("}, 1000);");
-  TXBuffer += F("};");
-  TXBuffer += F("timedRefresh(");
-  TXBuffer += wait;
-  TXBuffer += F(");");
+  addHtml(F("Please wait for <h1 id='countdown'>20..</h1>"));
+  addHtml(F("<script type='text/JavaScript'>"));
+  addHtml(F("function timedRefresh(timeoutPeriod) {"));
+  addHtml(F("var timer = setInterval(function() {"));
+  addHtml(F("if (timeoutPeriod > 0) {"));
+  addHtml(F("timeoutPeriod -= 1;"));
+  addHtml(F("document.getElementById('countdown').innerHTML = timeoutPeriod + '..' + '<br />';"));
+  addHtml(F("} else {"));
+  addHtml(F("clearInterval(timer);"));
+  addHtml(F("window.location.href = window.location.href;"));
+  addHtml(F("};"));
+  addHtml(F("}, 1000);"));
+  addHtml(F("};"));
+  addHtml(F("timedRefresh("));
+  addHtml(String(wait));
+  addHtml(F(");"));
   html_add_script_end();
-  TXBuffer += F("seconds while trying to connect");
+  addHtml(F("seconds while trying to connect"));
   return true;
 }
 

--- a/src/WebServer_SysInfoPage.ino
+++ b/src/WebServer_SysInfoPage.ino
@@ -190,8 +190,8 @@ void handle_sysinfo() {
   TXBuffer.startStream();
   sendHeadandTail_stdtemplate();
 
-  TXBuffer += printWebString;
-  TXBuffer += F("<form>");
+  addHtml(printWebString);
+  addHtml(F("<form>"));
 
   // the table header
   html_table_class_normal();
@@ -202,7 +202,7 @@ void handle_sysinfo() {
   // Not using addFormHeader() to get the copy button on the same header line as 2nd column
   html_TR();
   html_table_header(F("System Info"), 225);
-  TXBuffer += "<TH>"; // Needed to get the copy button on the same header line.
+  addHtml(F("<TH>")); // Needed to get the copy button on the same header line.
   addCopyButton(F("copyText"), F("\\n"), F("Copy info to clipboard"));
 
   TXBuffer += githublogo;
@@ -245,47 +245,67 @@ void handle_sysinfo_basicInfo() {
 
   addRowLabel(getLabel(LabelType::UPTIME));
   {
-    TXBuffer += getExtendedValue(LabelType::UPTIME);
+    addHtml(getExtendedValue(LabelType::UPTIME));
   }
 
   addRowLabel(getLabel(LabelType::LOAD_PCT));
 
   if (wdcounter > 0)
   {
-    TXBuffer += getCPUload();
-    TXBuffer += F("% (LC=");
-    TXBuffer += getLoopCountPerSec();
-    TXBuffer += ')';
+    String html;
+    html.reserve(32);
+    html += getCPUload();
+    html += F("% (LC=");
+    html += getLoopCountPerSec();
+    html += ')';
+    addHtml(html);
   }
   addRowLabelValue(LabelType::CPU_ECO_MODE);
 
   int freeMem = ESP.getFreeHeap();
   addRowLabel(F("Free Mem"));
-  TXBuffer += freeMem;
-  TXBuffer += " (";
-  TXBuffer += lowestRAM;
-  TXBuffer += F(" - ");
-  TXBuffer += lowestRAMfunction;
-  TXBuffer += ')';
+  {
+    String html;
+    html.reserve(64);
+
+    html += freeMem;
+    html += " (";
+    html += lowestRAM;
+    html += F(" - ");
+    html += lowestRAMfunction;
+    html += ')';
+    addHtml(html);
+  }
   addRowLabel(F("Free Stack"));
-  TXBuffer += getCurrentFreeStack();
-  TXBuffer += " (";
-  TXBuffer += lowestFreeStack;
-  TXBuffer += F(" - ");
-  TXBuffer += lowestFreeStackfunction;
-  TXBuffer += ')';
+  {
+    String html;
+    html.reserve(64);
+    html += getCurrentFreeStack();
+    html += " (";
+    html += lowestFreeStack;
+    html += F(" - ");
+    html += lowestFreeStackfunction;
+    html += ')';
+    addHtml(html);
+  }
 # ifdef CORE_POST_2_5_0
   addRowLabelValue(LabelType::HEAP_MAX_FREE_BLOCK);
   addRowLabelValue(LabelType::HEAP_FRAGMENTATION);
-  TXBuffer += '%';
+  addHtml("%");
 # endif // ifdef CORE_POST_2_5_0
 
 
   addRowLabel(F("Boot"));
-  TXBuffer += getLastBootCauseString();
-  TXBuffer += " (";
-  TXBuffer += RTC.bootCounter;
-  TXBuffer += ')';
+  {
+    String html;
+    html.reserve(64);
+
+    html += getLastBootCauseString();
+    html += " (";
+    html += RTC.bootCounter;
+    html += ')';
+    addHtml(html);
+  }
   addRowLabelValue(LabelType::RESET_REASON);
   addRowLabelValue(LabelType::LAST_TASK_BEFORE_REBOOT);
   addRowLabelValue(LabelType::SW_WD_COUNT);
@@ -304,21 +324,27 @@ void handle_sysinfo_Network() {
     byte PHYmode = 3; // wifi_get_phy_mode();
     # endif // if defined(ESP32)
 
-    switch (PHYmode)
     {
-      case 1:
-        TXBuffer += F("802.11B");
-        break;
-      case 2:
-        TXBuffer += F("802.11G");
-        break;
-      case 3:
-        TXBuffer += F("802.11N");
-        break;
+      String html;
+      html.reserve(64);
+
+      switch (PHYmode)
+      {
+        case 1:
+          html += F("802.11B");
+          break;
+        case 2:
+          html += F("802.11G");
+          break;
+        case 3:
+          html += F("802.11N");
+          break;
+      }
+      html += F(" (RSSI ");
+      html += WiFi.RSSI();
+      html += F(" dB)");
+      addHtml(html);
     }
-    TXBuffer += F(" (RSSI ");
-    TXBuffer += WiFi.RSSI();
-    TXBuffer += F(" dB)");
   }
   addRowLabelValue(LabelType::IP_CONFIG);
   addRowLabelValue(LabelType::IP_ADDRESS_SUBNET);
@@ -333,24 +359,30 @@ void handle_sysinfo_Network() {
     uint8_t *macread = WiFi.macAddress(mac);
     char     macaddress[20];
     formatMAC(macread, macaddress);
-    TXBuffer += macaddress;
+    addHtml(macaddress);
 
     addRowLabel(getLabel(LabelType::AP_MAC));
     macread = WiFi.softAPmacAddress(mac);
     formatMAC(macread, macaddress);
-    TXBuffer += macaddress;
+    addHtml(macaddress);
   }
 
   addRowLabel(getLabel(LabelType::SSID));
-  TXBuffer += WiFi.SSID();
-  TXBuffer += " (";
-  TXBuffer += WiFi.BSSIDstr();
-  TXBuffer += ')';
+  {
+    String html;
+    html.reserve(64);
+
+    html += WiFi.SSID();
+    html += " (";
+    html += WiFi.BSSIDstr();
+    html += ')';
+    addHtml(html);
+  }
 
   addRowLabelValue(LabelType::CHANNEL);
   addRowLabelValue(LabelType::CONNECTED);
   addRowLabel(getLabel(LabelType::LAST_DISCONNECT_REASON));
-  TXBuffer += getValue(LabelType::LAST_DISC_REASON_STR);
+  addHtml(getValue(LabelType::LAST_DISC_REASON_STR));
   addRowLabelValue(LabelType::NUMBER_RECONNECTS);
 }
 
@@ -371,40 +403,48 @@ void handle_sysinfo_Firmware() {
   addTableSeparator(F("Firmware"), 2, 3);
 
   addRowLabelValue_copy(LabelType::BUILD_DESC);
-  TXBuffer += ' ';
-  TXBuffer += F(BUILD_NOTES);
+  addHtml(" ");
+  addHtml(F(BUILD_NOTES));
 
   addRowLabelValue_copy(LabelType::SYSTEM_LIBRARIES);
   addRowLabelValue_copy(LabelType::GIT_BUILD);
   addRowLabelValue_copy(LabelType::PLUGIN_COUNT);
-  TXBuffer += ' ';
-  TXBuffer += getPluginDescriptionString();
+  addHtml(" ");
+  addHtml(getPluginDescriptionString());
 
   bool filenameDummy = String(CRCValues.binaryFilename).startsWith(F("ThisIsTheDummy"));
 
   if (!filenameDummy) {
     addRowLabel(F("Build Md5"));
 
-    for (byte i = 0; i < 16; i++) { TXBuffer += String(CRCValues.compileTimeMD5[i], HEX); }
+    String html;
+    html.reserve(64);
+
+    for (byte i = 0; i < 16; i++) {
+      html += String(CRCValues.compileTimeMD5[i], HEX);
+    }
+    addHtml(html);
 
     addRowLabel(F("Md5 check"));
 
     if (!CRCValues.checkPassed()) {
-      TXBuffer += F("<font color = 'red'>fail !</font>");
+      addHtml(F("<font color = 'red'>fail !</font>"));
     }
-    else { TXBuffer += F("passed."); }
+    else {
+      addHtml(F("passed."));
+    }
   }
   addRowLabel_copy(getLabel(LabelType::BUILD_TIME));
-  TXBuffer += String(CRCValues.compileDate);
-  TXBuffer += ' ';
-  TXBuffer += String(CRCValues.compileTime);
+  addHtml(String(CRCValues.compileDate));
+  addHtml(" ");
+  addHtml(String(CRCValues.compileTime));
 
   addRowLabel_copy(getLabel(LabelType::BINARY_FILENAME));
 
   if (filenameDummy) {
-    TXBuffer += F("<b>Self built!</b>");
+    addHtml(F("<b>Self built!</b>"));
   } else {
-    TXBuffer += String(CRCValues.binaryFilename);
+    addHtml(String(CRCValues.binaryFilename));
   }
 }
 
@@ -425,37 +465,47 @@ void handle_sysinfo_ESP_Board() {
 
   addRowLabel(getLabel(LabelType::ESP_CHIP_ID));
   # if defined(ESP8266)
-  TXBuffer += ESP.getChipId();
-  TXBuffer += F(" (0x");
-  String espChipId(ESP.getChipId(), HEX);
-  espChipId.toUpperCase();
-  TXBuffer += espChipId;
-  TXBuffer += ')';
+  {
+    String html;
+    html.reserve(32);
+    html += ESP.getChipId();
+    html += F(" (0x");
+    String espChipId(ESP.getChipId(), HEX);
+    espChipId.toUpperCase();
+    html += espChipId;
+    html += ')';
+    addHtml(html);
+  }
 
   addRowLabel(getLabel(LabelType::ESP_CHIP_FREQ));
-  TXBuffer += ESP.getCpuFreqMHz();
-  TXBuffer += F(" MHz");
+  addHtml(String(ESP.getCpuFreqMHz()));
+  addHtml(F(" MHz"));
   # endif // if defined(ESP8266)
   # if defined(ESP32)
-  TXBuffer += F(" (0x");
-  uint64_t chipid  = ESP.getEfuseMac(); // The chip ID is essentially its MAC address(length: 6 bytes).
-  uint32_t ChipId1 = (uint16_t)(chipid >> 32);
-  String   espChipIdS(ChipId1, HEX);
-  espChipIdS.toUpperCase();
-  TXBuffer += espChipIdS;
-  ChipId1   = (uint32_t)chipid;
-  String espChipIdS1(ChipId1, HEX);
-  espChipIdS1.toUpperCase();
-  TXBuffer += espChipIdS1;
-  TXBuffer += ')';
+  {
+    String html;
+    html.reserve(64);
+    html += F(" (0x");
+    uint64_t chipid  = ESP.getEfuseMac(); // The chip ID is essentially its MAC address(length: 6 bytes).
+    uint32_t ChipId1 = (uint16_t)(chipid >> 32);
+    String   espChipIdS(ChipId1, HEX);
+    espChipIdS.toUpperCase();
+    html   += espChipIdS;
+    ChipId1 = (uint32_t)chipid;
+    String espChipIdS1(ChipId1, HEX);
+    espChipIdS1.toUpperCase();
+    html += espChipIdS1;
+    html += ')';
+    addHtml(html);
+  }
 
   addRowLabel(getLabel(LabelType::ESP_CHIP_FREQ));
-  TXBuffer += ESP.getCpuFreqMHz();
-  TXBuffer += F(" MHz");
+  addHtml(String(ESP.getCpuFreqMHz()));
+  addHtml(F(" MHz"));
   # endif // if defined(ESP32)
   # ifdef ARDUINO_BOARD
   addRowLabel(getLabel(LabelType::ESP_BOARD_NAME));
-  TXBuffer += ARDUINO_BOARD;
+  addHtml(ARDUINO_BOARD);
   # endif // ifdef ARDUINO_BOARD
 }
 
@@ -468,111 +518,137 @@ void handle_sysinfo_Storage() {
 
   // Set to HEX may be something like 0x1640E0.
   // Where manufacturer is 0xE0 and device is 0x4016.
-  TXBuffer += F("Vendor: ");
-  TXBuffer += formatToHex(flashChipId & 0xFF);
+  addHtml(F("Vendor: "));
+  addHtml(formatToHex(flashChipId & 0xFF));
 
   if (flashChipVendorPuya())
   {
-    TXBuffer += F(" (PUYA");
+    addHtml(F(" (PUYA"));
 
     if (puyaSupport()) {
-      TXBuffer += F(", supported");
+      addHtml(F(", supported"));
     } else {
-      TXBuffer += F(HTML_SYMBOL_WARNING);
+      addHtml(F(HTML_SYMBOL_WARNING));
     }
-    TXBuffer += ')';
+    addHtml(")");
   }
-  TXBuffer += F(" Device: ");
+  addHtml(F(" Device: "));
   uint32_t flashDevice = (flashChipId & 0xFF00) | ((flashChipId >> 16) & 0xFF);
-  TXBuffer += formatToHex(flashDevice);
+  addHtml(formatToHex(flashDevice));
   # endif // if defined(ESP8266)
   uint32_t realSize = getFlashRealSizeInBytes();
   uint32_t ideSize  = ESP.getFlashChipSize();
 
   addRowLabel(getLabel(LabelType::FLASH_CHIP_REAL_SIZE));
-  TXBuffer += realSize / 1024;
-  TXBuffer += F(" kB");
+  addHtml(String(realSize / 1024));
+  addHtml(F(" kB"));
 
   addRowLabel(getLabel(LabelType::FLASH_IDE_SIZE));
-  TXBuffer += ideSize / 1024;
-  TXBuffer += F(" kB");
+  addHtml(String(ideSize / 1024));
+  addHtml(F(" kB"));
 
   // Please check what is supported for the ESP32
   # if defined(ESP8266)
   addRowLabel(getLabel(LabelType::FLASH_IDE_SPEED));
-  TXBuffer += ESP.getFlashChipSpeed() / 1000000;
-  TXBuffer += F(" MHz");
+  addHtml(String(ESP.getFlashChipSpeed() / 1000000));
+  addHtml(F(" MHz"));
 
   FlashMode_t ideMode = ESP.getFlashChipMode();
   addRowLabel(getLabel(LabelType::FLASH_IDE_MODE));
+  {
+    String html;
 
-  switch (ideMode) {
-    case FM_QIO:   TXBuffer += F("QIO");  break;
-    case FM_QOUT:  TXBuffer += F("QOUT"); break;
-    case FM_DIO:   TXBuffer += F("DIO");  break;
-    case FM_DOUT:  TXBuffer += F("DOUT"); break;
-    default:
-      TXBuffer += getUnknownString(); break;
+    switch (ideMode) {
+      case FM_QIO:   html += F("QIO");  break;
+      case FM_QOUT:  html += F("QOUT"); break;
+      case FM_DIO:   html += F("DIO");  break;
+      case FM_DOUT:  html += F("DOUT"); break;
+      default:
+        html += getUnknownString(); break;
+    }
+    addHtml(html);
   }
   # endif // if defined(ESP8266)
 
   addRowLabel(getLabel(LabelType::FLASH_WRITE_COUNT));
-  TXBuffer += RTC.flashDayCounter;
-  TXBuffer += F(" daily / ");
-  TXBuffer += RTC.flashCounter;
-  TXBuffer += F(" boot");
+  {
+    String html;
+    html.reserve(32);
+    html += RTC.flashDayCounter;
+    html += F(" daily / ");
+    html += RTC.flashCounter;
+    html += F(" boot");
+    addHtml(html);
+  }
 
   # if defined(ESP8266)
   {
     // FIXME TD-er: Must also add this for ESP32.
     addRowLabel(getLabel(LabelType::SKETCH_SIZE));
-    TXBuffer += ESP.getSketchSize() / 1024;
-    TXBuffer += F(" kB (");
-    TXBuffer += ESP.getFreeSketchSpace() / 1024;
-    TXBuffer += F(" kB free)");
+    {
+      String html;
+      html.reserve(32);
+      html += ESP.getSketchSize() / 1024;
+      html += F(" kB (");
+      html += ESP.getFreeSketchSpace() / 1024;
+      html += F(" kB free)");
+      addHtml(html);
+    }
 
     uint32_t maxSketchSize;
     bool     use2step;
     bool     otaEnabled = OTA_possible(maxSketchSize, use2step);
 
     addRowLabel(getLabel(LabelType::MAX_OTA_SKETCH_SIZE));
-    TXBuffer += maxSketchSize / 1024;
-    TXBuffer += F(" kB (");
-    TXBuffer += maxSketchSize;
-    TXBuffer += F(" bytes)");
+    {
+      String html;
+      html.reserve(32);
+
+      html += maxSketchSize / 1024;
+      html += F(" kB (");
+      html += maxSketchSize;
+      html += F(" bytes)");
+      addHtml(html);
+    }
 
     addRowLabel(getLabel(LabelType::OTA_POSSIBLE));
-    TXBuffer += boolToString(otaEnabled);
+    addHtml(boolToString(otaEnabled));
 
     addRowLabel(getLabel(LabelType::OTA_2STEP));
-    TXBuffer += boolToString(use2step);
+    addHtml(boolToString(use2step));
   }
   # endif // if defined(ESP8266)
 
   addRowLabel(getLabel(LabelType::SPIFFS_SIZE));
-  TXBuffer += SpiffsTotalBytes() / 1024;
-  TXBuffer += F(" kB (");
-  TXBuffer += SpiffsFreeSpace() / 1024;
-  TXBuffer += F(" kB free)");
+  {
+    String html;
+    html.reserve(32);
+
+    html += SpiffsTotalBytes() / 1024;
+    html += F(" kB (");
+    html += SpiffsFreeSpace() / 1024;
+    html += F(" kB free)");
+    addHtml(html);
+  }
 
   addRowLabel(F("Page size"));
-  TXBuffer += String(SpiffsPagesize());
+  addHtml(String(SpiffsPagesize()));
 
   addRowLabel(F("Block size"));
-  TXBuffer += String(SpiffsBlocksize());
+  addHtml(String(SpiffsBlocksize()));
 
   addRowLabel(F("Number of blocks"));
-  TXBuffer += String(SpiffsTotalBytes() / SpiffsBlocksize());
+  addHtml(String(SpiffsTotalBytes() / SpiffsBlocksize()));
 
   {
   # if defined(ESP8266)
     fs::FSInfo fs_info;
     SPIFFS.info(fs_info);
     addRowLabel(F("Maximum open files"));
-    TXBuffer += String(fs_info.maxOpenFiles);
+    addHtml(String(fs_info.maxOpenFiles));
 
     addRowLabel(F("Maximum path length"));
-    TXBuffer += String(fs_info.maxPathLength);
+    addHtml(String(fs_info.maxPathLength));
 
   # endif // if defined(ESP8266)
   }
@@ -582,17 +658,17 @@ void handle_sysinfo_Storage() {
   if (showSettingsFileLayout) {
     addTableSeparator(F("Settings Files"), 2, 3);
     html_TR_TD();
-    TXBuffer += F("Layout Settings File");
+    addHtml(F("Layout Settings File"));
     html_TD();
     getConfig_dat_file_layout();
     html_TR_TD();
     html_TD();
-    TXBuffer += F("(offset / size per item / index)");
+    addHtml(F("(offset / size per item / index)"));
 
     for (int st = 0; st < SettingsType_MAX; ++st) {
       SettingsType settingsType = static_cast<SettingsType>(st);
       html_TR_TD();
-      TXBuffer += getSettingsTypeString(settingsType);
+      addHtml(getSettingsTypeString(settingsType));
       html_TD();
       getStorageTableSVG(settingsType);
     }

--- a/src/WebServer_SysVarPage.ino
+++ b/src/WebServer_SysVarPage.ino
@@ -12,7 +12,7 @@ void handle_sysvars() {
   sendHeadandTail_stdtemplate();
 
   html_BR();
-  TXBuffer += F("<p>This page may load slow.<BR>Do not load too often, since it may affect performance of the node.</p>");
+  addHtml(F("<p>This page may load slow.<BR>Do not load too often, since it may affect performance of the node.</p>"));
   html_BR();
 
   // the table header
@@ -174,21 +174,26 @@ void handle_sysvars() {
 
 void addSysVar_html(const String& input) {
   html_TR_TD();
-  TXBuffer += F("<pre>"); // Make monospaced (<tt> tag?)
-  TXBuffer += F("<xmp>"); // Make sure HTML code is escaped. Tag depricated??
-  TXBuffer += input;
-  TXBuffer += F("</xmp>");
-  TXBuffer += F("</pre>");
+  {
+    String html;
+    html.reserve(24 + input.length());
+    html += F("<pre>"); // Make monospaced (<tt> tag?)
+    html += F("<xmp>"); // Make sure HTML code is escaped. Tag depricated??
+    html += input;
+    html += F("</xmp>");
+    html += F("</pre>");
+    addHtml(html);
+  }
   html_TD();
   String replacement(input);                // Make deepcopy for replacement
   parseSystemVariables(replacement, false); // Not URL encoded
   parseStandardConversions(replacement, false);
-  TXBuffer += replacement;
+  addHtml(replacement);
   html_TD();
   replacement = input;
   parseSystemVariables(replacement, true); // URL encoded
   parseStandardConversions(replacement, true);
-  TXBuffer += replacement;
+  addHtml(replacement);
   delay(0);
 }
 

--- a/src/WebServer_TimingStats.ino
+++ b/src/WebServer_TimingStats.ino
@@ -26,11 +26,11 @@ void handle_timingstats() {
   addFormHeader(F("Statistics"));
   addRowLabel(F("Start Period"));
   struct tm startPeriod = addSeconds(tm, -1.0 * timespan, false);
-  TXBuffer += getDateTimeString(startPeriod, '-', ':', ' ', false);
+  addHtml(getDateTimeString(startPeriod, '-', ':', ' ', false));
   addRowLabelValue(LabelType::LOCAL_TIME);
   addRowLabel(F("Time span"));
-  TXBuffer += String(timespan);
-  TXBuffer += " sec";
+  addHtml(String(timespan));
+  addHtml(F(" sec"));
   html_end_table();
 
   sendHeadandTail_stdtemplate(_TAIL);
@@ -46,7 +46,7 @@ void format_using_threshhold(unsigned long value) {
   if (value > TIMING_STATS_THRESHOLD) {
     html_B(String(value_msec, 3));
   } else {
-    TXBuffer += String(value_msec, 3);
+    addHtml(String(value_msec, 3));
   }
 }
 
@@ -55,10 +55,10 @@ void stream_html_timing_stats(const TimingStats& stats, long timeSinceLastReset)
   unsigned int  c = stats.getMinMax(minVal, maxVal);
 
   html_TD();
-  TXBuffer += c;
+  addHtml(String(c));
   html_TD();
   float call_per_sec = static_cast<float>(c) / static_cast<float>(timeSinceLastReset) * 1000.0;
-  TXBuffer += call_per_sec;
+  addHtml(String(call_per_sec, 2));
   html_TD();
   format_using_threshhold(minVal);
   html_TD();
@@ -73,18 +73,24 @@ long stream_timing_statistics(bool clearStats) {
   for (auto& x: pluginStats) {
     if (!x.second.isEmpty()) {
       const deviceIndex_t deviceIndex = static_cast<deviceIndex_t>(x.first / 256);
+
       if (validDeviceIndex(deviceIndex)) {
         if (x.second.thresholdExceeded(TIMING_STATS_THRESHOLD)) {
           html_TR_TD_highlight();
         } else {
           html_TR_TD();
         }
-        TXBuffer += F("P_");
-        TXBuffer += Device[deviceIndex].Number;
-        TXBuffer += '_';
-        TXBuffer += getPluginNameFromDeviceIndex(deviceIndex);
+        {
+          String html;
+          html.reserve(64);
+          html += F("P_");
+          html += Device[deviceIndex].Number;
+          html += '_';
+          html += getPluginNameFromDeviceIndex(deviceIndex);
+          addHtml(html);
+        }
         html_TD();
-        TXBuffer += getPluginFunctionName(x.first % 256);
+        addHtml(getPluginFunctionName(x.first % 256));
         stream_html_timing_stats(x.second, timeSinceLastReset);
       }
 
@@ -95,17 +101,24 @@ long stream_timing_statistics(bool clearStats) {
   for (auto& x: controllerStats) {
     if (!x.second.isEmpty()) {
       const int ProtocolIndex = x.first / 256;
+
       if (x.second.thresholdExceeded(TIMING_STATS_THRESHOLD)) {
         html_TR_TD_highlight();
       } else {
         html_TR_TD();
       }
-      TXBuffer += F("C_");
-      TXBuffer += Protocol[ProtocolIndex].Number;
-      TXBuffer += '_';
-      TXBuffer += getCPluginNameFromProtocolIndex(ProtocolIndex);
+      {
+        String html;
+        html.reserve(64);
+
+        html += F("C_");
+        html += Protocol[ProtocolIndex].Number;
+        html += '_';
+        html += getCPluginNameFromProtocolIndex(ProtocolIndex);
+        addHtml(html);
+      }
       html_TD();
-      TXBuffer += getCPluginCFunctionName(static_cast<CPlugin::Function>(x.first % 256));
+      addHtml(getCPluginCFunctionName(static_cast<CPlugin::Function>(x.first % 256)));
       stream_html_timing_stats(x.second, timeSinceLastReset);
 
       if (clearStats) { x.second.reset(); }
@@ -119,7 +132,7 @@ long stream_timing_statistics(bool clearStats) {
       } else {
         html_TR_TD();
       }
-      TXBuffer += getMiscStatsName(x.first);
+      addHtml(getMiscStatsName(x.first));
       html_TD();
       stream_html_timing_stats(x.second, timeSinceLastReset);
 

--- a/src/WebServer_ToolsPage.ino
+++ b/src/WebServer_ToolsPage.ino
@@ -11,17 +11,16 @@ void handle_tools() {
 
   String webrequest = WebServer.arg(F("cmd"));
 
-  TXBuffer += F("<form>");
+  addHtml(F("<form>"));
   html_table_class_normal();
 
   addFormHeader(F("Tools"));
 
   addFormSubHeader(F("Command"));
   html_TR_TD();
-  TXBuffer += F("<TR><TD style='width: 180px'>");
-  TXBuffer += F("<input class='wide' type='text' name='cmd' value='");
-  TXBuffer += webrequest;
-  TXBuffer += "'>";
+  addHtml(F("<TR><TD style='width: 180px'><input class='wide' type='text' name='cmd' value='"));
+  addHtml(webrequest);
+  addHtml("'>");
   html_TD();
   addSubmitButton();
   addHelpButton(F("ESPEasy_Command_Reference"));
@@ -37,9 +36,9 @@ void handle_tools() {
 
   if (printWebString.length() > 0)
   {
-    TXBuffer += F("<TR><TD colspan='2'>Command Output<BR><textarea readonly rows='10' wrap='on'>");
-    TXBuffer += printWebString;
-    TXBuffer += F("</textarea>");
+    addHtml(F("<TR><TD colspan='2'>Command Output<BR><textarea readonly rows='10' wrap='on'>"));
+    addHtml(printWebString);
+    addHtml(F("</textarea>"));
   }
 
   addFormSubHeader(F("System"));
@@ -79,13 +78,13 @@ void handle_tools() {
 
   #ifdef WEBSERVER_WIFI_SCANNER
   addWideButtonPlusDescription(F("wifiscanner"),          F("Scan"),       F("Scan for wifi networks"));
-  #endif
+  #endif // ifdef WEBSERVER_WIFI_SCANNER
 
-  # ifdef WEBSERVER_I2C_SCANNER
+  #ifdef WEBSERVER_I2C_SCANNER
   addFormSubHeader(F("Interfaces"));
 
   addWideButtonPlusDescription(F("i2cscanner"), F("I2C Scan"), F("Scan for I2C devices"));
-  # endif // ifdef WEBSERVER_I2C_SCANNER
+  #endif // ifdef WEBSERVER_I2C_SCANNER
 
   addFormSubHeader(F("Settings"));
 
@@ -93,22 +92,22 @@ void handle_tools() {
   addFormNote(F("(File MUST be renamed to \"config.dat\" before upload!)"));
   addWideButtonPlusDescription(F("download"), F("Save"), F("Saves a settings file"));
 
-# ifdef WEBSERVER_NEW_UI
-  #  if defined(ESP8266)
+#ifdef WEBSERVER_NEW_UI
+  # if defined(ESP8266)
 
   if ((SpiffsFreeSpace() / 1024) > 50) {
-    TXBuffer += F("<TR><TD>");
-    TXBuffer += F(
-      "<script>function downloadUI() { fetch('https://raw.githubusercontent.com/letscontrolit/espeasy_ui/master/build/index.htm.gz').then(r=>r.arrayBuffer()).then(r => {var f=new FormData();f.append('file', new File([new Blob([new Uint8Array(r)])], 'index.htm.gz'));f.append('edit', 1);fetch('/upload',{method:'POST',body:f}).then(() => {window.location.href='/';});}); }</script>");
-    TXBuffer += F("<a class=\"button link wide\" onclick=\"downloadUI()\">Download new UI</a>");
-    TXBuffer += F("</TD><TD>Download new UI(alpha)</TD></TR>");
+    html_TR_TD();
+    addHtml(F(
+              "<script>function downloadUI() { fetch('https://raw.githubusercontent.com/letscontrolit/espeasy_ui/master/build/index.htm.gz').then(r=>r.arrayBuffer()).then(r => {var f=new FormData();f.append('file', new File([new Blob([new Uint8Array(r)])], 'index.htm.gz'));f.append('edit', 1);fetch('/upload',{method:'POST',body:f}).then(() => {window.location.href='/';});}); }</script>"));
+    addHtml(F("<a class=\"button link wide\" onclick=\"downloadUI()\">Download new UI</a>"));
+    addHtml(F("</TD><TD>Download new UI(alpha)</TD></TR>"));
   }
-  #  endif // if defined(ESP8266)
-# endif    // WEBSERVER_NEW_UI
+  # endif // if defined(ESP8266)
+#endif     // WEBSERVER_NEW_UI
 
-# if defined(ESP8266)
+#if defined(ESP8266)
   {
-    #  ifndef NO_HTTP_UPDATER
+    # ifndef NO_HTTP_UPDATER
     {
       uint32_t maxSketchSize;
       bool     use2step;
@@ -118,35 +117,35 @@ void handle_tools() {
       addWideButton(F("update"), F("Update Firmware"), "", otaEnabled);
       addHelpButton(F("EasyOTA"));
       html_TD();
-      TXBuffer += F("Load a new firmware");
+      addHtml(F("Load a new firmware"));
 
       if (otaEnabled) {
         if (use2step) {
-          TXBuffer += F(" <b>WARNING</b> only use 2-step OTA update.");
+          addHtml(F(" <b>WARNING</b> only use 2-step OTA update."));
         }
       } else {
-        TXBuffer += F(" <b>WARNING</b> OTA not possible.");
+        addHtml(F(" <b>WARNING</b> OTA not possible."));
       }
-      TXBuffer += F(" Max sketch size: ");
-      TXBuffer += maxSketchSize / 1024;
-      TXBuffer += F(" kB (");
-      TXBuffer += maxSketchSize;
-      TXBuffer += F(" bytes)");
+      addHtml(F(" Max sketch size: "));
+      addHtml(String(maxSketchSize / 1024));
+      addHtml(F(" kB ("));
+      addHtml(String(maxSketchSize));
+      addHtml(F(" bytes)"));
     }
-    #  endif // ifndef NO_HTTP_UPDATER
+    # endif // ifndef NO_HTTP_UPDATER
   }
-# endif // if defined(ESP8266)
+#endif      // if defined(ESP8266)
 
   addFormSubHeader(F("Filesystem"));
 
   addWideButtonPlusDescription(F("filelist"),         F("File browser"),     F("Show files on internal flash file system"));
   addWideButtonPlusDescription(F("/factoryreset"),    F("Factory Reset"),    F("Select pre-defined configuration or full erase of settings"));
-  # ifdef USE_SETTINGS_ARCHIVE
+  #ifdef USE_SETTINGS_ARCHIVE
   addWideButtonPlusDescription(F("/settingsarchive"), F("Settings Archive"), F("Download settings from some archive"));
-  # endif // ifdef USE_SETTINGS_ARCHIVE
-# ifdef FEATURE_SD
+  #endif // ifdef USE_SETTINGS_ARCHIVE
+#ifdef FEATURE_SD
   addWideButtonPlusDescription(F("SDfilelist"),       F("SD Card"),          F("Show files on SD-Card"));
-# endif // ifdef FEATURE_SD
+#endif   // ifdef FEATURE_SD
 
   html_end_table();
   html_end_form();
@@ -156,7 +155,6 @@ void handle_tools() {
   printToWeb     = false;
 }
 
-
 // ********************************************************************************
 // Web Interface debug page
 // ********************************************************************************
@@ -165,7 +163,7 @@ void addWideButtonPlusDescription(const String& url, const String& buttonText, c
   html_TR_TD_height(30);
   addWideButton(url, buttonText);
   html_TD();
-  TXBuffer += description;
+  addHtml(description);
 }
 
 #endif // ifdef WEBSERVER_TOOLS

--- a/src/WebServer_UploadPage.ino
+++ b/src/WebServer_UploadPage.ino
@@ -11,8 +11,8 @@ void handle_upload() {
   TXBuffer.startStream();
   sendHeadandTail_stdtemplate();
 
-  TXBuffer += F(
-    "<form enctype='multipart/form-data' method='post'><p>Upload settings file:<br><input type='file' name='datafile' size='40'></p><div><input class='button link' type='submit' value='Upload'></div><input type='hidden' name='edit' value='1'></form>");
+  addHtml(F(
+            "<form enctype='multipart/form-data' method='post'><p>Upload settings file:<br><input type='file' name='datafile' size='40'></p><div><input class='button link' type='submit' value='Upload'></div><input type='hidden' name='edit' value='1'></form>"));
   sendHeadandTail_stdtemplate(true);
   TXBuffer.endStream();
   printWebString = "";
@@ -34,20 +34,20 @@ void handle_upload_post() {
 
   if (uploadResult == 1)
   {
-    TXBuffer += F("Upload OK!<BR>You may need to reboot to apply all settings...");
+    addHtml(F("Upload OK!<BR>You may need to reboot to apply all settings..."));
     LoadSettings();
   }
 
   if (uploadResult == 2) {
-    TXBuffer += F("<font color=\"red\">Upload file invalid!</font>");
+    addHtml(F("<font color=\"red\">Upload file invalid!</font>"));
   }
 
   if (uploadResult == 3) {
-    TXBuffer += F("<font color=\"red\">No filename!</font>");
+    addHtml(F("<font color=\"red\">No filename!</font>"));
   }
 
 
-  TXBuffer += F("Upload finished");
+  addHtml(F("Upload finished"));
   sendHeadandTail_stdtemplate(true);
   TXBuffer.endStream();
   printWebString = "";
@@ -62,9 +62,9 @@ void handle_upload_json() {
   if (!isLoggedIn()) { result = 255; }
 
   TXBuffer.startJsonStream();
-  TXBuffer += "{";
+  addHtml("{");
   stream_next_json_object_value(F("status"), String(result));
-  TXBuffer += "}";
+  addHtml("}");
 
   TXBuffer.endStream();
 }

--- a/src/WebServer_WiFiScanner.ino
+++ b/src/WebServer_WiFiScanner.ino
@@ -11,14 +11,14 @@ void handle_wifiscanner_json() {
   if (!isLoggedIn()) { return; }
   navMenuIndex = MENU_INDEX_TOOLS;
   TXBuffer.startJsonStream();
-  TXBuffer += "[{";
+  addHtml("[{");
   bool firstentry = true;
   int  n          = WiFi.scanNetworks(false, true);
 
   for (int i = 0; i < n; ++i)
   {
     if (firstentry) { firstentry = false; }
-    else { TXBuffer += ",{"; }
+    else { addHtml(",{"); }
     String authType;
 
     switch (WiFi.encryptionType(i)) {
@@ -49,9 +49,9 @@ void handle_wifiscanner_json() {
     stream_last_json_object_value(getLabel(LabelType::WIFI_RSSI), String(WiFi.RSSI(i)));
   }
   if (firstentry) {
-    TXBuffer += "}";
+    addHtml("}");
   }
-  TXBuffer += "]";
+  addHtml("]");
   TXBuffer.endStream();
 }
 
@@ -65,7 +65,7 @@ void handle_wifiscanner() {
   if (!isLoggedIn()) { return; }
 
   WiFiMode_t cur_wifimode = WiFi.getMode();
-  WifiScan(false); 
+  WifiScan(false);
   setWifiMode(cur_wifimode);
 
   navMenuIndex = MENU_INDEX_TOOLS;
@@ -79,8 +79,9 @@ void handle_wifiscanner() {
   html_table_header(F("RSSI"), 50);
 
   const int8_t scanCompleteStatus = WiFi.scanComplete();
+
   if (scanCompleteStatus <= 0) {
-    TXBuffer += F("No Access Points found");
+    addHtml(F("No Access Points found"));
   }
   else
   {
@@ -88,7 +89,7 @@ void handle_wifiscanner() {
     {
       html_TR_TD();
       int32_t rssi = 0;
-      TXBuffer += formatScanResult(i, "<TD>", rssi);
+      addHtml(formatScanResult(i, "<TD>", rssi));
       html_TD();
       getWiFi_RSSI_icon(rssi, 45);
     }

--- a/src/WebServer_login.ino
+++ b/src/WebServer_login.ino
@@ -11,12 +11,12 @@ void handle_login() {
   sendHeadandTail_stdtemplate(_HEAD);
 
   String webrequest = WebServer.arg(F("password"));
-  TXBuffer += F("<form method='post'>");
+  addHtml(F("<form method='post'>"));
   html_table_class_normal();
-  TXBuffer += F("<TR><TD>Password<TD>");
-  TXBuffer += F("<input class='wide' type='password' name='password' value='");
-  TXBuffer += webrequest;
-  TXBuffer += "'>";
+  addHtml(F("<TR><TD>Password<TD>"));
+  addHtml(F("<input class='wide' type='password' name='password' value='"));
+  addHtml(webrequest);
+  addHtml("'>");
   html_TR_TD();
   html_TD();
   addSubmitButton();
@@ -35,15 +35,16 @@ void handle_login() {
     {
       WebLoggedIn      = true;
       WebLoggedInTimer = 0;
-      TXBuffer         = F("<script>window.location = '.'</script>");
+      addHtml(F("<script>window.location = '.'</script>"));
     }
     else
     {
-      TXBuffer += F("Invalid password!");
+      addHtml(F("Invalid password!"));
 
       if (Settings.UseRules)
       {
         String event = F("Login#Failed");
+
         // TD-er: Do not add to the eventQueue, but execute right now.
         rulesProcessing(event);
       }


### PR DESCRIPTION
The TXBuffer is a "header only" implementation.
This means it may be compiled "inline" and thus takes quite a bit of compiled code.
This makes the binary larger and slows the ESP down.

Now it is even possible to make core 2.6.3 builds using "minimal OTA".
The "Dev" build is roughly 55k smaller.