### PR TITLE
[P023] Fix for text overflowing onto next line(s)

### DIFF
--- a/src/_P023_OLED.ino
+++ b/src/_P023_OLED.ino
@@ -626,8 +626,12 @@ void Plugin_023_sendStrXY(struct Plugin_023_OLED_SettingStruct &oled,  const cha
   unsigned char currentPixels = Y * 8; // setXY always uses font_width = 8, Y = 0-based
   unsigned char maxPixels = 128; // Assumed default display width
 
-  if (oled.type == OLED_64x48) // Cater for that 1 smaller size display
+  switch (oled.type) { // Cater for that 1 smaller size display
+    case OLED_64x48:
+    case OLED_64x48 | OLED_rotated:
       maxPixels = 64;
+      break;
+  }
 
   while (*string && currentPixels < maxPixels) // Prevent display overflow on the character level
   {

--- a/src/_P023_OLED.ino
+++ b/src/_P023_OLED.ino
@@ -623,8 +623,13 @@ void Plugin_023_sendStrXY(struct Plugin_023_OLED_SettingStruct &oled,  const cha
   Plugin_023_setXY(oled, X, Y);
   unsigned char i = 0;
   unsigned char font_width = 0;
+  unsigned char currentPixels = Y * 8; // setXY always uses font_width = 8, Y = 0-based
+  unsigned char maxPixels = 128; // Assumed default display width
 
-  while (*string)
+  if (oled.type == OLED_64x48) // Cater for that 1 smaller size display
+      maxPixels = 64;
+
+  while (*string && currentPixels < maxPixels) // Prevent display overflow on the character level
   {
     switch (oled.font_width)
     {
@@ -635,10 +640,11 @@ void Plugin_023_sendStrXY(struct Plugin_023_OLED_SettingStruct &oled,  const cha
         font_width = 8;
     }
 
-    for (i = 0; i < font_width; i++)
+    for (i = 0; i < font_width && currentPixels + i < maxPixels; i++) // Prevent display overflow on the pixel-level
     {
       Plugin_023_SendChar(oled, pgm_read_byte(Plugin_023_myFont[*string - 0x20] + i));
     }
+    currentPixels += font_width;
     string++;
   }
 }


### PR DESCRIPTION
Added pixel-counting to Plugin_023_sendStrXY to prevent overflowing onto the next line.
I tested with both Normal and Optimized Font Width settings, but as I have only 128 pixel wide displays, I couldn't test with a 64 pixel display, but I did take that width in account too.

Fixes #2877 