### PR TITLE
Add Gitpod config file

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,3 @@
+tasks:
+  - before: pip3 install -U platformio
+    command: platformio run -e custom_ESP8266_4M1M


### PR DESCRIPTION
Gitpod is a free online instance of Platfromio. For basic usage, see https://github.com/arendst/Tasmota/wiki/Compiling-Tasmota-on-Gitpod (substitite references to Tasmota's user_config_override.h for ESPEasy's custom.h).

This commit adds the Gitpod config file, to enable easy startup. It might be a good basis to build a solution to #2943. For a complete solution to this issue, take a look at https://github.com/benzino77/tasmocompiler, which also runs on Gitpod.