### PR TITLE
Fix deepsleep,0

### DIFF
--- a/docs/source/Plugin/P000_commands.repl
+++ b/docs/source/Plugin/P000_commands.repl
@@ -98,6 +98,7 @@
     :red:`Internal`","
     Switch the node to deep sleep.
     Max sleep time depends on library version and differs from roughly 71 minutes to 3h46.
+    If you specify a Min sleep time of 0, you'll have to wake the device yourself by pulling RST to GND. 
 
     ``DeepSleep,<sleep time in seconds>``"
     "

--- a/src/src/Commands/System.cpp
+++ b/src/src/Commands/System.cpp
@@ -17,7 +17,7 @@ String Command_System_NoSleep(struct EventStruct *event, const char* Line)
 
 String Command_System_deepSleep(struct EventStruct *event, const char* Line)
 {
-	if (event->Par1 > 0) {
+	if (event->Par1 >= 0) {
 		deepSleepStart(event->Par1); // call the second part of the function to avoid check and enable one-shot operation
 	}
 	return return_command_success();


### PR DESCRIPTION
Now, a second attempt (first I forgot to commit locally)...

I'll hope I've found the problem !?
This fix will enable the deepsleep-command with a value of 0 with my test.

I also hope, the way via branch/compare/commit is (now) correct !?