### PR TITLE
ESP32: fill binary filename, count MD5 only for esp8266

### DIFF
--- a/before_deploy
+++ b/before_deploy
@@ -78,7 +78,7 @@ do
       if [ -f $FIRMWARE_FACTORY_BIN ]; then
         FBIN=${BINARY_PATH}/${ENV}/ESP_Easy_${VERSION}_${ENV}_factory.bin
         cp ${FIRMWARE_FACTORY_BIN} $FBIN
-        #python2 crc2.py $FBIN
+        python2 crc2.py $FBIN
         mv $FBIN "${FBINDIR}/ESP_Easy_${VERSION}_${ENV}_factory.bin"
       fi
     else

--- a/crc2.py
+++ b/crc2.py
@@ -49,19 +49,22 @@ def showParts(fileContent, offset):
 #    print ("please give a filename")
 #    k=input("press close to exit")
 #    sys.exit(1)
-FileName = sys.argv[1]#"C:/ArduinoPortable/sketchbooks/build/sketch_jan15a.ino.bin"
+FileName = sys.argv[1]
 #FileName =  "C:/ArduinoPortable/sketchbooks/build/sketch_jan15a.ino.bin"
 print( "\n\nReplacing dummy MD5 checksum in .bin file")
 
 with open(FileName, mode='rb') as file: # b is important -> binary
     fileContent = file.read()
-    
-firmware_esp8266 = fileContent.find("Mega32") < 0
-if  firmware_esp8266:
+
+firmware_esp8266 = fileContent.find("ID_EASY_ESP8266") >= 0
+firmware_esp32   = fileContent.find("ID_EASY_ESP32") >= 0
+
+if firmware_esp8266:
   print("ESP8266 build")
-else:
+if firmware_esp32:
   print("ESP32 build")
 
+# TODO: showParts does not work for esp32
 if firmware_esp8266:
   nextpos =0;
   while nextpos >=0:

--- a/crc2.py
+++ b/crc2.py
@@ -53,12 +53,18 @@ FileName = sys.argv[1]#"C:/ArduinoPortable/sketchbooks/build/sketch_jan15a.ino.b
 #FileName =  "C:/ArduinoPortable/sketchbooks/build/sketch_jan15a.ino.bin"
 print( "\n\nReplacing dummy MD5 checksum in .bin file")
 
-
-
 with open(FileName, mode='rb') as file: # b is important -> binary
-    nextpos =0;
     fileContent = file.read()
-    while nextpos >=0:
+    
+firmware_esp8266 = fileContent.find("Mega32") < 0
+if  firmware_esp8266:
+  print("ESP8266 build")
+else:
+  print("ESP32 build")
+
+if firmware_esp8266:
+  nextpos =0;
+  while nextpos >=0:
         nextpos = showParts(fileContent,nextpos)
 
 startArray,endArray,hashString = "","",""
@@ -70,47 +76,49 @@ includeStr = "hash includes segments:"
 # 3: RAM (initialized by bin file. Can be read but changes as you go :-( )
 # 4: RAM
 
-for i in (1,2 ):     # use only stable segments, must be 4 in total. We use 2.
+if firmware_esp8266:
+  for i in (1,2 ):     # use only stable segments, must be 4 in total. We use 2.
     startArray =startArray + MemorySegmentStart[i]
     endArray =  endArray   + MemorySegmentEnd[i]
     hashString =hashString + MemoryContent[i]
     with open(FileName+str(i), mode='wb') as file: # b is important -> binary
       file.write(MemoryContent[i])
     includeStr = includeStr +" "+ str(i)
-print (includeStr)
-# IMPORTANT: pad array with zeros if you use only 3 segments (see above)
-while len(startArray) < 16 :
-	startArray =startArray + struct.pack("I",0)
-	endArray =  endArray   + struct.pack("I",0)
-# debug print (binascii.hexlify(startArray))
-# debug print (binascii.hexlify(endArray))
-if (len(endArray) + len (startArray)) != 32 :
+  print (includeStr)
+  
+  # IMPORTANT: pad array with zeros if you use only 3 segments (see above)
+  while len(startArray) < 16 :
+    startArray =startArray + struct.pack("I",0)
+    endArray =  endArray   + struct.pack("I",0)
+  # debug print (binascii.hexlify(startArray))
+  # debug print (binascii.hexlify(endArray))
+  if (len(endArray) + len (startArray)) != 32 :
     print("ERROR: please make sure you add / remove padding if you change the semgents.")
 
-BinaryFileName = "";
 if  fileContent.find( FILENAMEDUMMY) < 0:
     print("ERROR: FILENAMEDUMMY dummy not found in binary")
 else:
-	BinaryFileName=os.path.basename(FileName) +"\0"
-	if len(BinaryFileName) >64:								# check that filename is <48 chars
-		BinaryFileName=BinaryFileName[0:64]					# truncate if necessary. 49th char in ESP is zero already
-	else:
-		BinaryFileName= BinaryFileName.ljust(64,'\0');		# pad with zeros.
+    BinaryFileName=os.path.basename(FileName) +"\0"
+    if len(BinaryFileName) >64:								# check that filename is <48 chars
+        BinaryFileName=BinaryFileName[0:64]					# truncate if necessary. 49th char in ESP is zero already
+    else:
+        BinaryFileName= BinaryFileName.ljust(64,'\0');		# pad with zeros.
+    
+    fileContent=fileContent.replace(FILENAMEDUMMY,BinaryFileName)
 
-
-if  fileContent.find( MD5DUMMY) < 0:
+if firmware_esp8266:
+  if  fileContent.find( MD5DUMMY) < 0:
     print("ERROR: MD5 dummy not found in binary")
-else:
+  else:
     hashString=hashString.replace (MD5DUMMY,"",1)
     m = md5.new()
     m.update (hashString) #use segment 1
     md5hash = m.digest()
     print("MD5 hash: "+ m.hexdigest())
-    print("\nwriting output file:\n" + FileName)
-
     fileContent=fileContent.replace(MD5DUMMY,md5hash+startArray+endArray)
-    fileContent=fileContent.replace(FILENAMEDUMMY,BinaryFileName)
 
-    with open(FileName, mode='wb') as file: # b is important -> binary
-      file.write(fileContent)
+print("\nwriting output file:\n" + FileName)
+with open(FileName, mode='wb') as file: # b is important -> binary
+  file.write(fileContent)
+
 #k=input("press close to exit")

--- a/src/ESPEasy_checks.ino
+++ b/src/ESPEasy_checks.ino
@@ -32,7 +32,7 @@ template<typename T, typename U> constexpr size_t offsetOf(U T::*member)
 
 
 void run_compiletime_checks() {
-  check_size<CRCStruct,                             168u>();
+  check_size<CRCStruct,                             204u>();
   check_size<SecurityStruct,                        593u>();
   const unsigned int SettingsStructSize = (248 + 82 * TASKS_MAX);
   check_size<SettingsStruct,                        SettingsStructSize>();

--- a/src/src/DataStructs/CRCStruct.h
+++ b/src/src/DataStructs/CRCStruct.h
@@ -7,6 +7,18 @@
 * CRCStruct
 \*********************************************************************************************/
 struct CRCStruct {
+  char     crcStructTagID[16] =
+#if defined(ESP8266)
+// 1234567890123456
+  "ID_EASY_ESP8266";
+#elif defined(ESP32)
+  "ID_EASY_ESP32";
+#endif
+  int offsetof_compileTimeMD5 = __builtin_offsetof(CRCStruct,compileTimeMD5);
+  int offsetof_binaryFilename = __builtin_offsetof(CRCStruct,binaryFilename);
+  int offsetof_compileTime    = __builtin_offsetof(CRCStruct,compileTime);
+  int offsetof_compileDate    = __builtin_offsetof(CRCStruct,compileDate);
+  int offset_last_one         = 0;
   char     compileTimeMD5[16 + 32 + 1] = "MD5_MD5_MD5_MD5_BoundariesOfTheSegmentsGoHere...";
   char     binaryFilename[32 + 32 + 1] = "ThisIsTheDummyPlaceHolderForTheBinaryFilename64ByteLongFilenames";
   char     compileTime[16]             = __TIME__;


### PR DESCRIPTION
With this patch binary filename will be filled for esp8266/esp32/esp32-factory images

@TD-er you can try it, will also add one more string into CRCStruct for later use 