### PR TITLE
Make default reset button gpio configurable

### DIFF
--- a/src/Custom-sample.h
+++ b/src/Custom-sample.h
@@ -102,6 +102,8 @@
 #define DEFAULT_PIN_STATUS_LED                  (-1)
 #define DEFAULT_PIN_STATUS_LED_INVERSED         true
 
+#define DEFAULT_PIN_RESET_BUTTON                (-1)
+
 
 #define DEFAULT_USE_RULES                       false             // (true|false) Enable Rules?
 #define DEFAULT_RULES_OLDENGINE                 true

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -1180,7 +1180,7 @@ void ResetFactory()
   Settings.Pin_status_led  = gpio_settings.status_led;
   Settings.Pin_status_led_Inversed  = DEFAULT_PIN_STATUS_LED_INVERSED;
   Settings.Pin_sd_cs       = -1;
-  Settings.Pin_Reset       = -1;
+  Settings.Pin_Reset       = DEFAULT_PIN_RESET_BUTTON;
   Settings.Protocol[0]     = DEFAULT_PROTOCOL;
   Settings.deepSleep_wakeTime       = false;
   Settings.CustomCSS       = false;

--- a/src/src/DataStructs/ESPEasyDefaults.h
+++ b/src/src/DataStructs/ESPEasyDefaults.h
@@ -168,6 +168,9 @@
 #define DEFAULT_PIN_STATUS_LED_INVERSED  true
 #endif
 
+#ifndef DEFAULT_PIN_RESET_BUTTON
+#define DEFAULT_PIN_RESET_BUTTON         (-1)
+#endif
 
 
 // --- Advanced Settings ---------------------------------------------------------------------------------


### PR DESCRIPTION
Especially on some custom devices wich need custom builds, the variable
is missing. This provides a new environment variable to customize the
default pin for the reset button.