### PR TITLE
[ADC] Improve oversampling filtering + ESP32 support

### DIFF
--- a/docs/source/Plugin/P002.rst
+++ b/docs/source/Plugin/P002.rst
@@ -21,6 +21,60 @@ Maintainer: |P002_maintainer|
 
 Used libraries: |P002_usedlibraries|
 
+Description
+-----------
+
+The ESP82xx has 1 ADC included.
+This one can be set either to measure the Vdd pin (supplied voltage to the ESP) or to ``TOUT``, so it can measure the voltage on the ``A0`` pin.
+
+The ESP32 has 18 pins that can be used as ADC. It also has a Hall Effect sensor included.
+
+See the `ESP32 API reference <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/adc.html>`_ for more detailed information on the features and limitations of these pins.
+
+
+
+Hall Effect Sensor (ESP32)
+--------------------------
+
+The ESP32 has a Hall Effect Sensor included, to measure a magnetic field.
+
+N.B. This value can also be negative, if the polarity of the magnetic field is swapped.
+
+Note that even the hall sensor is internal to ESP32, reading from it uses channels 0 and 3 of ADC1 (GPIO 36 and 39). 
+Do not connect anything else to these pins and do not change their configuration. Otherwise it may affect the measurement of low value signal from the sensor.
+
+
+WiFi activity and ADC
+---------------------
+
+The ADC on the ESP8266 is also used during WiFi RF calibration.
+This can result in incorrect readings of the ADC while a WiFi connection attempt is in progress.
+
+ESP32 has 2 ADCs present.
+``ADC1`` and ``ADC2``
+
+Since the ``ADC2`` is shared with the WIFI module, which has higher priority, reading operation of ``adc2_get_raw()`` may fail between ``esp_wifi_start()`` and ``esp_wifi_stop()``.
+
+
+Oversampling
+------------
+
+When ``Oversampling`` is enabled, the plugin will take a reading 10 times a second.
+This reading is averaged over the entire interval time as set in the task configuration.
+
+The highest and lowest values are subtracted from the recorded values, to filter out single flukes.
+Measured values which are clipped either on the lower range or higher range are only added once per interval as they may occur for more than a single sample per interval.
+This is done to prevent a relative large offset in the averaging due to clipping or maybe unforceen interaction of the WiFi chip on the ADC measurements.
+
+
+Calibration
+-----------
+
+The plugin supports a 2-point calibration.
+The user can set these to convert the raw values into the desired unit of measure.
+When set, the configuration screen also displays the minimum, maximum and step size values based on the calibration settings.
+
+
 Supported hardware
 ------------------
 
@@ -42,8 +96,7 @@ Change log
 .. versionchanged:: 2.0
   ...
 
-  |added|
-  Major overhaul for 2.0 release.
+  |improved| 2020-04-25  Added support for ESP32 ADC pins + Hall Effect Sensor.
 
 .. versionadded:: 1.0
   ...

--- a/docs/source/Plugin/P095.rst
+++ b/docs/source/Plugin/P095.rst
@@ -1,0 +1,56 @@
+.. include:: ../Plugin/_plugin_substitutions_p09x.repl
+.. _P095_page:
+
+|P095_typename|
+==================================================
+
+|P095_shortinfo|
+
+Plugin details
+--------------
+
+Type: |P095_type|
+
+Name: |P095_name|
+
+Status: |P095_status|
+
+GitHub: |P095_github|_
+
+Maintainer: |P095_maintainer|
+
+Used libraries: |P095_usedlibraries|
+
+Description
+-----------
+
+This plugin allow to control a TFT screen (ILI9341) through HTTP API
+
+## Environment
+Tested with WEMOS D1 Mini Pro and Wemos TDFT 2.4
+Tested with ESPEasy 2.4.2  -tag mega-201902225)
+
+TFT Shield : https://docs.wemos.cc/en/latest/d1_mini_shiled/tft_2_4.html
+Price : ~ 5.40€/$ (https://fr.aliexpress.com/item/32919729730.html)
+
+
+
+Supported hardware
+------------------
+
+|P095_usedby|
+
+Commands available
+^^^^^^^^^^^^^^^^^^
+
+.. include:: P095_commands.repl
+
+
+
+Change log
+----------
+
+.. versionchanged:: 2.0
+  ...
+
+  |added| 2020-04-20

--- a/docs/source/Plugin/P095_commands.repl
+++ b/docs/source/Plugin/P095_commands.repl
@@ -1,0 +1,64 @@
+.. csv-table::
+        :header: "Command", "Extra information"
+        :widths: 20, 30
+
+        "
+        ``TFTCMD,<tftcmd_subcommand>``
+        ","
+        Control the screen (on, off, clear,..) 
+
+        Examples:
+
+        - ``tftcmd,on``           Switch display on.
+        - ``tftcmd,off``          Switch display off.
+        - ``tftcmd,clear``        Clear whole display.
+        - ``tftcmd,clear,green``  Clear whole display with green color.
+        - ``tftcmd,inv,1``        Invert the dispaly (value:0 normal display, 1 inverted display)
+        - ``tftcmd,rot,2``        Rotate display (value from 0 to 3 inclusive) 
+        "
+        "
+        ``TFT,<tft_subcommand>,....``
+        ","
+        Draw line, rect, circle, triangle and text
+
+        Subcommands:
+
+        - ``tft,txt,<text>``  Write simple text (use last position, color and size) 
+        - ``tft,txp,<X>,<Y>``  Set text position (move the cursor) 
+        - ``tft,txc,<foreColor>,<backgroundColor>``  Set text color (background is transparent if not provided 
+        - ``tft,txs,<SIZE>``  Set text size 
+        - ``tft,txtfull,<row>,<col>,<size=1>,<foreColor=white>,<backColor=black>,<text>``  Write text with all options 
+        - ``tft,l,<x1>,<y1>,<2>,<y2>,<color>``  Draw a simple line 
+        - ``tft,lh,<y>,<width>,<color>``  Draw an horizontal line (width = Line width in pixels (positive = right of first point, negative = point of first corner). 
+        - ``tft,lv,<x>,<height>,<color>``  Draw a vertical line (height= Line height in pixels (positive = below first point, negative = above first point).
+        - ``tft,r,<x>,<y>,<width>,<height>,<color>``  Draw a rectangle 
+        - ``tft,r,<x>,<y>,<width>,<height>,<bordercolor>,<innercolor>``  Draw a filled rectangle 
+        - ``tft,c,<x>,<y>,<radius>,<color>``  Draw a circle 
+        - ``tft,c,<x>,<y>,<radius>,<bordercolor>,<innercolor>``  Draw a filled circle 
+        - ``tft,t,<x1>,<y1>,<x2>,<y2>,<x3>,<y3>,<color>| Draw a triangle 
+        - ``tft,t,<x1>,<y1>,<x2>,<y2>,<x3>,<y3>,<bordercolor>,<innercolor>``  Draw a filled triangle 
+        - ``tft,r,<x>,<y>,<width>,<height>,<corner_radius>,<color>``  Draw a round rectangle 
+        - ``tft,r,<x>,<y>,<width>,<height>,<corner_radius>,<bordercolor>,<innercolor>``  Draw a filled round rectangle 
+        - ``tft,px,<x>,<y>,<color>``  Print a single pixel 
+       
+       Examples:
+
+	Write Text :
+		``tft,txtfull,0,0,HelloWorld``
+	
+	Write Text another place:
+		``tft,txtfull,100,40,HelloWorld``
+
+	Write bigger Text :
+		``tft,txtfull,0,0,3,HelloWorld``
+
+	Write RED Text :
+		``tft,txtfull,0,0,3,HelloWorld``
+
+	Write RED Text (size is 1):
+		``tft,txtfull,0,0,1,RED,HelloWorld``
+
+	Write RED Text on YELLOW background (size is 1):
+		``tft,txtfull,0,0,1,RED,YELLOW,HelloWorld``
+        "
+ 

--- a/docs/source/Plugin/P097.rst
+++ b/docs/source/Plugin/P097.rst
@@ -1,0 +1,56 @@
+.. include:: ../Plugin/_plugin_substitutions_p09x.repl
+.. _P097_page:
+
+|P097_typename|
+==================================================
+
+|P097_shortinfo|
+
+Plugin details
+--------------
+
+Type: |P097_type|
+
+Name: |P097_name|
+
+Status: |P097_status|
+
+GitHub: |P097_github|_
+
+Maintainer: |P097_maintainer|
+
+Used libraries: |P097_usedlibraries|
+
+Description
+-----------
+
+Touch pin support for ESP32.
+
+The ESP32 does have support for 10 touch pads.
+Such a touch pad can be as simple as a wire or a PCB pad connected to 
+one of the GPIO pins labelled with ``T0`` ... ``T9``.
+
+A touch pad pin can be considered as an analog input pin.
+When not touched, the reported value is "High", for example 100.
+
+When touched, the capacity of the pin increases, which in return lowers the number of charge/discharge cycles.
+A typical value for a touched pin is lower than 20.
+
+The user has to set a threshold value for when to consider a pin being touched.
+The best value has to be determined by trial and error and may differ per use case.
+
+
+Events
+~~~~~~
+
+.. include:: P097_events.repl
+
+
+
+Change log
+----------
+
+.. versionchanged:: 2.0
+  ...
+
+  |added| 2020-04-25

--- a/docs/source/Plugin/P097_events.repl
+++ b/docs/source/Plugin/P097_events.repl
@@ -1,0 +1,41 @@
+.. csv-table::
+   :header: "Event", "Example"
+   :widths: 30, 20
+
+   "
+   ``<taskname>#<taskvar>``
+
+   The regular events like in every other task. Only difference here is that you may have an event either when the touch pad is touched, released or both.
+   ","
+
+   .. code-block:: html
+
+      on touch#Touch do
+       GPIO,2,1 //LED on
+      endon
+
+   "
+   "
+   ``<taskname>#Duration=``
+   
+   When enabled, this event will be sent on release of the touch pad. The event variable is the time in msec the pad had been touched.
+   ","
+
+   .. code-block:: html
+   
+      on touch#Duration do
+         LogEntry,'Touch Duration %eventvalue% ms'
+      endon
+   
+   Example in the log:
+
+   .. code-block:: html
+   
+      6553261 : Info  : Touch : ADC2 ch5 (T5): 10
+      6553338 : Info  : EVENT: touch#Touch=10.00
+      6553638 : Info  : EVENT: touch#Duration=460
+      6553653 : Info  : ACT  : LogEntry,'Touch Duration 460 ms'
+      6553654 : Info  : Command: LogEntry
+      6553655 : Info  : Touch Duration 460 ms
+
+   "

--- a/docs/source/Plugin/_Plugin.rst
+++ b/docs/source/Plugin/_Plugin.rst
@@ -118,6 +118,8 @@ There's three different released versions of ESP Easy:
    ":ref:`P092_page`","|P092_status|","P092"
    ":ref:`P093_page`","|P093_status|","P093"
    ":ref:`P094_page`","|P094_status|","P094"
+   ":ref:`P095_page`","|P095_status|","P095"
+   ":ref:`P097_page`","|P097_status|","P097"
 
 
 Internal GPIO handling

--- a/docs/source/Plugin/_plugin_categories.repl
+++ b/docs/source/Plugin/_plugin_categories.repl
@@ -1,6 +1,6 @@
-.. |Plugin_Analog_input| replace:: :ref:`P002_page`, :ref:`P007_page`, :ref:`P025_page`, :ref:`P060_page`
+.. |Plugin_Analog_input| replace:: :ref:`P002_page`, :ref:`P007_page`, :ref:`P025_page`, :ref:`P060_page`, :ref:`P097_page`
 .. |Plugin_Communication| replace:: :ref:`P016_page`, :ref:`P020_page`, :ref:`P035_page`, :ref:`P044_page`, :ref:`P054_page`, :ref:`P071_page`, :ref:`P087_page`, :ref:`P089_page`, :ref:`P094_page`
-.. |Plugin_Display| replace:: :ref:`P012_page`, :ref:`P023_page`, :ref:`P036_page`, :ref:`P057_page`, :ref:`P073_page`, :ref:`P075_page`
+.. |Plugin_Display| replace:: :ref:`P012_page`, :ref:`P023_page`, :ref:`P036_page`, :ref:`P057_page`, :ref:`P073_page`, :ref:`P075_page`, :ref:`P095_page`
 .. |Plugin_Dust| replace:: :ref:`P018_page`, :ref:`P053_page`, :ref:`P056_page`
 .. |Plugin_Energy_AC| replace:: :ref:`P076_page`, :ref:`P077_page`, :ref:`P078_page`
 .. |Plugin_Energy_DC| replace:: :ref:`P027_page`, :ref:`P085_page`
@@ -22,6 +22,6 @@
 .. |Plugin_Position| replace:: :ref:`P013_page`, :ref:`P082_page`
 .. |Plugin_Regulator| replace:: :ref:`P021_page`
 .. |Plugin_RFID| replace:: :ref:`P008_page`, :ref:`P017_page`, :ref:`P040_page`
-.. |Plugin_Switch_input| replace:: :ref:`P001_page`, :ref:`P009_page`, :ref:`P019_page`, :ref:`P059_page`, :ref:`P080_page`, :ref:`P091_page`
+.. |Plugin_Switch_input| replace:: :ref:`P001_page`, :ref:`P009_page`, :ref:`P019_page`, :ref:`P059_page`, :ref:`P080_page`, :ref:`P091_page`, :ref:`P097_page`
 .. |Plugin_Weight| replace:: :ref:`P067_page`
 

--- a/docs/source/Plugin/_plugin_substitutions_p00x.repl
+++ b/docs/source/Plugin/_plugin_substitutions_p00x.repl
@@ -23,7 +23,7 @@
 .. _P001_github: https://github.com/letscontrolit/ESPEasy/blob/mega/src/_P001_Switch.ino
 .. |P001_usedby| replace:: :ref:`P001_Switch_page`, :ref:`P001_Door_switch_page`, :ref:`P001_PIR_sensor_page`
 .. |P001_shortinfo| replace:: `.`
-.. |P001_maintainer| replace:: `.`
+.. |P001_maintainer| replace:: `TD-er`
 .. |P001_compileinfo| replace:: `.`
 .. |P001_usedlibraries| replace:: `.`
 

--- a/docs/source/Plugin/_plugin_substitutions_p09x.repl
+++ b/docs/source/Plugin/_plugin_substitutions_p09x.repl
@@ -10,6 +10,7 @@
 .. |P090_maintainer| replace:: `TD-er`
 .. |P090_compileinfo| replace:: `.`
 .. |P090_usedlibraries| replace:: `.`
+
 .. |P091_name| replace:: :cyan:`Serial MCU controlled switch`
 .. |P091_type| replace:: :cyan:`Gases`
 .. |P091_typename| replace:: :cyan:`Switch input - Serial MCU controlled switch`
@@ -21,6 +22,7 @@
 .. |P091_maintainer| replace:: `enesbcs`
 .. |P091_compileinfo| replace:: `.`
 .. |P091_usedlibraries| replace:: `.`
+
 .. |P092_name| replace:: :cyan:`DL-Bus (Technische Alternative)`
 .. |P092_type| replace:: :cyan:`Heating`
 .. |P092_typename| replace:: :cyan:`Heating - DL-Bus (Technische Alternative)`
@@ -32,6 +34,7 @@
 .. |P092_maintainer| replace:: `.`
 .. |P092_compileinfo| replace:: `.`
 .. |P092_usedlibraries| replace:: `.`
+
 .. |P093_name| replace:: :cyan:`Mitsubishi Heat Pump`
 .. |P093_type| replace:: :cyan:`Energy (Heat)`
 .. |P093_typename| replace:: :cyan:`Energy (Heat) - Mitsubishi Heat Pump`
@@ -55,3 +58,29 @@
 .. |P094_maintainer| replace:: `TD-er`
 .. |P094_compileinfo| replace:: `.`
 .. |P094_usedlibraries| replace:: `.`
+
+.. |P095_name| replace:: :cyan:`TFT 2.4 inches ILI9341/XPT2046`
+.. |P095_type| replace:: :cyan:`Display`
+.. |P095_typename| replace:: :cyan:`Display - TFT 2.4 inches ILI9341/XPT2046`
+.. |P095_porttype| replace:: `.`
+.. |P095_status| replace:: :yellow:`TESTING`
+.. |P095_github| replace:: _P095_ILI9341.ino
+.. _P095_github: https://github.com/letscontrolit/ESPEasy/blob/mega/src/_P095_ILI9341.ino
+.. |P095_usedby| replace:: `.`
+.. |P095_shortinfo| replace:: `.`
+.. |P095_maintainer| replace:: `TD-er`
+.. |P095_compileinfo| replace:: `.`
+.. |P095_usedlibraries| replace:: `Adafruit GFX, Adafruit ILI9341`
+
+.. |P097_name| replace:: :cyan:`Touch ESP32`
+.. |P097_type| replace:: :cyan:`Internal`
+.. |P097_typename| replace:: :cyan:`Internal - Touch ESP32`
+.. |P097_porttype| replace:: `.`
+.. |P097_status| replace:: :yellow:`TESTING`
+.. |P097_github| replace:: _P097_Esp32Touch.ino
+.. _P097_github: https://github.com/letscontrolit/ESPEasy/blob/mega/src/_P097_Esp32Touch.ino
+.. |P097_usedby| replace:: `.`
+.. |P097_shortinfo| replace:: `.`
+.. |P097_maintainer| replace:: `TD-er`
+.. |P097_compileinfo| replace:: `.`
+.. |P097_usedlibraries| replace:: `.`

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,7 +21,7 @@ import sphinx_bootstrap_theme
 # -- Project information -----------------------------------------------------
 
 project = u'ESP Easy'
-copyright = u'2018, ESP Easy'
+copyright = u'2018-2020, ESP Easy'
 author = u'Grovkillen, TD-er & Friends'
 
 # The short X.Y version

--- a/pre_custom_esp32.py
+++ b/pre_custom_esp32.py
@@ -33,6 +33,7 @@ else:
     "USES_P059",  # Encoder
     "USES_P082",  # GPS
     "USES_P087",  # Serial Proxy
+    "USES_P097",  # Touch (ESP32)
 
     "USE_SETTINGS_ARCHIVE"
   ])

--- a/src/ESPEasy-Globals.cpp
+++ b/src/ESPEasy-Globals.cpp
@@ -49,6 +49,7 @@ unsigned long last_system_event_run = 0;
 #if FEATURE_ADC_VCC
 float vcc = -1.0;
 #endif
+uint16_t lastADCvalue = 0;
 
 boolean WebLoggedIn = false;
 int WebLoggedInTimer = 300;

--- a/src/ESPEasy-Globals.cpp
+++ b/src/ESPEasy-Globals.cpp
@@ -49,7 +49,7 @@ unsigned long last_system_event_run = 0;
 #if FEATURE_ADC_VCC
 float vcc = -1.0;
 #endif
-uint16_t lastADCvalue = 0;
+int lastADCvalue = 0;
 
 boolean WebLoggedIn = false;
 int WebLoggedInTimer = 300;

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -312,6 +312,9 @@ extern unsigned long last_system_event_run;
 #if FEATURE_ADC_VCC
 extern float vcc;
 #endif
+#ifdef ESP8266
+extern uint16_t lastADCvalue; // Keep track of last ADC value as it cannot be read while WiFi is connecting
+#endif
 
 extern boolean WebLoggedIn;
 extern int WebLoggedInTimer;

--- a/src/ESPEasy-Globals.h
+++ b/src/ESPEasy-Globals.h
@@ -313,7 +313,7 @@ extern unsigned long last_system_event_run;
 extern float vcc;
 #endif
 #ifdef ESP8266
-extern uint16_t lastADCvalue; // Keep track of last ADC value as it cannot be read while WiFi is connecting
+extern int lastADCvalue; // Keep track of last ADC value as it cannot be read while WiFi is connecting
 #endif
 
 extern boolean WebLoggedIn;

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -190,11 +190,16 @@ void setup()
 #endif
 
 
-#if FEATURE_ADC_VCC
+  // Read ADC at boot, before WiFi tries to connect.
+  // see https://github.com/letscontrolit/ESPEasy/issues/2646
   if (!wifiConnectInProgress) {
+#if FEATURE_ADC_VCC
     vcc = ESP.getVcc() / 1000.0;
-  }
 #endif
+#ifdef ESP8266
+    lastADCvalue = analogRead(A0);
+#endif
+  }  
 
   resetPluginTaskData();
 

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -192,14 +192,12 @@ void setup()
 
   // Read ADC at boot, before WiFi tries to connect.
   // see https://github.com/letscontrolit/ESPEasy/issues/2646
-  if (!wifiConnectInProgress) {
 #if FEATURE_ADC_VCC
-    vcc = ESP.getVcc() / 1000.0;
+  vcc = ESP.getVcc() / 1000.0;
 #endif
 #ifdef ESP8266
-    lastADCvalue = analogRead(A0);
+  lastADCvalue = analogRead(A0);
 #endif
-  }  
 
   resetPluginTaskData();
 

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -189,6 +189,13 @@ void setup()
 //  ets_isr_attach(8, sw_watchdog_callback, NULL);  // Set a callback for feeding the watchdog.
 #endif
 
+
+#if FEATURE_ADC_VCC
+  if (!wifiConnectInProgress) {
+    vcc = ESP.getVcc() / 1000.0;
+  }
+#endif
+
   resetPluginTaskData();
 
   checkRAM(F("setup"));
@@ -387,12 +394,6 @@ void setup()
 
   if (node_time.systemTimePresent())
     node_time.initTime();
-
-#if FEATURE_ADC_VCC
-  if (!wifiConnectInProgress) {
-    vcc = ESP.getVcc() / 1000.0;
-  }
-#endif
 
   if (Settings.UseRules)
   {

--- a/src/ESPEasy_common.cpp
+++ b/src/ESPEasy_common.cpp
@@ -2,15 +2,3 @@
 
 
 String getUnknownString() { return F("Unknown"); }
-
-/*********************************************************************************************\
-   Bitwise operators
-  \*********************************************************************************************/
-bool getBitFromUL(uint32_t number, byte bitnr) {
-  return (number >> bitnr) & 1UL;
-}
-
-void setBitToUL(uint32_t& number, byte bitnr, bool value) {
-  uint32_t newbit = value ? 1UL : 0UL;
-  number ^= (-newbit ^ number) & (1UL << bitnr);
-}

--- a/src/ESPEasy_common.h
+++ b/src/ESPEasy_common.h
@@ -28,17 +28,19 @@ namespace std
 
 #include "define_plugin_sets.h"
 
+#ifdef ESP32
+#include <esp8266-compat.h>
+
+#endif
+
+
 #define ZERO_FILL(S)  memset((S), 0, sizeof(S))
 #define ZERO_TERMINATE(S)  S[sizeof(S) - 1] = 0
 
 
+
 String getUnknownString();
 
-/*********************************************************************************************\
-   Bitwise operators
-  \*********************************************************************************************/
-bool getBitFromUL(uint32_t number, byte bitnr);
-void setBitToUL(uint32_t& number, byte bitnr, bool value);
 
 
 /******************************************************************************\

--- a/src/Hardware.ino
+++ b/src/Hardware.ino
@@ -465,5 +465,24 @@ bool getADC_gpio_info(int gpio_pin, int& adc, int& ch, int& t)
   return true;
 }
 
+int touchPinToGpio(int touch_pin)
+{
+  switch(touch_pin) {
+    case 0: return T0;
+    case 1: return T1;
+    case 2: return T2;
+    case 3: return T3;
+    case 4: return T4;
+    case 5: return T5;
+    case 6: return T6;
+    case 7: return T7;
+    case 8: return T8;
+    case 9: return T9;
+    default:
+    break;    
+  }
+  return -1;
+}
+
 
 #endif

--- a/src/Hardware.ino
+++ b/src/Hardware.ino
@@ -151,6 +151,54 @@ void checkResetFactoryPin() {
   }
 }
 
+
+#ifdef ESP8266
+int espeasy_analogRead(int pin) {
+  if (!wifiConnectInProgress) {
+    lastADCvalue = analogRead(A0);
+  }
+  return lastADCvalue;
+}
+#endif
+
+#ifdef ESP32
+int espeasy_analogRead(int pin) {
+  return espeasy_analogRead(pin, false);
+}
+
+int espeasy_analogRead(int pin, bool readAsTouch) {
+  int value = 0;
+  int adc, ch, t;
+  if (getADC_gpio_info(pin, adc, ch, t)) {
+    bool canread = false;
+    switch (adc) {
+      case 0:
+        value = hallRead();
+        break;
+      case 1:
+        canread = true;
+        break;
+      case 2:
+        if (WiFi.getMode() == WIFI_OFF) {
+          // See: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/adc.html#configuration-and-reading-adc
+          // ADC2 is shared with WiFi, so don't read ADC2 when WiFi is on.
+          canread = true;
+        }
+        break;
+    }
+    if (canread) {
+      if (readAsTouch && t >= 0) {
+        value = touchRead(pin);
+      } else {
+        value = analogRead(pin);
+      }
+    }
+  }
+  return value;
+}
+#endif
+
+
 /********************************************************************************************\
    Hardware specific configurations
  \*********************************************************************************************/
@@ -379,3 +427,43 @@ bool getGpioInfo(int gpio, int& pinnr, bool& input, bool& output, bool& warning)
 }
 
 #endif // ifdef ESP32
+
+
+#ifdef ESP32
+
+// Get ADC related info for a given GPIO pin
+// @param gpio_pin   GPIO pin number
+// @param adc        Number of ADC unit (0 == Hall effect)
+// @param ch         Channel number on ADC unit
+// @param t          index of touch pad ID
+bool getADC_gpio_info(int gpio_pin, int& adc, int& ch, int& t)
+{
+  t = -1;
+  switch (gpio_pin) {
+    case -1: adc = 0; break; // Hall effect Sensor
+    case 36: adc = 1; ch = 0; break;
+    case 37: adc = 1; ch = 1; break;
+    case 38: adc = 1; ch = 2; break;
+    case 39: adc = 1; ch = 3; break;
+    case 32: adc = 1; ch = 4; t = 9; break;
+    case 33: adc = 1; ch = 5; t = 8; break;
+    case 34: adc = 1; ch = 6; break;
+    case 35: adc = 1; ch = 7; break;
+    case 4:  adc = 2; ch = 0; t = 0; break;
+    case 0:  adc = 2; ch = 1; t = 1; break;
+    case 2:  adc = 2; ch = 2; t = 2; break;
+    case 15: adc = 2; ch = 3; t = 3; break;
+    case 13: adc = 2; ch = 4; t = 4; break;
+    case 12: adc = 2; ch = 5; t = 5; break;
+    case 14: adc = 2; ch = 6; t = 6; break;
+    case 27: adc = 2; ch = 7; t = 7; break;
+    case 25: adc = 2; ch = 8; break;
+    case 26: adc = 2; ch = 9; break;
+    default:
+      return false;
+  }
+  return true;
+}
+
+
+#endif

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -306,17 +306,6 @@ bool allocatedOnStack(const void* address) {
 #endif // ESP32
 
 
-uint16_t espeasy_analogRead(uint8 pin) {
-  #if defined(ESP8266)
-  if (!wifiConnectInProgress) {
-    lastADCvalue = analogRead(A0);
-  }
-  return lastADCvalue;
-  #endif // if defined(ESP8266)
-  #if defined(ESP32)
-  return analogRead(pin);
-  #endif // if defined(ESP32)
-}
 
 
 
@@ -567,6 +556,29 @@ String formatGpioName_TX_HW(bool optional) {
 String formatGpioName_RX_HW(bool optional) {
   return formatGpioName("TX (HW)", gpio_input, optional);
 }
+
+#ifdef ESP32
+
+String formatGpioName_ADC(int gpio_pin) {
+  int adc,ch, t;
+  if (getADC_gpio_info(gpio_pin, adc, ch, t)) {
+    if (adc == 0) {
+      return F("Hall Effect");
+    }
+    String res = F("ADC# ch?");
+    res.replace("#", String(adc));
+    res.replace("?", String(ch));
+    if (t >= 0) {
+      res += F(" (T");
+      res += t;
+      res += ')';
+    }
+    return res;
+  }
+  return "";
+}
+
+#endif
 
 /*********************************************************************************************\
    set pin mode & state (info table)

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -306,6 +306,20 @@ bool allocatedOnStack(const void* address) {
 #endif // ESP32
 
 
+uint16_t espeasy_analogRead(uint8 pin) {
+  #if defined(ESP8266)
+  if (!wifiConnectInProgress) {
+    lastADCvalue = analogRead(A0);
+  }
+  return lastADCvalue;
+  #endif // if defined(ESP8266)
+  #if defined(ESP32)
+  return analogRead(pin);
+  #endif // if defined(ESP32)
+}
+
+
+
 /**********************************************************
 *                                                         *
 * Deep Sleep related functions                            *

--- a/src/Scheduler.ino
+++ b/src/Scheduler.ino
@@ -612,11 +612,15 @@ void schedule_task_device_timer(unsigned long task_index, unsigned long runAt) {
   const deviceIndex_t DeviceIndex = getDeviceIndex_from_TaskIndex(task_index);
   if (!validDeviceIndex(DeviceIndex)) { return; }
 
+// TD-er: Tasks without a timer or optional timer set to 0 should still be able to call PLUGIN_READ
+// For example to schedule a read from the PLUGIN_TEN_PER_SECOND when a new value is ready.
+/*  
   if (!Device[DeviceIndex].TimerOption) { return; }
 
   if (Device[DeviceIndex].TimerOptional && (Settings.TaskDeviceTimer[task_index] == 0)) {
     return;
   }
+*/
 
   if (Settings.TaskDeviceEnabled[task_index]) {
     setNewTimerAt(getMixedId(TASK_DEVICE_TIMER, task_index), runAt);
@@ -624,6 +628,7 @@ void schedule_task_device_timer(unsigned long task_index, unsigned long runAt) {
 }
 
 void process_task_device_timer(unsigned long task_index, unsigned long lasttimer) {
+  if (!validTaskIndex(task_index)) { return; }
   unsigned long newtimer = Settings.TaskDeviceTimer[task_index];
 
   if (newtimer != 0) {

--- a/src/WebServer_DevicesPage.ino
+++ b/src/WebServer_DevicesPage.ino
@@ -349,7 +349,7 @@ void handle_devicess_ShowAllTasksTable(byte page)
   html_table_header("Name");
   html_table_header("Port");
   html_table_header(F("Ctr (IDX)"), 100);
-  html_table_header("GPIO",         70);
+  html_table_header("GPIO",         100);
   html_table_header(F("Values"));
 
   String deviceName;
@@ -511,7 +511,19 @@ void handle_devicess_ShowAllTasksTable(byte page)
             }
             case DEVICE_TYPE_ANALOG:
             {
-              addHtml(F("ADC (TOUT)"));
+              #ifdef ESP8266
+                #if FEATURE_ADC_VCC
+                  addHtml(F("ADC (VDD)"));
+                #else
+                  addHtml(F("ADC (TOUT)"));
+                #endif
+              #endif
+              #ifdef ESP32
+              showpin1 = true;
+              addHtml(formatGpioName_ADC(Settings.TaskDevicePin1[x]));
+              html_BR();
+              #endif
+
               break;
             }
             case DEVICE_TYPE_SERIAL_PLUS1:

--- a/src/WebServer_Markup.ino
+++ b/src/WebServer_Markup.ino
@@ -548,39 +548,45 @@ void addPinSelect(boolean forI2C, const String& id,  int choice)
 }
 
 #ifdef ESP32
-void addADC_PinSelect(const String& id,  int choice)
+void addADC_PinSelect(bool touchOnly, const String& id,  int choice)
 {
-  #define NR_ITEMS_PIN_DROPDOWN   19
+  int NR_ITEMS_PIN_DROPDOWN = touchOnly ? 10 : 19;
   String *gpio_labels  = new String[NR_ITEMS_PIN_DROPDOWN];
   int    *gpio_numbers = new int[NR_ITEMS_PIN_DROPDOWN];
 
-  // At i == 0 && gpio == -1, add the "- None -" option first
+  // At i == 0 && gpio == -1, add the "Hall Effect" option first
   int i    = 0;
   int gpio = -1;
 
   while (i < NR_ITEMS_PIN_DROPDOWN && gpio <= MAX_GPIO) {
     int  pinnr = -1;
     bool input, output, warning;
+    if (touchOnly) {
+      // For touch only list, sort based on touch number
+      // Default sort is on GPIO number.
+      gpio = touchPinToGpio(i);
+    }
 
     if (getGpioInfo(gpio, pinnr, input, output, warning) || (i == 0)) {
       int adc,ch, t;
       if (getADC_gpio_info(gpio, adc, ch, t)) {
-        if (adc != 0) {
-          gpio_labels[i]  = createGPIO_label(gpio, pinnr, input, output, warning);
-          gpio_labels[i] += F(" / ");
+        if (!touchOnly || t >= 0) {
+          gpio_labels[i] = formatGpioName_ADC(gpio);
+          if (adc != 0) {
+            gpio_labels[i] += F(" / ");
+            gpio_labels[i] += createGPIO_label(gpio, pinnr, input, output, warning);
+          }
+          gpio_numbers[i] = gpio;
+          ++i;
         }
-        gpio_labels[i] += formatGpioName_ADC(gpio);
-        gpio_numbers[i] = gpio;
-        ++i;
       }
     }
     ++gpio;
   }
   bool forI2C = false;
-  renderHTMLForPinSelect(gpio_labels, gpio_numbers, forI2C, id, choice, NR_ITEMS_PIN_DROPDOWN);
+  renderHTMLForPinSelect(gpio_labels, gpio_numbers, forI2C, id, choice, i);
   delete[] gpio_numbers;
   delete[] gpio_labels;
-  #undef NR_ITEMS_PIN_DROPDOWN
 }
 
 

--- a/src/WebServer_Markup.ino
+++ b/src/WebServer_Markup.ino
@@ -515,7 +515,7 @@ String createGPIO_label(int gpio, int pinnr, bool input, bool output, bool warni
   return result;
 }
 
-void addPinSelect(boolean forI2C, String id,  int choice)
+void addPinSelect(boolean forI2C, const String& id,  int choice)
 {
   #ifdef ESP32
     # define NR_ITEMS_PIN_DROPDOWN  35 // 34 GPIO + 1
@@ -546,6 +546,46 @@ void addPinSelect(boolean forI2C, String id,  int choice)
   delete[] gpio_labels;
   #undef NR_ITEMS_PIN_DROPDOWN
 }
+
+#ifdef ESP32
+void addADC_PinSelect(const String& id,  int choice)
+{
+  #define NR_ITEMS_PIN_DROPDOWN   19
+  String *gpio_labels  = new String[NR_ITEMS_PIN_DROPDOWN];
+  int    *gpio_numbers = new int[NR_ITEMS_PIN_DROPDOWN];
+
+  // At i == 0 && gpio == -1, add the "- None -" option first
+  int i    = 0;
+  int gpio = -1;
+
+  while (i < NR_ITEMS_PIN_DROPDOWN && gpio <= MAX_GPIO) {
+    int  pinnr = -1;
+    bool input, output, warning;
+
+    if (getGpioInfo(gpio, pinnr, input, output, warning) || (i == 0)) {
+      int adc,ch, t;
+      if (getADC_gpio_info(gpio, adc, ch, t)) {
+        if (adc != 0) {
+          gpio_labels[i]  = createGPIO_label(gpio, pinnr, input, output, warning);
+          gpio_labels[i] += F(" / ");
+        }
+        gpio_labels[i] += formatGpioName_ADC(gpio);
+        gpio_numbers[i] = gpio;
+        ++i;
+      }
+    }
+    ++gpio;
+  }
+  bool forI2C = false;
+  renderHTMLForPinSelect(gpio_labels, gpio_numbers, forI2C, id, choice, NR_ITEMS_PIN_DROPDOWN);
+  delete[] gpio_numbers;
+  delete[] gpio_labels;
+  #undef NR_ITEMS_PIN_DROPDOWN
+}
+
+
+#endif
+
 
 // ********************************************************************************
 // Helper function actually rendering dropdown list for addPinSelect()

--- a/src/_P002_ADC.ino
+++ b/src/_P002_ADC.ino
@@ -381,27 +381,27 @@ void P002_setEventParams(int pin, uint16_t threshold) {
   }
 }
 
-void P002_got_T0() IRAM_ATTR;
-void P002_got_T1() IRAM_ATTR;
-void P002_got_T2() IRAM_ATTR;
-void P002_got_T3() IRAM_ATTR;
-void P002_got_T4() IRAM_ATTR;
-void P002_got_T5() IRAM_ATTR;
-void P002_got_T6() IRAM_ATTR;
-void P002_got_T7() IRAM_ATTR;
-void P002_got_T8() IRAM_ATTR;
-void P002_got_T9() IRAM_ATTR;
+void P002_got_T0() ICACHE_RAM_ATTR;
+void P002_got_T1() ICACHE_RAM_ATTR;
+void P002_got_T2() ICACHE_RAM_ATTR;
+void P002_got_T3() ICACHE_RAM_ATTR;
+void P002_got_T4() ICACHE_RAM_ATTR;
+void P002_got_T5() ICACHE_RAM_ATTR;
+void P002_got_T6() ICACHE_RAM_ATTR;
+void P002_got_T7() ICACHE_RAM_ATTR;
+void P002_got_T8() ICACHE_RAM_ATTR;
+void P002_got_T9() ICACHE_RAM_ATTR;
 
-void P002_got_T0() { p002_pinTouched |= (1 << 0); }
-void P002_got_T1() { p002_pinTouched |= (1 << 1); }
-void P002_got_T2() { p002_pinTouched |= (1 << 2); }
-void P002_got_T3() { p002_pinTouched |= (1 << 3); }
-void P002_got_T4() { p002_pinTouched |= (1 << 4); }
-void P002_got_T5() { p002_pinTouched |= (1 << 5); }
-void P002_got_T6() { p002_pinTouched |= (1 << 6); }
-void P002_got_T7() { p002_pinTouched |= (1 << 7); }
-void P002_got_T8() { p002_pinTouched |= (1 << 8); }
-void P002_got_T9() { p002_pinTouched |= (1 << 9); }
+void P002_got_T0() { bitSet(p002_pinTouched, 0); }
+void P002_got_T1() { bitSet(p002_pinTouched, 1); }
+void P002_got_T2() { bitSet(p002_pinTouched, 2); }
+void P002_got_T3() { bitSet(p002_pinTouched, 3); }
+void P002_got_T4() { bitSet(p002_pinTouched, 4); }
+void P002_got_T5() { bitSet(p002_pinTouched, 5); }
+void P002_got_T6() { bitSet(p002_pinTouched, 6); }
+void P002_got_T7() { bitSet(p002_pinTouched, 7); }
+void P002_got_T8() { bitSet(p002_pinTouched, 8); }
+void P002_got_T9() { bitSet(p002_pinTouched, 9); }
 
 
 #endif // ifdef ESP32

--- a/src/_P002_ADC.ino
+++ b/src/_P002_ADC.ino
@@ -63,9 +63,10 @@ struct P002_data_struct : public PluginTaskData_base {
     return false;
   }
 
-  uint16_t OversamplingCount  = 0;
+  uint16_t OversamplingCount = 0;
 
 private:
+
   uint32_t OversamplingValue  = 0;
   uint16_t OversamplingMinVal = P002_MAX_ADC_VALUE;
   uint16_t OversamplingMaxVal = 0;
@@ -129,7 +130,8 @@ boolean Plugin_002(byte function, struct EventStruct *event, String& string)
       {
         // Output the statistics for the current settings.
         uint16_t raw_value = 0;
-        float value;
+        float    value;
+
         if (P002_getOutputValue(event, raw_value, value)) {
           P002_formatStatistics(F("Current"), raw_value, value);
         }
@@ -169,7 +171,7 @@ boolean Plugin_002(byte function, struct EventStruct *event, String& string)
       break;
     }
 
-    case PLUGIN_INIT:  
+    case PLUGIN_INIT:
     {
       if (!PCONFIG(0)) // Oversampling
       {
@@ -186,6 +188,7 @@ boolean Plugin_002(byte function, struct EventStruct *event, String& string)
         uint16_t currentValue;
         P002_performRead(event, currentValue);
       }
+
       // Fall through to PLUGIN_TEN_PER_SECOND
     }
     case PLUGIN_TEN_PER_SECOND:
@@ -210,7 +213,8 @@ boolean Plugin_002(byte function, struct EventStruct *event, String& string)
     case PLUGIN_READ:
     {
       uint16_t raw_value = 0;
-      float res_value = 0.0;
+      float    res_value = 0.0;
+
       if (P002_getOutputValue(event, raw_value, res_value)) {
         UserVar[event->BaseVarIndex] = res_value;
 
@@ -229,7 +233,7 @@ boolean Plugin_002(byte function, struct EventStruct *event, String& string)
               log += P002_data->OversamplingCount;
               log += F(" samples)");
             }
-          addLog(LOG_LEVEL_INFO, log);
+            addLog(LOG_LEVEL_INFO, log);
           }
           P002_data->reset();
           success = true;
@@ -250,7 +254,7 @@ boolean Plugin_002(byte function, struct EventStruct *event, String& string)
 
 bool P002_getOutputValue(struct EventStruct *event, uint16_t& raw_value, float& res_value) {
   float float_value = 0.0;
-  bool success = false;
+  bool  success     = false;
 
   P002_data_struct *P002_data =
     static_cast<P002_data_struct *>(getPluginTaskData(event->TaskIndex));
@@ -261,10 +265,11 @@ bool P002_getOutputValue(struct EventStruct *event, uint16_t& raw_value, float& 
     } else {
       if (P002_performRead(event, raw_value)) {
         float_value = static_cast<float>(raw_value);
-        success = true;
+        success     = true;
       }
     }
-    if (success) res_value = P002_applyCalibration(event, float_value);
+
+    if (success) { res_value = P002_applyCalibration(event, float_value); }
   }
   return success;
 }

--- a/src/_P002_ADC.ino
+++ b/src/_P002_ADC.ino
@@ -18,6 +18,26 @@
   # define P002_MAX_ADC_VALUE    1023
 #endif // ifdef ESP8266
 
+#define P002_NO_TOUCH            0
+#define P002_TOUCH               1
+#define P002_TOUCH_EVENT         2
+
+
+#define P002_OVERSAMPLING        PCONFIG(0)
+#define P002_READ_AS_TOUCH       PCONFIG(1)
+#define P002_TOUCH_THRESHOLD     PCONFIG(2)
+#define P002_CALIBRATION_ENABLED PCONFIG(3)
+#define P002_CALIBRATION_POINT1  PCONFIG_LONG(0)
+#define P002_CALIBRATION_POINT2  PCONFIG_LONG(1)
+#define P002_CALIBRATION_VALUE1  PCONFIG_FLOAT(0)
+#define P002_CALIBRATION_VALUE2  PCONFIG_FLOAT(1)
+
+#ifdef ESP32
+
+// Share this bitmap among all instances of this plugin
+DRAM_ATTR uint32_t p002_pinTouched = 0;
+
+#endif // ifdef ESP32
 
 struct P002_data_struct : public PluginTaskData_base {
   P002_data_struct() {}
@@ -30,10 +50,10 @@ struct P002_data_struct : public PluginTaskData_base {
     OversamplingValue  = 0;
     OversamplingCount  = 0;
     OversamplingMinVal = P002_MAX_ADC_VALUE;
-    OversamplingMaxVal = 0;
+    OversamplingMaxVal = -P002_MAX_ADC_VALUE;
   }
 
-  void addOversamplingValue(uint16_t currentValue) {
+  void addOversamplingValue(int currentValue) {
     // Extra check to only add min or max readings once.
     // They will be taken out of the averaging only one time.
     if ((currentValue == 0) && (currentValue == OversamplingMinVal)) {
@@ -56,7 +76,7 @@ struct P002_data_struct : public PluginTaskData_base {
     }
   }
 
-  bool getOversamplingValue(float& float_value, uint16_t& raw_value) {
+  bool getOversamplingValue(float& float_value, int& raw_value) {
     if (OversamplingCount > 0) {
       float sum   = static_cast<float>(OversamplingValue);
       float count = static_cast<float>(OversamplingCount);
@@ -77,9 +97,9 @@ struct P002_data_struct : public PluginTaskData_base {
 
 private:
 
-  uint32_t OversamplingValue  = 0;
-  uint16_t OversamplingMinVal = P002_MAX_ADC_VALUE;
-  uint16_t OversamplingMaxVal = 0;
+  int32_t OversamplingValue  = 0;
+  int16_t OversamplingMinVal = P002_MAX_ADC_VALUE;
+  int16_t OversamplingMaxVal = 0;
 };
 
 boolean Plugin_002(byte function, struct EventStruct *event, String& string)
@@ -118,40 +138,50 @@ boolean Plugin_002(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_WEBFORM_LOAD:
     {
-        #if defined(ESP32)
+      #if defined(ESP32)
       addHtml(F("<TR><TD>Analog Pin:<TD>"));
-      addPinSelect(false, F("taskdevicepin1"), CONFIG_PIN1);
-        #endif // if defined(ESP32)
+      addADC_PinSelect(F("taskdevicepin1"), CONFIG_PIN1);
 
-      addFormCheckBox(F("Oversampling"), F("p002_oversampling"), PCONFIG(0));
+      {
+        String options[3] = { F("No Touch"), F("Touch"), F("Touch + Event") };
+        int    values[3]  = { P002_NO_TOUCH, P002_TOUCH, P002_TOUCH_EVENT };
+        addFormSelector(F("Read as Touch Sensor"), F("p002_readtouch"), 3, options, values, P002_READ_AS_TOUCH);
+      }
+
+      addFormNumericBox(F("Touch Threshold"), F("p002_threshold"), P002_TOUCH_THRESHOLD, 0, P002_MAX_ADC_VALUE);
+      addFormNote(F("Used to trigger an event"));
+
+      #endif // if defined(ESP32)
+
+      addFormCheckBox(F("Oversampling"), F("p002_oversampling"), P002_OVERSAMPLING);
 
       addFormSubHeader(F("Two Point Calibration"));
 
-      addFormCheckBox(F("Calibration Enabled"), F("p002_cal"), PCONFIG(3));
+      addFormCheckBox(F("Calibration Enabled"), F("p002_cal"), P002_CALIBRATION_ENABLED);
 
-      addFormNumericBox(F("Point 1"), F("p002_adc1"), PCONFIG_LONG(0), 0, P002_MAX_ADC_VALUE);
+      addFormNumericBox(F("Point 1"), F("p002_adc1"), P002_CALIBRATION_POINT1, 0, P002_MAX_ADC_VALUE);
       html_add_estimate_symbol();
-      addTextBox(F("p002_out1"), String(PCONFIG_FLOAT(0), 3), 10);
+      addTextBox(F("p002_out1"), String(P002_CALIBRATION_VALUE1, 3), 10);
 
-      addFormNumericBox(F("Point 2"), F("p002_adc2"), PCONFIG_LONG(1), 0, P002_MAX_ADC_VALUE);
+      addFormNumericBox(F("Point 2"), F("p002_adc2"), P002_CALIBRATION_POINT2, 0, P002_MAX_ADC_VALUE);
       html_add_estimate_symbol();
-      addTextBox(F("p002_out2"), String(PCONFIG_FLOAT(1), 3), 10);
+      addTextBox(F("p002_out2"), String(P002_CALIBRATION_VALUE2, 3), 10);
 
       {
         // Output the statistics for the current settings.
-        uint16_t raw_value = 0;
-        float    value;
+        int   raw_value = 0;
+        float value;
 
         if (P002_getOutputValue(event, raw_value, value)) {
           P002_formatStatistics(F("Current"), raw_value, value);
         }
 
-        if (PCONFIG(3)) {
+        if (P002_CALIBRATION_ENABLED) {
           P002_formatStatistics(F("Minimum"),   0,                  P002_applyCalibration(event, 0));
           P002_formatStatistics(F("Maximum"),   P002_MAX_ADC_VALUE, P002_applyCalibration(event, P002_MAX_ADC_VALUE));
 
           float stepsize = P002_applyCalibration(event, 1.0) - P002_applyCalibration(event, 0.0);
-          P002_formatStatistics(F("Step size"), 1,                  stepsize);
+          P002_formatStatistics(F("Step size"), 1,                               stepsize);
         }
       }
 
@@ -161,15 +191,19 @@ boolean Plugin_002(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_WEBFORM_SAVE:
     {
-      PCONFIG(0) = isFormItemChecked(F("p002_oversampling"));
+      #ifdef ESP32
+      P002_READ_AS_TOUCH   = getFormItemInt(F("p002_readtouch"));
+      P002_TOUCH_THRESHOLD = getFormItemInt(F("p002_threshold"));
+      #endif // ifdef ESP32
+      P002_OVERSAMPLING = isFormItemChecked(F("p002_oversampling"));
 
-      PCONFIG(3) = isFormItemChecked(F("p002_cal"));
+      P002_CALIBRATION_ENABLED = isFormItemChecked(F("p002_cal"));
 
-      PCONFIG_LONG(0)  = getFormItemInt(F("p002_adc1"));
-      PCONFIG_FLOAT(0) = getFormItemFloat(F("p002_out1"));
+      P002_CALIBRATION_POINT1 = getFormItemInt(F("p002_adc1"));
+      P002_CALIBRATION_VALUE1 = getFormItemFloat(F("p002_out1"));
 
-      PCONFIG_LONG(1)  = getFormItemInt(F("p002_adc2"));
-      PCONFIG_FLOAT(1) = getFormItemFloat(F("p002_out2"));
+      P002_CALIBRATION_POINT2 = getFormItemInt(F("p002_adc2"));
+      P002_CALIBRATION_VALUE2 = getFormItemFloat(F("p002_out2"));
 
       success = true;
       break;
@@ -188,30 +222,53 @@ boolean Plugin_002(byte function, struct EventStruct *event, String& string)
         static_cast<P002_data_struct *>(getPluginTaskData(event->TaskIndex));
 
       success = (nullptr != P002_data);
+      #ifdef ESP32
+
+      if (P002_READ_AS_TOUCH == P002_TOUCH_EVENT) {
+        P002_setEventParams(CONFIG_PIN1, P002_TOUCH_THRESHOLD);
+      }
+      #endif // ifdef ESP32
       break;
     }
     case PLUGIN_TEN_PER_SECOND:
     {
-      if (PCONFIG(0)) // Oversampling
+      if (P002_OVERSAMPLING) // Oversampling
       {
         P002_data_struct *P002_data =
           static_cast<P002_data_struct *>(getPluginTaskData(event->TaskIndex));
 
         if (nullptr != P002_data) {
-          uint16_t currentValue;
+          int currentValue;
 
           P002_performRead(event, currentValue);
           P002_data->addOversamplingValue(currentValue);
         }
       }
+      #ifdef ESP32
+
+      if (p002_pinTouched != 0) {
+        // Some pin has been touched. Try to find which pin it was and send event.
+        for (unsigned int i = 0; i < 10; ++i) {
+          if (p002_pinTouched & (1 << i)) {
+            p002_pinTouched &= ~(1 << i); // reset bit
+
+            if (Settings.UseRules) {
+              String eventString = F("ADCtouch=");
+              eventString += i;
+              eventQueue.add(eventString);
+            }
+          }
+        }
+      }
+      #endif // ifdef ESP32
       success = true;
       break;
     }
 
     case PLUGIN_READ:
     {
-      uint16_t raw_value = 0;
-      float    res_value = 0.0;
+      int   raw_value = 0;
+      float res_value = 0.0;
 
       if (P002_getOutputValue(event, raw_value, res_value)) {
         UserVar[event->BaseVarIndex] = res_value;
@@ -226,7 +283,7 @@ boolean Plugin_002(byte function, struct EventStruct *event, String& string)
             log += F(" = ");
             log += String(UserVar[event->BaseVarIndex], 3);
 
-            if (PCONFIG(0)) {
+            if (P002_OVERSAMPLING) {
               log += F(" (");
               log += P002_data->OversamplingCount;
               log += F(" samples)");
@@ -247,7 +304,7 @@ boolean Plugin_002(byte function, struct EventStruct *event, String& string)
   return success;
 }
 
-bool P002_getOutputValue(struct EventStruct *event, uint16_t& raw_value, float& res_value) {
+bool P002_getOutputValue(struct EventStruct *event, int& raw_value, float& res_value) {
   P002_data_struct *P002_data =
     static_cast<P002_data_struct *>(getPluginTaskData(event->TaskIndex));
 
@@ -256,7 +313,8 @@ bool P002_getOutputValue(struct EventStruct *event, uint16_t& raw_value, float& 
   }
   float float_value = 0.0;
 
-  bool valueRead = PCONFIG(0) && P002_data->getOversamplingValue(float_value, raw_value);
+  bool valueRead = P002_OVERSAMPLING && P002_data->getOversamplingValue(float_value, raw_value);
+
   if (!valueRead) {
     P002_performRead(event, raw_value);
     float_value = static_cast<float>(raw_value);
@@ -267,12 +325,12 @@ bool P002_getOutputValue(struct EventStruct *event, uint16_t& raw_value, float& 
 }
 
 float P002_applyCalibration(struct EventStruct *event, float float_value) {
-  if (PCONFIG(3)) // Calibration?
+  if (P002_CALIBRATION_ENABLED) // Calibration?
   {
-    int   adc1 = PCONFIG_LONG(0);
-    int   adc2 = PCONFIG_LONG(1);
-    float out1 = PCONFIG_FLOAT(0);
-    float out2 = PCONFIG_FLOAT(1);
+    int   adc1 = P002_CALIBRATION_POINT1;
+    int   adc2 = P002_CALIBRATION_POINT2;
+    float out1 = P002_CALIBRATION_VALUE1;
+    float out2 = P002_CALIBRATION_VALUE2;
 
     if (adc1 != adc2)
     {
@@ -283,20 +341,70 @@ float P002_applyCalibration(struct EventStruct *event, float float_value) {
   return float_value;
 }
 
-void P002_performRead(struct EventStruct *event, uint16_t& value) {
+void P002_performRead(struct EventStruct *event, int& value) {
   #ifdef ESP8266
   value = espeasy_analogRead(A0);
   #endif // if defined(ESP8266)
   #if defined(ESP32)
-  value = espeasy_analogRead(CONFIG_PIN1);
+  value = espeasy_analogRead(CONFIG_PIN1, P002_READ_AS_TOUCH != P002_NO_TOUCH);
   #endif // if defined(ESP32)
 }
 
-void P002_formatStatistics(const String& label, int16_t raw, float float_value) {
+void P002_formatStatistics(const String& label, int raw, float float_value) {
   addRowLabel(label);
   addHtml(String(raw));
   html_add_estimate_symbol();
   addHtml(String(float_value, 3));
 }
+
+#ifdef ESP32
+
+/**********************************************************************************
+* Touch pin configuration
+**********************************************************************************/
+void P002_setEventParams(int pin, uint16_t threshold) {
+  int adc, ch, t;
+
+  if (getADC_gpio_info(pin, adc, ch, t)) {
+    switch (t) {
+      case 0: touchAttachInterrupt(T0, P002_got_T0, threshold); break;
+      case 1: touchAttachInterrupt(T1, P002_got_T1, threshold); break;
+      case 2: touchAttachInterrupt(T2, P002_got_T2, threshold); break;
+      case 3: touchAttachInterrupt(T3, P002_got_T3, threshold); break;
+      case 4: touchAttachInterrupt(T4, P002_got_T4, threshold); break;
+      case 5: touchAttachInterrupt(T5, P002_got_T5, threshold); break;
+      case 6: touchAttachInterrupt(T6, P002_got_T6, threshold); break;
+      case 7: touchAttachInterrupt(T7, P002_got_T7, threshold); break;
+      case 8: touchAttachInterrupt(T8, P002_got_T8, threshold); break;
+      case 9: touchAttachInterrupt(T9, P002_got_T9, threshold); break;
+    }
+  }
+}
+
+void P002_got_T0() IRAM_ATTR;
+void P002_got_T1() IRAM_ATTR;
+void P002_got_T2() IRAM_ATTR;
+void P002_got_T3() IRAM_ATTR;
+void P002_got_T4() IRAM_ATTR;
+void P002_got_T5() IRAM_ATTR;
+void P002_got_T6() IRAM_ATTR;
+void P002_got_T7() IRAM_ATTR;
+void P002_got_T8() IRAM_ATTR;
+void P002_got_T9() IRAM_ATTR;
+
+void P002_got_T0() { p002_pinTouched |= (1 << 0); }
+void P002_got_T1() { p002_pinTouched |= (1 << 1); }
+void P002_got_T2() { p002_pinTouched |= (1 << 2); }
+void P002_got_T3() { p002_pinTouched |= (1 << 3); }
+void P002_got_T4() { p002_pinTouched |= (1 << 4); }
+void P002_got_T5() { p002_pinTouched |= (1 << 5); }
+void P002_got_T6() { p002_pinTouched |= (1 << 6); }
+void P002_got_T7() { p002_pinTouched |= (1 << 7); }
+void P002_got_T8() { p002_pinTouched |= (1 << 8); }
+void P002_got_T9() { p002_pinTouched |= (1 << 9); }
+
+
+#endif // ifdef ESP32
+
 
 #endif // USES_P002

--- a/src/_P018_Dust.ino
+++ b/src/_P018_Dust.ino
@@ -75,7 +75,7 @@ boolean Plugin_018(byte function, struct EventStruct *event, String& string)
         {
           digitalWrite(Plugin_GP2Y10_LED_Pin, LOW);
           delayMicroseconds(280);
-          value = value + analogRead(A0);
+          value = value + espeasy_analogRead(A0);
           delayMicroseconds(40);
           digitalWrite(Plugin_GP2Y10_LED_Pin, HIGH);
           delayMicroseconds(9680);

--- a/src/_P036_FrameOLED.ino
+++ b/src/_P036_FrameOLED.ino
@@ -215,11 +215,6 @@ String DisplayLinesV0[P36_Nlines];                // used to load the CustomTask
 // Instantiate display here - does not work to do this within the INIT call
 OLEDDisplay *display=NULL;
 
-void P036_setBitToUL(uint32_t& number, byte bitnr, bool value) {
-  uint32_t mask = (0x01UL << bitnr);
-  uint32_t newbit = (value ? 1UL : 0UL) << bitnr;
-  number = (number & ~mask) | newbit;
-}
 uint8_t get8BitFromUL(uint32_t number, byte bitnr) {
   return (number >> bitnr) & 0xFF;
 }
@@ -352,7 +347,7 @@ boolean Plugin_036(uint8_t function, struct EventStruct *event, String& string)
 
         // FIXME TD-er: Why is this using pin3 and not pin1? And why isn't this using the normal pin selection functions?
         addFormPinSelect(F("Display button"), F("taskdevicepin3"), CONFIG_PIN3);
-        bPin3Invers = getBitFromUL(PCONFIG_LONG(0), 16);  // Bit 16
+        bPin3Invers = bitRead(PCONFIG_LONG(0), 16);  // Bit 16
         addFormCheckBox(F("Inversed Logic"), F("p036_pin3invers"), bPin3Invers);
 
         addFormNumericBox(F("Display Timeout"), F("p036_timer"), PCONFIG(4));
@@ -378,10 +373,10 @@ boolean Plugin_036(uint8_t function, struct EventStruct *event, String& string)
         addFormSelector(F("Header"),F("p036_header"), 14, options9, optionValues9, choice9);
         addFormSelector(F("Header (alternating)"),F("p036_headerAlternate"), 14, options9, optionValues9, choice10);
 
-        bScrollLines = getBitFromUL(PCONFIG_LONG(0), 17);  // Bit 17
+        bScrollLines = bitRead(PCONFIG_LONG(0), 17);  // Bit 17
         addFormCheckBox(F("Scroll long lines"), F("p036_ScrollLines"), bScrollLines);
 
-        bNoDisplayOnReceivedText = getBitFromUL(PCONFIG_LONG(0), 18);  // Bit 18
+        bNoDisplayOnReceivedText = bitRead(PCONFIG_LONG(0), 18);  // Bit 18
         addFormCheckBox(F("Wake display on receiving text"), F("p036_NoDisplay"), !bNoDisplayOnReceivedText);
         addFormNote(F("When checked, the display wakes up at receiving remote updates."));
 
@@ -414,9 +409,9 @@ boolean Plugin_036(uint8_t function, struct EventStruct *event, String& string)
         uint32_t lSettings = 0;
         set8BitToUL(lSettings, 8, uint8_t(getFormItemInt(F("p036_header")) & 0xff));            // Bit15-8 HeaderContent
         set8BitToUL(lSettings, 0, uint8_t(getFormItemInt(F("p036_headerAlternate")) & 0xff));   // Bit 7-0 HeaderContentAlternative
-        P036_setBitToUL(lSettings, 16, isFormItemChecked(F("p036_pin3invers")));                // Bit 16 Pin3Invers
-        P036_setBitToUL(lSettings, 17, isFormItemChecked(F("p036_ScrollLines")));               // Bit 17 ScrollLines
-        P036_setBitToUL(lSettings, 18, !isFormItemChecked(F("p036_NoDisplay")));                // Bit 18 NoDisplayOnReceivingText
+        bitWrite(lSettings, 16, isFormItemChecked(F("p036_pin3invers")));                // Bit 16 Pin3Invers
+        bitWrite(lSettings, 17, isFormItemChecked(F("p036_ScrollLines")));               // Bit 17 ScrollLines
+        bitWrite(lSettings, 18, !isFormItemChecked(F("p036_NoDisplay")));                // Bit 18 NoDisplayOnReceivingText
         // save CustomTaskSettings always in version V1
         set4BitToUL(lSettings, 20, 0x01);                                                       // Bit23-20 Version CustomTaskSettings -> version V1
 
@@ -537,7 +532,7 @@ boolean Plugin_036(uint8_t function, struct EventStruct *event, String& string)
         bAlternativHeader = (++HeaderCount > (lTaskTimer*5)); // change header after half of display time
         if (CONFIG_PIN3 != -1)
         {
-          bPin3Invers = getBitFromUL(PCONFIG_LONG(0), 16);  // Bit 16
+          bPin3Invers = bitRead(PCONFIG_LONG(0), 16);  // Bit 16
           if ((!bPin3Invers && digitalRead(CONFIG_PIN3)) || (bPin3Invers && !digitalRead(CONFIG_PIN3)))
           {
             display->displayOn();
@@ -545,7 +540,7 @@ boolean Plugin_036(uint8_t function, struct EventStruct *event, String& string)
             displayTimer = PCONFIG(4);
           }
         }
-        bScrollLines = getBitFromUL(PCONFIG_LONG(0), 17);  // Bit 17
+        bScrollLines = bitRead(PCONFIG_LONG(0), 17);  // Bit 17
         if ((UserVar[event->BaseVarIndex] == 1) && bScrollLines && (ScrollingPages.Scrolling == 0)) {
           // Display is on.
           OLEDIndex = PCONFIG(7);
@@ -762,7 +757,7 @@ boolean Plugin_036(uint8_t function, struct EventStruct *event, String& string)
 
             nextFrameToDisplay = LineNo / ScrollingPages.linesPerFrame; // next frame shows the new content
 
-            bNoDisplayOnReceivedText = getBitFromUL(PCONFIG_LONG(0), 18);  // Bit 18 NoDisplayOnReceivedText
+            bNoDisplayOnReceivedText = bitRead(PCONFIG_LONG(0), 18);  // Bit 18 NoDisplayOnReceivedText
             if (UserVar[event->BaseVarIndex] == 0 && !bNoDisplayOnReceivedText) {
               // display was OFF, turn it ON
               displayTimer = PCONFIG(4);

--- a/src/_P095_ILI9341.ino
+++ b/src/_P095_ILI9341.ino
@@ -39,7 +39,7 @@ TFT Subcommands:
 
 | TFT Subcommands | details | description |
 |-----|-----|-----|
-| txt | tx,<text> | Write simple text (use last position, color and size) |
+| txt | txt,<text> | Write simple text (use last position, color and size) |
 | txp | txp,<X>,<Y> | Set text position (move the cursor) |
 | txc | txc,<foreColor>,<backgroundColor> | Set text color (background is transparent if not provided |
 | txs | txs,<SIZE> | Set text size |

--- a/src/_P097_Esp32Touch.ino
+++ b/src/_P097_Esp32Touch.ino
@@ -1,0 +1,289 @@
+#ifdef USES_P097
+
+// #######################################################################################################
+// #################################### Plugin 097: ESP32 Touch ##########################################
+// #######################################################################################################
+
+
+#ifdef ESP32
+
+
+# define PLUGIN_097
+# define PLUGIN_ID_097         97
+# define PLUGIN_NAME_097       "Touch (ESP32) - internal"
+# define PLUGIN_VALUENAME1_097 "Touch"
+
+# include "_Plugin_Helper.h"
+
+# ifdef ESP32
+  #  define P097_MAX_ADC_VALUE    4095
+# endif // ifdef ESP32
+# ifdef ESP8266
+  #  define P097_MAX_ADC_VALUE    1023
+# endif // ifdef ESP8266
+
+
+# define P097_SEND_TOUCH_EVENT    PCONFIG(0)
+# define P097_SEND_RELEASE_EVENT  PCONFIG(1)
+# define P097_SEND_DURATION_EVENT PCONFIG(2)
+# define P097_TOUCH_THRESHOLD     PCONFIG(3)
+
+// Share this bitmap among all instances of this plugin
+DRAM_ATTR uint32_t p097_pinTouched     = 0;
+DRAM_ATTR uint32_t p097_pinTouchedPrev = 0;
+DRAM_ATTR uint32_t p097_timestamp[10]  = { 0 };
+
+
+boolean Plugin_097(byte function, struct EventStruct *event, String& string)
+{
+  boolean success = false;
+
+  switch (function)
+  {
+    case PLUGIN_DEVICE_ADD:
+    {
+      Device[++deviceCount].Number           = PLUGIN_ID_097;
+      Device[deviceCount].Type               = DEVICE_TYPE_ANALOG;
+      Device[deviceCount].VType              = SENSOR_TYPE_SINGLE;
+      Device[deviceCount].Ports              = 0;
+      Device[deviceCount].PullUpOption       = false;
+      Device[deviceCount].InverseLogicOption = false;
+      Device[deviceCount].FormulaOption      = true;
+      Device[deviceCount].ValueCount         = 1;
+      Device[deviceCount].SendDataOption     = true;
+      Device[deviceCount].DecimalsOnly       = false;
+      Device[deviceCount].TimerOption        = false;
+      Device[deviceCount].GlobalSyncOption   = true;
+      break;
+    }
+
+    case PLUGIN_GET_DEVICENAME:
+    {
+      string = F(PLUGIN_NAME_097);
+      break;
+    }
+
+    case PLUGIN_GET_DEVICEVALUENAMES:
+    {
+      strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[0], PSTR(PLUGIN_VALUENAME1_097));
+      break;
+    }
+
+    case PLUGIN_SET_DEFAULTS:
+    {
+      P097_SEND_TOUCH_EVENT = 1;
+      P097_SEND_DURATION_EVENT = 1;
+      P097_TOUCH_THRESHOLD = 20;
+      break;
+    }
+
+    case PLUGIN_WEBFORM_LOAD:
+    {
+      addHtml(F("<TR><TD>Analog Pin:<TD>"));
+      addADC_PinSelect(true, F("taskdevicepin1"), CONFIG_PIN1);
+
+      addFormSubHeader(F("Touch Settings"));
+
+      addFormCheckBox(F("Send Touch Event"),    F("p097_sendtouch"),    P097_SEND_TOUCH_EVENT);
+      addFormCheckBox(F("Send Release Event"),  F("p097_sendrelease"),  P097_SEND_RELEASE_EVENT);
+      addFormCheckBox(F("Send Duration Event"), F("p097_sendduration"), P097_SEND_DURATION_EVENT);
+      addFormNumericBox(F("Touch Threshold"), F("p097_threshold"), P097_TOUCH_THRESHOLD, 0, P097_MAX_ADC_VALUE);
+
+      // Show current value
+      addRowLabel(F("Current Pressure"));
+      addHtml(String(touchRead(CONFIG_PIN1)));
+
+      success = true;
+      break;
+    }
+
+    case PLUGIN_WEBFORM_SAVE:
+    {
+      P097_SEND_TOUCH_EVENT    = isFormItemChecked(F("p097_sendtouch"));
+      P097_SEND_RELEASE_EVENT  = isFormItemChecked(F("p097_sendrelease"));
+      P097_SEND_DURATION_EVENT = isFormItemChecked(F("p097_sendduration"));
+      P097_TOUCH_THRESHOLD     = getFormItemInt(F("p097_threshold"));
+
+      success = true;
+      break;
+    }
+
+    case PLUGIN_EXIT: {
+      clearPluginTaskData(event->TaskIndex);
+      success = true;
+      break;
+    }
+
+    case PLUGIN_INIT:
+    {
+      P097_setEventParams(CONFIG_PIN1, P097_TOUCH_THRESHOLD);
+      success = true;
+      break;
+    }
+    case PLUGIN_TEN_PER_SECOND:
+    {
+      if ((p097_pinTouched != 0) || (p097_pinTouchedPrev != 0)) {
+        // Some pin has been touched or released.
+        // Check if it is 'our' pin
+        int adc, ch, t;
+
+        if (getADC_gpio_info(CONFIG_PIN1, adc, ch, t)) {
+          const bool touched      = bitRead(p097_pinTouched, t);
+          const bool touched_prev = bitRead(p097_pinTouchedPrev, t);
+
+          if (touched) {
+            bitClear(p097_pinTouched, t);
+          }
+
+          if (touched != touched_prev) {
+            // state changed
+            UserVar[event->BaseVarIndex] = touchRead(CONFIG_PIN1);
+
+            if (touched) {
+              if (P097_SEND_TOUCH_EVENT) {
+                // schedule a read to update output values and send to controllers
+                schedule_task_device_timer(event->TaskIndex, millis());
+              }
+              bitSet(p097_pinTouchedPrev, t);
+            } else {
+              if (P097_SEND_RELEASE_EVENT) {
+                // schedule a read to update output values and send to controllers
+                schedule_task_device_timer(event->TaskIndex, millis());
+              }
+
+              if (P097_SEND_DURATION_EVENT) {
+                if (Settings.UseRules) {
+                  String eventString;
+                  eventString.reserve(32);
+                  eventString  = getTaskDeviceName(event->TaskIndex);
+                  eventString += F("#Duration=");
+                  eventString += timePassedSince(p097_timestamp[t]);
+                  eventQueue.add(eventString);
+                }
+              }
+              bitClear(p097_pinTouchedPrev, t);
+              p097_timestamp[t] = 0;
+            }
+          }
+        }
+      }
+      success = true;
+      break;
+    }
+
+    case PLUGIN_READ:
+    {
+      int raw_value = touchRead(CONFIG_PIN1);
+      UserVar[event->BaseVarIndex] = raw_value;
+
+      if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+        String log = F("Touch : ");
+        log += formatGpioName_ADC(CONFIG_PIN1);
+        log += F(": ");
+        log += raw_value;
+        addLog(LOG_LEVEL_INFO, log);
+      }
+      success = true;
+      break;
+    }
+  }
+  return success;
+}
+
+/**********************************************************************************
+* Touch pin callback functions
+**********************************************************************************/
+void P097_setEventParams(int pin, uint16_t threshold) {
+  int adc, ch, t;
+
+  if (getADC_gpio_info(pin, adc, ch, t)) {
+    switch (t) {
+      case 0: touchAttachInterrupt(T0, P097_got_T0, threshold); break;
+      case 1: touchAttachInterrupt(T1, P097_got_T1, threshold); break;
+      case 2: touchAttachInterrupt(T2, P097_got_T2, threshold); break;
+      case 3: touchAttachInterrupt(T3, P097_got_T3, threshold); break;
+      case 4: touchAttachInterrupt(T4, P097_got_T4, threshold); break;
+      case 5: touchAttachInterrupt(T5, P097_got_T5, threshold); break;
+      case 6: touchAttachInterrupt(T6, P097_got_T6, threshold); break;
+      case 7: touchAttachInterrupt(T7, P097_got_T7, threshold); break;
+      case 8: touchAttachInterrupt(T8, P097_got_T8, threshold); break;
+      case 9: touchAttachInterrupt(T9, P097_got_T9, threshold); break;
+    }
+  }
+}
+
+void P097_got_T0() ICACHE_RAM_ATTR;
+void P097_got_T1() ICACHE_RAM_ATTR;
+void P097_got_T2() ICACHE_RAM_ATTR;
+void P097_got_T3() ICACHE_RAM_ATTR;
+void P097_got_T4() ICACHE_RAM_ATTR;
+void P097_got_T5() ICACHE_RAM_ATTR;
+void P097_got_T6() ICACHE_RAM_ATTR;
+void P097_got_T7() ICACHE_RAM_ATTR;
+void P097_got_T8() ICACHE_RAM_ATTR;
+void P097_got_T9() ICACHE_RAM_ATTR;
+
+void P097_got_T0() {
+  bitSet(p097_pinTouched, 0);
+
+  if (p097_timestamp[0] == 0) { p097_timestamp[0] = millis(); }
+}
+
+void P097_got_T1() {
+  bitSet(p097_pinTouched, 1);
+
+  if (p097_timestamp[1] == 0) { p097_timestamp[1] = millis(); }
+}
+
+void P097_got_T2() {
+  bitSet(p097_pinTouched, 2);
+
+  if (p097_timestamp[2] == 0) { p097_timestamp[2] = millis(); }
+}
+
+void P097_got_T3() {
+  bitSet(p097_pinTouched, 3);
+
+  if (p097_timestamp[3] == 0) { p097_timestamp[3] = millis(); }
+}
+
+void P097_got_T4() {
+  bitSet(p097_pinTouched, 4);
+
+  if (p097_timestamp[4] == 0) { p097_timestamp[4] = millis(); }
+}
+
+void P097_got_T5() {
+  bitSet(p097_pinTouched, 5);
+
+  if (p097_timestamp[5] == 0) { p097_timestamp[5] = millis(); }
+}
+
+void P097_got_T6() {
+  bitSet(p097_pinTouched, 6);
+
+  if (p097_timestamp[6] == 0) { p097_timestamp[6] = millis(); }
+}
+
+void P097_got_T7() {
+  bitSet(p097_pinTouched, 7);
+
+  if (p097_timestamp[7] == 0) { p097_timestamp[7] = millis(); }
+}
+
+void P097_got_T8() {
+  bitSet(p097_pinTouched, 8);
+
+  if (p097_timestamp[8] == 0) { p097_timestamp[8] = millis(); }
+}
+
+void P097_got_T9() {
+  bitSet(p097_pinTouched, 9);
+
+  if (p097_timestamp[9] == 0) { p097_timestamp[9] = millis(); }
+}
+
+#endif // ifdef ESP32
+
+
+#endif // USES_P097

--- a/src/define_plugin_sets.h
+++ b/src/define_plugin_sets.h
@@ -834,6 +834,7 @@ To create/register a plugin, you have to :
     #define USES_P093   // Mitsubishi Heat Pump
     //#define USES_P094  // CUL Reader
     //#define USES_P095  // TFT ILI9341
+    #define USES_P097   // Touch (ESP32)
 #endif
 
 

--- a/src/src/DataStructs/ControllerSettingsStruct.cpp
+++ b/src/src/DataStructs/ControllerSettingsStruct.cpp
@@ -180,60 +180,60 @@ bool ControllerSettingsStruct::updateIPcache() {
 
 bool ControllerSettingsStruct::mqtt_cleanSession() const
 {
-  return getBitFromUL(MQTT_flags, 1);
+  return bitRead(MQTT_flags, 1);
 }
 
 void ControllerSettingsStruct::mqtt_cleanSession(bool value)
 {
-  setBitToUL(MQTT_flags, 1, value);
+  bitWrite(MQTT_flags, 1, value);
 }
 
 bool ControllerSettingsStruct::mqtt_sendLWT() const
 {
-  return !getBitFromUL(MQTT_flags, 2);
+  return !bitRead(MQTT_flags, 2);
 }
 
 void ControllerSettingsStruct::mqtt_sendLWT(bool value)
 {
-  setBitToUL(MQTT_flags, 2, !value);
+  bitWrite(MQTT_flags, 2, !value);
 }
 
 bool ControllerSettingsStruct::mqtt_willRetain() const
 {
-  return !getBitFromUL(MQTT_flags, 3);
+  return !bitRead(MQTT_flags, 3);
 }
 
 void ControllerSettingsStruct::mqtt_willRetain(bool value)
 {
-  setBitToUL(MQTT_flags, 3, !value);
+  bitWrite(MQTT_flags, 3, !value);
 }
 
 bool ControllerSettingsStruct::mqtt_uniqueMQTTclientIdReconnect() const
 {
-  return getBitFromUL(MQTT_flags, 4);
+  return bitRead(MQTT_flags, 4);
 }
 
 void ControllerSettingsStruct::mqtt_uniqueMQTTclientIdReconnect(bool value)
 {
-  setBitToUL(MQTT_flags, 4, value);
+  bitWrite(MQTT_flags, 4, value);
 }
 
 bool ControllerSettingsStruct::mqtt_retainFlag() const
 {
-  return getBitFromUL(MQTT_flags, 5);
+  return bitRead(MQTT_flags, 5);
 }
 
 void ControllerSettingsStruct::mqtt_retainFlag(bool value)
 {
-  setBitToUL(MQTT_flags, 5, value);
+  bitWrite(MQTT_flags, 5, value);
 }
 
 bool ControllerSettingsStruct::useExtendedCredentials() const
 {
-  return getBitFromUL(MQTT_flags, 6);
+  return bitRead(MQTT_flags, 6);
 }
 
 void ControllerSettingsStruct::useExtendedCredentials(bool value)
 {
-  setBitToUL(MQTT_flags, 6, value);
+  bitWrite(MQTT_flags, 6, value);
 }

--- a/src/src/DataStructs/FactoryDefaultPref.cpp
+++ b/src/src/DataStructs/FactoryDefaultPref.cpp
@@ -13,84 +13,84 @@ void ResetFactoryDefaultPreference_struct::setDeviceModel(DeviceModel model) {
 }
 
 bool ResetFactoryDefaultPreference_struct::keepWiFi() const {
-  return getBitFromUL(_preference, 9);
+  return bitRead(_preference, 9);
 }
 
 void ResetFactoryDefaultPreference_struct::keepWiFi(bool keep) {
-  setBitToUL(_preference, 9, keep);
+  bitWrite(_preference, 9, keep);
 }
 
 bool ResetFactoryDefaultPreference_struct::keepNTP() const {
-  return getBitFromUL(_preference, 10);
+  return bitRead(_preference, 10);
 }
 
 void ResetFactoryDefaultPreference_struct::keepNTP(bool keep) {
-  setBitToUL(_preference, 10, keep);
+  bitWrite(_preference, 10, keep);
 }
 
 bool ResetFactoryDefaultPreference_struct::keepNetwork() const {
-  return getBitFromUL(_preference, 11);
+  return bitRead(_preference, 11);
 }
 
 void ResetFactoryDefaultPreference_struct::keepNetwork(bool keep) {
-  setBitToUL(_preference, 11, keep);
+  bitWrite(_preference, 11, keep);
 }
 
 bool ResetFactoryDefaultPreference_struct::keepLogSettings() const {
-  return getBitFromUL(_preference, 12);
+  return bitRead(_preference, 12);
 }
 
 void ResetFactoryDefaultPreference_struct::keepLogSettings(bool keep) {
-  setBitToUL(_preference, 12, keep);
+  bitWrite(_preference, 12, keep);
 }
 
 bool ResetFactoryDefaultPreference_struct::keepUnitName() const {
-  return getBitFromUL(_preference, 13);
+  return bitRead(_preference, 13);
 }
 
 void ResetFactoryDefaultPreference_struct::keepUnitName(bool keep) {
-  setBitToUL(_preference, 13, keep);
+  bitWrite(_preference, 13, keep);
 }
 
 // filenr = 0...3 for files rules1.txt ... rules4.txt
 bool ResetFactoryDefaultPreference_struct::fetchRulesTXT(int filenr) const {
-  return getBitFromUL(_preference, 14 + filenr);
+  return bitRead(_preference, 14 + filenr);
 }
 
 void ResetFactoryDefaultPreference_struct::fetchRulesTXT(int filenr, bool fetch) {
-  setBitToUL(_preference, 14 + filenr, fetch);
+  bitWrite(_preference, 14 + filenr, fetch);
 }
 
 bool ResetFactoryDefaultPreference_struct::fetchNotificationDat() const {
-  return getBitFromUL(_preference, 18);
+  return bitRead(_preference, 18);
 }
 
 void ResetFactoryDefaultPreference_struct::fetchNotificationDat(bool fetch) {
-  setBitToUL(_preference, 18, fetch);
+  bitWrite(_preference, 18, fetch);
 }
 
 bool ResetFactoryDefaultPreference_struct::fetchSecurityDat() const {
-  return getBitFromUL(_preference, 19);
+  return bitRead(_preference, 19);
 }
 
 void ResetFactoryDefaultPreference_struct::fetchSecurityDat(bool fetch) {
-  setBitToUL(_preference, 19, fetch);
+  bitWrite(_preference, 19, fetch);
 }
 
 bool ResetFactoryDefaultPreference_struct::fetchConfigDat() const {
-  return getBitFromUL(_preference, 20);
+  return bitRead(_preference, 20);
 }
 
 void ResetFactoryDefaultPreference_struct::fetchConfigDat(bool fetch) {
-  setBitToUL(_preference, 20, fetch);
+  bitWrite(_preference, 20, fetch);
 }
 
 bool ResetFactoryDefaultPreference_struct::deleteFirst() const {
-  return getBitFromUL(_preference, 21);
+  return bitRead(_preference, 21);
 }
 
 void ResetFactoryDefaultPreference_struct::deleteFirst(bool checked) {
-  setBitToUL(_preference, 21, checked);
+  bitWrite(_preference, 21, checked);
 }
 
 uint32_t ResetFactoryDefaultPreference_struct::getPreference() {

--- a/src/src/DataStructs/SettingsStruct.cpp
+++ b/src/src/DataStructs/SettingsStruct.cpp
@@ -13,103 +13,103 @@ SettingsStruct_tmpl<N_TASKS>::SettingsStruct_tmpl() : ResetFactoryDefaultPrefere
 // VariousBits1 defaults to 0, keep in mind when adding bit lookups.
 template<unsigned int N_TASKS>
 bool SettingsStruct_tmpl<N_TASKS>::appendUnitToHostname()  const {
-  return !getBitFromUL(VariousBits1, 1);
+  return !bitRead(VariousBits1, 1);
 }
 
 template<unsigned int N_TASKS>
 void SettingsStruct_tmpl<N_TASKS>::appendUnitToHostname(bool value) {
-  setBitToUL(VariousBits1, 1, !value);
+  bitWrite(VariousBits1, 1, !value);
 }
 
 template<unsigned int N_TASKS>
 bool SettingsStruct_tmpl<N_TASKS>::uniqueMQTTclientIdReconnect_unused() const {
-  return getBitFromUL(VariousBits1, 2);
+  return bitRead(VariousBits1, 2);
 }
 
 template<unsigned int N_TASKS>
 void SettingsStruct_tmpl<N_TASKS>::uniqueMQTTclientIdReconnect_unused(bool value) {
-  setBitToUL(VariousBits1, 2, value);
+  bitWrite(VariousBits1, 2, value);
 }
 
 template<unsigned int N_TASKS>
 bool SettingsStruct_tmpl<N_TASKS>::OldRulesEngine() const {
-  return !getBitFromUL(VariousBits1, 3);
+  return !bitRead(VariousBits1, 3);
 }
 
 template<unsigned int N_TASKS>
 void SettingsStruct_tmpl<N_TASKS>::OldRulesEngine(bool value) {
-  setBitToUL(VariousBits1, 3, !value);
+  bitWrite(VariousBits1, 3, !value);
 }
 
 template<unsigned int N_TASKS>
 bool SettingsStruct_tmpl<N_TASKS>::ForceWiFi_bg_mode() const {
-  return getBitFromUL(VariousBits1, 4);
+  return bitRead(VariousBits1, 4);
 }
 
 template<unsigned int N_TASKS>
 void SettingsStruct_tmpl<N_TASKS>::ForceWiFi_bg_mode(bool value) {
-  setBitToUL(VariousBits1, 4, value);
+  bitWrite(VariousBits1, 4, value);
 }
 
 template<unsigned int N_TASKS>
 bool SettingsStruct_tmpl<N_TASKS>::WiFiRestart_connection_lost() const {
-  return getBitFromUL(VariousBits1, 5);
+  return bitRead(VariousBits1, 5);
 }
 
 template<unsigned int N_TASKS>
 void SettingsStruct_tmpl<N_TASKS>::WiFiRestart_connection_lost(bool value) {
-  setBitToUL(VariousBits1, 5, value);
+  bitWrite(VariousBits1, 5, value);
 }
 
 template<unsigned int N_TASKS>
 bool SettingsStruct_tmpl<N_TASKS>::EcoPowerMode() const {
-  return getBitFromUL(VariousBits1, 6);
+  return bitRead(VariousBits1, 6);
 }
 
 template<unsigned int N_TASKS>
 void SettingsStruct_tmpl<N_TASKS>::EcoPowerMode(bool value) {
-  setBitToUL(VariousBits1, 6, value);
+  bitWrite(VariousBits1, 6, value);
 }
 
 template<unsigned int N_TASKS>
 bool SettingsStruct_tmpl<N_TASKS>::WifiNoneSleep() const {
-  return getBitFromUL(VariousBits1, 7);
+  return bitRead(VariousBits1, 7);
 }
 
 template<unsigned int N_TASKS>
 void SettingsStruct_tmpl<N_TASKS>::WifiNoneSleep(bool value) {
-  setBitToUL(VariousBits1, 7, value);
+  bitWrite(VariousBits1, 7, value);
 }
 
 // Enable send gratuitous ARP by default, so invert the values (default = 0)
 template<unsigned int N_TASKS>
 bool SettingsStruct_tmpl<N_TASKS>::gratuitousARP() const {
-  return !getBitFromUL(VariousBits1, 8);
+  return !bitRead(VariousBits1, 8);
 }
 
 template<unsigned int N_TASKS>
 void SettingsStruct_tmpl<N_TASKS>::gratuitousARP(bool value) {
-  setBitToUL(VariousBits1, 8, !value);
+  bitWrite(VariousBits1, 8, !value);
 }
 
 template<unsigned int N_TASKS>
 bool SettingsStruct_tmpl<N_TASKS>::TolerantLastArgParse() const {
-  return getBitFromUL(VariousBits1, 9);
+  return bitRead(VariousBits1, 9);
 }
 
 template<unsigned int N_TASKS>
 void SettingsStruct_tmpl<N_TASKS>::TolerantLastArgParse(bool value) {
-  setBitToUL(VariousBits1, 9, value);
+  bitWrite(VariousBits1, 9, value);
 }
 
 template<unsigned int N_TASKS>
 bool SettingsStruct_tmpl<N_TASKS>::SendToHttp_ack() const {
-  return getBitFromUL(VariousBits1, 10);
+  return bitRead(VariousBits1, 10);
 }
 
 template<unsigned int N_TASKS>
 void SettingsStruct_tmpl<N_TASKS>::SendToHttp_ack(bool value) {
-  setBitToUL(VariousBits1, 10, value);
+  bitWrite(VariousBits1, 10, value);
 }
 
 template<unsigned int N_TASKS>


### PR DESCRIPTION
Oversampling:
Values only added when not already the min or max value.
This way a number of erroneous min values or max. values (e.g. due to WiFi activity) will not affect the averaging function.

Perform first reading of ADC before any WiFi activity is taking place. This first reading is shared among VCC readings of sysinfo plugin and ADC plugin.


ESP32 improvements:
- Display detailed ADC pin capabilities/description for GPIO selection
- Only allow GPIOs to be selected for pins that can actually be used for ADC.
- Allow to read the internal Hall Effect sensor in the ESP32
- Allow to use the "Touch" pins to be used as touch pins
- Allow to set a threshold and generate an event for touch pins

Fixes: #3023
Fixes: #1585
