### PR TITLE
Fix ESP32 build if P001 is not included

### DIFF
--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -703,6 +703,36 @@ String getPinModeString(byte mode) {
   return F("ERROR: Not Defined");
 }
 
+#if defined(ESP32)
+void analogWriteESP32(int pin, int value)
+{
+  // find existing channel if this pin has been used before
+  int8_t ledChannel = -1;
+
+  for (byte x = 0; x < 16; x++) {
+    if (ledChannelPin[x] == pin) {
+      ledChannel = x;
+    }
+  }
+
+  if (ledChannel == -1)             // no channel set for this pin
+  {
+    for (byte x = 0; x < 16; x++) { // find free channel
+      if (ledChannelPin[x] == -1)
+      {
+        int freq = 5000;
+        ledChannelPin[x] = pin; // store pin nr
+        ledcSetup(x, freq, 10); // setup channel
+        ledcAttachPin(pin, x);  // attach to this pin
+        ledChannel = x;
+        break;
+      }
+    }
+  }
+  ledcWrite(ledChannel, value);
+}
+#endif // if defined(ESP32)
+
 
 /********************************************************************************************\
   Status LED

--- a/src/_P001_Switch.ino
+++ b/src/_P001_Switch.ino
@@ -1173,37 +1173,6 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
   return success;
 }
 
-#if defined(ESP32)
-void analogWriteESP32(int pin, int value)
-{
-  // find existing channel if this pin has been used before
-  int8_t ledChannel = -1;
-
-  for (byte x = 0; x < 16; x++) {
-    if (ledChannelPin[x] == pin) {
-      ledChannel = x;
-    }
-  }
-
-  if (ledChannel == -1)             // no channel set for this pin
-  {
-    for (byte x = 0; x < 16; x++) { // find free channel
-      if (ledChannelPin[x] == -1)
-      {
-        int freq = 5000;
-        ledChannelPin[x] = pin; // store pin nr
-        ledcSetup(x, freq, 10); // setup channel
-        ledcAttachPin(pin, x);  // attach to this pin
-        ledChannel = x;
-        break;
-      }
-    }
-  }
-  ledcWrite(ledChannel, value);
-}
-
-#endif // if defined(ESP32)
-
 // TD-er: Needed to fix a mistake in earlier fixes.
 byte P001_getSwitchType(struct EventStruct *event) {
   byte choice = PCONFIG(0);


### PR DESCRIPTION
ESP32 build fails if plugin P001 is not included due to missing analogWriteESP32