### PR TITLE
[Hotfix] Core 2.7.0 OTA update fails with XMC Flash chip

### DIFF
--- a/platformio_core_defs.ini
+++ b/platformio_core_defs.ini
@@ -101,8 +101,8 @@ lib_ignore                = ${esp82xx_defaults.lib_ignore}, IRremoteESP8266, Hea
 [core_2_7_0]
 extends                   = esp82xx_2_6_x
 platform                  = espressif8266@2.5.0
-platform_packages         =
-	framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git#2.7.0
+platform_packages         = 
+  framework-arduinoespressif8266 @ https://github.com/tasmota/Arduino/releases/download/2.7.0/esp8266-2.7.0.zip
 build_flags               = ${esp82xx_2_6_x.build_flags} 
                             -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190703
 
@@ -110,8 +110,8 @@ build_flags               = ${esp82xx_2_6_x.build_flags}
 [core_2_7_0_sdk3]
 extends                   = esp82xx_2_6_x
 platform                  = espressif8266@2.5.0
-platform_packages         =
-	framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git#2.7.0
+platform_packages         = 
+  framework-arduinoespressif8266 @ https://github.com/tasmota/Arduino/releases/download/2.7.0/esp8266-2.7.0.zip
 build_flags               = ${esp82xx_2_6_x.build_flags} 
                             -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK3
 


### PR DESCRIPTION
See: https://github.com/esp8266/Arduino/issues/7267
Using [Tasmota Hotfix: Use patched Core 2.7.0](https://github.com/arendst/Tasmota/pull/8342/files)