### PR TITLE
ESP32: Allow to select one of the two available SPI ports

### DIFF
--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -23,7 +23,7 @@ void sendData(struct EventStruct *event)
     createRuleEvents(event);
   }
 
-  if (Settings.UseValueLogger && Settings.InitSPI && (Settings.Pin_sd_cs >= 0)) {
+  if (Settings.UseValueLogger && Settings.InitSPI>0 && (Settings.Pin_sd_cs >= 0)) {
     SendValueLogger(event->TaskIndex);
   }
 

--- a/src/Custom-sample.h
+++ b/src/Custom-sample.h
@@ -99,6 +99,8 @@
 #define DEFAULT_PIN_I2C_SCL                     5
 #define DEFAULT_I2C_CLOCK_SPEED                 400000            // Use 100 kHz if working with old I2C chips
 
+#define DEFAULT_SPI                             0                 //0=disabled 1=enabled and for ESP32 there is option 2 =HSPI
+
 #define DEFAULT_PIN_STATUS_LED                  (-1)
 #define DEFAULT_PIN_STATUS_LED_INVERSED         true
 

--- a/src/Hardware.ino
+++ b/src/Hardware.ino
@@ -52,10 +52,25 @@ void hardwareInit()
   initI2C();
 
   // SPI Init
-  if (Settings.InitSPI)
+  if (Settings.InitSPI>0)
   {
     SPI.setHwCs(false);
+    
+    //MFD: for ESP32 enable the SPI on HSPI as the default is VSPI
+    #ifdef ESP32 
+    if (Settings.InitSPI==2)
+    {
+      #define HSPI_MISO   12
+      #define HSPI_MOSI   13
+      #define HSPI_SCLK   14
+      #define HSPI_SS     15
+      SPI.begin(HSPI_SCLK, HSPI_MISO, HSPI_MOSI); //HSPI
+    }
+    else
+     SPI.begin(); //VSPI
+    #else
     SPI.begin();
+    #endif
     String log = F("INIT : SPI Init (without CS)");
     addLog(LOG_LEVEL_INFO, log);
   }

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -1240,7 +1240,7 @@ void ResetFactory()
   Settings.Protocol[0]     = DEFAULT_PROTOCOL;
   Settings.deepSleep_wakeTime       = false;
   Settings.CustomCSS       = false;
-  Settings.InitSPI         = false;
+  Settings.InitSPI         = DEFAULT_SPI;
   for (taskIndex_t x = 0; x < TASKS_MAX; x++)
   {
     Settings.TaskDevicePin1[x] = -1;

--- a/src/WebServer_HardwarePage.ino
+++ b/src/WebServer_HardwarePage.ino
@@ -19,7 +19,11 @@ void handle_hardware() {
     Settings.Pin_i2c_sda             = getFormItemInt(F("psda"));
     Settings.Pin_i2c_scl             = getFormItemInt(F("pscl"));
     Settings.I2C_clockSpeed          = getFormItemInt(F("pi2csp"), DEFAULT_I2C_CLOCK_SPEED);
-    Settings.InitSPI                 = isFormItemChecked(F("initspi")); // SPI Init
+    #ifdef ESP32
+      Settings.InitSPI               = getFormItemInt(F("initspi"), 0);
+    #else //for ESP8266 we keep the old UI
+      Settings.InitSPI               = isFormItemChecked(F("initspi")); // SPI Init
+    #endif
     Settings.Pin_sd_cs               = getFormItemInt(F("sd"));
     int gpio = 0;
 
@@ -69,12 +73,19 @@ void handle_hardware() {
 
   // SPI Init
   addFormSubHeader(F("SPI Interface"));
-  addFormCheckBox(F("Init SPI"), F("initspi"), Settings.InitSPI);
+  #ifdef ESP32
+    String spi_options[3] = { F("Disabled"), F("VSPI: CLK=GPIO-18, MISO=GPIO-19, MOSI=GPIO-23"), F("HSPI: CLK=GPIO-14, MISO=GPIO-12, MOSI=GPIO-13")};
+    addFormSelector(F("Init SPI"), F("initspi"), 3, spi_options, NULL, Settings.InitSPI);
+    addFormNote(F("Changing SPI settings requires to manualy restart"));
+  #else //for ESP8266 we keep the existing UI
+  addFormCheckBox(F("Init SPI"), F("initspi"), Settings.InitSPI>0);
   addFormNote(F("CLK=GPIO-14 (D5), MISO=GPIO-12 (D6), MOSI=GPIO-13 (D7)"));
+  #endif
   addFormNote(F("Chip Select (CS) config must be done in the plugin"));
-#ifdef FEATURE_SD
-  addFormPinSelect(formatGpioName_output("SD Card CS"), "sd", Settings.Pin_sd_cs);
-#endif // ifdef FEATURE_SD
+  
+  #ifdef FEATURE_SD
+    addFormPinSelect(formatGpioName_output("SD Card CS"), "sd", Settings.Pin_sd_cs);
+  #endif // ifdef FEATURE_SD
 
   addFormSubHeader(F("GPIO boot states"));
   int gpio = 0;

--- a/src/src/DataStructs/SettingsStruct.cpp
+++ b/src/src/DataStructs/SettingsStruct.cpp
@@ -221,7 +221,7 @@ void SettingsStruct_tmpl<N_TASKS>::clearMisc() {
   GlobalSync                       = false;
   ConnectionFailuresThreshold      = 0;
   MQTTRetainFlag_unused            = false;
-  InitSPI                          = false;
+  InitSPI                          = DEFAULT_SPI;
   Pin_status_led_Inversed          = false;
   deepSleepOnFail                  = false;
   UseValueLogger                   = false;

--- a/src/src/DataStructs/SettingsStruct.h
+++ b/src/src/DataStructs/SettingsStruct.h
@@ -6,6 +6,10 @@
 #include "../DataStructs/ESPEasyLimits.h"
 #include "../Globals/Plugins.h"
 
+//we disable SPI if not defined
+#ifndef DEFAULT_SPI
+ #define DEFAULT_SPI 0
+#endif
 
 /*********************************************************************************************\
  * SettingsStruct
@@ -121,7 +125,7 @@ class SettingsStruct_tmpl
   unsigned long ConnectionFailuresThreshold;
   int16_t       TimeZone;
   boolean       MQTTRetainFlag_unused;
-  boolean       InitSPI;
+  byte          InitSPI; //0 = disabled, 1= enabled but for ESP32 there is option 2= SPI2 
   // FIXME TD-er: Must change to cpluginID_t, but then also another check must be added since changing the pluginID_t will also render settings incompatible
   byte          Protocol[CONTROLLER_MAX];
   byte          Notification[NOTIFICATION_MAX]; //notifications, point to a NPLUGIN id


### PR DESCRIPTION
ESP32: has available for use two SPI ports.
This allows to select either one of them to be used by ESPEasy.

Limitations: 
- Only one can meb used at a time for now.
- Requires to restart the board to take effect when changing.
