### PR TITLE
Fix for allowing negative timeOffset from UTC in constructor

### DIFF
--- a/src/src/DataStructs/TimeChangeRule.cpp
+++ b/src/src/DataStructs/TimeChangeRule.cpp
@@ -4,7 +4,7 @@
 
 TimeChangeRule::TimeChangeRule() :  week(0), dow(1), month(1), hour(0), offset(0) {}
 
-TimeChangeRule::TimeChangeRule(uint8_t weeknr, uint8_t downr, uint8_t m, uint8_t h, uint16_t minutesoffset) :
+TimeChangeRule::TimeChangeRule(uint8_t weeknr, uint8_t downr, uint8_t m, uint8_t h, int16_t minutesoffset) :
   week(weeknr), dow(downr), month(m), hour(h), offset(minutesoffset) {}
 
 // Construct time change rule from stored values optimized for minimum space.

--- a/src/src/DataStructs/TimeChangeRule.h
+++ b/src/src/DataStructs/TimeChangeRule.h
@@ -19,7 +19,7 @@ struct TimeChangeRule {
 
   TimeChangeRule();
 
-  TimeChangeRule(uint8_t weeknr, uint8_t downr, uint8_t m, uint8_t h, uint16_t minutesoffset);
+  TimeChangeRule(uint8_t weeknr, uint8_t downr, uint8_t m, uint8_t h, int16_t minutesoffset);
 
   // Construct time change rule from stored values optimized for minimum space.
   TimeChangeRule(uint16_t flash_stored_value, int16_t minutesoffset);


### PR DESCRIPTION
changed uint16_t to int16_t to match the internal variable and allow negative offset from UTC