### PR TITLE
[Transformation] Add P/p (Password display)

### DIFF
--- a/docs/source/Rules/Rules.rst
+++ b/docs/source/Rules/Rules.rst
@@ -388,6 +388,7 @@ Transformation
 * A "binary" transformation can be "inverted" by adding a leading ``!``.
 * A "binary" value is considered 0 when its string value is "0" or empty, otherwise it is an 1. (float values are rounded)
 * A "binary" value can also be used to detect presence of a string, as it is 0 on an empty string or 1 otherwise.
+* If the transformation contains ``R``, under certain circumstances, the value will be right-aligned.
 
 Binary transformations:
 
@@ -417,8 +418,15 @@ Floating point transformations:
 * ``F``: Floor (round down)
 * ``E``: cEiling (round up)
 
+Other transformations:
+
+* ``p``: Password display, replacing all value characters by asterisks ``*``. If the value is "0", nothing will be displayed.
+* ``Pc``: Password display with custom character ``c``. For example P- will display value "123" as "---". If the value is "0", nothing will be displayed.
+
 Justification
 ^^^^^^^^^^^^^
+
+To apply a justification, a transformation must also be used. If no transformation is needed, use the ``V`` (value) transformation.
 
 * ``Pn``: Prefix Fill with n spaces.
 * ``Sn``: Suffix Fill with n spaces.

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -1980,6 +1980,33 @@ void transformValue(
           {
           case 'V': //value = value without transformations
             break;
+          case 'P': // Password hide using a custom password character: Pc
+            if (tempValueFormatLength > 1)
+            {
+              if (value == F("0")) {
+                value = "";
+              } else {
+                const int valueLength = value.length();
+                for (int i = 0; i < valueLength; i++) {
+                  value[i] = tempValueFormat[1];
+                }
+              }
+            } else {
+              value = F("ERR");
+            }
+            break;
+          case 'p': // Password hide using asterisks
+            {
+              if (value == F("0")) {
+                value = "";
+              } else {
+                const int valueLength = value.length();
+                for (int i = 0; i < valueLength; i++) {
+                  value[i] = '*';
+                }
+              }
+            }
+            break;
           case 'O':
             value = logicVal == 0 ? F("OFF") : F(" ON"); //(equivalent to XOR operator)
             break;


### PR DESCRIPTION
To enable entering a pin/passcode using a keypad, and display the 'progress' on a display (OLED/LCD).
* Value 0 displays as empty
* Use p to display asterisks, displays `***` for value `123`
* Use Pc to display custom character c, example `P-` displays `---` for value `123`
