### PR TITLE
Reduce RAM usage considerably on controllers

### DIFF
--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -109,32 +109,12 @@ void callback(char *c_topic, byte *b_payload, unsigned int length) {
     return;
   }
 
-  struct EventStruct TempEvent;
-
   // TD-er: This one cannot set the TaskIndex, but that may seem to work out.... hopefully.
-  TempEvent.String1 = c_topic;
-  TempEvent.String2.reserve(length);
-
-  for (unsigned int i = 0; i < length; ++i) {
-    char c = static_cast<char>(*(b_payload + i));
-    TempEvent.String2 += c;
-  }
-
-  /*
-     if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE)) {
-      String log;
-      log=F("MQTT : Topic: ");
-      log+=c_topic;
-      addLog(LOG_LEVEL_DEBUG_MORE, log);
-
-      log=F("MQTT : Payload: ");
-      log+=TempEvent.String2;
-      addLog(LOG_LEVEL_DEBUG_MORE, log);
-     }
-   */
-
   protocolIndex_t ProtocolIndex = getProtocolIndex_from_ControllerIndex(enabledMqttController);
-  schedule_controller_event_timer(ProtocolIndex, CPlugin::Function::CPLUGIN_PROTOCOL_RECV, &TempEvent);
+  schedule_mqtt_controller_event_timer(
+    ProtocolIndex, 
+    CPlugin::Function::CPLUGIN_PROTOCOL_RECV,
+    c_topic, b_payload, length);
 }
 
 /*********************************************************************************************\

--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -308,6 +308,7 @@ bool MQTTCheck(controllerIndex_t controller_idx)
           }
         } else {
           MQTTclient_must_send_LWT_connected = false;
+        }
       }
     }
   }

--- a/src/ESPEasy_fdwdecl.h
+++ b/src/ESPEasy_fdwdecl.h
@@ -124,6 +124,7 @@ void MQTTDisconnect();
 bool MQTTConnect(controllerIndex_t controller_idx);
 bool MQTTCheck(controllerIndex_t controller_idx);
 void schedule_all_tasks_using_MQTT_controller();
+bool MQTT_queueFull(controllerIndex_t controller_idx);
 bool MQTTpublish(controllerIndex_t controller_idx, const char *topic, const char *payload, bool retained);
 #endif // ifdef USES_MQTT
 

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -1330,21 +1330,24 @@ void ResetFactory()
   addPredefinedRules(gpio_settings);
 
 #if DEFAULT_CONTROLLER
-  MakeControllerSettings(ControllerSettings);
-  safe_strncpy(ControllerSettings.Subscribe, F(DEFAULT_SUB), sizeof(ControllerSettings.Subscribe));
-  safe_strncpy(ControllerSettings.Publish, F(DEFAULT_PUB), sizeof(ControllerSettings.Publish));
-  safe_strncpy(ControllerSettings.MQTTLwtTopic, F(DEFAULT_MQTT_LWT_TOPIC), sizeof(ControllerSettings.MQTTLwtTopic));
-  safe_strncpy(ControllerSettings.LWTMessageConnect, F(DEFAULT_MQTT_LWT_CONNECT_MESSAGE), sizeof(ControllerSettings.LWTMessageConnect));
-  safe_strncpy(ControllerSettings.LWTMessageDisconnect, F(DEFAULT_MQTT_LWT_DISCONNECT_MESSAGE), sizeof(ControllerSettings.LWTMessageDisconnect));
-  str2ip((char*)DEFAULT_SERVER, ControllerSettings.IP);
-  ControllerSettings.setHostname(F(DEFAULT_SERVER_HOST));
-  ControllerSettings.UseDNS = DEFAULT_SERVER_USEDNS;
-  ControllerSettings.useExtendedCredentials(DEFAULT_USE_EXTD_CONTROLLER_CREDENTIALS);
-  ControllerSettings.Port = DEFAULT_PORT;
-  setControllerUser(0, ControllerSettings, F(DEFAULT_CONTROLLER_USER));
-  setControllerPass(0, ControllerSettings, F(DEFAULT_CONTROLLER_PASS));
+  {
+    // Place in a scope to have its memory freed ASAP
+    MakeControllerSettings(ControllerSettings);
+    safe_strncpy(ControllerSettings.Subscribe, F(DEFAULT_SUB), sizeof(ControllerSettings.Subscribe));
+    safe_strncpy(ControllerSettings.Publish, F(DEFAULT_PUB), sizeof(ControllerSettings.Publish));
+    safe_strncpy(ControllerSettings.MQTTLwtTopic, F(DEFAULT_MQTT_LWT_TOPIC), sizeof(ControllerSettings.MQTTLwtTopic));
+    safe_strncpy(ControllerSettings.LWTMessageConnect, F(DEFAULT_MQTT_LWT_CONNECT_MESSAGE), sizeof(ControllerSettings.LWTMessageConnect));
+    safe_strncpy(ControllerSettings.LWTMessageDisconnect, F(DEFAULT_MQTT_LWT_DISCONNECT_MESSAGE), sizeof(ControllerSettings.LWTMessageDisconnect));
+    str2ip((char*)DEFAULT_SERVER, ControllerSettings.IP);
+    ControllerSettings.setHostname(F(DEFAULT_SERVER_HOST));
+    ControllerSettings.UseDNS = DEFAULT_SERVER_USEDNS;
+    ControllerSettings.useExtendedCredentials(DEFAULT_USE_EXTD_CONTROLLER_CREDENTIALS);
+    ControllerSettings.Port = DEFAULT_PORT;
+    setControllerUser(0, ControllerSettings, F(DEFAULT_CONTROLLER_USER));
+    setControllerPass(0, ControllerSettings, F(DEFAULT_CONTROLLER_PASS));
 
-   SaveControllerSettings(0, ControllerSettings);
+    SaveControllerSettings(0, ControllerSettings);
+  }
 #endif
 
   SaveSettings();

--- a/src/Networking.ino
+++ b/src/Networking.ino
@@ -878,6 +878,9 @@ bool connectClient(WiFiClient& client, IPAddress ip, uint16_t port)
   if (!NetworkConnected()) {
     return false;
   }
+  // In case of domain name resolution error result can be negative.
+  // https://github.com/esp8266/Arduino/blob/18f643c7e2d6a0da9d26ff2b14c94e6536ab78c1/libraries/Ethernet/src/Dns.cpp#L44
+  // Thus must match the result with 1.
   bool connected = (client.connect(ip, port) == 1);
   yield();
 

--- a/src/Scheduler.ino
+++ b/src/Scheduler.ino
@@ -1,5 +1,6 @@
 #include "src/Globals/RTC.h"
 #include "src/DataStructs/RTCStruct.h"
+#include "src/DataStructs/ESPEasy_EventStruct.h"
 #include "src/DataStructs/EventValueSource.h"
 #include "src/Globals/Device.h"
 #include "src/Globals/CPlugins.h"
@@ -8,6 +9,7 @@
 #include "src/Helpers/ESPEasy_time_calc.h"
 
 #include "ESPEasy_plugindefs.h"
+#include "ESPEasy-Globals.h"
 
 #define TIMER_ID_SHIFT    28
 
@@ -655,6 +657,22 @@ void schedule_plugin_task_event_timer(deviceIndex_t DeviceIndex, byte Function, 
 void schedule_controller_event_timer(protocolIndex_t ProtocolIndex, byte Function, struct EventStruct *event) {
   if (validProtocolIndex(ProtocolIndex)) {
     schedule_event_timer(ControllerPluginEnum, ProtocolIndex, Function, event);
+  }
+}
+
+void schedule_mqtt_controller_event_timer(protocolIndex_t ProtocolIndex, byte Function, char *c_topic, byte *b_payload, unsigned int length) {
+  if (validProtocolIndex(ProtocolIndex)) {
+    const unsigned long mixedId = createSystemEventMixedId(ControllerPluginEnum, ProtocolIndex, Function);
+    EventQueue.emplace_back(mixedId, EventStruct());
+    EventQueue.back().event.String1 = c_topic;
+
+    String& payload = EventQueue.back().event.String2;
+    payload.reserve(length);
+
+    for (unsigned int i = 0; i < length; ++i) {
+      char c = static_cast<char>(*(b_payload + i));
+      payload += c;
+    }
   }
 }
 

--- a/src/WebServer_AdvancedConfigPage.ino
+++ b/src/WebServer_AdvancedConfigPage.ino
@@ -211,22 +211,6 @@ void handle_advanced() {
 }
 
 void addFormDstSelect(bool isStart, uint16_t choice) {
-  String weekid  = isStart ? F("dststartweek")  : F("dstendweek");
-  String dowid   = isStart ? F("dststartdow")   : F("dstenddow");
-  String monthid = isStart ? F("dststartmonth") : F("dstendmonth");
-  String hourid  = isStart ? F("dststarthour")  : F("dstendhour");
-
-  String weeklabel = isStart ? F("Start (week, dow, month)")  : F("End (week, dow, month)");
-  String hourlabel = isStart ? F("Start (localtime, e.g. 2h&rarr;3h)")  : F("End (localtime, e.g. 3h&rarr;2h)");
-
-  String week[5]       = { F("Last"), F("1st"), F("2nd"), F("3rd"), F("4th") };
-  int    weekValues[5] = { 0, 1, 2, 3, 4 };
-  String dow[7]        = { F("Sun"), F("Mon"), F("Tue"), F("Wed"), F("Thu"), F("Fri"), F("Sat") };
-  int    dowValues[7]  = { 1, 2, 3, 4, 5, 6, 7 };
-  String month[12]     = { F("Jan"), F("Feb"), F("Mar"), F("Apr"), F("May"), F("Jun"), F("Jul"), F("Aug"), F("Sep"), F("Oct"), F("Nov"), F(
-                             "Dec") };
-  int    monthValues[12] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-
   uint16_t tmpstart(choice);
   uint16_t tmpend(choice);
 
@@ -234,15 +218,39 @@ void addFormDstSelect(bool isStart, uint16_t choice) {
     time_zone.getDefaultDst_flash_values(tmpstart, tmpend);
   }
   TimeChangeRule rule(isStart ? tmpstart : tmpend, 0);
-  addRowLabel(weeklabel);
-  addSelector(weekid, 5, week, weekValues, NULL, rule.week);
-  html_BR();
-  addSelector(dowid, 7, dow, dowValues, NULL, rule.dow);
-  html_BR();
-  addSelector(monthid, 12, month, monthValues, NULL, rule.month);
+  {
+    String weeklabel = isStart ? F("Start (week, dow, month)")  : F("End (week, dow, month)");
+    String weekid  = isStart ? F("dststartweek")  : F("dstendweek");
+    String week[5]       = { F("Last"), F("1st"), F("2nd"), F("3rd"), F("4th") };
+    int    weekValues[5] = { 0, 1, 2, 3, 4 };
 
-  addFormNumericBox(hourlabel, hourid, rule.hour, 0, 23);
-  addUnit(isStart ? F("hour &#x21b7;") : F("hour &#x21b6;"));
+    addRowLabel(weeklabel);
+    addSelector(weekid, 5, week, weekValues, NULL, rule.week);
+  }
+  html_BR();
+  {
+    String dowid   = isStart ? F("dststartdow")   : F("dstenddow");
+    String dow[7]        = { F("Sun"), F("Mon"), F("Tue"), F("Wed"), F("Thu"), F("Fri"), F("Sat") };
+    int    dowValues[7]  = { 1, 2, 3, 4, 5, 6, 7 };
+
+    addSelector(dowid, 7, dow, dowValues, NULL, rule.dow);
+  }
+  html_BR();
+  {
+    String monthid = isStart ? F("dststartmonth") : F("dstendmonth");
+    String month[12]     = { F("Jan"), F("Feb"), F("Mar"), F("Apr"), F("May"), F("Jun"), F("Jul"), F("Aug"), F("Sep"), F("Oct"), F("Nov"), F(
+                             "Dec") };
+    int    monthValues[12] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+
+    addSelector(monthid, 12, month, monthValues, NULL, rule.month);
+  }
+  {
+    String hourid  = isStart ? F("dststarthour")  : F("dstendhour");
+    String hourlabel = isStart ? F("Start (localtime, e.g. 2h&rarr;3h)")  : F("End (localtime, e.g. 3h&rarr;2h)");
+
+    addFormNumericBox(hourlabel, hourid, rule.hour, 0, 23);
+    addUnit(isStart ? F("hour &#x21b7;") : F("hour &#x21b6;"));
+  }
 }
 
 void addFormLogLevelSelect(const String& label, const String& id, int choice)

--- a/src/WebServer_ControllerPage.ino
+++ b/src/WebServer_ControllerPage.ino
@@ -22,33 +22,36 @@ void handle_controllers() {
   // submitted data
   if ((protocol != -1) && !controllerNotSet)
   {
-    MakeControllerSettings(ControllerSettings);
     bool mustInit = false;
-
-    if (Settings.Protocol[controllerindex] != protocol)
     {
-      // Protocol has changed.
-      Settings.Protocol[controllerindex] = protocol;
+      // Place in a scope to free ControllerSettings memory ASAP
+      MakeControllerSettings(ControllerSettings);
 
-      // there is a protocol selected?
-      if (protocol != 0)
+      if (Settings.Protocol[controllerindex] != protocol)
       {
-        mustInit = true;
-        handle_controllers_clearLoadDefaults(controllerindex, ControllerSettings);
-      }
-    }
+        // Protocol has changed.
+        Settings.Protocol[controllerindex] = protocol;
 
-    // subitted same protocol
-    else
-    {
-      // there is a protocol selected
-      if (protocol != 0)
-      {
-        mustInit = true;
-        handle_controllers_CopySubmittedSettings(controllerindex, ControllerSettings);
+        // there is a protocol selected?
+        if (protocol != 0)
+        {
+          mustInit = true;
+          handle_controllers_clearLoadDefaults(controllerindex, ControllerSettings);
+        }
       }
+
+      // subitted same protocol
+      else
+      {
+        // there is a protocol selected
+        if (protocol != 0)
+        {
+          mustInit = true;
+          handle_controllers_CopySubmittedSettings(controllerindex, ControllerSettings);
+        }
+      }
+      addHtmlError(SaveControllerSettings(controllerindex, ControllerSettings));
     }
-    addHtmlError(SaveControllerSettings(controllerindex, ControllerSettings));
     addHtmlError(SaveSettings());
 
     if (mustInit) {

--- a/src/_C002.ino
+++ b/src/_C002.ino
@@ -11,6 +11,9 @@
 #include "src/Commands/InternalCommands.h"
 #include <ArduinoJson.h>
 
+String CPlugin_002_pubname;
+bool CPlugin_002_retain = false;
+
 bool CPlugin_002(CPlugin::Function function, struct EventStruct *event, String& string)
 {
   bool success = false;
@@ -41,6 +44,8 @@ bool CPlugin_002(CPlugin::Function function, struct EventStruct *event, String& 
       MakeControllerSettings(ControllerSettings);
       LoadControllerSettings(event->ControllerIndex, ControllerSettings);
       MQTTDelayHandler.configureControllerSettings(ControllerSettings);
+      CPlugin_002_pubname = ControllerSettings.Publish;
+      CPlugin_002_retain = ControllerSettings.mqtt_retainFlag();
       break;
     }
 
@@ -172,16 +177,6 @@ bool CPlugin_002(CPlugin::Function function, struct EventStruct *event, String& 
     {
       if (event->idx != 0)
       {
-        MakeControllerSettings(ControllerSettings);
-        LoadControllerSettings(event->ControllerIndex, ControllerSettings);
-
-        /*
-                  if (!ControllerSettings.checkHostReachable(true)) {
-                    success = false;
-                    break;
-                  }
-         */
-
         DynamicJsonDocument root(200);
         root[F("idx")]  = event->idx;
         root[F("RSSI")] = mapRSSItoDomoticz();
@@ -237,10 +232,10 @@ bool CPlugin_002(CPlugin::Function function, struct EventStruct *event, String& 
         addLog(LOG_LEVEL_DEBUG, log);
 #endif // ifndef BUILD_NO_DEBUG
 
-        String pubname = ControllerSettings.Publish;
+        String pubname = CPlugin_002_pubname;
         parseControllerVariables(pubname, event, false);
 
-        success = MQTTpublish(event->ControllerIndex, pubname.c_str(), json.c_str(), ControllerSettings.mqtt_retainFlag());
+        success = MQTTpublish(event->ControllerIndex, pubname.c_str(), json.c_str(), CPlugin_002_retain);
       } // if ixd !=0
       else
       {

--- a/src/_C005.ino
+++ b/src/_C005.ino
@@ -110,7 +110,6 @@ bool CPlugin_005(CPlugin::Function function, struct EventStruct *event, String& 
         String pubname = ControllerSettings.Publish;
         parseControllerVariables(pubname, event, false);
 
-        String value = "";
         byte valueCount = getValueCountFromSensorType(event->sensorType);
         for (byte x = 0; x < valueCount; x++)
         {
@@ -120,15 +119,23 @@ bool CPlugin_005(CPlugin::Function function, struct EventStruct *event, String& 
              
           String tmppubname = pubname;
           tmppubname.replace(F("%valname%"), ExtraTaskSettings.TaskDeviceValueNames[x]);
-          value = formatUserVarNoCheck(event, x);
-
-          MQTTpublish(event->ControllerIndex, tmppubname.c_str(), value.c_str(), ControllerSettings.mqtt_retainFlag());
+          String value = "";
+          // Small optimization so we don't try to copy potentially large strings
+          if (event->sensorType == SENSOR_TYPE_STRING) {
+            MQTTpublish(event->ControllerIndex, tmppubname.c_str(), event->String2.c_str(), ControllerSettings.mqtt_retainFlag());
+            value = event->String2.substring(0, 20); // For the log
+          } else {
+            value = formatUserVarNoCheck(event, x);
+            MQTTpublish(event->ControllerIndex, tmppubname.c_str(), value.c_str(), ControllerSettings.mqtt_retainFlag());
+          }
 #ifndef BUILD_NO_DEBUG
-          String log = F("MQTT : ");
-          log += tmppubname;
-          log += ' ';
-          log += value;
-          addLog(LOG_LEVEL_DEBUG, log);
+          if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+            String log = F("MQTT : ");
+            log += tmppubname;
+            log += ' ';
+            log += value;
+            addLog(LOG_LEVEL_DEBUG, log);
+          }
 #endif
         }
         break;

--- a/src/_C005.ino
+++ b/src/_C005.ino
@@ -94,20 +94,21 @@ bool CPlugin_005(CPlugin::Function function, struct EventStruct *event, String& 
 
     case CPlugin::Function::CPLUGIN_PROTOCOL_SEND:
       {
-        MakeControllerSettings(ControllerSettings);
-        LoadControllerSettings(event->ControllerIndex, ControllerSettings);
-        if (!ControllerSettings.checkHostReachable(true)) {
-            success = false;
-            break;
+        String pubname;
+        bool mqtt_retainFlag;
+        {
+          // Place the ControllerSettings in a scope to free the memory as soon as we got all relevant information.
+          MakeControllerSettings(ControllerSettings);
+          LoadControllerSettings(event->ControllerIndex, ControllerSettings);
+          pubname = ControllerSettings.Publish;
+          mqtt_retainFlag = ControllerSettings.mqtt_retainFlag();
         }
-        statusLED(true);
 
         if (ExtraTaskSettings.TaskIndex != event->TaskIndex) {
           String dummy;
           PluginCall(PLUGIN_GET_DEVICEVALUENAMES, event, dummy);
         }
 
-        String pubname = ControllerSettings.Publish;
         parseControllerVariables(pubname, event, false);
 
         byte valueCount = getValueCountFromSensorType(event->sensorType);
@@ -122,11 +123,11 @@ bool CPlugin_005(CPlugin::Function function, struct EventStruct *event, String& 
           String value = "";
           // Small optimization so we don't try to copy potentially large strings
           if (event->sensorType == SENSOR_TYPE_STRING) {
-            MQTTpublish(event->ControllerIndex, tmppubname.c_str(), event->String2.c_str(), ControllerSettings.mqtt_retainFlag());
+            MQTTpublish(event->ControllerIndex, tmppubname.c_str(), event->String2.c_str(), mqtt_retainFlag);
             value = event->String2.substring(0, 20); // For the log
           } else {
             value = formatUserVarNoCheck(event, x);
-            MQTTpublish(event->ControllerIndex, tmppubname.c_str(), value.c_str(), ControllerSettings.mqtt_retainFlag());
+            MQTTpublish(event->ControllerIndex, tmppubname.c_str(), value.c_str(), mqtt_retainFlag);
           }
 #ifndef BUILD_NO_DEBUG
           if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {

--- a/src/_C005.ino
+++ b/src/_C005.ino
@@ -7,6 +7,10 @@
 #define CPLUGIN_ID_005         5
 #define CPLUGIN_NAME_005       "Home Assistant (openHAB) MQTT"
 
+String CPlugin_005_pubname;
+bool CPlugin_005_mqtt_retainFlag;
+
+
 bool CPlugin_005(CPlugin::Function function, struct EventStruct *event, String& string)
 {
   bool success = false;
@@ -37,6 +41,8 @@ bool CPlugin_005(CPlugin::Function function, struct EventStruct *event, String& 
         MakeControllerSettings(ControllerSettings);
         LoadControllerSettings(event->ControllerIndex, ControllerSettings);
         MQTTDelayHandler.configureControllerSettings(ControllerSettings);
+        CPlugin_005_pubname = ControllerSettings.Publish;
+        CPlugin_005_mqtt_retainFlag = ControllerSettings.mqtt_retainFlag();
         break;
       }
 
@@ -94,15 +100,8 @@ bool CPlugin_005(CPlugin::Function function, struct EventStruct *event, String& 
 
     case CPlugin::Function::CPLUGIN_PROTOCOL_SEND:
       {
-        String pubname;
-        bool mqtt_retainFlag;
-        {
-          // Place the ControllerSettings in a scope to free the memory as soon as we got all relevant information.
-          MakeControllerSettings(ControllerSettings);
-          LoadControllerSettings(event->ControllerIndex, ControllerSettings);
-          pubname = ControllerSettings.Publish;
-          mqtt_retainFlag = ControllerSettings.mqtt_retainFlag();
-        }
+        String pubname = CPlugin_005_pubname;
+        bool mqtt_retainFlag = CPlugin_005_mqtt_retainFlag;
 
         if (ExtraTaskSettings.TaskIndex != event->TaskIndex) {
           String dummy;

--- a/src/_C006.ino
+++ b/src/_C006.ino
@@ -104,14 +104,18 @@ bool CPlugin_006(CPlugin::Function function, struct EventStruct *event, String& 
         String pubname = ControllerSettings.Publish;
         parseControllerVariables(pubname, event, false);
 
-        String value = "";
         byte valueCount = getValueCountFromSensorType(event->sensorType);
         for (byte x = 0; x < valueCount; x++)
         {
           String tmppubname = pubname;
           tmppubname.replace(F("%valname%"), ExtraTaskSettings.TaskDeviceValueNames[x]);
-          value = formatUserVarNoCheck(event, x);
-          MQTTpublish(event->ControllerIndex, tmppubname.c_str(), value.c_str(), ControllerSettings.mqtt_retainFlag());
+          // Small optimization so we don't try to copy potentially large strings
+          if (event->sensorType == SENSOR_TYPE_STRING) {
+            MQTTpublish(event->ControllerIndex, tmppubname.c_str(), event->String2.c_str(), ControllerSettings.mqtt_retainFlag());
+          } else {
+            String value = formatUserVarNoCheck(event, x);
+            MQTTpublish(event->ControllerIndex, tmppubname.c_str(), value.c_str(), ControllerSettings.mqtt_retainFlag());
+          }
         }
         break;
       }

--- a/src/_C006.ino
+++ b/src/_C006.ino
@@ -7,6 +7,10 @@
 #define CPLUGIN_ID_006         6
 #define CPLUGIN_NAME_006       "PiDome MQTT"
 
+String CPlugin_006_pubname;
+bool CPlugin_006_mqtt_retainFlag;
+
+
 bool CPlugin_006(CPlugin::Function function, struct EventStruct *event, String& string)
 {
   bool success = false;
@@ -37,6 +41,8 @@ bool CPlugin_006(CPlugin::Function function, struct EventStruct *event, String& 
         MakeControllerSettings(ControllerSettings);
         LoadControllerSettings(event->ControllerIndex, ControllerSettings);
         MQTTDelayHandler.configureControllerSettings(ControllerSettings);
+        CPlugin_006_pubname = ControllerSettings.Publish;
+        CPlugin_006_mqtt_retainFlag = ControllerSettings.mqtt_retainFlag();
         break;
       }
 
@@ -91,15 +97,8 @@ bool CPlugin_006(CPlugin::Function function, struct EventStruct *event, String& 
           success = false;
           break;
         }
-        String pubname;
-        bool mqtt_retainFlag;
-        {
-          // Place the ControllerSettings in a scope to free the memory as soon as we got all relevant information.
-          MakeControllerSettings(ControllerSettings);
-          LoadControllerSettings(event->ControllerIndex, ControllerSettings);
-          pubname = ControllerSettings.Publish;
-          mqtt_retainFlag = ControllerSettings.mqtt_retainFlag();
-        }
+        String pubname = CPlugin_006_pubname;
+        bool mqtt_retainFlag = CPlugin_006_mqtt_retainFlag;
 
         statusLED(true);
 

--- a/src/_C008.ino
+++ b/src/_C008.ino
@@ -50,6 +50,19 @@ bool CPlugin_008(CPlugin::Function function, struct EventStruct *event, String& 
 
     case CPlugin::Function::CPLUGIN_PROTOCOL_SEND:
       {
+        String pubname;
+        {
+          // Place the ControllerSettings in a scope to free the memory as soon as we got all relevant information.
+          MakeControllerSettings(ControllerSettings);
+          if (!AllocatedControllerSettings()) {
+            addLog(LOG_LEVEL_ERROR, F("C008 : Generic HTTP - Cannot send, out of RAM"));
+            break;
+          }
+          LoadControllerSettings(event->ControllerIndex, ControllerSettings);
+          pubname = ControllerSettings.Publish;
+        }
+
+
         // Collect the values at the same run, to make sure all are from the same sample
         byte valueCount = getValueCountFromSensorType(event->sensorType);
         C008_queue_element element(event, valueCount);
@@ -58,13 +71,6 @@ bool CPlugin_008(CPlugin::Function function, struct EventStruct *event, String& 
           PluginCall(PLUGIN_GET_DEVICEVALUENAMES, event, dummy);
         }
 
-        String pubname;
-        {
-          // Place the ControllerSettings in a scope to free the memory as soon as we got all relevant information.
-          MakeControllerSettings(ControllerSettings);
-          LoadControllerSettings(event->ControllerIndex, ControllerSettings);
-          pubname = ControllerSettings.Publish;
-        }
 
         for (byte x = 0; x < valueCount; x++)
         {

--- a/src/_C008.ino
+++ b/src/_C008.ino
@@ -58,8 +58,13 @@ bool CPlugin_008(CPlugin::Function function, struct EventStruct *event, String& 
           PluginCall(PLUGIN_GET_DEVICEVALUENAMES, event, dummy);
         }
 
-        MakeControllerSettings(ControllerSettings);
-        LoadControllerSettings(event->ControllerIndex, ControllerSettings);
+        String pubname;
+        {
+          // Place the ControllerSettings in a scope to free the memory as soon as we got all relevant information.
+          MakeControllerSettings(ControllerSettings);
+          LoadControllerSettings(event->ControllerIndex, ControllerSettings);
+          pubname = ControllerSettings.Publish;
+        }
 
         for (byte x = 0; x < valueCount; x++)
         {
@@ -67,7 +72,7 @@ bool CPlugin_008(CPlugin::Function function, struct EventStruct *event, String& 
           String formattedValue = formatUserVar(event, x, isvalid);
           if (isvalid) {
             element.txt[x] = "/";
-            element.txt[x] += ControllerSettings.Publish;
+            element.txt[x] += pubname;
             element.txt[x].replace(F("%valname%"), ExtraTaskSettings.TaskDeviceValueNames[x]);
             element.txt[x].replace(F("%value%"), formattedValue);
             parseControllerVariables(element.txt[x], event, true);

--- a/src/_C008.ino
+++ b/src/_C008.ino
@@ -81,7 +81,8 @@ bool CPlugin_008(CPlugin::Function function, struct EventStruct *event, String& 
 #endif
           }
         }
-        success = C008_DelayHandler.addToQueue(element);
+        // FIXME TD-er must define a proper move operator
+        success = C008_DelayHandler.addToQueue(C008_queue_element(element));
         scheduleNextDelayQueue(TIMER_C008_DELAY_QUEUE, C008_DelayHandler.getNextScheduleTime());
         break;
       }

--- a/src/_C009.ino
+++ b/src/_C009.ino
@@ -68,7 +68,8 @@ bool CPlugin_009(CPlugin::Function function, struct EventStruct *event, String& 
         {
           element.txt[x] = formatUserVarNoCheck(event, x);
         }
-        success = C009_DelayHandler.addToQueue(element);
+        // FIXME TD-er must define a proper move operator
+        success = C009_DelayHandler.addToQueue(C009_queue_element(element));
         scheduleNextDelayQueue(TIMER_C009_DELAY_QUEUE, C009_DelayHandler.getNextScheduleTime());
         break;
       }

--- a/src/_C010.ino
+++ b/src/_C010.ino
@@ -63,7 +63,8 @@ bool CPlugin_010(CPlugin::Function function, struct EventStruct *event, String& 
             addLog(LOG_LEVEL_DEBUG_MORE, element.txt[x]);
           }
         }
-        success = C010_DelayHandler.addToQueue(element);
+        // FIXME TD-er must define a proper move operator
+        success = C010_DelayHandler.addToQueue(C010_queue_element(element));
         scheduleNextDelayQueue(TIMER_C010_DELAY_QUEUE, C010_DelayHandler.getNextScheduleTime());
         break;
       }

--- a/src/_C012.ino
+++ b/src/_C012.ino
@@ -60,7 +60,8 @@ bool CPlugin_012(CPlugin::Function function, struct EventStruct *event, String& 
             addLog(LOG_LEVEL_DEBUG_MORE, element.txt[x]);
           }
         }
-        success = C012_DelayHandler.addToQueue(element);
+        // FIXME TD-er must define a proper move operator
+        success = C012_DelayHandler.addToQueue(C012_queue_element(element));
         scheduleNextDelayQueue(TIMER_C012_DELAY_QUEUE, C012_DelayHandler.getNextScheduleTime());
         break;
       }

--- a/src/_C014.ino
+++ b/src/_C014.ino
@@ -37,6 +37,9 @@
 
 byte msgCounter=0; // counter for send Messages (currently for information / log only!
 
+String CPlugin_014_pubname;
+bool CPlugin_014_mqtt_retainFlag;
+
 
 // send MQTT Message with complete Topic / Payload
 bool CPlugin_014_sendMQTTmsg(String& topic, const char* payload, int& errorCounter) {
@@ -157,6 +160,8 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
         MakeControllerSettings(ControllerSettings);
         LoadControllerSettings(event->ControllerIndex, ControllerSettings);
         MQTTDelayHandler.configureControllerSettings(ControllerSettings);
+        CPlugin_014_pubname = ControllerSettings.Publish;
+        CPlugin_014_mqtt_retainFlag = ControllerSettings.mqtt_retainFlag();
         break;
       }
 
@@ -680,15 +685,8 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
 
     case CPlugin::Function::CPLUGIN_PROTOCOL_SEND:
       {
-        String pubname;
-        bool mqtt_retainFlag;
-        {
-          // Place the ControllerSettings in a scope to free the memory as soon as we got all relevant information.
-          MakeControllerSettings(ControllerSettings);
-          LoadControllerSettings(event->ControllerIndex, ControllerSettings);
-          pubname = ControllerSettings.Publish;
-          mqtt_retainFlag = ControllerSettings.mqtt_retainFlag();
-        }
+        String pubname = CPlugin_014_pubname;
+        bool mqtt_retainFlag = CPlugin_014_mqtt_retainFlag;
 
         statusLED(true);
 

--- a/src/_C014.ino
+++ b/src/_C014.ino
@@ -708,9 +708,15 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
         {
           String tmppubname = pubname;
           tmppubname.replace(F("%valname%"), ExtraTaskSettings.TaskDeviceValueNames[x]);
-          value = formatUserVarNoCheck(event, x);
 
-          MQTTpublish(event->ControllerIndex, tmppubname.c_str(), value.c_str(), ControllerSettings.mqtt_retainFlag());
+          // Small optimization so we don't try to copy potentially large strings
+          if (event->sensorType == SENSOR_TYPE_STRING) {
+            MQTTpublish(event->ControllerIndex, tmppubname.c_str(), event->String2.c_str(), ControllerSettings.mqtt_retainFlag());
+            value = event->String2.substring(0, 20); // For the log
+          } else {
+            value = formatUserVarNoCheck(event, x);
+            MQTTpublish(event->ControllerIndex, tmppubname.c_str(), value.c_str(), ControllerSettings.mqtt_retainFlag());
+          }
           if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
             String log = F("C014 : Sent to ");
             log += tmppubname;

--- a/src/_C017.ino
+++ b/src/_C017.ino
@@ -56,7 +56,8 @@ bool CPlugin_017(CPlugin::Function function, struct EventStruct *event, String &
       {
         element.txt[x] = formatUserVarNoCheck(event, x);
       }
-      success = C017_DelayHandler.addToQueue(element);
+      // FIXME TD-er must define a proper move operator
+      success = C017_DelayHandler.addToQueue(C017_queue_element(element));
       scheduleNextDelayQueue(TIMER_C017_DELAY_QUEUE, C017_DelayHandler.getNextScheduleTime());
       break;
     }

--- a/src/_CPlugin_Helper.cpp
+++ b/src/_CPlugin_Helper.cpp
@@ -277,7 +277,7 @@ bool try_connect_host(int controller_number, WiFiUDP& client, ControllerSettings
 #ifndef BUILD_NO_DEBUG
   log_connecting_to(F("UDP  : "), controller_number, ControllerSettings);
 #endif // ifndef BUILD_NO_DEBUG
-  bool success      = ControllerSettings.beginPacket(client) != 0;
+  bool success      = ControllerSettings.beginPacket(client);
   const bool result = count_connection_results(
     success,
     F("UDP  : "), controller_number, ControllerSettings);

--- a/src/_P001_Switch.ino
+++ b/src/_P001_Switch.ino
@@ -164,26 +164,30 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
         globalMapPortStatus[key].previousTask = event->TaskIndex;
       }
 
-      String options[2];
-      options[0] = F("Switch");
-      options[1] = F("Dimmer");
-      int optionValues[2]   = { PLUGIN_001_TYPE_SWITCH, PLUGIN_001_TYPE_DIMMER };
-      const byte switchtype = P001_getSwitchType(event);
-      addFormSelector(F("Switch Type"), F("p001_type"), 2, options, optionValues, switchtype);
-
-      if (switchtype == PLUGIN_001_TYPE_DIMMER)
       {
-        addFormNumericBox(F("Dim value"), F("p001_dimvalue"), PCONFIG(1), 0, 255);
+        String options[2];
+        options[0] = F("Switch");
+        options[1] = F("Dimmer");
+        int optionValues[2]   = { PLUGIN_001_TYPE_SWITCH, PLUGIN_001_TYPE_DIMMER };
+        const byte switchtype = P001_getSwitchType(event);
+        addFormSelector(F("Switch Type"), F("p001_type"), 2, options, optionValues, switchtype);
+
+        if (switchtype == PLUGIN_001_TYPE_DIMMER)
+        {
+          addFormNumericBox(F("Dim value"), F("p001_dimvalue"), PCONFIG(1), 0, 255);
+        }
       }
 
-      byte   choice = PCONFIG(2);
-      String buttonOptions[3];
-      buttonOptions[0] = F("Normal Switch");
-      buttonOptions[1] = F("Push Button Active Low");
-      buttonOptions[2] = F("Push Button Active High");
-      int buttonOptionValues[3] =
-      { PLUGIN_001_BUTTON_TYPE_NORMAL_SWITCH, PLUGIN_001_BUTTON_TYPE_PUSH_ACTIVE_LOW, PLUGIN_001_BUTTON_TYPE_PUSH_ACTIVE_HIGH };
-      addFormSelector(F("Switch Button Type"), F("p001_button"), 3, buttonOptions, buttonOptionValues, choice);
+      {
+        byte   choice = PCONFIG(2);
+        String buttonOptions[3];
+        buttonOptions[0] = F("Normal Switch");
+        buttonOptions[1] = F("Push Button Active Low");
+        buttonOptions[2] = F("Push Button Active High");
+        int buttonOptionValues[3] =
+        { PLUGIN_001_BUTTON_TYPE_NORMAL_SWITCH, PLUGIN_001_BUTTON_TYPE_PUSH_ACTIVE_LOW, PLUGIN_001_BUTTON_TYPE_PUSH_ACTIVE_HIGH };
+        addFormSelector(F("Switch Button Type"), F("p001_button"), 3, buttonOptions, buttonOptionValues, choice);
+      }
 
       addFormCheckBox(F("Send Boot state"), F("p001_boot"),
                       PCONFIG(3));
@@ -197,15 +201,17 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
         PCONFIG_FLOAT(1) = PLUGIN_001_DOUBLECLICK_MIN_INTERVAL;
       }
 
-      byte   choiceDC = PCONFIG(4);
-      String buttonDC[4];
-      buttonDC[0] = F("Disabled");
-      buttonDC[1] = F("Active only on LOW (EVENT=3)");
-      buttonDC[2] = F("Active only on HIGH (EVENT=3)");
-      buttonDC[3] = F("Active on LOW & HIGH (EVENT=3)");
-      int buttonDCValues[4] = { PLUGIN_001_DC_DISABLED, PLUGIN_001_DC_LOW, PLUGIN_001_DC_HIGH, PLUGIN_001_DC_BOTH };
+      {
+        byte   choiceDC = PCONFIG(4);
+        String buttonDC[4];
+        buttonDC[0] = F("Disabled");
+        buttonDC[1] = F("Active only on LOW (EVENT=3)");
+        buttonDC[2] = F("Active only on HIGH (EVENT=3)");
+        buttonDC[3] = F("Active on LOW & HIGH (EVENT=3)");
+        int buttonDCValues[4] = { PLUGIN_001_DC_DISABLED, PLUGIN_001_DC_LOW, PLUGIN_001_DC_HIGH, PLUGIN_001_DC_BOTH };
 
-      addFormSelector(F("Doubleclick event"), F("p001_dc"), 4, buttonDC, buttonDCValues, choiceDC);
+        addFormSelector(F("Doubleclick event"), F("p001_dc"), 4, buttonDC, buttonDCValues, choiceDC);
+      }
 
       addFormNumericBox(F("Doubleclick max. interval (ms)"),
                         F("p001_dcmaxinterval"),
@@ -218,15 +224,17 @@ boolean Plugin_001(byte function, struct EventStruct *event, String& string)
         PCONFIG_FLOAT(2) = PLUGIN_001_LONGPRESS_MIN_INTERVAL;
       }
 
-      byte   choiceLP = PCONFIG(5);
-      String buttonLP[4];
-      buttonLP[0] = F("Disabled");
-      buttonLP[1] = F("Active only on LOW (EVENT= 10 [NORMAL] or 11 [INVERSED])");
-      buttonLP[2] = F("Active only on HIGH (EVENT= 11 [NORMAL] or 10 [INVERSED])");
-      buttonLP[3] = F("Active on LOW & HIGH (EVENT= 10 or 11)");
-      int buttonLPValues[4] =
-      { PLUGIN_001_LONGPRESS_DISABLED, PLUGIN_001_LONGPRESS_LOW, PLUGIN_001_LONGPRESS_HIGH, PLUGIN_001_LONGPRESS_BOTH };
-      addFormSelector(F("Longpress event"), F("p001_lp"), 4, buttonLP, buttonLPValues, choiceLP);
+      {
+        byte   choiceLP = PCONFIG(5);
+        String buttonLP[4];
+        buttonLP[0] = F("Disabled");
+        buttonLP[1] = F("Active only on LOW (EVENT= 10 [NORMAL] or 11 [INVERSED])");
+        buttonLP[2] = F("Active only on HIGH (EVENT= 11 [NORMAL] or 10 [INVERSED])");
+        buttonLP[3] = F("Active on LOW & HIGH (EVENT= 10 or 11)");
+        int buttonLPValues[4] =
+        { PLUGIN_001_LONGPRESS_DISABLED, PLUGIN_001_LONGPRESS_LOW, PLUGIN_001_LONGPRESS_HIGH, PLUGIN_001_LONGPRESS_BOTH };
+        addFormSelector(F("Longpress event"), F("p001_lp"), 4, buttonLP, buttonLPValues, choiceLP);
+      }
 
       addFormNumericBox(F("Longpress min. interval (ms)"),
                         F("p001_lpmininterval"),

--- a/src/_P033_Dummy.ino
+++ b/src/_P033_Dummy.ino
@@ -41,6 +41,7 @@ boolean Plugin_033(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_GET_DEVICEVALUENAMES:
       {
+        // FIXME TD-er: Copy names as done in P026_Sysinfo.ino.
         strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[0], PSTR(PLUGIN_VALUENAME1_033));
         break;
       }

--- a/src/_P037_MQTTImport.ino
+++ b/src/_P037_MQTTImport.ino
@@ -377,19 +377,17 @@ void mqttcallback_037(char* c_topic, byte* b_payload, unsigned int length)
     return;
   }
 
-  // We generate a temp event structure to pass to the plugins
-
-  struct EventStruct TempEvent;
-
-  TempEvent.String1 = topic;                            // This is the topic of the message
-  TempEvent.String2 = payload;                          // This is the payload
-
   //  Here we loop over all tasks and call each 037 plugin with function PLUGIN_IMPORT
 
   for (taskIndex_t y = 0; y < TASKS_MAX; y++)
   {
     if (Settings.TaskDeviceNumber[y] == PLUGIN_ID_037)                // if we have found a 037 device, then give it something to think about!
     {
+      // We generate a temp event structure to pass to the plugins
+      struct EventStruct TempEvent;
+
+      TempEvent.String1 = topic;                            // This is the topic of the message
+      TempEvent.String2 = payload;                          // This is the payload
       TempEvent.TaskIndex = y;
       LoadTaskSettings(TempEvent.TaskIndex);
       TempEvent.BaseVarIndex = y * VARS_PER_TASK;           // This is the index in Uservar where values for this task are stored
@@ -423,6 +421,11 @@ boolean MQTTConnect_037()
     return false; // Not connected, so no use in wasting time to connect to a host.
   }
   MakeControllerSettings(ControllerSettings);
+  if (!AllocatedControllerSettings()) {
+    addLog(LOG_LEVEL_ERROR, F("IMPT : Cannot load controller settings, out of RAM"));
+    return false;
+  }
+
   LoadControllerSettings(enabledMqttController, ControllerSettings);
   if (ControllerSettings.UseDNS) {
     MQTTclient_037->setServer(ControllerSettings.getHost().c_str(), ControllerSettings.Port);

--- a/src/_P044_P1WifiGateway.ino
+++ b/src/_P044_P1WifiGateway.ino
@@ -64,7 +64,7 @@ struct P044_Task : public PluginTaskData_base {
     stopServer();
     gatewayPort = portnumber;
     P1GatewayServer = new WiFiServer(portnumber);
-    if (nullptr != P1GatewayServer && WiFiConnected()) {
+    if (nullptr != P1GatewayServer && NetworkConnected()) {
       P1GatewayServer->begin();
       if(serverActive(P1GatewayServer)) {
         addLog(LOG_LEVEL_INFO, String(F("P1   : WiFi server started at port ")) + portnumber);
@@ -76,7 +76,7 @@ struct P044_Task : public PluginTaskData_base {
   }
 
   void checkServer() {
-    if (nullptr != P1GatewayServer && !serverActive(P1GatewayServer) && WiFiConnected()) {
+    if (nullptr != P1GatewayServer && !serverActive(P1GatewayServer) && NetworkConnected()) {
       P1GatewayServer->close();
       P1GatewayServer->begin();
       if(serverActive(P1GatewayServer)) {

--- a/src/src/Commands/Blynk.cpp
+++ b/src/src/Commands/Blynk.cpp
@@ -86,14 +86,17 @@ bool Blynk_get(const String& command, controllerIndex_t controllerIndex, float *
 
 
   // We now create a URI for the request
-  char request[300] = { 0 };
-  sprintf_P(request,
-            PSTR("GET /%s/%s HTTP/1.1\r\n Host: %s \r\n Connection: close\r\n\r\n"),
-            getControllerPass(controllerIndex, ControllerSettings).c_str(),
-            command.c_str(),
-            ControllerSettings.getHost().c_str());
-  addLog(LOG_LEVEL_DEBUG, request);
-  client.print(request);
+  {
+    // Place this stack allocated array in its own scope, as it is quite big.
+    char request[300] = { 0 };
+    sprintf_P(request,
+              PSTR("GET /%s/%s HTTP/1.1\r\n Host: %s \r\n Connection: close\r\n\r\n"),
+              getControllerPass(controllerIndex, ControllerSettings).c_str(),
+              command.c_str(),
+              ControllerSettings.getHost().c_str());
+    addLog(LOG_LEVEL_DEBUG, request);
+    client.print(request);
+  }
   bool success = !ControllerSettings.MustCheckReply;
 
   if (ControllerSettings.MustCheckReply || data) {

--- a/src/src/Commands/Blynk.cpp
+++ b/src/src/Commands/Blynk.cpp
@@ -66,6 +66,11 @@ String Command_Blynk_Get(struct EventStruct *event, const char *Line)
 bool Blynk_get(const String& command, controllerIndex_t controllerIndex, float *data)
 {
   MakeControllerSettings(ControllerSettings);
+  if (!AllocatedControllerSettings()) {
+    addLog(LOG_LEVEL_ERROR, F("Blynk : Cannot run GET, out of RAM"));
+    return false;
+  }
+
   LoadControllerSettings(controllerIndex, ControllerSettings);
 
   if ((getControllerPass(controllerIndex, ControllerSettings).length() == 0)) {

--- a/src/src/Commands/MQTT.cpp
+++ b/src/src/Commands/MQTT.cpp
@@ -34,6 +34,12 @@ String Command_MQTT_Publish(struct EventStruct *event, const char *Line)
     {
       // Place the ControllerSettings in a scope to free the memory as soon as we got all relevant information.
       MakeControllerSettings(ControllerSettings);
+      if (!AllocatedControllerSettings()) {
+        String error = F("MQTT : Cannot publish, out of RAM");
+        addLog(LOG_LEVEL_ERROR, error);
+        return error;
+      }
+
       LoadControllerSettings(event->ControllerIndex, ControllerSettings);
       mqtt_retainFlag = ControllerSettings.mqtt_retainFlag();
     }
@@ -81,6 +87,11 @@ String Command_MQTT_Subscribe(struct EventStruct *event, const char* Line)
       {
         // Place the ControllerSettings in a scope to free the memory as soon as we got all relevant information.
         MakeControllerSettings(ControllerSettings);
+        if (!AllocatedControllerSettings()) {
+          String error = F("MQTT : Cannot subscribe, out of RAM");
+          addLog(LOG_LEVEL_ERROR, error);
+          return error;
+        }
         LoadControllerSettings(event->ControllerIndex, ControllerSettings);
         mqtt_retainFlag = ControllerSettings.mqtt_retainFlag();
       }

--- a/src/src/Commands/MQTT.cpp
+++ b/src/src/Commands/MQTT.cpp
@@ -29,8 +29,14 @@ String Command_MQTT_Publish(struct EventStruct *event, const char *Line)
   addLog(LOG_LEVEL_DEBUG, String(F("Publish: ")) + topic + value);
 
   if ((topic.length() > 0) && (value.length() > 0)) {
-    MakeControllerSettings(ControllerSettings);
-    LoadControllerSettings(enabledMqttController, ControllerSettings);
+
+    bool mqtt_retainFlag;
+    {
+      // Place the ControllerSettings in a scope to free the memory as soon as we got all relevant information.
+      MakeControllerSettings(ControllerSettings);
+      LoadControllerSettings(event->ControllerIndex, ControllerSettings);
+      mqtt_retainFlag = ControllerSettings.mqtt_retainFlag();
+    }
 
 
     // @giig1967g: if payload starts with '=' then treat it as a Formula and evaluate accordingly
@@ -40,10 +46,10 @@ String Command_MQTT_Publish(struct EventStruct *event, const char *Line)
 
     bool success = false;
     if (value[0] != '=') {
-      success = MQTTpublish(enabledMqttController, topic.c_str(), value.c_str(), ControllerSettings.mqtt_retainFlag());
+      success = MQTTpublish(enabledMqttController, topic.c_str(), value.c_str(), mqtt_retainFlag);
     }
     else {
-      success = MQTTpublish(enabledMqttController, topic.c_str(), String(event->Par2).c_str(), ControllerSettings.mqtt_retainFlag());
+      success = MQTTpublish(enabledMqttController, topic.c_str(), String(event->Par2).c_str(), mqtt_retainFlag);
     }
     if (success) {
       return return_command_success();
@@ -71,12 +77,17 @@ String Command_MQTT_Subscribe(struct EventStruct *event, const char* Line)
     // ToDo TD-er: Not sure about this function, but at least it sends to an existing MQTTclient
     controllerIndex_t enabledMqttController = firstEnabledMQTT_ControllerIndex();
     if (validControllerIndex(enabledMqttController)) {
-      MakeControllerSettings(ControllerSettings);
-      LoadControllerSettings(enabledMqttController, ControllerSettings);
+      bool mqtt_retainFlag;
+      {
+        // Place the ControllerSettings in a scope to free the memory as soon as we got all relevant information.
+        MakeControllerSettings(ControllerSettings);
+        LoadControllerSettings(event->ControllerIndex, ControllerSettings);
+        mqtt_retainFlag = ControllerSettings.mqtt_retainFlag();
+      }
 
       String eventName = Line;
       String topic = eventName.substring(10);
-      if (!MQTTsubscribe(enabledMqttController, topic.c_str(), ControllerSettings.mqtt_retainFlag()))
+      if (!MQTTsubscribe(enabledMqttController, topic.c_str(), mqtt_retainFlag))
          return_command_failed();
       return_command_success();
     }

--- a/src/src/ControllerQueue/ControllerDelayHandlerStruct.h
+++ b/src/src/ControllerQueue/ControllerDelayHandlerStruct.h
@@ -82,7 +82,7 @@ struct ControllerDelayHandlerStruct {
 
   // Try to add to the queue, if permitted by "delete_oldest"
   // Return false when no item was added.
-  bool addToQueue(const T& element) {
+  bool addToQueue(T&& element) {
     if (delete_oldest) {
       // Force add to the queue.
       // If max buffer is reached, the oldest in the queue (first to be served) will be removed.

--- a/src/src/ControllerQueue/queue_element_single_value_base.cpp
+++ b/src/src/ControllerQueue/queue_element_single_value_base.cpp
@@ -11,6 +11,19 @@ queue_element_single_value_base::queue_element_single_value_base(const struct Ev
   valuesSent(0),
   valueCount(value_count) {}
 
+/*
+queue_element_single_value_base::queue_element_single_value_base(queue_element_single_value_base &&rval)
+: idx(rval.idx), TaskIndex(rval.TaskIndex), 
+  controller_idx(rval.controller_idx), 
+  valuesSent(rval.valuesSent), valueCount(rval.valueCount)
+{
+  for (byte i = 0; i < VARS_PER_TASK; ++i) {
+    String tmp(std::move(rval.txt[i]));
+    txt[i] = tmp;
+  }
+}
+*/
+
 bool queue_element_single_value_base::checkDone(bool succesfull) const {
   if (succesfull) { ++valuesSent; }
   return valuesSent >= valueCount || valuesSent >= VARS_PER_TASK;

--- a/src/src/ControllerQueue/queue_element_single_value_base.h
+++ b/src/src/ControllerQueue/queue_element_single_value_base.h
@@ -21,6 +21,8 @@ public:
   queue_element_single_value_base(const struct EventStruct *event,
                                   byte                      value_count);
 
+//  queue_element_single_value_base(queue_element_single_value_base &&rval);
+
   bool   checkDone(bool succesfull) const;
 
   size_t getSize() const;

--- a/src/src/DataStructs/ControllerSettingsStruct.h
+++ b/src/src/DataStructs/ControllerSettingsStruct.h
@@ -57,8 +57,8 @@ struct ControllerSettingsStruct
   //   IDs of controller settings, used to generate web forms
   // ********************************************************************************
   enum VarType {
-    CONTROLLER_USE_DNS = 0,                   // PLace this before HOSTNAME/IP
-    CONTROLLER_USE_EXTENDED_CREDENTIALS = 1,  // Place this before USER/PASS
+    CONTROLLER_USE_DNS                  = 0, // PLace this before HOSTNAME/IP
+    CONTROLLER_USE_EXTENDED_CREDENTIALS = 1, // Place this before USER/PASS
     CONTROLLER_HOSTNAME,
     CONTROLLER_IP,
     CONTROLLER_PORT,
@@ -92,6 +92,8 @@ struct ControllerSettingsStruct
 
   void      reset();
 
+  bool      isSet() const;
+
   void      validate();
 
   IPAddress getIP() const;
@@ -100,12 +102,11 @@ struct ControllerSettingsStruct
 
   void      setHostname(const String& controllerhostname);
 
-  boolean   checkHostReachable(bool quick);
+  bool      checkHostReachable(bool quick);
 
-  boolean   connectToHost(WiFiClient& client);
+  bool      connectToHost(WiFiClient& client);
 
-  // Returns 1 if successful, 0 if there was a problem resolving the hostname or port
-  int       beginPacket(WiFiUDP& client);
+  bool      beginPacket(WiFiUDP& client);
 
   String    getHostPortString() const;
 
@@ -140,16 +141,16 @@ struct ControllerSettingsStruct
   unsigned int MinimalTimeBetweenMessages;
   unsigned int MaxQueueDepth;
   unsigned int MaxRetry;
-  boolean      DeleteOldest;       // Action to perform when buffer full, delete oldest, or ignore newest.
+  bool         DeleteOldest;       // Action to perform when buffer full, delete oldest, or ignore newest.
   unsigned int ClientTimeout;
-  boolean      MustCheckReply;     // When set to false, a sent message is considered always successful.
+  bool         MustCheckReply;     // When set to false, a sent message is considered always successful.
   taskIndex_t  SampleSetInitiator; // The first task to start a sample set.
   uint32_t     MQTT_flags;         // Various flags for MQTT controllers
   char         ClientID[65];       // Used to define the Client ID used by the controller
 
 private:
 
-  bool ipSet();
+  bool ipSet() const;
 
   bool updateIPcache();
 };

--- a/src/src/DataStructs/ControllerSettingsStruct.h
+++ b/src/src/DataStructs/ControllerSettingsStruct.h
@@ -159,4 +159,7 @@ typedef std::shared_ptr<ControllerSettingsStruct> ControllerSettingsStruct_ptr_t
 #define MakeControllerSettings(T) ControllerSettingsStruct_ptr_type ControllerSettingsStruct_ptr(new ControllerSettingsStruct()); \
   ControllerSettingsStruct& (T) = *ControllerSettingsStruct_ptr;
 
+// Check to see if MakeControllerSettings was successful
+#define AllocatedControllerSettings() (ControllerSettingsStruct_ptr.get() != nullptr)
+
 #endif // DATASTRUCTS_CONTROLLERSETTINGSSTRUCT_H


### PR DESCRIPTION
Loading of the Controller settings was done a lot and this controller settings struct is also quite large.
On fragmented memory it is possible this would lead to a crash.

For a lot of calls only a single string and/or bool was needed, so these can be cached in the controller itself.
Also the MQTT publish calls were making quite a lot of rather large copy calls when handling the strings for the topic and the message.

This also could lead to some very strange and hard to reproduce crashes.
