### PR TITLE
[Transformation] Optimizations for Password transformation

### DIFF
--- a/docs/source/Rules/Rules.rst
+++ b/docs/source/Rules/Rules.rst
@@ -421,7 +421,7 @@ Floating point transformations:
 Other transformations:
 
 * ``p``: Password display, replacing all value characters by asterisks ``*``. If the value is "0", nothing will be displayed.
-* ``Pc``: Password display with custom character ``c``. For example P- will display value "123" as "---". If the value is "0", nothing will be displayed.
+* ``pc``: Password display with custom character ``c``. For example p- will display value "123" as "---". If the value is "0", nothing will be displayed.
 
 Justification
 ^^^^^^^^^^^^^

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -1991,29 +1991,19 @@ void transformValue(
           {
           case 'V': //value = value without transformations
             break;
-          case 'P': // Password hide using a custom password character: Pc
-            if (tempValueFormatLength > 1)
+          case 'p': // Password hide using asterisks or custom character: pc
             {
-              if (value == F("0")) {
-                value = "";
-              } else {
-                const int valueLength = value.length();
-                for (int i = 0; i < valueLength; i++) {
-                  value[i] = tempValueFormat[1];
-                }
+              char maskChar = '*';
+              if (tempValueFormatLength > 1)
+              {
+                maskChar = tempValueFormat[1];
               }
-            } else {
-              value = F("ERR");
-            }
-            break;
-          case 'p': // Password hide using asterisks
-            {
               if (value == F("0")) {
                 value = "";
               } else {
                 const int valueLength = value.length();
                 for (int i = 0; i < valueLength; i++) {
-                  value[i] = '*';
+                  value[i] = maskChar;
                 }
               }
             }


### PR DESCRIPTION
2 optimizations (I wanted to do this before the original transformation got merged, but that happened quicker then I expected 😄)
- Shaved off 64 bytes of compiled code by 'merging' P and p transformations into 1, with * being the default password character
- Freeing up 'P' from being used as a transformation option (expect nobody is using that yet, as it hasn't been in a release...)