### PR TITLE
[TaskDisable] Bugfix for plugins without PLUGIN_EXIT implementation

### DIFF
--- a/src/src/Commands/Tasks.cpp
+++ b/src/src/Commands/Tasks.cpp
@@ -55,8 +55,6 @@ String Command_Task_Disable(struct EventStruct *event, const char *Line)
     PluginCall(PLUGIN_EXIT, event, dummy);
     if (setTaskEnableStatus(taskIndex, false)) {
       return return_command_success();
-    } else {
-      return return_command_failed();
     }
   }
   return return_command_failed();

--- a/src/src/Commands/Tasks.cpp
+++ b/src/src/Commands/Tasks.cpp
@@ -51,7 +51,7 @@ String Command_Task_Disable(struct EventStruct *event, const char *Line)
   unsigned int varNr;
   String dummy;
 
-  if (validTaskVars(event, taskIndex, varNr) && PluginCall(PLUGIN_EXIT, event, dummy) && setTaskEnableStatus(taskIndex, false)) {
+  if (validTaskVars(event, taskIndex, varNr) && (PluginCall(PLUGIN_EXIT, event, dummy) || true) && setTaskEnableStatus(taskIndex, false)) {
     return return_command_success();
   }
   return return_command_failed();

--- a/src/src/Commands/Tasks.cpp
+++ b/src/src/Commands/Tasks.cpp
@@ -51,8 +51,13 @@ String Command_Task_Disable(struct EventStruct *event, const char *Line)
   unsigned int varNr;
   String dummy;
 
-  if (validTaskVars(event, taskIndex, varNr) && (PluginCall(PLUGIN_EXIT, event, dummy) || true) && setTaskEnableStatus(taskIndex, false)) {
-    return return_command_success();
+  if (validTaskVars(event, taskIndex, varNr)) {
+    PluginCall(PLUGIN_EXIT, event, dummy);
+    if (setTaskEnableStatus(taskIndex, false)) {
+      return return_command_success();
+    } else {
+      return return_command_failed();
+    }
   }
   return return_command_failed();
 }


### PR DESCRIPTION
Fixes #3153 

When there is no PLUGIN_EXIT implementation, the return value is false, and the plugin wasn't disabled. This fixes that situation.