### PR TITLE
[Syslog] Fix crash with syslog enabled on wifi (re)connect (#3147 #3072)

### DIFF
--- a/src/ESPEasy_Log.h
+++ b/src/ESPEasy_Log.h
@@ -25,9 +25,6 @@ String getLogLevelDisplayString(int logLevel);
 
 String getLogLevelDisplayStringFromIndex(byte index, int& logLevel);
 
-void addToLog(byte loglevel, const String& string);
-void addToLog(byte logLevel, const __FlashStringHelper* flashString);
-
 void disableSerialLog();
 
 void setLogLevelFor(byte destination, byte logLevel);
@@ -44,6 +41,8 @@ bool loglevelActiveFor(byte destination, byte logLevel);
 
 
 bool loglevelActive(byte logLevel, byte logLevelSettings);
+
+void addToLog(byte loglevel, const String& string);
 
 void addToLog(byte logLevel, const char *line);
 

--- a/src/Serial.ino
+++ b/src/Serial.ino
@@ -46,8 +46,7 @@ void serial()
 
 void addToSerialBuffer(const char *line) {
   process_serialWriteBuffer(); // Try to make some room first.
-  const size_t line_length = strlen(line);
-  int roomLeft             = getMaxFreeBlock();
+  int roomLeft = getMaxFreeBlock();
 
   if (roomLeft < 1000) {
     roomLeft = 0;                              // Do not append to buffer.
@@ -57,12 +56,15 @@ void addToSerialBuffer(const char *line) {
     roomLeft -= 4000;                          // leave some free for normal use.
   }
 
-  if (roomLeft > 0) {
-    size_t pos = 0;
-
-    while (pos < line_length && pos < static_cast<size_t>(roomLeft)) {
-      serialWriteBuffer.push_back(line[pos]);
-      ++pos;
+  const char* c = line;
+  while (roomLeft > 0) {
+    // Must use PROGMEM aware functions here.
+    char ch = pgm_read_byte(c++);
+    if (ch == '\0') {
+      return;
+    } else {
+      serialWriteBuffer.push_back(ch);
+      --roomLeft;
     }
   }
 }
@@ -82,10 +84,11 @@ void process_serialWriteBuffer() {
 
     if (snip < bytes_to_write) { bytes_to_write = snip; }
 
-    for (size_t i = 0; i < bytes_to_write; ++i) {
+    while (bytes_to_write > 0) {
       const char c = serialWriteBuffer.front();
       Serial.write(c);
       serialWriteBuffer.pop_front();
+      --bytes_to_write;
     }
   }
 }

--- a/src/src/DataStructs/LogStruct.cpp
+++ b/src/src/DataStructs/LogStruct.cpp
@@ -20,7 +20,9 @@ void LogStruct::add(const byte loglevel, const char *line) {
   }
   timeStamp[write_idx] = millis();
   log_level[write_idx] = loglevel;
-  unsigned linelength = strlen(line);
+
+  // Must use PROGMEM aware functions here to process line
+  unsigned linelength = strlen_P(line);
 
   if (linelength > LOG_STRUCT_MESSAGE_SIZE - 1) {
     linelength = LOG_STRUCT_MESSAGE_SIZE - 1;
@@ -28,8 +30,9 @@ void LogStruct::add(const byte loglevel, const char *line) {
   Message[write_idx] = "";
   Message[write_idx].reserve(linelength);
 
+  const char* c = line;
   for (unsigned i = 0; i < linelength; ++i) {
-    Message[write_idx] += *(line + i);
+    Message[write_idx] += static_cast<char>(pgm_read_byte(c++));
   }
 }
 


### PR DESCRIPTION
Fixes: #3147
Fixes: #3072

It appeared the log handling function was sometimes processing flash strings or progmem strings and thus crashing with an exception.

Crashes like these:
```
 ets Jan  8 2013,rst cause:4, boot mode:(3,6)

0x40275929 in String::operator=(char const*) at ??:?
0x4022cab9 in process_serialWriteBuffer() at ??:?
0x4023532b in addToSerialBuffer(char const*) at ??:?
0x402756a0 in String::copy(char const*, unsigned int) at ??:?
0x40238bd3 in addToLog(unsigned char, char const*) at ??:?
0x40275cac in String::concat(String const&) at ??:?
0x402b3849 in wifi_station_get_rssi at ??:?
0x402754bd in String::invalidate() at ??:?
0x40238c88 in addToLog(unsigned char, String const&) at ??:?
0x4025be2a in WiFiConnected() at ??:?
0x4025a500 in NetworkConnected() at ??:?
0x402cd8b0 in chip_v6_unset_chanfreq at ??:?
0x40238a9e in syslog(unsigned char, char const*) at ??:?
0x4021ebd3 in getMaxFreeBlock() at ??:?
0x4022cab9 in process_serialWriteBuffer() at ??:?
0x402754bd in String::invalidate() at ??:?
0x40238c25 in addToLog(unsigned12484 : Info  : EVENT: Clock#Time=Mon,11:27
```