### PR TITLE
[Build] Add P029 to PLUGIN_SET_ONLY_SWITCH

### DIFF
--- a/src/define_plugin_sets.h
+++ b/src/define_plugin_sets.h
@@ -233,6 +233,9 @@ To create/register a plugin, you have to :
 #ifdef USES_DOMOTICZ
     #define USES_C001   // Domoticz HTTP
     #define USES_C002   // Domoticz MQTT
+    #ifndef USES_P029
+      #define USES_P029   // Output
+    #endif
 #endif
 
 #ifdef USES_FHEM
@@ -447,6 +450,7 @@ To create/register a plugin, you have to :
     #define PLUGIN_SET_ONLY_SWITCH
     #define CONTROLLER_SET_STABLE
     #define NOTIFIER_SET_STABLE
+    #define USES_P029   // Output
 #endif
 
 #ifdef PLUGIN_SET_SHELLY_PLUG_S
@@ -455,6 +459,7 @@ To create/register a plugin, you have to :
     #define PLUGIN_SET_ONLY_SWITCH
     #define CONTROLLER_SET_STABLE
     #define NOTIFIER_SET_STABLE
+    #define USES_P029   // Output
     #define USES_P076   // HWL8012   in POW r1
     #define USES_P081   // Cron
 #endif
@@ -574,9 +579,6 @@ To create/register a plugin, you have to :
     #endif
     #ifndef USES_P026
       #define USES_P026   // SysInfo
-    #endif
-    #ifndef USES_P029
-      #define USES_P029   // Output
     #endif
     #ifndef USES_P033
       #define USES_P033   // Dummy

--- a/src/define_plugin_sets.h
+++ b/src/define_plugin_sets.h
@@ -442,7 +442,6 @@ To create/register a plugin, you have to :
     #define PLUGIN_SET_ONLY_SWITCH
     #define CONTROLLER_SET_STABLE
     #define NOTIFIER_SET_STABLE
-    #define USES_P029   // Output
 #endif
 
 #ifdef PLUGIN_SET_SHELLY_PLUG_S
@@ -451,7 +450,6 @@ To create/register a plugin, you have to :
     #define PLUGIN_SET_ONLY_SWITCH
     #define CONTROLLER_SET_STABLE
     #define NOTIFIER_SET_STABLE
-    #define USES_P029   // Output
     #define USES_P076   // HWL8012   in POW r1
     #define USES_P081   // Cron
 #endif

--- a/src/define_plugin_sets.h
+++ b/src/define_plugin_sets.h
@@ -230,14 +230,6 @@ To create/register a plugin, you have to :
     #endif
 #endif
 
-#ifdef USES_DOMOTICZ
-    #define USES_C001   // Domoticz HTTP
-    #define USES_C002   // Domoticz MQTT
-    #ifndef USES_P029
-      #define USES_P029   // Output
-    #endif
-#endif
-
 #ifdef USES_FHEM
     #define USES_C009   // FHEM HTTP
 #endif
@@ -1025,6 +1017,18 @@ To create/register a plugin, you have to :
   #ifndef USES_DOMOTICZ
     #define USES_DOMOTICZ
   #endif
+#endif
+
+#ifdef USES_DOMOTICZ  // Move Domoticz enabling logic together
+    #ifndef USES_C001
+      #define USES_C001   // Domoticz HTTP
+    #endif
+    #ifndef USES_C002
+      #define USES_C002   // Domoticz MQTT
+    #endif
+    #ifndef USES_P029
+      #define USES_P029   // Output
+    #endif
 #endif
 
 #if defined(USES_C002) || defined (USES_C005) || defined(USES_C006) || defined(USES_C014) || defined(USES_P037)

--- a/src/define_plugin_sets.h
+++ b/src/define_plugin_sets.h
@@ -575,6 +575,9 @@ To create/register a plugin, you have to :
     #ifndef USES_P026
       #define USES_P026   // SysInfo
     #endif
+    #ifndef USES_P029
+      #define USES_P029   // Output
+    #endif
     #ifndef USES_P033
       #define USES_P033   // Dummy
     #endif


### PR DESCRIPTION
When experimenting with the Shelly 1PM I found that the PLUGIN_SET_ONLY_SWITCH didn't have the Domoticz helper plugin, but that plugin is rather convenient to have when using Domoticz, IMHO way easier than using the MQTT input plugin (that also requires a MQTT controller installed for your Domoticz server).
It does add ~492 bytes to the code though, but most ONLY_SWITCH configs should have enough space to still allow OTA updates.