### PR TITLE
[P010] Changes to enable use on ESP32 (#3175)

### DIFF
--- a/lib/AS_BH1750/AS_BH1750.h
+++ b/lib/AS_BH1750/AS_BH1750.h
@@ -27,6 +27,10 @@
 #ifndef AS_BH1750_h
 #define AS_BH1750_h
 
+// #ifndef ARDUINO
+//   #define ARDUINO 100
+// #endif
+
 #if (ARDUINO >= 100)
 #include <Arduino.h>
 #else
@@ -87,7 +91,12 @@ typedef enum
   }  
   sensors_resolution_t;
 
+#ifdef ESP32
+typedef void (*DelayFuncPtr)(uint32_t);
+#endif
+#ifdef ESP8266
 typedef void (*DelayFuncPtr)(unsigned long);
+#endif
 typedef unsigned long (*TimeFuncPtr)(void);
 
 /**

--- a/lib/AS_BH1750/AS_BH1750.h
+++ b/lib/AS_BH1750/AS_BH1750.h
@@ -27,10 +27,6 @@
 #ifndef AS_BH1750_h
 #define AS_BH1750_h
 
-// #ifndef ARDUINO
-//   #define ARDUINO 100
-// #endif
-
 #if (ARDUINO >= 100)
 #include <Arduino.h>
 #else

--- a/lib/AS_BH1750/AS_BH1750A.h
+++ b/lib/AS_BH1750/AS_BH1750A.h
@@ -89,7 +89,12 @@ typedef enum
   }  
   sensors_resolution_t;
 
+#ifdef ESP32
+typedef void (*DelayFuncPtr)(uint32_t);
+#endif
+#ifdef ESP8266
 typedef void (*DelayFuncPtr)(unsigned long);
+#endif
 typedef unsigned long (*TimeFuncPtr)(void);
 
 /**

--- a/platformio_esp32_envs.ini
+++ b/platformio_esp32_envs.ini
@@ -9,7 +9,7 @@
 [esp32_common]
 extends                   = common
 platform                  = ${core_esp32_1_12_2.platform}
-lib_ignore                = AS_BH1750, ESP8266WiFi, ESP8266Ping, ESP8266WebServer, ESP8266HTTPUpdateServer, ESP8266mDNS, IRremoteESP8266, ESPEasy_ESP8266Ping, ESP32_ping, HeatpumpIR
+lib_ignore                = ESP8266WiFi, ESP8266Ping, ESP8266WebServer, ESP8266HTTPUpdateServer, ESP8266mDNS, IRremoteESP8266, ESPEasy_ESP8266Ping, ESP32_ping, HeatpumpIR
 lib_deps                  = https://github.com/TD-er/ESPEasySerial.git#v2.0.3, Adafruit ILI9341,  Adafruit GFX Library, LOLIN_EPD, Adafruit BusIO
 board_build.f_flash       = 80000000L
 board_build.flash_mode    = dout

--- a/src/_P010_BH1750.ino
+++ b/src/_P010_BH1750.ino
@@ -6,9 +6,9 @@
 //#######################################################################################################
 
 
-#ifdef ESP8266  // Needed for precompile issues.
+//#ifdef ESP8266  // Needed for precompile issues.
 #include "AS_BH1750.h"
-#endif
+//#endif
 
 #define PLUGIN_010
 #define PLUGIN_ID_010         10

--- a/src/define_plugin_sets.h
+++ b/src/define_plugin_sets.h
@@ -959,7 +959,7 @@ To create/register a plugin, you have to :
  * Remove incompatible plugins ************************************************
 \******************************************************************************/
 #ifdef PLUGIN_SET_TEST_ESP32
-  #undef USES_P010   // BH1750          (doesn't work yet on ESP32)
+//  #undef USES_P010   // BH1750          (doesn't work yet on ESP32)
 //  #undef USES_P049   // MHZ19           (doesn't work yet on ESP32)
 
 //  #undef USES_P052   // SenseAir        (doesn't work yet on ESP32)


### PR DESCRIPTION
- Fixed compile errors to allow inclusion in ESP32 release
- Adjust build configuration to not explicitly exclude the needed library
- Don't disable plugin for ESP32 builds

@TD-er :
Not sure if the `#typedef` should also be used for ESP8266?

Resolves #3175 