### PR TITLE
[GPS] Apply sanity check on received data.

### DIFF
--- a/lib/TinyGPSPlus-1.0.2/src/TinyGPS++.cpp
+++ b/lib/TinyGPSPlus-1.0.2/src/TinyGPS++.cpp
@@ -41,6 +41,7 @@ TinyGPSPlus::TinyGPSPlus()
   ,  sentencesWithFixCount(0)
   ,  failedChecksumCount(0)
   ,  passedChecksumCount(0)
+  ,  invalidDataCount(0)
 {
   term[0] = '\0';
 }
@@ -57,6 +58,7 @@ bool TinyGPSPlus::encode(char c)
   {
   case ',': // term terminators
     parity ^= (uint8_t)c;
+    // fall through
   case '\r':
   case '\n':
   case '*':
@@ -81,14 +83,14 @@ bool TinyGPSPlus::encode(char c)
     curSentenceSystem = GPS_SYSTEM_GPS;
     isChecksumTerm = false;
     sentenceHasFix = false;
-    return false;
+    break;
 
   default: // ordinary characters
     if (curTermOffset < sizeof(term) - 1)
       term[curTermOffset++] = c;
     if (!isChecksumTerm)
       parity ^= c;
-    return false;
+    break;
   }
 
   return false;
@@ -128,22 +130,34 @@ int32_t TinyGPSPlus::parseDecimal(const char *term)
 // Parse degrees in that funny NMEA format DDMM.MMMM
 void TinyGPSPlus::parseDegrees(const char *term, RawDegrees &deg)
 {
-  uint32_t leftOfDecimal = (uint32_t)atol(term);
-  uint16_t minutes = (uint16_t)(leftOfDecimal % 100);
+  deg.deg = 181; // Set to invalid value
+  if (!isdigit(*term) && *term != '.') {
+    // An invalid character
+    // TODO: Must check if the degree is allowed to start with a decimal point.
+    return;
+  }
+
+  const uint32_t leftOfDecimal = (uint32_t)atol(term);
+
+  while (isdigit(*term)) {
+    ++term;
+  }
+
+  if (*term != '.') {
+    // Degree must have a decimal point
+    return;
+  }
+
+  deg.deg = (int16_t)(leftOfDecimal / 100);
+  const uint16_t minutes = (uint16_t)(leftOfDecimal % 100);
   uint32_t multiplier = 10000000UL;
   uint32_t tenMillionthsOfMinutes = minutes * multiplier;
 
-  deg.deg = (int16_t)(leftOfDecimal / 100);
-
-  while (isdigit(*term))
-    ++term;
-
-  if (*term == '.')
-    while (isdigit(*++term))
-    {
-      multiplier /= 10;
-      tenMillionthsOfMinutes += (*term - '0') * multiplier;
-    }
+  while (isdigit(*++term))
+  {
+    multiplier /= 10;
+    tenMillionthsOfMinutes += (*term - '0') * multiplier;
+  }
 
   deg.billionths = (5 * tenMillionthsOfMinutes + 1) / 3;
   deg.negative = false;
@@ -170,22 +184,41 @@ bool TinyGPSPlus::endOfTermHandler()
       case GPS_SENTENCE_GPRMC:
         date.commit();
         time.commit();
-        if (sentenceHasFix)
+        if (sentenceHasFix && date.valid && time.valid)
         {
            location.commit();
            speed.commit();
            course.commit();
+           if (!(location.valid && speed.valid && course.valid)) {
+              // one of them is invalid, so consider the entire sentence invalid
+              date.valid = false;
+              time.valid = false;
+              location.valid = false;
+              speed.valid = false;
+              course.valid = false;
+              ++invalidDataCount;
+           }
         }
         break;
       case GPS_SENTENCE_GPGGA:
         time.commit();
-        if (sentenceHasFix)
+        satellites.commit();
+        hdop.commit();
+        if (sentenceHasFix && time.valid)
         {
           location.commit();
           altitude.commit();
+          if (!(satellites.valid && hdop.valid && location.valid && altitude.valid)) {
+            // one of them is invalid, so consider the entire sentence invalid
+            time.valid = false;
+            satellites.valid = false;
+            hdop.valid = false;
+            location.valid = false;
+            altitude.valid = false;
+            ++invalidDataCount;
+          }
         }
-        satellites.commit();
-        hdop.commit();
+ 
         break;
       case GPS_SENTENCE_GPGSV:
         satellitesStats.commit();
@@ -376,12 +409,13 @@ const char *TinyGPSPlus::cardinal(double course)
 
 void TinyGPSLocation::commit()
 {
-   rawLatData = rawNewLatData;
-   rawLngData = rawNewLngData;
-   fixQuality = newFixQuality;
-   fixMode = newFixMode;
-   lastCommitTime = millis();
-   valid = updated = true;
+  rawLatData = rawNewLatData;
+  rawLngData = rawNewLngData;
+  fixQuality = newFixQuality;
+  fixMode = newFixMode;
+  lastCommitTime = millis();
+  updated = true;
+  valid = (rawNewLatData.deg <= 90 && rawNewLngData.deg <= 180);
 }
 
 void TinyGPSLocation::setLatitude(const char *term)
@@ -431,16 +465,54 @@ void TinyGPSSatellites::commit()
 
 void TinyGPSDate::commit()
 {
+   const uint32_t olddate = date;
    date = newDate;
+   valid = false;
+   
+   {
+     const uint16_t newyear = year();
+     if (newyear < 2020) {
+       // Very unlikely the year of received date is before 2020, which is now.
+       date = olddate;
+       return;
+     }
+   }
+   {
+     const uint8_t newmonth = month();
+     if (newmonth > 12 || newmonth == 0) {
+       date = olddate;
+       return;
+     }
+   }
+   {
+     const uint8_t newday = day();
+     if (newday > 31 || newday == 0) {
+       // Day of month
+       date = olddate;
+       return;
+     }
+   }
    lastCommitTime = millis();
-   valid = updated = true;
+   valid = true;
+   updated = true;
 }
 
 void TinyGPSTime::commit()
 {
    time = newTime;
    lastCommitTime = millis();
-   valid = updated = true;
+   valid = false;
+   if (second() > 60) {
+     return;
+   }
+   if (minute() > 59) {
+     return;
+   }
+   if (hour() > 23) {
+     return;
+   }
+   updated = true;
+   valid = true;
 }
 
 void TinyGPSSatellites::setSatId(const char *term)

--- a/src/_P082_GPS.ino
+++ b/src/_P082_GPS.ino
@@ -184,6 +184,9 @@ struct P082_data_struct : public PluginTaskData_base {
     if (gps->date.age() > P082_TIMESTAMP_AGE) {
       return false;
     }
+    if (!gps->date.isValid() || !gps->time.isValid()) {
+      return false;
+    }
     dateTime.tm_year = gps->date.year() - 1970;
     dateTime.tm_mon  = gps->date.month();
     dateTime.tm_mday = gps->date.day();
@@ -606,6 +609,8 @@ void P082_logStats(struct EventStruct *event) {
   log += P082_data->gps->passedChecksum();
   log += '/';
   log += P082_data->gps->failedChecksum();
+  log += F(" invalid: ");
+  log += P082_data->gps->invalidData();
   addLog(LOG_LEVEL_DEBUG, log);
 }
 
@@ -723,11 +728,13 @@ void P082_html_show_stats(struct EventStruct *event) {
     addHtml(F("-"));
   }
 
-  addRowLabel(F("Checksum (pass/fail)"));
+  addRowLabel(F("Checksum (pass/fail/invalid)"));
   String chksumStats;
   chksumStats  = P082_data->gps->passedChecksum();
   chksumStats += '/';
   chksumStats += P082_data->gps->failedChecksum();
+  chksumStats += '/';
+  chksumStats += P082_data->gps->invalidData();
   addHtml(chksumStats);
 }
 


### PR DESCRIPTION
Add simple checks to validate the data received from the GPS.
Every now and then the data received apparently has a valid checksum, but the data clearly isn't.
For example:
- time/date is in readable format, so you can simply check day/month and hour/min/sec ranges.
- GPS coordinates should not exceed 180 degree in longitude and 90 degree in latitude (N/S/E/W is an extra field to mark the negative sign)

Not sure what causes these issues, but they do happen on the cheap GPS nodes.
On my test node, they seem to occur roughly once per 200'000 GPS messages.  (when there is no fix, this counter is not increased for invalid data)

This also does fix the issue where GPS is used as only time source, where the system time may jump several years (often to 2040 or 1999) when such invalid data is processed and used as system time.