### PR TITLE
[ESPEasy p2p] Init node data to 0

### DIFF
--- a/src/Networking.ino
+++ b/src/Networking.ino
@@ -422,7 +422,7 @@ void sendSysInfoUDP(byte repeats)
     uint8_t  mac[]   = { 0, 0, 0, 0, 0, 0 };
     uint8_t *macread = NetworkMacAddressAsBytes(mac);
 
-    byte     data[80];
+    byte     data[80] = {0};
     data[0] = 255;
     data[1] = 1;
 

--- a/src/WebServer_I2C_Scanner.ino
+++ b/src/WebServer_I2C_Scanner.ino
@@ -73,6 +73,7 @@ void handle_i2cscanner_json() {
 // FIXME TD-er: Query all included plugins for their supported addresses (return name of plugin)
 String getKnownI2Cdevice(byte address) {
   String result;
+  #ifndef LIMIT_BUILD_SIZE
 
   switch (address)
   {
@@ -173,6 +174,7 @@ String getKnownI2Cdevice(byte address) {
       result =  F("Arduino PME");
       break;
   }
+  #endif // LIMIT_BUILD_SIZE
   return result;
 }
 


### PR DESCRIPTION
Node struct data was not initialized to 0, so when adding new data to these packets, you could receive uninitialized data from older nodes.