### PR TITLE
[Controller] Convert controller delay handler to pointer

### DIFF
--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -419,22 +419,28 @@ void SendStatus(EventValueSource::Enum source, const String& status)
 
 #ifdef USES_MQTT
 bool MQTT_queueFull(controllerIndex_t controller_idx) {
+  if (MQTTDelayHandler == nullptr) {
+    return true;
+  }
   MQTT_queue_element dummy_element;
   dummy_element.controller_idx = controller_idx;
-  if (MQTTDelayHandler.queueFull(dummy_element)) {
+  if (MQTTDelayHandler->queueFull(dummy_element)) {
     // The queue is full, try to make some room first.
     processMQTTdelayQueue();
-    return MQTTDelayHandler.queueFull(dummy_element);
+    return MQTTDelayHandler->queueFull(dummy_element);
   }
   return false;
 }
 
 bool MQTTpublish(controllerIndex_t controller_idx, const char *topic, const char *payload, bool retained)
 {
+  if (MQTTDelayHandler == nullptr) {
+    return false;
+  }
   if (MQTT_queueFull(controller_idx)) {
     return false;
   }
-  const bool success = MQTTDelayHandler.addToQueue(MQTT_queue_element(controller_idx, topic, payload, retained));
+  const bool success = MQTTDelayHandler->addToQueue(MQTT_queue_element(controller_idx, topic, payload, retained));
   scheduleNextMQTTdelayQueue();
   return success;
 }

--- a/src/Misc.ino
+++ b/src/Misc.ino
@@ -1092,20 +1092,22 @@ void ResetFactory()
   {
     // Place in a scope to have its memory freed ASAP
     MakeControllerSettings(ControllerSettings);
-    safe_strncpy(ControllerSettings.Subscribe, F(DEFAULT_SUB), sizeof(ControllerSettings.Subscribe));
-    safe_strncpy(ControllerSettings.Publish, F(DEFAULT_PUB), sizeof(ControllerSettings.Publish));
-    safe_strncpy(ControllerSettings.MQTTLwtTopic, F(DEFAULT_MQTT_LWT_TOPIC), sizeof(ControllerSettings.MQTTLwtTopic));
-    safe_strncpy(ControllerSettings.LWTMessageConnect, F(DEFAULT_MQTT_LWT_CONNECT_MESSAGE), sizeof(ControllerSettings.LWTMessageConnect));
-    safe_strncpy(ControllerSettings.LWTMessageDisconnect, F(DEFAULT_MQTT_LWT_DISCONNECT_MESSAGE), sizeof(ControllerSettings.LWTMessageDisconnect));
-    str2ip((char*)DEFAULT_SERVER, ControllerSettings.IP);
-    ControllerSettings.setHostname(F(DEFAULT_SERVER_HOST));
-    ControllerSettings.UseDNS = DEFAULT_SERVER_USEDNS;
-    ControllerSettings.useExtendedCredentials(DEFAULT_USE_EXTD_CONTROLLER_CREDENTIALS);
-    ControllerSettings.Port = DEFAULT_PORT;
-    setControllerUser(0, ControllerSettings, F(DEFAULT_CONTROLLER_USER));
-    setControllerPass(0, ControllerSettings, F(DEFAULT_CONTROLLER_PASS));
+    if (AllocatedControllerSettings()) {
+      safe_strncpy(ControllerSettings.Subscribe, F(DEFAULT_SUB), sizeof(ControllerSettings.Subscribe));
+      safe_strncpy(ControllerSettings.Publish, F(DEFAULT_PUB), sizeof(ControllerSettings.Publish));
+      safe_strncpy(ControllerSettings.MQTTLwtTopic, F(DEFAULT_MQTT_LWT_TOPIC), sizeof(ControllerSettings.MQTTLwtTopic));
+      safe_strncpy(ControllerSettings.LWTMessageConnect, F(DEFAULT_MQTT_LWT_CONNECT_MESSAGE), sizeof(ControllerSettings.LWTMessageConnect));
+      safe_strncpy(ControllerSettings.LWTMessageDisconnect, F(DEFAULT_MQTT_LWT_DISCONNECT_MESSAGE), sizeof(ControllerSettings.LWTMessageDisconnect));
+      str2ip((char*)DEFAULT_SERVER, ControllerSettings.IP);
+      ControllerSettings.setHostname(F(DEFAULT_SERVER_HOST));
+      ControllerSettings.UseDNS = DEFAULT_SERVER_USEDNS;
+      ControllerSettings.useExtendedCredentials(DEFAULT_USE_EXTD_CONTROLLER_CREDENTIALS);
+      ControllerSettings.Port = DEFAULT_PORT;
+      setControllerUser(0, ControllerSettings, F(DEFAULT_CONTROLLER_USER));
+      setControllerPass(0, ControllerSettings, F(DEFAULT_CONTROLLER_PASS));
 
-    SaveControllerSettings(0, ControllerSettings);
+      SaveControllerSettings(0, ControllerSettings);
+    }
   }
 #endif
 

--- a/src/WebServer_ControllerPage.ino
+++ b/src/WebServer_ControllerPage.ino
@@ -161,62 +161,63 @@ void handle_controllers_ShowAllControllersTable()
   html_table_header("Port");
 
   MakeControllerSettings(ControllerSettings);
-
-  for (controllerIndex_t x = 0; x < CONTROLLER_MAX; x++)
-  {
-    const bool cplugin_set = Settings.Protocol[x] != INVALID_C_PLUGIN_ID;
-
-
-    LoadControllerSettings(x, ControllerSettings);
-    html_TR_TD();
-
-    if (cplugin_set && !supportedCPluginID(Settings.Protocol[x])) {
-      html_add_button_prefix(F("red"), true);
-    } else {
-      html_add_button_prefix();
-    }
+  if (AllocatedControllerSettings()) {
+    for (controllerIndex_t x = 0; x < CONTROLLER_MAX; x++)
     {
-      String html;
-      html.reserve(32);
-      html += F("controllers?index=");
-      html += x + 1;
-      html += F("'>");
+      const bool cplugin_set = Settings.Protocol[x] != INVALID_C_PLUGIN_ID;
 
-      if (cplugin_set) {
-        html += F("Edit");
+
+      LoadControllerSettings(x, ControllerSettings);
+      html_TR_TD();
+
+      if (cplugin_set && !supportedCPluginID(Settings.Protocol[x])) {
+        html_add_button_prefix(F("red"), true);
       } else {
-        html += F("Add");
+        html_add_button_prefix();
       }
-      html += F("</a><TD>");
-      html += getControllerSymbol(x);
-      addHtml(html);
-    }
-    html_TD();
-
-    if (cplugin_set)
-    {
-      addEnabled(Settings.ControllerEnabled[x]);
-
-      html_TD();
-      addHtml(getCPluginNameFromCPluginID(Settings.Protocol[x]));
-      html_TD();
       {
-        const protocolIndex_t ProtocolIndex = getProtocolIndex_from_ControllerIndex(x);
-        String hostDescription;
-        CPluginCall(ProtocolIndex, CPlugin::Function::CPLUGIN_WEBFORM_SHOW_HOST_CONFIG, 0, hostDescription);
+        String html;
+        html.reserve(32);
+        html += F("controllers?index=");
+        html += x + 1;
+        html += F("'>");
 
-        if (hostDescription.length() != 0) {
-          addHtml(hostDescription);
+        if (cplugin_set) {
+          html += F("Edit");
         } else {
-          addHtml(ControllerSettings.getHost());
+          html += F("Add");
         }
+        html += F("</a><TD>");
+        html += getControllerSymbol(x);
+        addHtml(html);
       }
-
       html_TD();
-      addHtml(String(ControllerSettings.Port));
-    }
-    else {
-      html_TD(3);
+
+      if (cplugin_set)
+      {
+        addEnabled(Settings.ControllerEnabled[x]);
+
+        html_TD();
+        addHtml(getCPluginNameFromCPluginID(Settings.Protocol[x]));
+        html_TD();
+        {
+          const protocolIndex_t ProtocolIndex = getProtocolIndex_from_ControllerIndex(x);
+          String hostDescription;
+          CPluginCall(ProtocolIndex, CPlugin::Function::CPLUGIN_WEBFORM_SHOW_HOST_CONFIG, 0, hostDescription);
+
+          if (hostDescription.length() != 0) {
+            addHtml(hostDescription);
+          } else {
+            addHtml(ControllerSettings.getHost());
+          }
+        }
+
+        html_TD();
+        addHtml(String(ControllerSettings.Port));
+      }
+      else {
+        html_TD(3);
+      }
     }
   }
   html_end_table();
@@ -258,102 +259,106 @@ void handle_controllers_ControllerSettingsPage(controllerIndex_t controllerindex
   if (Settings.Protocol[controllerindex])
   {
     MakeControllerSettings(ControllerSettings);
-    LoadControllerSettings(controllerindex, ControllerSettings);
+    if (!AllocatedControllerSettings()) {
+      addHtmlError(F("Out of memory, cannot load page"));
+    } else {
+      LoadControllerSettings(controllerindex, ControllerSettings);
 
-    if (!Protocol[ProtocolIndex].Custom)
-    {
-      if (Protocol[ProtocolIndex].usesHost) {
-        addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_USE_DNS);
+      if (!Protocol[ProtocolIndex].Custom)
+      {
+        if (Protocol[ProtocolIndex].usesHost) {
+          addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_USE_DNS);
 
-        if (ControllerSettings.UseDNS)
-        {
-          addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_HOSTNAME);
+          if (ControllerSettings.UseDNS)
+          {
+            addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_HOSTNAME);
+          }
+          else
+          {
+            addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_IP);
+          }
         }
-        else
+        addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_PORT);
+
+        if (Protocol[ProtocolIndex].usesQueue) {
+          addTableSeparator(F("Controller Queue"), 2, 3);
+          addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_MIN_SEND_INTERVAL);
+          addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_MAX_QUEUE_DEPTH);
+          addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_MAX_RETRIES);
+          addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_FULL_QUEUE_ACTION);
+        }
+
+        if (Protocol[ProtocolIndex].usesCheckReply) {
+          addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_CHECK_REPLY);
+        }
+
+        if (Protocol[ProtocolIndex].usesTimeout) {
+          addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_TIMEOUT);
+        }
+
+        if (Protocol[ProtocolIndex].usesSampleSets) {
+          addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_SAMPLE_SET_INITIATOR);
+        }
+
+        if (Protocol[ProtocolIndex].useExtendedCredentials()) {
+          addTableSeparator(F("Credentials"), 2, 3);
+          addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_USE_EXTENDED_CREDENTIALS);
+        }
+
+        if (Protocol[ProtocolIndex].usesAccount)
         {
-          addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_IP);
+          addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_USER);
+        }
+
+        if (Protocol[ProtocolIndex].usesPassword)
+        {
+          addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_PASS);
+        }
+        #ifdef USES_MQTT
+        if (Protocol[ProtocolIndex].usesMQTT) {
+          addTableSeparator(F("MQTT"), 2, 3);
+
+          addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_CLIENT_ID);
+          addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_UNIQUE_CLIENT_ID_RECONNECT);        
+          addRowLabel(F("Current Client ID"));
+          addHtml(getMQTTclientID(ControllerSettings));
+          addFormNote(F("Updated on load of this page"));
+          addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_RETAINFLAG);
+        }
+        #endif // USES_MQTT
+
+
+        if (Protocol[ProtocolIndex].usesTemplate || Protocol[ProtocolIndex].usesMQTT)
+        {
+          addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_SUBSCRIBE);
+          addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_PUBLISH);
+        }
+        #ifdef USES_MQTT
+        if (Protocol[ProtocolIndex].usesMQTT)
+        {
+          addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_LWT_TOPIC);
+          addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_LWT_CONNECT_MESSAGE);
+          addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_LWT_DISCONNECT_MESSAGE);
+          addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_SEND_LWT);
+          addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_WILL_RETAIN);
+          addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_CLEAN_SESSION);
+        }
+        #endif // USES_MQTT
+      }
+      {
+        // Load controller specific settings
+        struct EventStruct TempEvent;
+        TempEvent.ControllerIndex = controllerindex;
+
+        String webformLoadString;
+        CPluginCall(ProtocolIndex, CPlugin::Function::CPLUGIN_WEBFORM_LOAD, &TempEvent, webformLoadString);
+
+        if (webformLoadString.length() > 0) {
+          addHtmlError(F("Bug in CPlugin::Function::CPLUGIN_WEBFORM_LOAD, should not append to string, use addHtml() instead"));
         }
       }
-      addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_PORT);
-
-      if (Protocol[ProtocolIndex].usesQueue) {
-        addTableSeparator(F("Controller Queue"), 2, 3);
-        addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_MIN_SEND_INTERVAL);
-        addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_MAX_QUEUE_DEPTH);
-        addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_MAX_RETRIES);
-        addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_FULL_QUEUE_ACTION);
-      }
-
-      if (Protocol[ProtocolIndex].usesCheckReply) {
-        addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_CHECK_REPLY);
-      }
-
-      if (Protocol[ProtocolIndex].usesTimeout) {
-        addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_TIMEOUT);
-      }
-
-      if (Protocol[ProtocolIndex].usesSampleSets) {
-        addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_SAMPLE_SET_INITIATOR);
-      }
-
-      if (Protocol[ProtocolIndex].useExtendedCredentials()) {
-        addTableSeparator(F("Credentials"), 2, 3);
-        addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_USE_EXTENDED_CREDENTIALS);
-      }
-
-      if (Protocol[ProtocolIndex].usesAccount)
-      {
-        addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_USER);
-      }
-
-      if (Protocol[ProtocolIndex].usesPassword)
-      {
-        addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_PASS);
-      }
-      #ifdef USES_MQTT
-      if (Protocol[ProtocolIndex].usesMQTT) {
-        addTableSeparator(F("MQTT"), 2, 3);
-
-        addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_CLIENT_ID);
-        addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_UNIQUE_CLIENT_ID_RECONNECT);        
-        addRowLabel(F("Current Client ID"));
-        addHtml(getMQTTclientID(ControllerSettings));
-        addFormNote(F("Updated on load of this page"));
-        addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_RETAINFLAG);
-      }
-      #endif // USES_MQTT
-
-
-      if (Protocol[ProtocolIndex].usesTemplate || Protocol[ProtocolIndex].usesMQTT)
-      {
-        addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_SUBSCRIBE);
-        addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_PUBLISH);
-      }
-      #ifdef USES_MQTT
-      if (Protocol[ProtocolIndex].usesMQTT)
-      {
-        addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_LWT_TOPIC);
-        addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_LWT_CONNECT_MESSAGE);
-        addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_LWT_DISCONNECT_MESSAGE);
-        addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_SEND_LWT);
-        addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_WILL_RETAIN);
-        addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_CLEAN_SESSION);
-      }
-      #endif // USES_MQTT
+      addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_ENABLED);
     }
-    {
-      // Load controller specific settings
-      struct EventStruct TempEvent;
-      TempEvent.ControllerIndex = controllerindex;
-
-      String webformLoadString;
-      CPluginCall(ProtocolIndex, CPlugin::Function::CPLUGIN_WEBFORM_LOAD, &TempEvent, webformLoadString);
-
-      if (webformLoadString.length() > 0) {
-        addHtmlError(F("Bug in CPlugin::Function::CPLUGIN_WEBFORM_LOAD, should not append to string, use addHtml() instead"));
-      }
-    }
-    addControllerParameterForm(ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_ENABLED);
   }
 
   addFormSeparator(2);

--- a/src/_C001.ino
+++ b/src/_C001.ino
@@ -35,14 +35,21 @@ bool CPlugin_001(CPlugin::Function function, struct EventStruct *event, String& 
 
     case CPlugin::Function::CPLUGIN_INIT:
       {
-        MakeControllerSettings(ControllerSettings);
-        LoadControllerSettings(event->ControllerIndex, ControllerSettings);
-        C001_DelayHandler.configureControllerSettings(ControllerSettings);
+        success = init_c001_delay_queue(event->ControllerIndex);
+        break;
+      }
+
+    case CPlugin::Function::CPLUGIN_EXIT:
+      {
+        exit_c001_delay_queue();
         break;
       }
 
     case CPlugin::Function::CPLUGIN_PROTOCOL_SEND:
       {
+        if (C001_DelayHandler == nullptr) {
+          break;
+        }
         if (event->idx != 0)
         {
           // We now create a URI for the request
@@ -98,8 +105,8 @@ bool CPlugin_001(CPlugin::Function function, struct EventStruct *event, String& 
             url += mapVccToDomoticz();
           #endif
 
-          success = C001_DelayHandler.addToQueue(C001_queue_element(event->ControllerIndex, url));
-          Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C001_DELAY_QUEUE, C001_DelayHandler.getNextScheduleTime());
+          success = C001_DelayHandler->addToQueue(C001_queue_element(event->ControllerIndex, url));
+          Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C001_DELAY_QUEUE, C001_DelayHandler->getNextScheduleTime());
         } // if ixd !=0
         else
         {

--- a/src/_C002.ino
+++ b/src/_C002.ino
@@ -13,7 +13,7 @@
 #include <ArduinoJson.h>
 
 String CPlugin_002_pubname;
-bool CPlugin_002_retain = false;
+bool CPlugin_002_mqtt_retainFlag = false;
 
 bool CPlugin_002(CPlugin::Function function, struct EventStruct *event, String& string)
 {
@@ -42,11 +42,13 @@ bool CPlugin_002(CPlugin::Function function, struct EventStruct *event, String& 
 
     case CPlugin::Function::CPLUGIN_INIT:
     {
-      MakeControllerSettings(ControllerSettings);
-      LoadControllerSettings(event->ControllerIndex, ControllerSettings);
-      MQTTDelayHandler.configureControllerSettings(ControllerSettings);
-      CPlugin_002_pubname = ControllerSettings.Publish;
-      CPlugin_002_retain = ControllerSettings.mqtt_retainFlag();
+      success = init_mqtt_delay_queue(event->ControllerIndex, CPlugin_002_pubname, CPlugin_002_mqtt_retainFlag);
+      break;
+    }
+
+    case CPlugin::Function::CPLUGIN_EXIT:
+    {
+      exit_mqtt_delay_queue();
       break;
     }
 
@@ -236,7 +238,7 @@ bool CPlugin_002(CPlugin::Function function, struct EventStruct *event, String& 
         String pubname = CPlugin_002_pubname;
         parseControllerVariables(pubname, event, false);
 
-        success = MQTTpublish(event->ControllerIndex, pubname.c_str(), json.c_str(), CPlugin_002_retain);
+        success = MQTTpublish(event->ControllerIndex, pubname.c_str(), json.c_str(), CPlugin_002_mqtt_retainFlag);
       } // if ixd !=0
       else
       {

--- a/src/_C003.ino
+++ b/src/_C003.ino
@@ -33,22 +33,30 @@ bool CPlugin_003(CPlugin::Function function, struct EventStruct *event, String& 
 
     case CPlugin::Function::CPLUGIN_INIT:
       {
-        MakeControllerSettings(ControllerSettings);
-        LoadControllerSettings(event->ControllerIndex, ControllerSettings);
-        C003_DelayHandler.configureControllerSettings(ControllerSettings);
+        success = init_c003_delay_queue(event->ControllerIndex);
+        break;
+      }
+
+    case CPlugin::Function::CPLUGIN_EXIT:
+      {
+        exit_c003_delay_queue();
         break;
       }
 
     case CPlugin::Function::CPLUGIN_PROTOCOL_SEND:
       {
+        if (C003_DelayHandler == nullptr) {
+          break;
+        }
+
         // We now create a URI for the request
         String url = F("variableset ");
         url += event->idx;
         url += ",";
         url += formatUserVarNoCheck(event, 0);
         url += "\n";
-        success = C003_DelayHandler.addToQueue(C003_queue_element(event->ControllerIndex, url));
-        Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C003_DELAY_QUEUE, C003_DelayHandler.getNextScheduleTime());
+        success = C003_DelayHandler->addToQueue(C003_queue_element(event->ControllerIndex, url));
+        Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C003_DELAY_QUEUE, C003_DelayHandler->getNextScheduleTime());
 
         break;
       }

--- a/src/_C004.ino
+++ b/src/_C004.ino
@@ -33,9 +33,13 @@ bool CPlugin_004(CPlugin::Function function, struct EventStruct *event, String& 
 
     case CPlugin::Function::CPLUGIN_INIT:
       {
-        MakeControllerSettings(ControllerSettings);
-        LoadControllerSettings(event->ControllerIndex, ControllerSettings);
-        C004_DelayHandler.configureControllerSettings(ControllerSettings);
+        success = init_c004_delay_queue(event->ControllerIndex);
+        break;
+      }
+
+    case CPlugin::Function::CPLUGIN_EXIT:
+      {
+        exit_c004_delay_queue();
         break;
       }
 
@@ -58,8 +62,11 @@ bool CPlugin_004(CPlugin::Function function, struct EventStruct *event, String& 
 
     case CPlugin::Function::CPLUGIN_PROTOCOL_SEND:
       {
-        success = C004_DelayHandler.addToQueue(C004_queue_element(event));
-        Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C004_DELAY_QUEUE, C004_DelayHandler.getNextScheduleTime());
+        if (C004_DelayHandler == nullptr) {
+          break;
+        }
+        success = C004_DelayHandler->addToQueue(C004_queue_element(event));
+        Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C004_DELAY_QUEUE, C004_DelayHandler->getNextScheduleTime());
 
         break;
       }

--- a/src/_C005.ino
+++ b/src/_C005.ino
@@ -39,11 +39,13 @@ bool CPlugin_005(CPlugin::Function function, struct EventStruct *event, String& 
 
     case CPlugin::Function::CPLUGIN_INIT:
       {
-        MakeControllerSettings(ControllerSettings);
-        LoadControllerSettings(event->ControllerIndex, ControllerSettings);
-        MQTTDelayHandler.configureControllerSettings(ControllerSettings);
-        CPlugin_005_pubname = ControllerSettings.Publish;
-        CPlugin_005_mqtt_retainFlag = ControllerSettings.mqtt_retainFlag();
+        success = init_mqtt_delay_queue(event->ControllerIndex, CPlugin_005_pubname, CPlugin_005_mqtt_retainFlag);
+        break;
+      }
+
+    case CPlugin::Function::CPLUGIN_EXIT:
+      {
+        exit_mqtt_delay_queue();
         break;
       }
 

--- a/src/_C006.ino
+++ b/src/_C006.ino
@@ -39,11 +39,13 @@ bool CPlugin_006(CPlugin::Function function, struct EventStruct *event, String& 
 
     case CPlugin::Function::CPLUGIN_INIT:
       {
-        MakeControllerSettings(ControllerSettings);
-        LoadControllerSettings(event->ControllerIndex, ControllerSettings);
-        MQTTDelayHandler.configureControllerSettings(ControllerSettings);
-        CPlugin_006_pubname = ControllerSettings.Publish;
-        CPlugin_006_mqtt_retainFlag = ControllerSettings.mqtt_retainFlag();
+        success = init_mqtt_delay_queue(event->ControllerIndex, CPlugin_006_pubname, CPlugin_006_mqtt_retainFlag);
+        break;
+      }
+
+    case CPlugin::Function::CPLUGIN_EXIT:
+      {
+        exit_mqtt_delay_queue();
         break;
       }
 

--- a/src/_C007.ino
+++ b/src/_C007.ino
@@ -33,14 +33,22 @@ bool CPlugin_007(CPlugin::Function function, struct EventStruct *event, String& 
 
     case CPlugin::Function::CPLUGIN_INIT:
       {
-        MakeControllerSettings(ControllerSettings);
-        LoadControllerSettings(event->ControllerIndex, ControllerSettings);
-        C007_DelayHandler.configureControllerSettings(ControllerSettings);
+        success = init_c004_delay_queue(event->ControllerIndex);
+        break;
+      }
+
+    case CPlugin::Function::CPLUGIN_EXIT:
+      {
+        exit_c007_delay_queue();
         break;
       }
 
     case CPlugin::Function::CPLUGIN_PROTOCOL_SEND:
       {
+        if (C007_DelayHandler == nullptr) {
+          break;
+        }
+
         if (event->sensorType == SENSOR_TYPE_STRING) {
           addLog(LOG_LEVEL_ERROR, F("emoncms : No support for SENSOR_TYPE_STRING"));
           break;
@@ -50,8 +58,8 @@ bool CPlugin_007(CPlugin::Function function, struct EventStruct *event, String& 
           addLog(LOG_LEVEL_ERROR, F("emoncms : Unknown sensortype or too many sensor values"));
           break;
         }
-        success = C007_DelayHandler.addToQueue(C007_queue_element(event));
-        Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C007_DELAY_QUEUE, C007_DelayHandler.getNextScheduleTime());
+        success = C007_DelayHandler->addToQueue(C007_queue_element(event));
+        Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C007_DELAY_QUEUE, C007_DelayHandler->getNextScheduleTime());
         break;
       }
 

--- a/src/_C008.ino
+++ b/src/_C008.ino
@@ -37,9 +37,13 @@ bool CPlugin_008(CPlugin::Function function, struct EventStruct *event, String& 
 
     case CPlugin::Function::CPLUGIN_INIT:
       {
-        MakeControllerSettings(ControllerSettings);
-        LoadControllerSettings(event->ControllerIndex, ControllerSettings);
-        C008_DelayHandler.configureControllerSettings(ControllerSettings);
+        success = init_c008_delay_queue(event->ControllerIndex);
+        break;
+      }
+
+    case CPlugin::Function::CPLUGIN_EXIT:
+      {
+        exit_c008_delay_queue();
         break;
       }
 
@@ -52,6 +56,10 @@ bool CPlugin_008(CPlugin::Function function, struct EventStruct *event, String& 
 
     case CPlugin::Function::CPLUGIN_PROTOCOL_SEND:
       {
+        if (C008_DelayHandler == nullptr) {
+          break;
+        }
+
         String pubname;
         {
           // Place the ControllerSettings in a scope to free the memory as soon as we got all relevant information.
@@ -66,12 +74,12 @@ bool CPlugin_008(CPlugin::Function function, struct EventStruct *event, String& 
 
         // FIXME TD-er must define a proper move operator
         byte valueCount = getValueCountFromSensorType(event->sensorType);
-        success = C008_DelayHandler.addToQueue(C008_queue_element(event, valueCount));
+        success = C008_DelayHandler->addToQueue(C008_queue_element(event, valueCount));
         if (success) {
           // Element was added.
           // Now we try to append to the existing element 
           // and thus preventing the need to create a long string only to copy it to a queue element.
-          C008_queue_element &element = C008_DelayHandler.sendQueue.back();
+          C008_queue_element &element = C008_DelayHandler->sendQueue.back();
 
           // Collect the values at the same run, to make sure all are from the same sample
           if (ExtraTaskSettings.TaskIndex != event->TaskIndex) {
@@ -95,7 +103,7 @@ bool CPlugin_008(CPlugin::Function function, struct EventStruct *event, String& 
             }
           }
         }
-        Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C008_DELAY_QUEUE, C008_DelayHandler.getNextScheduleTime());
+        Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C008_DELAY_QUEUE, C008_DelayHandler->getNextScheduleTime());
         break;
       }
 

--- a/src/_C009.ino
+++ b/src/_C009.ino
@@ -57,12 +57,31 @@ bool CPlugin_009(CPlugin::Function function, struct EventStruct *event, String& 
         break;
       }
 
+    case CPlugin::Function::CPLUGIN_INIT:
+      {
+        success = init_c009_delay_queue(event->ControllerIndex);
+        break;
+      }
+
+    case CPlugin::Function::CPLUGIN_EXIT:
+      {
+        exit_c009_delay_queue();
+        break;
+      }
+
     case CPlugin::Function::CPLUGIN_PROTOCOL_SEND:
       {
+        if (C009_DelayHandler == nullptr) {
+          break;
+        }
+
         byte valueCount = getValueCountFromSensorType(event->sensorType);
         C009_queue_element element(event);
 
         MakeControllerSettings(ControllerSettings);
+        if (!AllocatedControllerSettings()) {
+          break;
+        }
         LoadControllerSettings(event->ControllerIndex, ControllerSettings);
 
         for (byte x = 0; x < valueCount; x++)
@@ -70,8 +89,8 @@ bool CPlugin_009(CPlugin::Function function, struct EventStruct *event, String& 
           element.txt[x] = formatUserVarNoCheck(event, x);
         }
         // FIXME TD-er must define a proper move operator
-        success = C009_DelayHandler.addToQueue(C009_queue_element(element));
-        Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C009_DELAY_QUEUE, C009_DelayHandler.getNextScheduleTime());
+        success = C009_DelayHandler->addToQueue(C009_queue_element(element));
+        Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C009_DELAY_QUEUE, C009_DelayHandler->getNextScheduleTime());
         break;
       }
 

--- a/src/_C010.ino
+++ b/src/_C010.ino
@@ -39,8 +39,24 @@ bool CPlugin_010(CPlugin::Function function, struct EventStruct *event, String& 
         break;
       }
 
+    case CPlugin::Function::CPLUGIN_INIT:
+      {
+        success = init_c010_delay_queue(event->ControllerIndex);
+        break;
+      }
+
+    case CPlugin::Function::CPLUGIN_EXIT:
+      {
+        exit_c010_delay_queue();
+        break;
+      }
+
     case CPlugin::Function::CPLUGIN_PROTOCOL_SEND:
       {
+        if (C010_DelayHandler == nullptr) {
+          break;
+        }
+
         byte valueCount = getValueCountFromSensorType(event->sensorType);
         C010_queue_element element(event, valueCount);
         if (ExtraTaskSettings.TaskIndex != event->TaskIndex) {
@@ -49,6 +65,9 @@ bool CPlugin_010(CPlugin::Function function, struct EventStruct *event, String& 
         }
 
         MakeControllerSettings(ControllerSettings);
+        if (!AllocatedControllerSettings()) {
+          break;
+        }
         LoadControllerSettings(event->ControllerIndex, ControllerSettings);
 
         for (byte x = 0; x < valueCount; x++)
@@ -65,8 +84,8 @@ bool CPlugin_010(CPlugin::Function function, struct EventStruct *event, String& 
           }
         }
         // FIXME TD-er must define a proper move operator
-        success = C010_DelayHandler.addToQueue(C010_queue_element(element));
-        Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C010_DELAY_QUEUE, C010_DelayHandler.getNextScheduleTime());
+        success = C010_DelayHandler->addToQueue(C010_queue_element(element));
+        Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C010_DELAY_QUEUE, C010_DelayHandler->getNextScheduleTime());
         break;
       }
 

--- a/src/_C012.ino
+++ b/src/_C012.ino
@@ -36,8 +36,23 @@ bool CPlugin_012(CPlugin::Function function, struct EventStruct *event, String& 
         break;
       }
 
-     case CPlugin::Function::CPLUGIN_PROTOCOL_SEND:
+    case CPlugin::Function::CPLUGIN_INIT:
       {
+        success = init_c012_delay_queue(event->ControllerIndex);
+        break;
+      }
+
+    case CPlugin::Function::CPLUGIN_EXIT:
+      {
+        exit_c012_delay_queue();
+        break;
+      }
+
+    case CPlugin::Function::CPLUGIN_PROTOCOL_SEND:
+      {
+        if (C012_DelayHandler == nullptr) {
+          break;
+        }
         // Collect the values at the same run, to make sure all are from the same sample
         byte valueCount = getValueCountFromSensorType(event->sensorType);
         C012_queue_element element(event, valueCount);
@@ -47,6 +62,10 @@ bool CPlugin_012(CPlugin::Function function, struct EventStruct *event, String& 
         }
 
         MakeControllerSettings(ControllerSettings);
+        if (!AllocatedControllerSettings()) {
+          break;
+        }
+
         LoadControllerSettings(event->ControllerIndex, ControllerSettings);
 
         for (byte x = 0; x < valueCount; x++)
@@ -62,8 +81,8 @@ bool CPlugin_012(CPlugin::Function function, struct EventStruct *event, String& 
           }
         }
         // FIXME TD-er must define a proper move operator
-        success = C012_DelayHandler.addToQueue(C012_queue_element(element));
-        Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C012_DELAY_QUEUE, C012_DelayHandler.getNextScheduleTime());
+        success = C012_DelayHandler->addToQueue(C012_queue_element(element));
+        Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C012_DELAY_QUEUE, C012_DelayHandler->getNextScheduleTime());
         break;
       }
 

--- a/src/_C013.ino
+++ b/src/_C013.ino
@@ -97,7 +97,7 @@ bool CPlugin_013(CPlugin::Function function, struct EventStruct *event, String& 
       /*
           case CPlugin::Function::CPLUGIN_FLUSH:
             {
-              process_c013_delay_queue();
+              process_c013_delay_queue(event->ControllerIndex);
               delay(0);
               break;
             }

--- a/src/_C014.ino
+++ b/src/_C014.ino
@@ -158,11 +158,13 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
 
     case CPlugin::Function::CPLUGIN_INIT:
       {
-        MakeControllerSettings(ControllerSettings);
-        LoadControllerSettings(event->ControllerIndex, ControllerSettings);
-        MQTTDelayHandler.configureControllerSettings(ControllerSettings);
-        CPlugin_014_pubname = ControllerSettings.Publish;
-        CPlugin_014_mqtt_retainFlag = ControllerSettings.mqtt_retainFlag();
+        success = init_mqtt_delay_queue(event->ControllerIndex, CPlugin_014_pubname, CPlugin_014_mqtt_retainFlag);
+        break;
+      }
+
+    case CPlugin::Function::CPLUGIN_EXIT:
+      {
+        exit_mqtt_delay_queue();
         break;
       }
 

--- a/src/_C015.ino
+++ b/src/_C015.ino
@@ -88,12 +88,20 @@ bool CPlugin_015(CPlugin::Function function, struct EventStruct *event, String& 
 
     case CPlugin::Function::CPLUGIN_INIT:
       {
-       // when connected to another server and user has changed settings
-       if (Blynk.connected()){
+        success = init_c015_delay_queue(event->ControllerIndex);
+
+        // when connected to another server and user has changed settings
+        if (success && Blynk.connected()){
           addLog(LOG_LEVEL_INFO, F(C015_LOG_PREFIX "disconnect from server"));
           Blynk.disconnect();
-       }
-       break;
+        }
+        break;
+      }
+
+    case CPlugin::Function::CPLUGIN_EXIT:
+      {
+        exit_c015_delay_queue();
+        break;
       }
 
     #ifdef CPLUGIN_015_SSL
@@ -142,6 +150,10 @@ bool CPlugin_015(CPlugin::Function function, struct EventStruct *event, String& 
 
      case CPlugin::Function::CPLUGIN_PROTOCOL_SEND:
       {
+        if (C015_DelayHandler == nullptr) {
+          break;
+        }
+
         if (!Settings.ControllerEnabled[event->ControllerIndex])
           break;
 
@@ -149,12 +161,12 @@ bool CPlugin_015(CPlugin::Function function, struct EventStruct *event, String& 
         byte valueCount = getValueCountFromSensorType(event->sensorType);
         
         // FIXME TD-er must define a proper move operator
-        success = C015_DelayHandler.addToQueue(C015_queue_element(event, valueCount));
+        success = C015_DelayHandler->addToQueue(C015_queue_element(event, valueCount));
         if (success) {
           // Element was added.
           // Now we try to append to the existing element 
           // and thus preventing the need to create a long string only to copy it to a queue element.
-          C015_queue_element &element = C015_DelayHandler.sendQueue.back();
+          C015_queue_element &element = C015_DelayHandler->sendQueue.back();
           if (ExtraTaskSettings.TaskIndex != event->TaskIndex) {
             String dummy;
             PluginCall(PLUGIN_GET_DEVICEVALUENAMES, event, dummy);
@@ -196,7 +208,7 @@ bool CPlugin_015(CPlugin::Function function, struct EventStruct *event, String& 
             element.txt[x] = formattedValue;
           }
         }
-        Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C015_DELAY_QUEUE, C015_DelayHandler.getNextScheduleTime());
+        Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C015_DELAY_QUEUE, C015_DelayHandler->getNextScheduleTime());
         break;
       }
 

--- a/src/_C016.ino
+++ b/src/_C016.ino
@@ -62,10 +62,14 @@ bool CPlugin_016(CPlugin::Function function, struct EventStruct *event, String& 
 
     case CPlugin::Function::CPLUGIN_INIT:
       {
-        MakeControllerSettings(ControllerSettings);
-        LoadControllerSettings(event->ControllerIndex, ControllerSettings);
-        C016_DelayHandler.configureControllerSettings(ControllerSettings);
+        success = init_c016_delay_queue(event->ControllerIndex);
         ControllerCache.init();
+        break;
+      }
+
+    case CPlugin::Function::CPLUGIN_EXIT:
+      {
+        exit_c016_delay_queue();
         break;
       }
 
@@ -96,10 +100,14 @@ bool CPlugin_016(CPlugin::Function function, struct EventStruct *event, String& 
         success = ControllerCache.write((uint8_t*)&element, sizeof(element));
 
 /*
+        if (C016_DelayHandler == nullptr) {
+          break;
+        }
+
         MakeControllerSettings(ControllerSettings);
         LoadControllerSettings(event->ControllerIndex, ControllerSettings);
-        success = C016_DelayHandler.addToQueue(element);
-        Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C016_DELAY_QUEUE, C016_DelayHandler.getNextScheduleTime());
+        success = C016_DelayHandler->addToQueue(element);
+        Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C016_DELAY_QUEUE, C016_DelayHandler->getNextScheduleTime());
 */
         break;
       }

--- a/src/_C017.ino
+++ b/src/_C017.ino
@@ -45,12 +45,30 @@ bool CPlugin_017(CPlugin::Function function, struct EventStruct *event, String &
       break;
     }
 
+    case CPlugin::Function::CPLUGIN_INIT:
+      {
+        success = init_c017_delay_queue(event->ControllerIndex);
+        break;
+      }
+
+    case CPlugin::Function::CPLUGIN_EXIT:
+      {
+        exit_c017_delay_queue();
+        break;
+      }
+
     case CPlugin::Function::CPLUGIN_PROTOCOL_SEND:
-    {
+      {
+      if (C017_DelayHandler == nullptr) {
+        break;
+      }
       byte valueCount = getValueCountFromSensorType(event->sensorType);
       C017_queue_element element(event);
 
       MakeControllerSettings(ControllerSettings);
+      if (!AllocatedControllerSettings()) {
+        break;
+      }
       LoadControllerSettings(event->ControllerIndex, ControllerSettings);
 
       for (byte x = 0; x < valueCount; x++)
@@ -58,8 +76,8 @@ bool CPlugin_017(CPlugin::Function function, struct EventStruct *event, String &
         element.txt[x] = formatUserVarNoCheck(event, x);
       }
       // FIXME TD-er must define a proper move operator
-      success = C017_DelayHandler.addToQueue(C017_queue_element(element));
-      Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C017_DELAY_QUEUE, C017_DelayHandler.getNextScheduleTime());
+      success = C017_DelayHandler->addToQueue(C017_queue_element(element));
+      Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C017_DELAY_QUEUE, C017_DelayHandler->getNextScheduleTime());
       break;
     }
 

--- a/src/_C018.ino
+++ b/src/_C018.ino
@@ -454,15 +454,19 @@ bool CPlugin_018(CPlugin::Function function, struct EventStruct *event, String& 
       break;
     }
 
-    case CPlugin::Function::CPLUGIN_EXIT:
+    case CPlugin::Function::CPLUGIN_INIT:
     {
-      C018_data.reset();
+      success = init_c018_delay_queue(event->ControllerIndex);
+      if (success) {
+        C018_init(event);
+      }
       break;
     }
 
-    case CPlugin::Function::CPLUGIN_INIT:
+    case CPlugin::Function::CPLUGIN_EXIT:
     {
-      C018_init(event);
+      C018_data.reset();
+      exit_c018_delay_queue();
       break;
     }
 
@@ -635,9 +639,13 @@ bool CPlugin_018(CPlugin::Function function, struct EventStruct *event, String& 
 
     case CPlugin::Function::CPLUGIN_PROTOCOL_SEND:
     {
-      success = C018_DelayHandler.addToQueue(
+      if (C018_DelayHandler == nullptr) {
+        break;
+      }
+
+      success = C018_DelayHandler->addToQueue(
         C018_queue_element(event, C018_data.getSampleSetCount(event->TaskIndex)));
-      Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C018_DELAY_QUEUE, C018_DelayHandler.getNextScheduleTime());
+      Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C018_DELAY_QUEUE, C018_DelayHandler->getNextScheduleTime());
       if (!C018_data.isInitialized()) {
         // Sometimes the module does need some time after power on to respond.
         // So it may not be initialized well at the call of CPLUGIN_INIT
@@ -678,8 +686,12 @@ bool CPlugin_018(CPlugin::Function function, struct EventStruct *event, String& 
 
 bool C018_init(struct EventStruct *event) {
   MakeControllerSettings(ControllerSettings);
+  if (!AllocatedControllerSettings()) {
+    return false;
+  }
+
   LoadControllerSettings(event->ControllerIndex, ControllerSettings);
-  C018_DelayHandler.configureControllerSettings(ControllerSettings);
+  C018_DelayHandler->configureControllerSettings(ControllerSettings);
 
   C018_ConfigStruct customConfig;
   LoadCustomControllerSettings(event->ControllerIndex, (byte *)&customConfig, sizeof(customConfig));

--- a/src/src/ControllerQueue/ControllerDelayHandlerStruct.h
+++ b/src/src/ControllerQueue/ControllerDelayHandlerStruct.h
@@ -204,13 +204,17 @@ struct ControllerDelayHandlerStruct {
   bool do_process_c##NNN####M##_delay_queue(int controller_number,                                                     \
                                            const C##NNN####M##_queue_element & element,                                \
                                            ControllerSettingsStruct & ControllerSettings);                             \
-  extern ControllerDelayHandlerStruct<C##NNN####M##_queue_element>C##NNN####M##_DelayHandler;                          \
+  typedef ControllerDelayHandlerStruct<C##NNN####M##_queue_element> C##NNN####M##_DelayHandler_t;                      \
+  extern C##NNN####M##_DelayHandler_t *C##NNN####M##_DelayHandler;                                                     \
   void process_c##NNN####M##_delay_queue();                                                                            \
+  bool init_c##NNN####M##_delay_queue(controllerIndex_t ControllerIndex);                                              \
+  void exit_c##NNN####M##_delay_queue();                                                                               \
 
 #define DEFINE_Cxxx_DELAY_QUEUE_MACRO_CPP(NNN, M)                                                                      \
-  ControllerDelayHandlerStruct<C##NNN####M##_queue_element>C##NNN####M##_DelayHandler;                                 \
+  C##NNN####M##_DelayHandler_t *C##NNN####M##_DelayHandler = nullptr;                                                  \
   void process_c##NNN####M##_delay_queue() {                                                                           \
-    C##NNN####M##_queue_element *element(C##NNN####M##_DelayHandler.getNext());                                        \
+    if (C##NNN####M##_DelayHandler == nullptr) return;                                                                 \
+    C##NNN####M##_queue_element *element(C##NNN####M##_DelayHandler->getNext());                                       \
     if (element == NULL) return;                                                                                       \
     MakeControllerSettings(ControllerSettings);                                                                        \
     bool ready = true;                                                                                                 \
@@ -218,16 +222,37 @@ struct ControllerDelayHandlerStruct {
       ready = false;                                                                                                   \
     } else {                                                                                                           \
       LoadControllerSettings(element->controller_idx, ControllerSettings);                                             \
-      C##NNN####M##_DelayHandler.configureControllerSettings(ControllerSettings);                                      \
-      if (!C##NNN####M##_DelayHandler.readyToProcess(*element)) { ready = false; }                                     \
+      C##NNN####M##_DelayHandler->configureControllerSettings(ControllerSettings);                                     \
+      if (!C##NNN####M##_DelayHandler->readyToProcess(*element)) { ready = false; }                                    \
     }                                                                                                                  \
     if (ready) {                                                                                                       \
       START_TIMER;                                                                                                     \
-      C##NNN####M##_DelayHandler.markProcessed(do_process_c##NNN####M##_delay_queue(M, *element, ControllerSettings)); \
+      C##NNN####M##_DelayHandler->markProcessed(do_process_c##NNN####M##_delay_queue(M, *element, ControllerSettings)); \
       STOP_TIMER(C##NNN####M##_DELAY_QUEUE);                                                                           \
     }                                                                                                                  \
-    Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C##NNN####M##_DELAY_QUEUE, C##NNN####M##_DelayHandler.getNextScheduleTime());         \
-  }
+    Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C##NNN####M##_DELAY_QUEUE, C##NNN####M##_DelayHandler->getNextScheduleTime());         \
+  }                                                                                                                    \
+  bool init_c##NNN####M##_delay_queue(controllerIndex_t ControllerIndex) {                                             \
+    if (C##NNN####M##_DelayHandler == nullptr) {                                                                       \
+      C##NNN####M##_DelayHandler = new C##NNN####M##_DelayHandler_t;                                                   \
+    }                                                                                                                  \
+    if (C##NNN####M##_DelayHandler == nullptr) { return false; }                                                       \
+    MakeControllerSettings(ControllerSettings);                                                                        \
+    if (!AllocatedControllerSettings()) {                                                                              \
+      return false;                                                                                                    \
+    }                                                                                                                  \
+    LoadControllerSettings(ControllerIndex, ControllerSettings);                                                       \
+    C##NNN####M##_DelayHandler->configureControllerSettings(ControllerSettings);                                       \
+    return true;                                                                                                       \
+  }                                                                                                                    \
+  void exit_c##NNN####M##_delay_queue() {                                                                              \
+    if (C##NNN####M##_DelayHandler != nullptr) {                                                                       \
+      delete C##NNN####M##_DelayHandler;                                                                               \
+      C##NNN####M##_DelayHandler = nullptr;                                                                            \
+    }                                                                                                                  \
+  }                                                                                                                    \
+
+
 
 
 // Uncrustify must not be used on macros, but we're now done, so turn Uncrustify on again.

--- a/src/src/ControllerQueue/DelayQueueElements.cpp
+++ b/src/src/ControllerQueue/DelayQueueElements.cpp
@@ -2,7 +2,33 @@
 
 
 #ifdef USES_MQTT
-ControllerDelayHandlerStruct<MQTT_queue_element> MQTTDelayHandler;
+ControllerDelayHandlerStruct<MQTT_queue_element> *MQTTDelayHandler = nullptr;
+
+bool init_mqtt_delay_queue(controllerIndex_t ControllerIndex, String& pubname, bool& retainFlag) {
+  MakeControllerSettings(ControllerSettings);
+  if (!AllocatedControllerSettings()) {
+    return false;
+  }
+  LoadControllerSettings(ControllerIndex, ControllerSettings);
+  if (MQTTDelayHandler == nullptr) {
+    MQTTDelayHandler = new ControllerDelayHandlerStruct<MQTT_queue_element>;
+  }
+  if (MQTTDelayHandler == nullptr) {
+    return false;
+  }
+  MQTTDelayHandler->configureControllerSettings(ControllerSettings);
+  pubname = ControllerSettings.Publish;
+  retainFlag = ControllerSettings.mqtt_retainFlag();
+  return true;
+}
+
+void exit_mqtt_delay_queue() {
+  if (MQTTDelayHandler != nullptr) {
+    delete MQTTDelayHandler;
+    MQTTDelayHandler = nullptr;
+  }
+}
+
 #endif // USES_MQTT
 
 

--- a/src/src/ControllerQueue/DelayQueueElements.h
+++ b/src/src/ControllerQueue/DelayQueueElements.h
@@ -28,7 +28,10 @@
 
 #ifdef USES_MQTT
 # include "../ControllerQueue/MQTT_queue_element.h"
-extern ControllerDelayHandlerStruct<MQTT_queue_element> MQTTDelayHandler;
+extern ControllerDelayHandlerStruct<MQTT_queue_element> *MQTTDelayHandler;
+
+bool init_mqtt_delay_queue(controllerIndex_t ControllerIndex, String& pubname, bool& retainFlag);
+void exit_mqtt_delay_queue();
 #endif // USES_MQTT
 
 

--- a/src/src/Helpers/PeriodicalActions.cpp
+++ b/src/src/Helpers/PeriodicalActions.cpp
@@ -220,7 +220,7 @@ void runEach30Seconds()
 
 
 void scheduleNextMQTTdelayQueue() {
-  Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_MQTT_DELAY_QUEUE, MQTTDelayHandler.getNextScheduleTime());
+  Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_MQTT_DELAY_QUEUE, MQTTDelayHandler->getNextScheduleTime());
 }
 
 void schedule_all_tasks_using_MQTT_controller() {
@@ -239,8 +239,12 @@ void schedule_all_tasks_using_MQTT_controller() {
 }
 
 void processMQTTdelayQueue() {
+  if (MQTTDelayHandler == nullptr) {
+    return;
+  }
+
   START_TIMER;
-  MQTT_queue_element *element(MQTTDelayHandler.getNext());
+  MQTT_queue_element *element(MQTTDelayHandler->getNext());
 
   if (element == NULL) { return; }
 
@@ -248,14 +252,14 @@ void processMQTTdelayQueue() {
     if (connectionFailures > 0) {
       --connectionFailures;
     }
-    MQTTDelayHandler.markProcessed(true);
+    MQTTDelayHandler->markProcessed(true);
   } else {
-    MQTTDelayHandler.markProcessed(false);
+    MQTTDelayHandler->markProcessed(false);
 #ifndef BUILD_NO_DEBUG
 
     if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
       String log = F("MQTT : process MQTT queue not published, ");
-      log += MQTTDelayHandler.sendQueue.size();
+      log += MQTTDelayHandler->sendQueue.size();
       log += F(" items left in queue");
       addLog(LOG_LEVEL_DEBUG, log);
     }


### PR DESCRIPTION
To reduce memory usage when not used.

It is a preparation for a later change into something similar as `PluginTaskData_base` used for plugins.
When switching to an array of controller data, addressed by controller index, we can support multiple instances of the same controller with different settings per controller (e.g. other hosts or topics)