### PR TITLE
[P044] Accept '_' in meter ID (#3227)

### DIFF
--- a/src/src/PluginStructs/P044_data_struct.cpp
+++ b/src/src/PluginStructs/P044_data_struct.cpp
@@ -196,6 +196,7 @@ bool P044_Task::validP1char(char ch) {
     case '-':
     case '*':
     case ':':
+    case '_':
       return true;
   }
   return false;


### PR DESCRIPTION
Small fix to accept underscores in the meter ID.
Resolves #3227 