### PR TITLE
HeatpumpIR support for ESP32

### DIFF
--- a/lib/HeatpumpIR/IRSender.h
+++ b/lib/HeatpumpIR/IRSender.h
@@ -6,7 +6,7 @@
 
 #include <Arduino.h>
 
-#ifdef ESP8266
+#if defined(ESP8266) || defined(ESP32)
 #include <IRsend.h>  // From IRremoteESP8266 library
 #include <stdint.h>
 #endif
@@ -75,7 +75,7 @@ class IRSenderESP32 : public IRSender
 };
 #endif
 
-#ifdef ESP8266
+#if defined(ESP8266) || defined(ESP32)
 class IRSenderIRremoteESP8266 : public IRSender
 {
   public:

--- a/lib/HeatpumpIR/IRSenderIRremoteESP8266.cpp
+++ b/lib/HeatpumpIR/IRSenderIRremoteESP8266.cpp
@@ -1,5 +1,5 @@
 #include <Arduino.h>
-#ifdef ESP8266
+#if defined(ESP8266) || defined(ESP32)
 #include <IRSender.h>
 
 IRSenderIRremoteESP8266::IRSenderIRremoteESP8266(uint8_t pin) : IRSender(pin), _ir(pin) 

--- a/lib/HeatpumpIR/library.properties
+++ b/lib/HeatpumpIR/library.properties
@@ -1,5 +1,5 @@
 name=HeatpumpIR
-version=1.0.15
+version=1.0.16
 author=Toni Arte<toni.arte@iki.fi>
 maintainer=Toni Arte<toni.arte@iki.fi>
 sentence=Heatpump / Air Conditioner infrared control

--- a/platformio_esp32_envs.ini
+++ b/platformio_esp32_envs.ini
@@ -68,6 +68,12 @@ build_flags               = ${esp32_common.build_flags}
 board                     = lolin_d32_pro
 extra_scripts             = ${esp32_common.extra_scripts}
 
+[env:test_ESP32_IRExt_4M316k]
+extends                   = env:test_ESP32_4M316k
+lib_ignore                = AS_BH1750, ESP8266WiFi, ESP8266Ping, ESP8266WebServer, ESP8266HTTPUpdateServer, ESP8266mDNS, ESPEasy_ESP8266Ping, ESP32_ping
+build_flags               = ${esp32_common.build_flags}
+                            -DPLUGIN_BUILD_NORMAL_IRext
+
 ; Custom: 4096k version --------------------------
 [env:custom_ESP32_4M316k_ETH]
 extends                   = env:custom_ESP32_4M316k


### PR DESCRIPTION
* HeatpumpIR library updated to version 1.0.16, which supports ESP32 with the IRremoteESP8266 library
* Build definition for image test_ESP32_IRExt_4M316k, build by running `platformio run -e test_ESP32_IRExt_4M316k`

Tested with M5STACK ATOM LITE (https://m5stack.com/collections/m5-atom/products/atom-lite-esp32-development-kit), using the built-in IR led on GPIO-12