### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ ESPEasy_mega-20190225_normal_ESP8285_1M.bin  | ESP8285 with 1MB flash  | Stable 
 ESPEasy_mega-20190225_test_ESP8285_1M.bin    | ESP8285 with 1MB flash  | Stable + Test               |
 ESPEasy_mega-20190225_dev_ESP8285_1M.bin     | ESP8285 with 1MB flash  | Stable + Test + Development |
 
-## More info
+## Documentation & more info
 
-Details and discussion are on the "Experimental" section of the forum: https://www.letscontrolit.com/forum/viewforum.php?f=18
+Our new, in-depth documentation can be found at [ESPEasy.readthedocs.io](https://espeasy.readthedocs.io/en/latest/). Automatically built, so always up-to-date according to the contributed contents. The old Wiki documention can be found at [letscontrolit.com/wiki](https://www.letscontrolit.com/wiki/index.php?title=ESPEasy).
 
-Automated builds of the (new) documentation can be found at [ESPEasy.readthedocs.io](https://espeasy.readthedocs.io/en/latest/)
+Additional details and discussion are on the "Experimental" section of the forum: https://www.letscontrolit.com/forum/viewforum.php?f=18
 
 ## Icons used
 


### PR DESCRIPTION
I was stuck with the old Wiki documentation and did not find the full-fledged, new documentation at first, but only came across it, through a mentioning in an [issue discussion](https://github.com/letscontrolit/ESPEasy/issues/3233#issuecomment-681140819), and a Google Search thereafter.

I edited the related section in your README.md accordingly and most importantly, began the headline with the keyword **Documentation** (which is what it is all about).