### PR TITLE
Fix used sensor type on plugins allowing to select output type

### DIFF
--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -39,7 +39,7 @@ void sendData(struct EventStruct *event)
   if (event->sensorType == Sensor_VType::SENSOR_TYPE_NONE) {
     const deviceIndex_t DeviceIndex = getDeviceIndex_from_TaskIndex(event->TaskIndex);
     if (validDeviceIndex(DeviceIndex)) {
-      event->sensorType = Device[DeviceIndex].VType;
+      event->sensorType = getDeviceVTypeForTask(event->TaskIndex);
     }
   }
 
@@ -86,7 +86,7 @@ bool validUserVar(struct EventStruct *event) {
     default:
       break;
   }
-  byte valueCount = getValueCountFromSensorType(event->sensorType);
+  byte valueCount = getValueCountForTask(event->TaskIndex);
 
   for (int i = 0; i < valueCount; ++i) {
     const float f(UserVar[event->BaseVarIndex + i]);
@@ -522,8 +522,8 @@ void SensorSendTask(taskIndex_t TaskIndex)
     LoadTaskSettings(TaskIndex);
 
     struct EventStruct TempEvent(TaskIndex);
+    TempEvent.sensorType = getDeviceVTypeForTask(TaskIndex);
     // TempEvent.idx = Settings.TaskDeviceID[TaskIndex]; todo check
-    TempEvent.sensorType = Device[DeviceIndex].VType;
 
     float preValue[VARS_PER_TASK]; // store values before change, in case we need it in the formula
     for (byte varNr = 0; varNr < VARS_PER_TASK; varNr++)

--- a/src/ESPEasy_fdwdecl.h
+++ b/src/ESPEasy_fdwdecl.h
@@ -147,13 +147,19 @@ bool hasIPaddr();
 //void printDirectory(File dir, int numTabs);
 
 
-
-
-
-
 bool beginWiFiUDP_randomPort(WiFiUDP& udp);
 
 
 void Blynk_Run_c015();
+
+
+
+// FIXME TD-er: Convert WebServer_Markup.ino to .h/.cpp
+void addFormSubHeader(const String& header);
+void addSelector_Head(const String& id);
+void addSelector_Item(const String& option, int index, boolean selected, boolean disabled, const String& attr);
+int getFormItemInt(const String& key, int defaultValue);
+void addSelector_Foot();
+void addFormSelector(const String& label, const String& id, int optionCount, const String options[], const int indices[], int selectedIndex);
 
 #endif // ESPEASY_FWD_DECL_H

--- a/src/WebServer_DevicesPage.ino
+++ b/src/WebServer_DevicesPage.ino
@@ -4,7 +4,10 @@
 # include "src/Globals/Device.h"
 # include "src/Globals/CPlugins.h"
 # include "src/Globals/Plugins.h"
+
 # include "src/Static/WebStaticData.h"
+
+# include "src/Helpers/_CPlugin_SensorTypeHelper.h"
 # include "src/Helpers/StringGenerator_GPIO.h"
 
 

--- a/src/_C004.ino
+++ b/src/_C004.ino
@@ -103,7 +103,7 @@ bool do_process_c004_delay_queue(int controller_number, const C004_queue_element
       postDataStr += element.txt;    // FIXME TD-er: Is this correct?
       // See: https://nl.mathworks.com/help/thingspeak/writedata.html
   } else {
-    byte valueCount = getValueCountFromSensorType(element.sensorType);
+    byte valueCount = getValueCountForTask(element.TaskIndex);
     for (byte x = 0; x < valueCount; x++)
     {
       postDataStr += F("&field");

--- a/src/_C005.ino
+++ b/src/_C005.ino
@@ -108,7 +108,7 @@ bool CPlugin_005(CPlugin::Function function, struct EventStruct *event, String& 
         LoadTaskSettings(event->TaskIndex);
         parseControllerVariables(pubname, event, false);
 
-        byte valueCount = getValueCountFromSensorType(event->sensorType);
+        byte valueCount = getValueCountForTask(event->TaskIndex);
         for (byte x = 0; x < valueCount; x++)
         {
           //MFD: skip publishing for values with empty labels (removes unnecessary publishing of unwanted values)

--- a/src/_C006.ino
+++ b/src/_C006.ino
@@ -107,7 +107,7 @@ bool CPlugin_006(CPlugin::Function function, struct EventStruct *event, String& 
         LoadTaskSettings(event->TaskIndex);
         parseControllerVariables(pubname, event, false);
 
-        byte valueCount = getValueCountFromSensorType(event->sensorType);
+        byte valueCount = getValueCountForTask(event->TaskIndex);
         for (byte x = 0; x < valueCount; x++)
         {
           String tmppubname = pubname;

--- a/src/_C007.ino
+++ b/src/_C007.ino
@@ -53,7 +53,7 @@ bool CPlugin_007(CPlugin::Function function, struct EventStruct *event, String& 
           addLog(LOG_LEVEL_ERROR, F("emoncms : No support for Sensor_VType::SENSOR_TYPE_STRING"));
           break;
         }
-        const byte valueCount = getValueCountFromSensorType(event->sensorType);
+        const byte valueCount = getValueCountForTask(event->TaskIndex);
         if (valueCount == 0 || valueCount > 3) {
           addLog(LOG_LEVEL_ERROR, F("emoncms : Unknown sensortype or too many sensor values"));
           break;
@@ -91,7 +91,7 @@ bool do_process_c007_delay_queue(int controller_number, const C007_queue_element
   String url = F("/emoncms/input/post.json?node=");
   url += Settings.Unit;
   url += F("&json=");
-  const byte valueCount = getValueCountFromSensorType(element.sensorType);
+  const byte valueCount = getValueCountForTask(element.TaskIndex);
   for (byte i = 0; i < valueCount; ++i) {
     url += (i == 0) ? F("{") : F(",");
     url += F("field");

--- a/src/_C008.ino
+++ b/src/_C008.ino
@@ -73,7 +73,7 @@ bool CPlugin_008(CPlugin::Function function, struct EventStruct *event, String& 
         }
 
         // FIXME TD-er must define a proper move operator
-        byte valueCount = getValueCountFromSensorType(event->sensorType);
+        byte valueCount = getValueCountForTask(event->TaskIndex);
         success = C008_DelayHandler->addToQueue(C008_queue_element(event, valueCount));
         if (success) {
           // Element was added.

--- a/src/_C009.ino
+++ b/src/_C009.ino
@@ -75,7 +75,7 @@ bool CPlugin_009(CPlugin::Function function, struct EventStruct *event, String& 
           break;
         }
 
-        byte valueCount = getValueCountFromSensorType(event->sensorType);
+        byte valueCount = getValueCountForTask(event->TaskIndex);
         C009_queue_element element(event);
 
         for (byte x = 0; x < valueCount; x++)
@@ -144,7 +144,7 @@ bool do_process_c009_delay_queue(int controller_number, const C009_queue_element
 
     // Create nested SENSOR json object
     JsonObject SENSOR = data.createNestedObject(String(F("SENSOR")));
-    byte valueCount = getValueCountFromSensorType(element.sensorType);
+    byte valueCount = getValueCountForTask(element.TaskIndex);
     // char itemNames[valueCount][2];
     for (byte x = 0; x < valueCount; x++)
     {

--- a/src/_C010.ino
+++ b/src/_C010.ino
@@ -58,7 +58,7 @@ bool CPlugin_010(CPlugin::Function function, struct EventStruct *event, String& 
         }
 
         LoadTaskSettings(event->TaskIndex);
-        byte valueCount = getValueCountFromSensorType(event->sensorType);
+        byte valueCount = getValueCountForTask(event->TaskIndex);
         C010_queue_element element(event, valueCount);
 
         {

--- a/src/_C011.ino
+++ b/src/_C011.ino
@@ -330,7 +330,7 @@ void ReplaceTokenByValue(String& s, struct EventStruct *event, bool sendBinary)
   //  Wert=%val3%%/3%%4%%LF%%vname4%,Standort=%tskname% Wert=%val4%%/4%
   addLog(LOG_LEVEL_DEBUG_MORE, F("HTTP before parsing: "));
   addLog(LOG_LEVEL_DEBUG_MORE, s);
-  const byte valueCount = getValueCountFromSensorType(event->sensorType);
+  const byte valueCount = getValueCountForTask(event->TaskIndex);
 
   DeleteNotNeededValues(s, valueCount);
 

--- a/src/_C012.ino
+++ b/src/_C012.ino
@@ -56,7 +56,7 @@ bool CPlugin_012(CPlugin::Function function, struct EventStruct *event, String& 
         LoadTaskSettings(event->TaskIndex);
 
         // Collect the values at the same run, to make sure all are from the same sample
-        byte valueCount = getValueCountFromSensorType(event->sensorType);
+        byte valueCount = getValueCountForTask(event->TaskIndex);
         C012_queue_element element(event, valueCount);
 
         for (byte x = 0; x < valueCount; x++)

--- a/src/_C014.ino
+++ b/src/_C014.ino
@@ -697,7 +697,7 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
         LoadTaskSettings(event->TaskIndex);
 
         String value = "";
-        byte valueCount = getValueCountFromSensorType(event->sensorType);
+        byte valueCount = getValueCountForTask(event->TaskIndex);
         for (byte x = 0; x < valueCount; x++)
         {
           String tmppubname = pubname;

--- a/src/_C015.ino
+++ b/src/_C015.ino
@@ -158,7 +158,7 @@ bool CPlugin_015(CPlugin::Function function, struct EventStruct *event, String& 
           break;
 
         // Collect the values at the same run, to make sure all are from the same sample
-        byte valueCount = getValueCountFromSensorType(event->sensorType);
+        byte valueCount = getValueCountForTask(event->TaskIndex);
         
         // FIXME TD-er must define a proper move operator
         success = C015_DelayHandler->addToQueue(C015_queue_element(event, valueCount));

--- a/src/_C016.ino
+++ b/src/_C016.ino
@@ -97,7 +97,7 @@ bool CPlugin_016(CPlugin::Function function, struct EventStruct *event, String& 
     case CPlugin::Function::CPLUGIN_PROTOCOL_SEND:
       {
         // Collect the values at the same run, to make sure all are from the same sample
-        byte valueCount = getValueCountFromSensorType(event->sensorType);
+        byte valueCount = getValueCountForTask(event->TaskIndex);
         C016_queue_element element(event, valueCount, node_time.getUnixTime());
         success = ControllerCache.write((uint8_t*)&element, sizeof(element));
 

--- a/src/_C017.ino
+++ b/src/_C017.ino
@@ -62,7 +62,7 @@ bool CPlugin_017(CPlugin::Function function, struct EventStruct *event, String &
       if (C017_DelayHandler == nullptr) {
         break;
       }
-      byte valueCount = getValueCountFromSensorType(event->sensorType);
+      byte valueCount = getValueCountForTask(event->TaskIndex);
       C017_queue_element element(event);
 
       for (byte x = 0; x < valueCount; x++)
@@ -96,7 +96,7 @@ bool do_process_c017_delay_queue(int controller_number, const C017_queue_element
 
 bool do_process_c017_delay_queue(int controller_number, const C017_queue_element &element, ControllerSettingsStruct &ControllerSettings)
 {
-  byte valueCount = getValueCountFromSensorType(element.sensorType);
+  byte valueCount = getValueCountForTask(element.TaskIndex);
   if (valueCount == 0)
     return true; //exit if we don't have anything to send.
 

--- a/src/_CPlugin_LoRa_TTN_helper.ino
+++ b/src/_CPlugin_LoRa_TTN_helper.ino
@@ -9,7 +9,7 @@
 
 String getPackedFromPlugin(struct EventStruct *event, uint8_t sampleSetCount)
 {
-  byte   value_count = getValueCountFromSensorType(event->sensorType);
+  byte   value_count = getValueCountForTask(event->TaskIndex);
   String raw_packed;
 
   if (PluginCall(PLUGIN_GET_PACKED_RAW_DATA, event, raw_packed)) {

--- a/src/_P040_ID12.ino
+++ b/src/_P040_ID12.ino
@@ -129,10 +129,10 @@ boolean Plugin_040(byte function, struct EventStruct *event, String& string)
                 break;
               }
               event->setTaskIndex(index);
+              event->sensorType = getDeviceVTypeForTask(index);
               if (!validUserVarIndex(event->BaseVarIndex)) {
                 break;
               }
-              event->sensorType = Device[DeviceIndex].VType;
               // endof workaround
 
               unsigned long key = 0, old_key = 0;

--- a/src/_P094_CULReader.ino
+++ b/src/_P094_CULReader.ino
@@ -10,6 +10,7 @@
 
 #include "_Plugin_Helper.h"
 
+#include "src/Helpers/StringConverter.h"
 #include "src/PluginStructs/P094_data_struct.h"
 
 #include <Regexp.h>

--- a/src/src/Commands/InternalCommands.cpp
+++ b/src/src/Commands/InternalCommands.cpp
@@ -3,6 +3,7 @@
 #include "../../ESPEasy_common.h"
 #include "../../ESPEasy_fdwdecl.h"
 #include "../../ESPEasy_Log.h"
+#include "../../_Plugin_Helper.h"
 #include "../Globals/Settings.h"
 
 #ifdef USES_BLYNK
@@ -395,6 +396,7 @@ bool ExecuteCommand(taskIndex_t taskIndex, EventValueSource::Enum source, const 
   // FIXME TD-er: Not sure what happens now, but TaskIndex cannot always be set here
   // since commands can originate from anywhere.
   TempEvent.setTaskIndex(taskIndex);
+  TempEvent.sensorType = getDeviceVTypeForTask(taskIndex);
   TempEvent.Source = source;
 
   String action(Line);

--- a/src/src/DataStructs/ESPEasy_EventStruct.cpp
+++ b/src/src/DataStructs/ESPEasy_EventStruct.cpp
@@ -9,7 +9,8 @@
 EventStruct::EventStruct() {}
 
 EventStruct::EventStruct(taskIndex_t taskIndex) :
-  TaskIndex(taskIndex), BaseVarIndex(taskIndex * VARS_PER_TASK) {}
+  TaskIndex(taskIndex), BaseVarIndex(taskIndex * VARS_PER_TASK) 
+{}
 
 EventStruct::EventStruct(const struct EventStruct& event) :
   String1(event.String1)

--- a/src/src/Globals/Plugins.cpp
+++ b/src/src/Globals/Plugins.cpp
@@ -341,7 +341,7 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
 
             if (validDeviceIndex(DeviceIndex)) {
               TempEvent.setTaskIndex(taskIndex);
-              TempEvent.sensorType   = Device[DeviceIndex].VType;
+              TempEvent.sensorType   = getDeviceVTypeForTask(taskIndex);
               prepare_I2C_by_taskIndex(taskIndex, DeviceIndex);
               checkRAM(F("PluginCall_s"), taskIndex);
               START_TIMER;
@@ -384,9 +384,9 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
 
           if (validDeviceIndex(DeviceIndex)) {
             TempEvent.setTaskIndex(taskIndex);
+            TempEvent.sensorType = getDeviceVTypeForTask(taskIndex);
 
             // TempEvent.idx = Settings.TaskDeviceID[taskIndex]; todo check
-            TempEvent.sensorType = Device[DeviceIndex].VType;
             prepare_I2C_by_taskIndex(taskIndex, DeviceIndex);
             START_TIMER;
             bool retval =  (Plugin_ptr[DeviceIndex](Function, &TempEvent, str));
@@ -427,9 +427,9 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
 
             if (validDeviceIndex(DeviceIndex)) {
               TempEvent.setTaskIndex(taskIndex);
+              TempEvent.sensorType = getDeviceVTypeForTask(taskIndex);
 
               // TempEvent.idx = Settings.TaskDeviceID[taskIndex]; todo check
-              TempEvent.sensorType      = Device[DeviceIndex].VType;
               TempEvent.OriginTaskIndex = event->TaskIndex;
               checkRAM(F("PluginCall_s"), taskIndex);
 
@@ -470,6 +470,7 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
           LoadTaskSettings(event->TaskIndex);
         }
         event->BaseVarIndex = event->TaskIndex * VARS_PER_TASK;
+        event->sensorType = getDeviceVTypeForTask(event->TaskIndex);
         {
           String descr;
           descr.reserve(20);
@@ -532,7 +533,7 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
           event->Par1 = Device[DeviceIndex].ValueCount;
         }
         if (Function == PLUGIN_GET_DEVICEVTYPE) {
-          event->Par1 = static_cast<int>(Device[DeviceIndex].VType);
+          event->sensorType = Device[DeviceIndex].VType;
         }
 
         START_TIMER;

--- a/src/src/Helpers/Scheduler.cpp
+++ b/src/src/Helpers/Scheduler.cpp
@@ -1,6 +1,7 @@
 #include "Scheduler.h"
 
 #include "../../ESPEasy_common.h"
+#include "../../_Plugin_Helper.h"
 
 #include "../ControllerQueue/DelayQueueElements.h"
 #include "../Globals/RTC.h"
@@ -485,7 +486,7 @@ void ESPEasy_Scheduler::process_plugin_task_timer(unsigned long id) {
   systemTimers.erase(mixedTimerId);
 
   if (validDeviceIndex(deviceIndex)) {
-    TempEvent.sensorType = Device[deviceIndex].VType;
+    TempEvent.sensorType = getDeviceVTypeForTask(it->second.TaskIndex);
 
     if (validUserVarIndex(TempEvent.BaseVarIndex)) {
       String dummy;

--- a/src/src/Helpers/_CPlugin_SensorTypeHelper.cpp
+++ b/src/src/Helpers/_CPlugin_SensorTypeHelper.cpp
@@ -1,9 +1,16 @@
-#include "src/Globals/Device.h"
-#include "src/Globals/Plugins.h"
-#include "src/DataStructs/DeviceStruct.h"
+#include "_CPlugin_SensorTypeHelper.h"
+
+#include "../../_Plugin_Helper.h"
+#include "../../ESPEasy_Log.h"
+#include "../DataStructs/DeviceStruct.h"
+#include "../Globals/Device.h"
+#include "../Globals/Plugins.h"
 
 /*********************************************************************************************\
    Get value count from sensor type
+
+   Only use this function to determine nr of output values when changing output type of a task
+   To get the actual output values for a task, use getValueCountForTask
 \*********************************************************************************************/
 byte getValueCountFromSensorType(Sensor_VType sensorType)
 {

--- a/src/src/Helpers/_CPlugin_SensorTypeHelper.h
+++ b/src/src/Helpers/_CPlugin_SensorTypeHelper.h
@@ -1,0 +1,35 @@
+#ifndef HELPER_CPLUGIN_SENSORTYPEHELPER_H
+#define HELPER_CPLUGIN_SENSORTYPEHELPER_H
+
+#include <Arduino.h>
+
+#include "../DataStructs/DeviceStruct.h"
+
+/*********************************************************************************************\
+   Get value count from sensor type
+
+   Only use this function to determine nr of output values when changing output type of a task
+   To get the actual output values for a task, use getValueCountForTask
+\*********************************************************************************************/
+byte getValueCountFromSensorType(Sensor_VType sensorType);
+
+String getSensorTypeLabel(Sensor_VType sensorType);
+
+void sensorTypeHelper_webformLoad_allTypes(struct EventStruct *event, byte pconfigIndex);
+
+void sensorTypeHelper_webformLoad_header();
+
+void sensorTypeHelper_webformLoad_simple(struct EventStruct *event, byte pconfigIndex);
+
+void sensorTypeHelper_webformLoad(struct EventStruct *event, byte pconfigIndex, int optionCount, const byte options[]);
+
+void sensorTypeHelper_saveOutputSelector(struct EventStruct *event, byte pconfigIndex, byte valueIndex, const String& defaultValueName);
+
+void pconfig_webformSave(struct EventStruct *event, byte pconfigIndex);
+
+void sensorTypeHelper_loadOutputSelector(
+  struct EventStruct *event, byte pconfigIndex, byte valuenr,
+  int optionCount, const String options[]);
+
+
+#endif // HELPER_CPLUGIN_SENSORTYPEHELPER_H


### PR DESCRIPTION
There was still an issue with the set sensorType in the events.
Not all occasions where the sensor type was needed, was the task queried , but rather the plugin.