### PR TITLE
[Load] Fix high CPU load introduced by fixing sensorType consistency

### DIFF
--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -1,6 +1,7 @@
 #include "ESPEasy_common.h"
 #include "ESPEasy_fdwdecl.h"
 #include "_CPlugin_Helper.h"
+#include "_Plugin_Helper.h"
 
 #include "src/ControllerQueue/MQTT_queue_element.h"
 
@@ -36,12 +37,6 @@ void sendData(struct EventStruct *event)
   }
 
   LoadTaskSettings(event->TaskIndex); // could have changed during background tasks.
-  if (event->sensorType == Sensor_VType::SENSOR_TYPE_NONE) {
-    const deviceIndex_t DeviceIndex = getDeviceIndex_from_TaskIndex(event->TaskIndex);
-    if (validDeviceIndex(DeviceIndex)) {
-      event->sensorType = getDeviceVTypeForTask(event->TaskIndex);
-    }
-  }
 
   for (controllerIndex_t x = 0; x < CONTROLLER_MAX; x++)
   {
@@ -80,7 +75,7 @@ void sendData(struct EventStruct *event)
 }
 
 bool validUserVar(struct EventStruct *event) {
-  switch (event->sensorType) {
+  switch (event->getSensorType()) {
     case Sensor_VType::SENSOR_TYPE_LONG:    return true;
     case Sensor_VType::SENSOR_TYPE_STRING:  return true; // FIXME TD-er: Must look at length of event->String2 ?
     default:
@@ -522,7 +517,7 @@ void SensorSendTask(taskIndex_t TaskIndex)
     LoadTaskSettings(TaskIndex);
 
     struct EventStruct TempEvent(TaskIndex);
-    TempEvent.sensorType = getDeviceVTypeForTask(TaskIndex);
+    checkDeviceVTypeForTask(&TempEvent);
     // TempEvent.idx = Settings.TaskDeviceID[TaskIndex]; todo check
 
     float preValue[VARS_PER_TASK]; // store values before change, in case we need it in the formula

--- a/src/ESPEasyRules.ino
+++ b/src/ESPEasyRules.ino
@@ -1067,7 +1067,6 @@ void createRuleEvents(struct EventStruct *event) {
   if (!validDeviceIndex(DeviceIndex)) { return; }
 
   LoadTaskSettings(event->TaskIndex);
-  const Sensor_VType sensorType = getDeviceVTypeForTask(event->TaskIndex);
 
   const byte valueCount = getValueCountForTask(event->TaskIndex);
 
@@ -1079,7 +1078,7 @@ void createRuleEvents(struct EventStruct *event) {
     eventString += ExtraTaskSettings.TaskDeviceValueNames[varNr];
     eventString += F("=");
 
-    switch (sensorType) {
+    switch (event->getSensorType()) {
       case Sensor_VType::SENSOR_TYPE_LONG:
         eventString += (unsigned long)UserVar[event->BaseVarIndex] +
                        ((unsigned long)UserVar[event->BaseVarIndex + 1] << 16);

--- a/src/WebServer_DevicesPage.ino
+++ b/src/WebServer_DevicesPage.ino
@@ -293,8 +293,7 @@ void handle_devices_CopySubmittedSettings(taskIndex_t taskIndex, pluginID_t task
     case Output_Data_type_t::Simple:
     case Output_Data_type_t::All:
     {
-      int pconfigIndex = -1;
-      getDeviceVTypeForTask(taskIndex, pconfigIndex);
+      int pconfigIndex = checkDeviceVTypeForTask(&TempEvent);
       if (pconfigIndex >= 0 && pconfigIndex < PLUGIN_CONFIGVAR_MAX) {
         Sensor_VType VType = static_cast<Sensor_VType>(getFormItemInt(PCONFIG_LABEL(pconfigIndex), 0));
         Settings.TaskDevicePluginConfig[taskIndex][pconfigIndex] = static_cast<int>(VType);
@@ -1071,8 +1070,7 @@ void devicePage_show_output_data_type(taskIndex_t taskIndex, deviceIndex_t Devic
 {
   struct EventStruct TempEvent(taskIndex);
 
-  int pconfigIndex = -1;
-  getDeviceVTypeForTask(taskIndex, pconfigIndex);
+  int pconfigIndex = checkDeviceVTypeForTask(&TempEvent);
 
   switch(Device[DeviceIndex].OutputDataType) {
     case Output_Data_type_t::Default:

--- a/src/_C001.ino
+++ b/src/_C001.ino
@@ -57,8 +57,10 @@ bool CPlugin_001(CPlugin::Function function, struct EventStruct *event, String& 
           url.reserve(128);
           url = F("/json.htm?type=command&param=");
 
+          const Sensor_VType sensorType = event->getSensorType();
 
-          switch (event->sensorType)
+
+          switch (sensorType)
           {
             case Sensor_VType::SENSOR_TYPE_SWITCH:
             case Sensor_VType::SENSOR_TYPE_DIMMER:
@@ -68,7 +70,7 @@ bool CPlugin_001(CPlugin::Function function, struct EventStruct *event, String& 
               if (UserVar[event->BaseVarIndex] == 0) {
                 url += F("Off");
               } else {
-                if (event->sensorType == Sensor_VType::SENSOR_TYPE_SWITCH) {
+                if (sensorType == Sensor_VType::SENSOR_TYPE_SWITCH) {
                   url += F("On");
                 } else {
                   url += F("Set%20Level&level=");

--- a/src/_C002.ino
+++ b/src/_C002.ino
@@ -184,7 +184,9 @@ bool CPlugin_002(CPlugin::Function function, struct EventStruct *event, String& 
         root[F("Battery")] = mapVccToDomoticz();
           #endif // if FEATURE_ADC_VCC
 
-        switch (event->sensorType)
+        const Sensor_VType sensorType = event->getSensorType();
+
+        switch (sensorType)
         {
           case Sensor_VType::SENSOR_TYPE_SWITCH:
             root[F("command")] = String(F("switchlight"));

--- a/src/_C014.ino
+++ b/src/_C014.ino
@@ -704,7 +704,7 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
           tmppubname.replace(F("%valname%"), ExtraTaskSettings.TaskDeviceValueNames[x]);
 
           // Small optimization so we don't try to copy potentially large strings
-          if (event->sensorType == Sensor_VType::SENSOR_TYPE_STRING) {
+          if (event->getSensorType() == Sensor_VType::SENSOR_TYPE_STRING) {
             MQTTpublish(event->ControllerIndex, tmppubname.c_str(), event->String2.c_str(), mqtt_retainFlag);
             value = event->String2.substring(0, 20); // For the log
           } else {

--- a/src/_CPlugin_DomoticzHelper.ino
+++ b/src/_CPlugin_DomoticzHelper.ino
@@ -64,7 +64,7 @@ String formatUserVarDomoticz(int value) {
 String formatDomoticzSensorType(struct EventStruct *event) {
   String values;
 
-  switch (event->sensorType)
+  switch (event->getSensorType())
   {
     case Sensor_VType::SENSOR_TYPE_SINGLE: // single value sensor, used for Dallas, BH1750, etc
       values = formatUserVarDomoticz(event, 0);

--- a/src/_CPlugin_LoRa_TTN_helper.ino
+++ b/src/_CPlugin_LoRa_TTN_helper.ino
@@ -34,7 +34,7 @@ String getPackedFromPlugin(struct EventStruct *event, uint8_t sampleSetCount)
   if (raw_packed.length() > 0) {
     packed += raw_packed;
   } else {
-    switch (event->sensorType)
+    switch (event->getSensorType())
     {
       case Sensor_VType::SENSOR_TYPE_LONG:
       {

--- a/src/_P040_ID12.ino
+++ b/src/_P040_ID12.ino
@@ -129,10 +129,10 @@ boolean Plugin_040(byte function, struct EventStruct *event, String& string)
                 break;
               }
               event->setTaskIndex(index);
-              event->sensorType = getDeviceVTypeForTask(index);
               if (!validUserVarIndex(event->BaseVarIndex)) {
                 break;
               }
+              checkDeviceVTypeForTask(event);
               // endof workaround
 
               unsigned long key = 0, old_key = 0;

--- a/src/_Plugin_Helper.cpp
+++ b/src/_Plugin_Helper.cpp
@@ -138,18 +138,6 @@ int getValueCountForTask(taskIndex_t   taskIndex) {
   return TempEvent.Par1;
 }
 
-Sensor_VType getDeviceVTypeForTask(taskIndex_t   taskIndex) {
-  int dummyIndex;
-  return getDeviceVTypeForTask(taskIndex, dummyIndex);
-}
-
-Sensor_VType getDeviceVTypeForTask(taskIndex_t   taskIndex, int& pconfig_index) {
-  struct EventStruct TempEvent(taskIndex);
-  pconfig_index = checkDeviceVTypeForTask(&TempEvent);
-  return TempEvent.sensorType;
-}
-
-
 int checkDeviceVTypeForTask(struct EventStruct* event) {
   if (event->sensorType == Sensor_VType::SENSOR_TYPE_NOT_SET) {
     if (validTaskIndex(event->TaskIndex)) {

--- a/src/_Plugin_Helper.cpp
+++ b/src/_Plugin_Helper.cpp
@@ -145,11 +145,19 @@ Sensor_VType getDeviceVTypeForTask(taskIndex_t   taskIndex) {
 
 Sensor_VType getDeviceVTypeForTask(taskIndex_t   taskIndex, int& pconfig_index) {
   struct EventStruct TempEvent(taskIndex);
-  String dummy;
-  if (PluginCall(PLUGIN_GET_DEVICEVTYPE, &TempEvent, dummy)) {
-    pconfig_index = TempEvent.idx;
-  } else {
-    pconfig_index = -1;
-  }
+  pconfig_index = checkDeviceVTypeForTask(&TempEvent);
   return TempEvent.sensorType;
+}
+
+
+int checkDeviceVTypeForTask(struct EventStruct* event) {
+  if (event->sensorType == Sensor_VType::SENSOR_TYPE_NOT_SET) {
+    if (validTaskIndex(event->TaskIndex)) {
+      String dummy;
+      if (PluginCall(PLUGIN_GET_DEVICEVTYPE, event, dummy)) {
+        return event->idx; // pconfig_index
+      }
+    }
+  }
+  return -1;
 }

--- a/src/_Plugin_Helper.h
+++ b/src/_Plugin_Helper.h
@@ -104,4 +104,8 @@ int getValueCountForTask(taskIndex_t   taskIndex);
 Sensor_VType getDeviceVTypeForTask(taskIndex_t taskIndex);
 Sensor_VType getDeviceVTypeForTask(taskIndex_t taskIndex, int& pconfig_index);
 
+// Check if the DeviceVType is set and update if it isn't.
+// Return pconfig_index
+int checkDeviceVTypeForTask(struct EventStruct* event);
+
 #endif // PLUGIN_HELPER_H

--- a/src/_Plugin_Helper.h
+++ b/src/_Plugin_Helper.h
@@ -101,9 +101,6 @@ bool pluginOptionalTaskIndexArgumentMatch(taskIndex_t   taskIndex,
 
 int getValueCountForTask(taskIndex_t   taskIndex);
 
-Sensor_VType getDeviceVTypeForTask(taskIndex_t taskIndex);
-Sensor_VType getDeviceVTypeForTask(taskIndex_t taskIndex, int& pconfig_index);
-
 // Check if the DeviceVType is set and update if it isn't.
 // Return pconfig_index
 int checkDeviceVTypeForTask(struct EventStruct* event);

--- a/src/src/Commands/InternalCommands.cpp
+++ b/src/src/Commands/InternalCommands.cpp
@@ -391,12 +391,11 @@ bool ExecuteCommand(taskIndex_t taskIndex, EventValueSource::Enum source, const 
     }
   }
 
-  struct EventStruct TempEvent;
-
   // FIXME TD-er: Not sure what happens now, but TaskIndex cannot always be set here
   // since commands can originate from anywhere.
+  struct EventStruct TempEvent;
   TempEvent.setTaskIndex(taskIndex);
-  TempEvent.sensorType = getDeviceVTypeForTask(taskIndex);
+  checkDeviceVTypeForTask(&TempEvent);
   TempEvent.Source = source;
 
   String action(Line);

--- a/src/src/DataStructs/DeviceStruct.h
+++ b/src/src/DataStructs/DeviceStruct.h
@@ -42,7 +42,9 @@ enum class Sensor_VType : byte {
   SENSOR_TYPE_DIMMER          =   11,
   SENSOR_TYPE_LONG            =   20,
   SENSOR_TYPE_WIND            =   21,
-  SENSOR_TYPE_STRING          =   22
+  SENSOR_TYPE_STRING          =   22,
+
+  SENSOR_TYPE_NOT_SET         = 255
 };
 
 enum class Output_Data_type_t : byte {

--- a/src/src/DataStructs/ESPEasy_EventStruct.cpp
+++ b/src/src/DataStructs/ESPEasy_EventStruct.cpp
@@ -6,6 +6,8 @@
 #include "../Globals/CPlugins.h"
 #include "../Globals/NPlugins.h"
 
+#include "../../_Plugin_Helper.h"
+
 EventStruct::EventStruct() {}
 
 EventStruct::EventStruct(taskIndex_t taskIndex) :
@@ -57,4 +59,12 @@ EventStruct& EventStruct::operator=(const struct EventStruct& other) {
 void EventStruct::setTaskIndex(taskIndex_t taskIndex) {
   TaskIndex    = taskIndex;
   BaseVarIndex = taskIndex * VARS_PER_TASK;
+  sensorType   = Sensor_VType::SENSOR_TYPE_NOT_SET;
+}
+
+Sensor_VType EventStruct::getSensorType() {
+  const int tmp_idx = idx;
+  checkDeviceVTypeForTask(this);
+  idx = tmp_idx;
+  return sensorType;
 }

--- a/src/src/DataStructs/ESPEasy_EventStruct.h
+++ b/src/src/DataStructs/ESPEasy_EventStruct.h
@@ -20,6 +20,9 @@ struct EventStruct
 
   void setTaskIndex(taskIndex_t taskIndex);
 
+  // Check (and update) sensorType if not set, plus return (corrected) sensorType
+  Sensor_VType getSensorType();
+
   String String1;
   String String2;
   String String3;
@@ -39,7 +42,7 @@ struct EventStruct
   controllerIndex_t      ControllerIndex   = INVALID_CONTROLLER_INDEX; // index position in Settings.Controller, 0-3
   notifierIndex_t        NotificationIndex = INVALID_NOTIFIER_INDEX;   // index position in Settings.Notification, 0-3
   byte                   BaseVarIndex      = 0;
-  Sensor_VType           sensorType        = Sensor_VType::SENSOR_TYPE_NONE;
+  Sensor_VType           sensorType        = Sensor_VType::SENSOR_TYPE_NOT_SET;
   byte                   OriginTaskIndex   = 0;
 };
 

--- a/src/src/Globals/CPlugins.cpp
+++ b/src/src/Globals/CPlugins.cpp
@@ -5,6 +5,7 @@
 #include "../Globals/Protocol.h"
 #include "../Globals/Settings.h"
 #include "../../ESPEasy_Log.h"
+#include "../../_Plugin_Helper.h"
 
 
 protocolIndex_t   INVALID_PROTOCOL_INDEX   = CPLUGIN_MAX;
@@ -101,6 +102,9 @@ bool CPluginCall(CPlugin::Function Function, struct EventStruct *event, String& 
 
       if (Settings.ControllerEnabled[controllerindex] && supportedCPluginID(Settings.Protocol[controllerindex]))
       {
+        if (Function == CPlugin::Function::CPLUGIN_PROTOCOL_SEND) {
+          checkDeviceVTypeForTask(event);
+        }
         protocolIndex_t ProtocolIndex = getProtocolIndex_from_ControllerIndex(controllerindex);
         CPluginCall(ProtocolIndex, Function, event, str);
       }

--- a/src/src/Globals/Plugins.cpp
+++ b/src/src/Globals/Plugins.cpp
@@ -341,7 +341,7 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
 
             if (validDeviceIndex(DeviceIndex)) {
               TempEvent.setTaskIndex(taskIndex);
-              TempEvent.sensorType   = getDeviceVTypeForTask(taskIndex);
+              //checkDeviceVTypeForTask(&TempEvent);
               prepare_I2C_by_taskIndex(taskIndex, DeviceIndex);
               checkRAM(F("PluginCall_s"), taskIndex);
               START_TIMER;
@@ -384,7 +384,7 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
 
           if (validDeviceIndex(DeviceIndex)) {
             TempEvent.setTaskIndex(taskIndex);
-            TempEvent.sensorType = getDeviceVTypeForTask(taskIndex);
+            //checkDeviceVTypeForTask(&TempEvent);
 
             // TempEvent.idx = Settings.TaskDeviceID[taskIndex]; todo check
             prepare_I2C_by_taskIndex(taskIndex, DeviceIndex);
@@ -427,7 +427,7 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
 
             if (validDeviceIndex(DeviceIndex)) {
               TempEvent.setTaskIndex(taskIndex);
-              TempEvent.sensorType = getDeviceVTypeForTask(taskIndex);
+              //checkDeviceVTypeForTask(&TempEvent);
 
               // TempEvent.idx = Settings.TaskDeviceID[taskIndex]; todo check
               TempEvent.OriginTaskIndex = event->TaskIndex;
@@ -470,7 +470,6 @@ byte PluginCall(byte Function, struct EventStruct *event, String& str)
           LoadTaskSettings(event->TaskIndex);
         }
         event->BaseVarIndex = event->TaskIndex * VARS_PER_TASK;
-        event->sensorType = getDeviceVTypeForTask(event->TaskIndex);
         {
           String descr;
           descr.reserve(20);

--- a/src/src/Helpers/Scheduler.cpp
+++ b/src/src/Helpers/Scheduler.cpp
@@ -486,9 +486,8 @@ void ESPEasy_Scheduler::process_plugin_task_timer(unsigned long id) {
   systemTimers.erase(mixedTimerId);
 
   if (validDeviceIndex(deviceIndex)) {
-    TempEvent.sensorType = getDeviceVTypeForTask(it->second.TaskIndex);
-
     if (validUserVarIndex(TempEvent.BaseVarIndex)) {
+      //checkDeviceVTypeForTask(&TempEvent);
       String dummy;
       Plugin_ptr[deviceIndex](PLUGIN_TIMER_IN, &TempEvent, dummy);
     }

--- a/src/src/Helpers/StringConverter.cpp
+++ b/src/src/Helpers/StringConverter.cpp
@@ -214,8 +214,7 @@ String doFormatUserVar(struct EventStruct *event, byte rel_index, bool mustCheck
   }
 
   const byte valueCount = getValueCountForTask(event->TaskIndex);
-
-  Sensor_VType sensorType = getDeviceVTypeForTask(event->TaskIndex);
+  Sensor_VType sensorType = event->getSensorType();
 
   if (valueCount <= rel_index) {
     isvalid = false;
@@ -685,7 +684,7 @@ void parseEventVariables(String& s, struct EventStruct *event, boolean useURLenc
   SMART_REPL(F("%id%"), String(event->idx))
 
   if (s.indexOf(F("%val")) != -1) {
-    if (event->sensorType == Sensor_VType::SENSOR_TYPE_LONG) {
+    if (event->getSensorType() == Sensor_VType::SENSOR_TYPE_LONG) {
       SMART_REPL(F("%val1%"), String((unsigned long)UserVar[event->BaseVarIndex] + ((unsigned long)UserVar[event->BaseVarIndex + 1] << 16)))
     } else {
       for (byte i = 0; i < getValueCountForTask(event->TaskIndex); ++i) {

--- a/src/src/Helpers/_CPlugin_SensorTypeHelper.cpp
+++ b/src/src/Helpers/_CPlugin_SensorTypeHelper.cpp
@@ -110,7 +110,8 @@ void sensorTypeHelper_webformLoad(struct EventStruct *event, byte pconfigIndex, 
     PCONFIG(pconfigIndex) = static_cast<byte>(choice);
   } else if (getValueCountFromSensorType(choice) != getValueCountForTask(event->TaskIndex)) {
     // Invalid value
-    choice                = getDeviceVTypeForTask(event->TaskIndex);
+    checkDeviceVTypeForTask(event);
+    choice                = event->sensorType;
     PCONFIG(pconfigIndex) = static_cast<byte>(choice);
   }
   addRowLabel(F("Output Data Type"));


### PR DESCRIPTION
See https://github.com/letscontrolit/ESPEasy/commit/33640451a520cdea3a883c853b42a2ea5768013a

In general, only sync `sensorType` when being used.
So for every place where an event `sensorType` is used, call `getSensorType()` which syncs the sensorType if it was not set.

Also no longer create an event just to get the sensorType, but use the present event.