### PR TITLE
[SendToHTTP] Return command failed if no connection could be made

### DIFF
--- a/src/src/Commands/HTTP.cpp
+++ b/src/src/Commands/HTTP.cpp
@@ -54,7 +54,11 @@ String Command_HTTP_SendToHTTP(struct EventStruct *event, const char* Line)
 #endif
             bool mustCheckAck = Settings.SendToHttp_ack();
 			send_via_http(F("Command_HTTP_SendToHTTP"), client, request, mustCheckAck);
+			return return_command_success();
 		}
+		addLog(LOG_LEVEL_ERROR, F("SendToHTTP connection failed"));
+	} else {
+		addLog(LOG_LEVEL_ERROR, F("SendToHTTP Not connected to network"));
 	}
-	return return_command_success();
+	return return_command_failed();
 }


### PR DESCRIPTION
The user did not get a lot of feedback on the sendToHTTP command when it failed.

[One example on the forum](https://www.letscontrolit.com/forum/viewtopic.php?f=4&t=7995)