### PR TITLE
[WiFi] Fix WiFi (re)connect issues caused by new WiFi timers

### DIFF
--- a/lib/RN2483-Arduino-Library/src/rn2xx3.cpp
+++ b/lib/RN2483-Arduino-Library/src/rn2xx3.cpp
@@ -242,6 +242,11 @@ String rn2xx3::peekLastError() const
   return _rn2xx3_handler.peekLastError();
 }
 
+float rn2xx3::getLoRaAirTime(uint8_t  pl) const
+{
+  return _rn2xx3_handler.getLoRaAirTime(pl);
+}
+
 String rn2xx3::getLastError()
 {
   return _rn2xx3_handler.getLastError();

--- a/lib/RN2483-Arduino-Library/src/rn2xx3.h
+++ b/lib/RN2483-Arduino-Library/src/rn2xx3.h
@@ -221,6 +221,42 @@ public:
    * This can be overwritten by the network when using OTAA.
    * So to force a datarate, call this function after initOTAA().
    */
+  /*
+    EU / CN
+    Frequencies:
+
+    EU 863-870 MHz (LoRaWAN Specification (2015), Page 35, Table 14)
+    CN 779-787 MHz (LoRaWAN Specification (2015), Page 44, Table 25)
+    EU 433 MHz (LoRaWAN Specification (2015), Page 48, Table 31)
+    DataRate    Modulation  SF  BW  bit/s
+    0           LoRa        12  125 250
+    1           LoRa        11  125 440
+    2           LoRa        10  125 980
+    3           LoRa        9   125 1'760
+    4           LoRa        8   125 3'125
+    5           LoRa        7   125 5'470
+    6           LoRa        7   250 11'000
+    7           FSK 50 kbps         50'000
+    Data rates 8-15 are reserved.
+
+    US
+    Frequencies:
+
+    US 902-928 MHz (LoRaWAN Specification (2015), Page 40, Table 18)
+    DataRate    Modulation  SF  BW  bit/s
+    0           LoRa        10  125 980
+    1           LoRa        9   125 1'760
+    2           LoRa        8   125 3'125
+    3           LoRa        7   125 5'470
+    4           LoRa        8   500 12'500
+    8           LoRa        12  500 980
+    9           LoRa        11  500 1'760
+    10          LoRa        10  500 3'900
+    11          LoRa        9   500 7'000
+    12          LoRa        8   500 12'500
+    13          LoRa        7   500 21'900
+    Data rates 5-7 and 14-15 are reserved.
+  */
   bool                     setDR(int dr);
 
   /*
@@ -286,6 +322,11 @@ public:
   String                   getLastError();
 
   String                   peekLastError() const;
+
+  // Compute the air time for a packet in msec.
+  // Formula used from https://www.loratools.nl/#/airtime
+  // @param pl   Payload length in bytes
+  float getLoRaAirTime(uint8_t  pl) const;
 
   bool                     hasJoined() const {
     return _rn2xx3_handler.Status.Joined;

--- a/lib/RN2483-Arduino-Library/src/rn2xx3_handler.cpp
+++ b/lib/RN2483-Arduino-Library/src/rn2xx3_handler.cpp
@@ -441,6 +441,7 @@ bool rn2xx3_handler::setSF(uint8_t sf)
     if (dr >= 0)
     {
       _sf = sf;
+      _dr = dr;
       return setDR(dr);
     }
   }
@@ -590,10 +591,10 @@ bool rn2xx3_handler::setFrequencyPlan(RN2xx3_datatypes::Freq_plan fp)
     default:
     {
       // set default channels 868.1, 868.3 and 868.5?
-      returnValue = false; // well we didn't do anything, so yes, false
-      break;
+      return false; // well we didn't do anything, so yes, false
     }
   }
+  _fp = fp;
 
   return returnValue;
 }
@@ -695,6 +696,56 @@ bool rn2xx3_handler::getRxDelayValues(uint32_t& rxdelay1,
   rxdelay1 = _rxdelay1;
   rxdelay2 = _rxdelay2;
   return _rxdelay1 != 0 && _rxdelay2 != 0;
+}
+
+float rn2xx3_handler::getLoRaAirTime(uint8_t  pl) const
+{
+  uint8_t  sf         = _sf;  // Spreading factor 7 - 12
+  uint16_t bw         = 125;  // Bandwidth 125 kHz default for LoRaWAN. 250 kHz also supported.
+  uint8_t  cr         = 1;    // Code Rate 4 / (CR + 4) = 4/5.  4/5 default for LoRaWAN
+  uint8_t  n_preamble = 8;    // Preamble length Default for frame = 8, beacon = 10
+  bool     header     = true; // Explicit header Default on for LoRaWAN
+  bool     crc        = true; // CRC Default on for LoRaWAN
+
+  if (sf > 12) {
+    sf = 12;
+  } else if (sf < 7) {
+    sf = 7;
+  }
+
+  if (cr > 4) {
+    cr = 4;
+  } else if (cr < 1) {
+    cr = 1;
+  }
+
+  // Symbols in frame
+  int payload_length = 8;
+  {
+    int beta_offset = 28;
+
+    if (crc) { beta_offset += 16; }
+
+    if (!header) { beta_offset -= 20; }
+    float beta_f                  = 8.0f * pl - 4.0f * sf + beta_offset;
+    bool  lowDataRateOptimization = (bw == 125 && sf >= 11);
+
+    if (lowDataRateOptimization) {
+      beta_f = beta_f / (4.0f * (sf - 2));
+    } else {
+      beta_f = beta_f / (4.0f * sf);
+    }
+    int beta = static_cast<int>(beta_f + 1.0f); // ceil
+
+    if (beta > 0) {
+      payload_length += (beta * (cr + 4));
+    }
+  }
+
+  // t_symbol and t_air in msec
+  float t_symbol = static_cast<float>(1 << sf) / bw;
+  float t_air    = ((n_preamble + 4.25f) + payload_length) * t_symbol;
+  return t_air;
 }
 
 void rn2xx3_handler::set_state(rn2xx3_handler::RN_state state) {

--- a/lib/RN2483-Arduino-Library/src/rn2xx3_handler.h
+++ b/lib/RN2483-Arduino-Library/src/rn2xx3_handler.h
@@ -189,6 +189,12 @@ public:
   bool          getRxDelayValues(uint32_t& rxdelay1,
                                  uint32_t& rxdelay2);
 
+  // Compute the air time for a packet in msec.
+  // Formula used from https://www.loratools.nl/#/airtime
+  // @param pl   Payload length in bytes
+  float getLoRaAirTime(uint8_t  pl) const;
+
+
 private:
 
   RN2xx3_datatypes::Model configureModuleType();
@@ -259,6 +265,7 @@ private:
   RN2xx3_datatypes::Model _moduleType = RN2xx3_datatypes::Model::RN_NA;
   RN2xx3_datatypes::Freq_plan _fp     = RN2xx3_datatypes::Freq_plan::TTN_EU;
   uint8_t _sf                         = 7;
+  uint8_t _dr                         = 5;
 
   bool _otaa      = true;  // Switch between OTAA or ABP activation (default OTAA)
   bool _asyncMode = false; // When set, the user must call async_loop() frequently

--- a/src/ESPEasyWiFiEvent.cpp
+++ b/src/ESPEasyWiFiEvent.cpp
@@ -71,7 +71,6 @@ void WiFiEvent(system_event_id_t event, system_event_info_t info) {
       ssid_copy[32] = 0; // Potentially add 0-termination if none present earlier
       last_ssid = (const char*) ssid_copy;
       lastConnectMoment.setNow();
-      wifi_considered_stable = false;
       processedConnect  = false;
       break;
     }
@@ -82,7 +81,7 @@ void WiFiEvent(system_event_id_t event, system_event_info_t info) {
         WiFi.persistent(false);
         WiFi.disconnect(true);
 
-        if (last_wifi_connect_attempt_moment.isSet() && (lastConnectMoment > last_wifi_connect_attempt_moment)) {
+        if (last_wifi_connect_attempt_moment.isSet() && (!lastConnectMoment.isSet())) {
           // There was an unsuccessful connection attempt
           lastConnectedDuration_us = last_wifi_connect_attempt_moment.timeDiff(lastDisconnectMoment);
         } else {
@@ -169,7 +168,6 @@ void WiFiEvent(system_event_id_t event, system_event_info_t info) {
 
 void onConnected(const WiFiEventStationModeConnected& event) {
   lastConnectMoment.setNow();
-  wifi_considered_stable = false;
   processedConnect  = false;
   channel_changed   = RTC.lastWiFiChannel != event.channel;
   RTC.lastWiFiChannel      = event.channel;
@@ -187,7 +185,7 @@ void onConnected(const WiFiEventStationModeConnected& event) {
 void onDisconnect(const WiFiEventStationModeDisconnected& event) {
   lastDisconnectMoment.setNow();
 
-  if (lastConnectMoment > last_wifi_connect_attempt_moment) {
+  if (last_wifi_connect_attempt_moment.isSet() && !lastConnectMoment.isSet()) {
     // There was an unsuccessful connection attempt
     lastConnectedDuration_us = last_wifi_connect_attempt_moment.timeDiff(lastDisconnectMoment);
   } else {

--- a/src/ESPEasyWifi.cpp
+++ b/src/ESPEasyWifi.cpp
@@ -213,7 +213,11 @@ void WiFiConnectRelaxed() {
     log += wifi_connect_attempt + 1;
     addLog(LOG_LEVEL_INFO, log);
   }
+  wifiStatus            = ESPEASY_WIFI_DISCONNECTED;
   lastDisconnectMoment.clear();
+  lastConnectMoment.clear();
+  lastGetIPmoment.clear();
+  wifi_considered_stable = false;
   last_wifi_connect_attempt_moment.setNow();
   wifiConnectInProgress            = true;
 
@@ -258,7 +262,9 @@ bool prepareWiFi() {
   WiFi.config(INADDR_NONE, INADDR_NONE, INADDR_NONE);
   #endif // if defined(ESP32)
 
-  if (RTC.lastWiFiChannel == 0 && wifi_connect_attempt <= 1) {
+  const bool canSkipScan = RTC.lastWiFiChannel != 0 && wifi_connect_attempt <= 1;
+
+  if (!canSkipScan) {
     WifiScan(false, true);
   }
   setConnectionSpeed();
@@ -322,7 +328,7 @@ void resetWiFi() {
     // Don't reset WiFi too often
     return;
   }
-  lastDisconnectMoment.setNow();
+  lastDisconnectMoment.clear();
   lastWiFiResetMoment.setNow();
   wifiStatus            = ESPEASY_WIFI_DISCONNECTED;
   lastConnectMoment.clear();
@@ -645,7 +651,12 @@ bool wifiConnectTimeoutReached() {
   // For the first attempt, do not wait to start connecting.
   if (wifi_connect_attempt == 0) { return true; }
 
-  if (lastDisconnectMoment.isSet() && (last_wifi_connect_attempt_moment > lastDisconnectMoment)) {
+  if (!last_wifi_connect_attempt_moment.isSet()) {
+    // No attempt made
+    return true;
+  }
+
+  if (lastDisconnectMoment.isSet()) {
     // Connection attempt was already ended.
     return true;
   }
@@ -656,7 +667,7 @@ bool wifiConnectTimeoutReached() {
   }
 
   // wait until it connects + add some device specific random offset to prevent
-  // all nodes overloading the accesspoint when turning on at the same time.
+  // all nodes overloading the access point when turning on at the same time.
   #if defined(ESP8266)
   const unsigned int randomOffset_in_msec = (wifi_connect_attempt == 1) ? 0 : 1000 * ((ESP.getChipId() & 0xF));
   #endif // if defined(ESP8266)

--- a/src/ESPEasyWifi_ProcessEvent.cpp
+++ b/src/ESPEasyWifi_ProcessEvent.cpp
@@ -128,7 +128,7 @@ void handle_unprocessedWiFiEvents()
   if (wifi_connect_attempt > 0) {
     // We only want to clear this counter if the connection is currently stable.
     if (bitRead(wifiStatus, ESPEASY_WIFI_SERVICES_INITIALIZED)) {
-      if (lastConnectMoment.timeoutReached(WIFI_CONNECTION_CONSIDERED_STABLE)) {
+      if (lastConnectMoment.isSet() && lastConnectMoment.timeoutReached(WIFI_CONNECTION_CONSIDERED_STABLE)) {
         // Connection considered stable
         wifi_connect_attempt = 0;
         wifi_considered_stable = true;

--- a/src/src/DataStructs/TimingStats.cpp
+++ b/src/src/DataStructs/TimingStats.cpp
@@ -228,6 +228,7 @@ String getMiscStatsName(int stat) {
     case PARSE_SYSVAR:            return F("parseSystemVariables()");
     case PARSE_SYSVAR_NOCHANGE:   return F("parseSystemVariables() No change");
     case HANDLE_SERVING_WEBPAGE:  return F("handle webpage");
+    case C018_AIR_TIME:           return F("C018 LoRa TTN - Air Time");
     case C001_DELAY_QUEUE:
     case C002_DELAY_QUEUE:
     case C003_DELAY_QUEUE:

--- a/src/src/DataStructs/TimingStats.h
+++ b/src/src/DataStructs/TimingStats.h
@@ -54,26 +54,33 @@
 # define C018_DELAY_QUEUE        33
 # define C019_DELAY_QUEUE        34
 # define C020_DELAY_QUEUE        35
-# define TRY_CONNECT_HOST_TCP    36
-# define TRY_CONNECT_HOST_UDP    37
-# define HOST_BY_NAME_STATS      38
-# define CONNECT_CLIENT_STATS    39
-# define LOAD_CUSTOM_TASK_STATS  40
-# define WIFI_ISCONNECTED_STATS  41
-# define WIFI_NOTCONNECTED_STATS 42
-# define LOAD_TASK_SETTINGS      43
-# define TRY_OPEN_FILE           44
-# define FS_GC_SUCCESS           45
-# define FS_GC_FAIL              46
-# define PARSE_SYSVAR            47
-# define PARSE_SYSVAR_NOCHANGE   48
-# define PARSE_TEMPLATE_PADDED   49
-# define RULES_PROCESSING        50
-# define GRAT_ARP_STATS          51
-# define BACKGROUND_TASKS        52
-# define HANDLE_SCHEDULER_IDLE   53
-# define HANDLE_SCHEDULER_TASK   54
-# define HANDLE_SERVING_WEBPAGE  55
+# define C021_DELAY_QUEUE        36
+# define C022_DELAY_QUEUE        37
+# define C023_DELAY_QUEUE        38
+# define C024_DELAY_QUEUE        39
+# define C025_DELAY_QUEUE        40
+# define C018_AIR_TIME           41
+# define TRY_CONNECT_HOST_TCP    42
+# define TRY_CONNECT_HOST_UDP    43
+# define HOST_BY_NAME_STATS      44
+# define CONNECT_CLIENT_STATS    45
+# define LOAD_CUSTOM_TASK_STATS  46
+# define WIFI_ISCONNECTED_STATS  47
+# define WIFI_NOTCONNECTED_STATS 48
+# define LOAD_TASK_SETTINGS      49
+# define TRY_OPEN_FILE           50
+# define FS_GC_SUCCESS           51
+# define FS_GC_FAIL              52
+# define PARSE_SYSVAR            53
+# define PARSE_SYSVAR_NOCHANGE   54
+# define PARSE_TEMPLATE_PADDED   55
+# define RULES_PROCESSING        56
+# define GRAT_ARP_STATS          57
+# define BACKGROUND_TASKS        58
+# define HANDLE_SCHEDULER_IDLE   59
+# define HANDLE_SCHEDULER_TASK   60
+# define HANDLE_SERVING_WEBPAGE  61
+
 
 class TimingStats {
 public:
@@ -109,7 +116,7 @@ extern std::map<int, TimingStats> controllerStats;
 extern std::map<int, TimingStats> miscStats;
 extern unsigned long timingstats_last_reset;
 
-# define START_TIMER const unsigned statisticsTimerStart(micros());
+# define START_TIMER const unsigned long statisticsTimerStart(micros());
 # define STOP_TIMER_TASK(T, F) \
   if (mustLogFunction(F)) pluginStats[(T) * 256 + (F)].add(usecPassedSince(statisticsTimerStart));
 # define STOP_TIMER_CONTROLLER(T, F) \
@@ -118,12 +125,16 @@ extern unsigned long timingstats_last_reset;
 // #define STOP_TIMER_LOADFILE miscStats[LOADFILE_STATS].add(usecPassedSince(statisticsTimerStart));
 # define STOP_TIMER(L) miscStats[L].add(usecPassedSince(statisticsTimerStart));
 
+// Add a timer statistic value in usec.
+# define ADD_TIMER_STAT(L, T) miscStats[L].add(T);
+
 #else // ifdef USES_TIMING_STATS
 
 # define START_TIMER
 # define STOP_TIMER_TASK(T, F) ;
 # define STOP_TIMER_CONTROLLER(T, F) ;
 # define STOP_TIMER(L) ;
+# define ADD_TIMER_STAT(L, T) ;
 
 
 // FIXME TD-er: This class is used as a parameter in functions defined in .ino files.

--- a/src/src/Helpers/LongTermTimer.h
+++ b/src/src/Helpers/LongTermTimer.h
@@ -10,6 +10,10 @@ public:
 
   LongTermTimer() {}
 
+  explicit LongTermTimer(bool usenow) : _timer_usec(0ull) {
+    if (usenow) setNow();
+  }
+
   //explicit LongTermTimer(uint64_t start_time) : _timer_usec(start_time) {}
 
   inline bool operator<(const LongTermTimer& rhs) const


### PR DESCRIPTION
In a quite recent commit, a fix was made for devices connected over 2^31 msec (close to 25 days)
But this also introduced some new issues which could manifest itself if the initial WiFi connect wasn't immediate.

Symptoms:
- Connect to fallback WiFi may take several minutes (sometimes > 10 minutes)
- Connect to hidden AP during setup may not work or take minutes to complete
- Reconnect to AP may fail if the AP wasn't found on initial scan at boot of ESP.
- MQTT may not always reconnect or web page may only react after several minutes if there has been a WiFi reconnect (or just 2nd attempt)