### PR TITLE
[I2C] Update I2C clock based on frequency, not in low/high speed mode

### DIFF
--- a/src/src/Helpers/Hardware.cpp
+++ b/src/src/Helpers/Hardware.cpp
@@ -202,14 +202,14 @@ void initI2C() {
 }
 
 void I2CSelectClockSpeed(bool setLowSpeed) {
-  static uint8_t lastI2CClockSpeed = 255;  
-  const uint8_t newI2CClockSpeed = setLowSpeed ? 0 : 1;
+  static uint32_t lastI2CClockSpeed = 0;
+  const uint32_t newI2CClockSpeed = setLowSpeed ? Settings.I2C_clockSpeed_Slow : Settings.I2C_clockSpeed;
   if (newI2CClockSpeed == lastI2CClockSpeed) {
     // No need to change the clock speed.
     return;
   }
   lastI2CClockSpeed = newI2CClockSpeed;  
-  Wire.setClock(setLowSpeed ? Settings.I2C_clockSpeed_Slow : Settings.I2C_clockSpeed);
+  Wire.setClock(newI2CClockSpeed);
 }
 
 #ifdef FEATURE_I2CMULTIPLEXER


### PR DESCRIPTION
It was updating the I2C clock speed based on high/low speed mode, thus changes in I2C clock frequency settings were not applied until a reboot. (or a task was set to use low speed)