### PR TITLE
[command] Trim spaces from commands given via web interface Tools page

### DIFF
--- a/src/src/WebServer/ToolsPage.cpp
+++ b/src/src/WebServer/ToolsPage.cpp
@@ -46,6 +46,7 @@ void handle_tools() {
   printToWeb     = true;
   printWebString = "";
 
+  webrequest.trim();
   if (webrequest.length() > 0)
   {
     ExecuteCommand_all(EventValueSource::Enum::VALUE_SOURCE_WEB_FRONTEND, webrequest.c_str());


### PR DESCRIPTION
` gpio.2.0` (with leading space) would result in "Failed" as reply.
