### PR TITLE
[P056] Fixed bug when SDS sensor is not reporting

### DIFF
--- a/lib/SerialDevices/jkSDS011.cpp
+++ b/lib/SerialDevices/jkSDS011.cpp
@@ -94,6 +94,9 @@ void CjkSDS011::SetWorkingPeriod(int minutes) {
   const int currentWorkingPeriod = GetWorkingPeriod();
   if (minutes != currentWorkingPeriod)
     SendCommand(8, 1, minutes);
+  // In some cases the Sensor is set to "report query"-mode, this makes sure to set active reporting of values, otherwise the sensor won't work.
+  Process();
+  SendCommand(2, 1, 0);
 }
 
 int CjkSDS011::GetWorkingPeriod() {


### PR DESCRIPTION
Fixed bug that makes the sensor not reporting values even when everything is well connected.
The problem is that the Sensor is in "Query reporting" mode, and therefore it is not actively sending values.
The fix consist of setting the Sensor in "Active reporting" (command 2,1,0), when setting the working during configuration.
The change is tested an validated on a SDS011 with a NodeMCU ESP8266 + 0.96 Inch OLED, bringing life to my sensor after a long search.