### PR TITLE
[P073] Display a zero-prefix for temperatures between 0.9 and -0.9

### DIFF
--- a/src/_P073_7DGT.ino
+++ b/src/_P073_7DGT.ino
@@ -129,7 +129,9 @@ struct P073_data_struct : public PluginTaskData_base {
   void FillBufferWithTemp(long temperature) {
     ClearBuffer();
     char p073_digit[8];
-    sprintf_P(p073_digit, PSTR("%7d"), static_cast<int>(temperature));
+    bool between10and0 = (temperature < 10 && temperature >= 0);      // To have a zero prefix (0.x and -0.x) display between 0.9 and -0.9 degrees,
+    bool between0andMinus10 = (temperature < 0 && temperature > -10); // as all display types use 1 digit for temperatures between 10.0 and -10.0
+    sprintf_P(p073_digit, (between10and0 ? PSTR("     %02d") : (between0andMinus10 ? PSTR("    %03d") : PSTR("%7d"))), static_cast<int>(temperature));
     int p073_numlenght = strlen(p073_digit);
 
     for (int i = 0; i < p073_numlenght; i++) {


### PR DESCRIPTION
To display `0.9` .. `-0.9` instead of `.9` .. `-.9`.

Adds an exception for temperatures between 0.9 and -0.9 degrees as all display types use 1 digit accuracy when between 10 and -10 degrees.

Resolves #3450 