### PR TITLE
Increase buffer size

### DIFF
--- a/src/src/PluginStructs/P044_data_struct.cpp
+++ b/src/src/PluginStructs/P044_data_struct.cpp
@@ -117,8 +117,12 @@ void P044_Task::checkBlinkLED() {
 }
 
 void P044_Task::clearBuffer() {
+  if (serial_buffer.length() > maxMessageSize) {
+    maxMessageSize = serial_buffer.length();
+  }
+
   serial_buffer = "";
-  serial_buffer.reserve(P044_DATAGRAM_MAX_SIZE);
+  serial_buffer.reserve(maxMessageSize);
 }
 
 void P044_Task::addChar(char ch) {
@@ -143,11 +147,11 @@ bool P044_Task::checkDatagram() const {
 
   const int checksumStartIndex = endChar + 1;
 
-  if (PLUGIN_044_DEBUG) {
+  #ifdef PLUGIN_044_DEBUG
     for (unsigned int cnt = 0; cnt < serial_buffer.length(); ++cnt) {
       serialPrint(serial_buffer.substring(cnt, 1));
     }
-  }
+  #endif
 
   // calculate the CRC and check if it equals the hexadecimal one attached to the datagram
   unsigned int crc = CRC16(serial_buffer, checksumStartIndex);
@@ -332,11 +336,11 @@ bool P044_Task::handleChar(char ch) {
     // input is not a datagram char
     addLog(LOG_LEVEL_DEBUG, F("P1   : Error: DATA corrupt, discarded input."));
 
-    if (PLUGIN_044_DEBUG) {
+    #ifdef PLUGIN_044_DEBUG
       serialPrint(F("faulty char>"));
       serialPrint(String(ch));
       serialPrintln("<");
-    }
+    #endif
     state = ParserState::WAITING; // reset
   }
 

--- a/src/src/PluginStructs/P044_data_struct.h
+++ b/src/src/PluginStructs/P044_data_struct.h
@@ -7,9 +7,7 @@
 
 #include <ESPeasySerial.h>
 
-#ifndef PLUGIN_044_DEBUG
-  # define PLUGIN_044_DEBUG                 false // extra logging in serial out
-#endif // ifndef PLUGIN_044_DEBUG
+// #define PLUGIN_044_DEBUG  // extra logging in serial out
 
 #define P044_STATUS_LED                    12
 #define P044_CHECKSUM_LENGTH               4
@@ -97,6 +95,7 @@ struct P044_Task : public PluginTaskData_base {
   boolean        CRCcheck          = false;
   ESPeasySerial *P1EasySerial      = nullptr;
   unsigned long  blinkLEDStartTime = 0;
+  size_t         maxMessageSize    = P044_DATAGRAM_MAX_SIZE / 4;
 };
 
 #endif

--- a/src/src/PluginStructs/P044_data_struct.h
+++ b/src/src/PluginStructs/P044_data_struct.h
@@ -15,7 +15,7 @@
 #define P044_CHECKSUM_LENGTH               4
 #define P044_DATAGRAM_START_CHAR           '/'
 #define P044_DATAGRAM_END_CHAR             '!'
-#define P044_DATAGRAM_MAX_SIZE             1024
+#define P044_DATAGRAM_MAX_SIZE             2048
 
 
 struct P044_Task : public PluginTaskData_base {


### PR DESCRIPTION
It turns out some DSMR5 meters return bigger telegrams than the current DATAGRAM_MAX_SIZE value. I saw a telegram of around 1100 bytes.
This is likely to occur on 3-phase meters with a gasmeter connected and some power failure occurrences.

I doubled the size to make sure telegrams in the future with even more data fields are not causing issues. However, I'm not sure this size could cause any other issues, so I could lower it a bit.