### PR TITLE
Added choice SH1106 controller to plugin 23

### DIFF
--- a/src/_P023_OLED.ino
+++ b/src/_P023_OLED.ino
@@ -65,6 +65,8 @@ boolean Plugin_023(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_WEBFORM_LOAD:
     {
+      addFormCheckBox(F("Use SH1106 controller"), F("p023_use_sh1106"), PCONFIG(5));
+
       {
         byte choice2         = PCONFIG(1);
         String options2[2]   = { F("Normal"), F("Rotated") };
@@ -109,6 +111,8 @@ boolean Plugin_023(byte function, struct EventStruct *event, String& string)
       PCONFIG(2) = getFormItemInt(F("plugin_23_timer"));
       PCONFIG(3) = getFormItemInt(F("p023_size"));
       PCONFIG(4) = getFormItemInt(F("p023_font_spacing"));
+      PCONFIG(5) = isFormItemChecked(F("p023_use_sh1106"));
+
 
       // FIXME TD-er: This is a huge stack allocated object.
       char   deviceTemplate[P23_Nlines][P23_Nchars];
@@ -135,6 +139,8 @@ boolean Plugin_023(byte function, struct EventStruct *event, String& string)
       byte type                              = 0;
       P023_data_struct::Spacing font_spacing = P023_data_struct::Spacing::normal;
       byte displayTimer                      = PCONFIG(2);
+      byte use_sh1106                        = PCONFIG(5);
+
 
       switch (PCONFIG(3)) {
         case 1:
@@ -161,7 +167,7 @@ boolean Plugin_023(byte function, struct EventStruct *event, String& string)
           break;
       }
 
-      initPluginTaskData(event->TaskIndex, new (std::nothrow) P023_data_struct(address, type, font_spacing, displayTimer));
+      initPluginTaskData(event->TaskIndex, new (std::nothrow) P023_data_struct(address, type, font_spacing, displayTimer, use_sh1106));
       P023_data_struct *P023_data =
         static_cast<P023_data_struct *>(getPluginTaskData(event->TaskIndex));
 

--- a/src/src/PluginStructs/P023_data_struct.cpp
+++ b/src/src/PluginStructs/P023_data_struct.cpp
@@ -205,8 +205,8 @@ const char Plugin_023_myFont[][8] PROGMEM = {
 };
 
 
-P023_data_struct::P023_data_struct(byte _address,   byte _type, P023_data_struct::Spacing _font_spacing, byte _displayTimer)
-  :  address(_address), type(_type),  font_spacing(_font_spacing),  displayTimer(_displayTimer)
+P023_data_struct::P023_data_struct(byte _address,   byte _type, P023_data_struct::Spacing _font_spacing, byte _displayTimer,byte _use_sh1106)
+  :  address(_address), type(_type),  font_spacing(_font_spacing),  displayTimer(_displayTimer), use_sh1106(_use_sh1106)
 {}
 
 void P023_data_struct::setDisplayTimer(byte _displayTimer) {
@@ -315,6 +315,12 @@ void P023_data_struct::sendCommand(unsigned char com)
 // or 8 COL * 5 ROW map (64x48 pixels)
 void P023_data_struct::setXY(unsigned char row, unsigned char col)
 {
+  unsigned char col_offset = 0;
+
+  if (use_sh1106) {
+      col_offset = 0x02;    // offset of 2 when using SSH1106 controller
+  }
+
   switch (type)
   {
     case OLED_64x48:
@@ -325,9 +331,9 @@ void P023_data_struct::setXY(unsigned char row, unsigned char col)
       row += 2;
   }
 
-  sendCommand(0xb0 + row);                     // set page address
-  sendCommand(0x00 + (8 * col & 0x0f));        // set low col address
-  sendCommand(0x10 + ((8 * col >> 4) & 0x0f)); // set high col address
+  sendCommand(0xb0 + row);                              // set page address
+  sendCommand(0x00 + ((8 * col + col_offset) & 0x0f));  // set low col address
+  sendCommand(0x10 + ((8 * col >> 4) & 0x0f));          // set high col address
 }
 
 // Prints a string regardless the cursor position.
@@ -407,16 +413,24 @@ void P023_data_struct::init_OLED()
   sendCommand(0xD3);       // SETDISPLAYOFFSET
   sendCommand(0x00);       // no offset
   sendCommand(0x40 | 0x0); // SETSTARTLINE
-  sendCommand(0x8D);       // CHARGEPUMP
-  sendCommand(0x14);
+  if (use_sh1106) {
+    sendCommand(0xAD);       // CHARGEPUMP mode SH1106
+    sendCommand(0x8B);       // CHARGEPUMP On SH1106
+    sendCommand(0x32);       // CHARGEPUMP voltage 8V SH1106
+    sendCommand(0x81);       // SETCONTRAS
+    sendCommand(0x80);       // SH1106
+  } else {
+    sendCommand(0x8D);       // CHARGEPUMP
+    sendCommand(0x14);
+    sendCommand(0x81);       // SETCONTRAS
+    sendCommand(0xCF);
+  }
   sendCommand(0x20);       // MEMORYMODE
   sendCommand(0x00);       // 0x0 act like ks0108
   sendCommand(0xA0);       // 128x32 ???
   sendCommand(0xC0);       // 128x32 ???
   sendCommand(0xDA);       // COMPINS
   sendCommand(compins);    // 0x02 if 128x32, 0x12 if others (e.g. 128x64)
-  sendCommand(0x81);       // SETCONTRAS
-  sendCommand(0xCF);
   sendCommand(0xD9);       // SETPRECHARGE
   sendCommand(0xF1);
   sendCommand(0xDB);       // SETVCOMDETECT

--- a/src/src/PluginStructs/P023_data_struct.h
+++ b/src/src/PluginStructs/P023_data_struct.h
@@ -26,7 +26,8 @@ struct P023_data_struct : public PluginTaskData_base {
   P023_data_struct(byte    _address,
                    byte    _type,
                    Spacing _font_spacing,
-                   byte    _displayTimer);
+                   byte    _displayTimer,
+                   byte    _use_sh1106);
 
   void   setDisplayTimer(byte _displayTimer);
   void   checkDisplayTimer();
@@ -75,6 +76,8 @@ struct P023_data_struct : public PluginTaskData_base {
   byte    type         = 0;
   Spacing font_spacing = Spacing::normal;
   byte    displayTimer = 0;
+  byte    use_sh1106   = 0;
+
 };
 
 #endif // ifdef USES_P023


### PR DESCRIPTION
There are oled 1.3 inch displays which are using SH1106 controller instead of SSD1306. When using this display with the original SSD1306 plugin, the pixels are shifted. This pixel shift is adjusted wjen using this changes.
Will resolve https://github.com/letscontrolit/ESPEasy/issues/2185