### PR TITLE
[WiFi] Fix crash when deleting element from empty list

### DIFF
--- a/src/src/ESPEasyCore/Serial.cpp
+++ b/src/src/ESPEasyCore/Serial.cpp
@@ -119,7 +119,7 @@ void process_serialWriteBuffer() {
 
     if (snip < bytes_to_write) { bytes_to_write = snip; }
 
-    while (bytes_to_write > 0) {
+    while (bytes_to_write > 0 && !serialWriteBuffer.empty()) {
       const char c = serialWriteBuffer.front();
       Serial.write(c);
       serialWriteBuffer.pop_front();

--- a/src/src/Helpers/WiFi_AP_CandidatesList.cpp
+++ b/src/src/Helpers/WiFi_AP_CandidatesList.cpp
@@ -105,7 +105,9 @@ bool WiFi_AP_CandidatesList::getNext() {
 
   if (mustPop) {
     known_it = known.begin();
-    candidates.pop_front();
+    if (!candidates.empty()) {
+      candidates.pop_front();
+    }
   }
   return true;
 }


### PR DESCRIPTION
Erase from a list from an element that does not exist may cause strange crashes when it is deleted either using `pop_front()`, `pop_back()` or `erase()`.