### PR TITLE
Clear error by reading the error register loglevel independent

### DIFF
--- a/src/_P090_CCS811.ino
+++ b/src/_P090_CCS811.ino
@@ -316,10 +316,12 @@ boolean Plugin_090(byte function, struct EventStruct *event, String& string)
       }
       else if (P090_data->myCCS811.checkForStatusError())
       {
+        // get error and also clear it
+        String errorMsg = P090_data->myCCS811.getSensorError();
         if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
           // If the CCS811 found an internal error, print it.
           String log = F("CCS811 : Error: ");
-          log += P090_data->myCCS811.getSensorError();
+          log += errorMsg;
           addLog(LOG_LEVEL_ERROR, log);
         }
       }


### PR DESCRIPTION
According to the manual the ERROR_ID register will be cleared by the following events:
- The application software performs a read of the ERROR register on the I2C interface
- The application software performs the SW_RESET sequence by writing the appropriate code to the
SW_RESET mailbox
- A power on reset is issued
- The nRESET signal is asserted

Reading the status register is insufficient to reset the error. Therefore, if an error occurred always read the error register, thus independent of the log level used.