### PR TITLE
 [ESPEasy p2p] Add check on buffer allocation received UDP data

### DIFF
--- a/src/src/Helpers/Networking.cpp
+++ b/src/src/Helpers/Networking.cpp
@@ -63,7 +63,6 @@ void etharp_gratuitous_r(struct netif *netif) {
 #endif  // USE_SETTINGS_ARCHIVE
 
 
-
 /*********************************************************************************************\
    Syslog client
 \*********************************************************************************************/
@@ -72,6 +71,7 @@ void syslog(byte logLevel, const char *message)
   if ((Settings.Syslog_IP[0] != 0) && NetworkConnected())
   {
     IPAddress broadcastIP(Settings.Syslog_IP[0], Settings.Syslog_IP[1], Settings.Syslog_IP[2], Settings.Syslog_IP[3]);
+
     if (portUDP.beginPacket(broadcastIP, Settings.SyslogPort) == 0) {
       // problem resolving the hostname or port
       return;
@@ -97,32 +97,34 @@ void syslog(byte logLevel, const char *message)
       hostname.trim();
       hostname.replace(' ', '_');
       header.reserve(16 + hostname.length());
-      char str[8] = {0};
+      char str[8] = { 0 };
       snprintf_P(str, sizeof(str), PSTR("<%u>"), prio);
-      header = str;
+      header  = str;
       header += hostname;
       header += F(" EspEasy: ");
       #ifdef ESP8266
-      portUDP.write(header.c_str(), header.length());
-      #endif
+      portUDP.write(header.c_str(),            header.length());
+      #endif // ifdef ESP8266
       #ifdef ESP32
       portUDP.write((uint8_t *)header.c_str(), header.length());
-      #endif
+      #endif // ifdef ESP32
     }
-    const char* c = message;
-    bool done = false;
+    const char *c = message;
+    bool done     = false;
+
     while (!done) {
       // Must use PROGMEM aware functions here to process message
       char ch = pgm_read_byte(c++);
+
       if (ch == '\0') {
         done = true;
       } else {
         #ifdef ESP8266
         portUDP.write(ch);
-        #endif
+        #endif // ifdef ESP8266
         #ifdef ESP32
         portUDP.write((uint8_t)ch);
-        #endif
+        #endif // ifdef ESP32
       }
     }
     portUDP.endPacket();
@@ -139,13 +141,16 @@ void updateUDPport()
   if (Settings.UDPPort == lastUsedUDPPort) {
     return;
   }
+
   if (lastUsedUDPPort != 0) {
     portUDP.stop();
     lastUsedUDPPort = 0;
   }
+
   if (!NetworkConnected()) {
     return;
   }
+
   if (Settings.UDPPort != 0) {
     if (portUDP.begin(Settings.UDPPort) == 0) {
       if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
@@ -155,6 +160,7 @@ void updateUDPport()
       }
     } else {
       lastUsedUDPPort = Settings.UDPPort;
+
       if (loglevelActiveFor(LOG_LEVEL_INFO)) {
         String log = F("UDP : Start listening on port ");
         log += String(Settings.UDPPort);
@@ -163,8 +169,6 @@ void updateUDPport()
     }
   }
 }
-
-
 
 /*********************************************************************************************\
    Check UDP messages (ESPEasy propiertary protocol)
@@ -198,9 +202,9 @@ void checkUDP()
       return;
     }
 
-    // UDP_PACKETSIZE_MAX should be as small as possible but still enough to hold all 
+    // UDP_PACKETSIZE_MAX should be as small as possible but still enough to hold all
     // data for PLUGIN_UDP_IN or CPLUGIN_UDP_IN calls
-    // This node may also receive other UDP packets which may be quite large 
+    // This node may also receive other UDP packets which may be quite large
     // and then crash due to memory allocation failures
     if ((packetSize >= 2) && (packetSize < UDP_PACKETSIZE_MAX)) {
       // Allocate buffer to process packet.
@@ -257,10 +261,11 @@ void checkUDP()
                   tmpNodeName[25]     = 0;
                   it->second.nodeName = tmpNodeName;
                   it->second.nodeName.trim();
-                  it->second.nodeType = packetBuffer[40];
+                  it->second.nodeType          = packetBuffer[40];
                   it->second.webgui_portnumber = 80;
-                  if (len >= 43 && it->second.build >= 20107) {
-                    it->second.webgui_portnumber = makeWord(packetBuffer[42],packetBuffer[41]);
+
+                  if ((len >= 43) && (it->second.build >= 20107)) {
+                    it->second.webgui_portnumber = makeWord(packetBuffer[42], packetBuffer[41]);
                   }
                 }
               }
@@ -294,6 +299,7 @@ void checkUDP()
       }
     }
   }
+
   // Flush any remaining content of the packet.
   while (portUDP.available()) {
     // Do not call portUDP.flush() as that's meant to sending the packet (on ESP8266)
@@ -335,7 +341,7 @@ String formatUnitToIPAddress(byte unit, byte formatCode) {
 
   if (unitIPAddress[0] == 0) { // Invalid?
     switch (formatCode) {
-      case 1: // Return empty string
+      case 1:                  // Return empty string
       {
         return F("");
       }
@@ -347,6 +353,7 @@ String formatUnitToIPAddress(byte unit, byte formatCode) {
   }
   return unitIPAddress.toString();
 }
+
 /*********************************************************************************************\
    Get IP address for unit
 \*********************************************************************************************/
@@ -381,6 +388,7 @@ void sendUDP(byte unit, const byte *data, byte size)
   }
 
   IPAddress remoteNodeIP = getIPAddressForUnit(unit);
+
   if (remoteNodeIP[0] == 0) {
     return;
   }
@@ -462,16 +470,16 @@ void sendSysInfoUDP(byte repeats)
     uint8_t  mac[]   = { 0, 0, 0, 0, 0, 0 };
     uint8_t *macread = NetworkMacAddressAsBytes(mac);
 
-    byte     data[80] = {0};
+    byte data[80] = { 0 };
     data[0] = 255;
     data[1] = 1;
 
     for (byte x = 0; x < 6; x++) {
       data[x + 2] = macread[x];
     }
-    
+
     IPAddress ip = NetworkLocalIP();
-    
+
     for (byte x = 0; x < 4; x++) {
       data[x + 8] = ip[x];
     }
@@ -526,6 +534,7 @@ void SSDP_schema(WiFiClient& client) {
   const IPAddress ip     = NetworkLocalIP();
   const uint32_t  chipId = ESP.getChipId();
   char uuid[64];
+
   sprintf_P(uuid, PSTR("38323636-4558-4dda-9188-cda0e6%02x%02x%02x"),
             (uint16_t)((chipId >> 16) & 0xff),
             (uint16_t)((chipId >>  8) & 0xff),
@@ -544,6 +553,7 @@ void SSDP_schema(WiFiClient& client) {
     "<minor>0</minor>"
     "</specVersion>"
     "<URLBase>http://");
+
   ssdp_schema += formatIP(ip);
   ssdp_schema += F(":80/</URLBase>"
                    "<device>"
@@ -611,8 +621,10 @@ bool SSDP_begin() {
   _server->ref();
 
   ip_addr_t ifaddr;
+
   ifaddr.addr = NetworkLocalIP();
   ip_addr_t multicast_addr;
+
   multicast_addr.addr = (uint32_t)SSDP_MULTICAST_ADDR;
 
   if (igmp_joingroup(&ifaddr, &multicast_addr) != ERR_OK) {
@@ -687,15 +699,16 @@ void SSDP_send(byte method) {
               (uint16_t)chipId        & 0xff);
 
     char *buffer = new (std::nothrow) char[1460]();
+
     if (buffer == nullptr) { return; }
-    int   len    = snprintf(buffer, 1460,
-                            _ssdp_packet_template.c_str(),
-                            (method == 0) ? _ssdp_response_template.c_str() : _ssdp_notify_template.c_str(),
-                            SSDP_INTERVAL,
-                            Settings.Build,
-                            uuid,
-                            IPADDR2STR(&ip)
-                            );
+    int len = snprintf(buffer, 1460,
+                       _ssdp_packet_template.c_str(),
+                       (method == 0) ? _ssdp_response_template.c_str() : _ssdp_notify_template.c_str(),
+                       SSDP_INTERVAL,
+                       Settings.Build,
+                       uuid,
+                       IPADDR2STR(&ip)
+                       );
 
     _server->append(buffer, len);
     delete[] buffer;
@@ -856,7 +869,7 @@ void SSDP_update() {
 }
 
 # endif // ifdef USES_SSDP
-#endif // if defined(ESP8266)
+#endif  // if defined(ESP8266)
 
 
 // ********************************************************************************
@@ -867,10 +880,10 @@ bool getSubnetRange(IPAddress& low, IPAddress& high)
   if (!WiFiEventData.WiFiGotIP()) {
     return false;
   }
-  
-  const IPAddress ip = NetworkLocalIP();
+
+  const IPAddress ip     = NetworkLocalIP();
   const IPAddress subnet = NetworkSubnetMask();
-  
+
   low  = ip;
   high = ip;
 
@@ -894,8 +907,8 @@ bool getSubnetRange(IPAddress& low, IPAddress& high)
 
 
 bool hasIPaddr() {
-  if (useStaticIP()) return true;
-  
+  if (useStaticIP()) { return true; }
+
 #ifdef CORE_POST_2_5_0
   bool configured = false;
 
@@ -937,7 +950,7 @@ bool NetworkConnected(uint32_t timeout_ms) {
 }
 
 bool hostReachable(const IPAddress& ip) {
-    if (!NetworkConnected()) { return false; }
+  if (!NetworkConnected()) { return false; }
 
   return true; // Disabled ping as requested here:
   // https://github.com/letscontrolit/ESPEasy/issues/1494#issuecomment-397872538
@@ -987,10 +1000,12 @@ bool connectClient(WiFiClient& client, IPAddress ip, uint16_t port)
     return false;
   }
   PrepareSend();
+
   // In case of domain name resolution error result can be negative.
   // https://github.com/esp8266/Arduino/blob/18f643c7e2d6a0da9d26ff2b14c94e6536ab78c1/libraries/Ethernet/src/Dns.cpp#L44
   // Thus must match the result with 1.
   bool connected = (client.connect(ip, port) == 1);
+
   delay(0);
 
   if (!connected) {
@@ -1035,6 +1050,7 @@ bool hostReachable(const String& hostname) {
     return hostReachable(remote_addr);
   }
   String log = F("Hostname cannot be resolved: ");
+
   log += hostname;
   addLog(LOG_LEVEL_ERROR, log);
   return false;
@@ -1119,6 +1135,7 @@ String splitURL(const String& fullURL, String& host, uint16_t& port, String& fil
     starthost += 2;
   }
   int endhost = fullURL.indexOf('/', starthost);
+
   splitHostPortString(fullURL.substring(starthost, endhost), host, port);
   int startfile = fullURL.lastIndexOf('/');
 
@@ -1177,6 +1194,7 @@ bool downloadFile(const String& url, String file_save, const String& user, const
   unsigned long timeout = millis() + 2000;
   WiFiClient    client;
   HTTPClient    http;
+
   http.begin(client, host, port, uri);
   {
     if ((user.length() > 0) && (pass.length() > 0)) {


### PR DESCRIPTION
Buffer was allocated for processing received UDP data, but was never checked if this allocation was successful.
On low memory situations, receiving p2p data may cause a crash.