### PR TITLE
[P044] P1 buffer overflow fix

### DIFF
--- a/src/src/PluginStructs/P044_data_struct.cpp
+++ b/src/src/PluginStructs/P044_data_struct.cpp
@@ -117,9 +117,9 @@ void P044_Task::checkBlinkLED() {
 }
 
 void P044_Task::clearBuffer() {
-  if (serial_buffer.length() > maxMessageSize) {
-    maxMessageSize = serial_buffer.length();
-  }
+  // if (serial_buffer.length() > maxMessageSize) {
+    // maxMessageSize = serial_buffer.length();
+  // }
 
   serial_buffer = "";
   serial_buffer.reserve(maxMessageSize);

--- a/src/src/PluginStructs/P044_data_struct.cpp
+++ b/src/src/PluginStructs/P044_data_struct.cpp
@@ -117,9 +117,9 @@ void P044_Task::checkBlinkLED() {
 }
 
 void P044_Task::clearBuffer() {
-  // if (serial_buffer.length() > maxMessageSize) {
-    // maxMessageSize = serial_buffer.length();
-  // }
+  if (serial_buffer.length() > maxMessageSize) {
+    maxMessageSize = _min(serial_buffer.length(), P044_DATAGRAM_MAX_SIZE);
+  }
 
   serial_buffer = "";
   serial_buffer.reserve(maxMessageSize);

--- a/src/src/PluginStructs/P044_data_struct.h
+++ b/src/src/PluginStructs/P044_data_struct.h
@@ -95,7 +95,7 @@ struct P044_Task : public PluginTaskData_base {
   boolean        CRCcheck          = false;
   ESPeasySerial *P1EasySerial      = nullptr;
   unsigned long  blinkLEDStartTime = 0;
-  size_t         maxMessageSize    = P044_DATAGRAM_MAX_SIZE / 4;
+  size_t         maxMessageSize    = P044_DATAGRAM_MAX_SIZE / 2;
 };
 
 #endif

--- a/src/src/PluginStructs/P044_data_struct.h
+++ b/src/src/PluginStructs/P044_data_struct.h
@@ -95,7 +95,7 @@ struct P044_Task : public PluginTaskData_base {
   boolean        CRCcheck          = false;
   ESPeasySerial *P1EasySerial      = nullptr;
   unsigned long  blinkLEDStartTime = 0;
-  size_t         maxMessageSize    = P044_DATAGRAM_MAX_SIZE / 2;
+  size_t         maxMessageSize    = P044_DATAGRAM_MAX_SIZE;
 };
 
 #endif

--- a/src/src/PluginStructs/P044_data_struct.h
+++ b/src/src/PluginStructs/P044_data_struct.h
@@ -95,7 +95,7 @@ struct P044_Task : public PluginTaskData_base {
   boolean        CRCcheck          = false;
   ESPeasySerial *P1EasySerial      = nullptr;
   unsigned long  blinkLEDStartTime = 0;
-  size_t         maxMessageSize    = P044_DATAGRAM_MAX_SIZE;
+  size_t         maxMessageSize    = P044_DATAGRAM_MAX_SIZE / 4;
 };
 
 #endif


### PR DESCRIPTION
The latest changes for a bigger buffer for P1 telegram messages turned out to cause issues on a ESP-01 in combination with some smart meters (Most issues with Sagemcom xs210, but also noticed on others). On Wemos D1 there were no issues.

I made a change so the buffer won't get bigger than the defined max size. This was tested on the meters with issues and turned out to be a fix.