### PR TITLE
[Build] Make test_ESP8266_4M1M build again

### DIFF
--- a/platformio_esp82xx_envs.ini
+++ b/platformio_esp82xx_envs.ini
@@ -388,6 +388,13 @@ build_flags               = ${normal_ir_extended_no_rx.build_flags}
 ; Includes "normal" + "testing" plugins                               ;
 ; *********************************************************************
 
+[env:test_ESP8266_4M1M]
+extends                   = esp8266_4M1M
+platform                  = ${testing.platform}
+platform_packages         = ${testing.platform_packages}
+build_flags               = ${testing.build_flags}
+                            ${esp8266_4M1M.build_flags}
+
 
 ; TEST: 4096k version + FEATURE_ADC_VCC ----------
 [env:test_ESP8266_4M1M_VCC]

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -908,7 +908,7 @@ To create/register a plugin, you have to :
     #define USES_P082   // GPS
     #define USES_P083   // SGP30
     #define USES_P084   // VEML6070
-    #define USES_P085   // AcuDC24x
+    //#define USES_P085   // AcuDC24x
     #define USES_P086   // Receiving values according Homie convention. Works together with C014 Homie controller
     //#define USES_P087   // Serial Proxy
     #define USES_P089   // Ping
@@ -925,7 +925,7 @@ To create/register a plugin, you have to :
     #define USES_P101   // Wake On Lan
     #define USES_P106   // BME680
     #define USES_P107   // SI1145 UV index
-    #define USES_P108   // DDS238-x ZN MODBUS energy meter (was P224 in the Playground)
+    //#define USES_P108   // DDS238-x ZN MODBUS energy meter (was P224 in the Playground)
 #endif
 
 

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -899,9 +899,9 @@ To create/register a plugin, you have to :
     #define USES_P072   // HDC1080
     #define USES_P074   // TSL2561
     #define USES_P075   // Nextion
-    #define USES_P076   // HWL8012   in POW r1
+    //#define USES_P076   // HWL8012   in POW r1
     // Needs CSE7766 Energy sensor, via Serial RXD 4800 baud 8E1 (GPIO1), TXD (GPIO3)
-    #define USES_P077	  // CSE7766   in POW R2
+    //#define USES_P077	  // CSE7766   in POW R2
     #define USES_P078   // Eastron Modbus Energy meters
     #define USES_P080   // iButton Sensor  DS1990A
     #define USES_P081   // Cron
@@ -938,9 +938,7 @@ To create/register a plugin, you have to :
      #define USES_P027   // INA219
    #endif
    #ifndef USES_P076 
-//     TD-er: Disabled as it causes this 'energy' build to fail due to low iRAM.
-//     It is still present in the POW builds.
-//     #define USES_P076   // HWL8012   in POW r1
+     #define USES_P076   // HWL8012   in POW r1
    #endif
    #ifndef USES_P077 
      // Needs CSE7766 Energy sensor, via Serial RXD 4800 baud 8E1 (GPIO1), TXD (GPIO3)


### PR DESCRIPTION
4 "energy" plugins are now excluded from the "testing" build as they are part of the "energy" builds