### PR TITLE
[ESP32] Update to PIO espressif32@3.1.0

### DIFF
--- a/platformio_core_defs.ini
+++ b/platformio_core_defs.ini
@@ -139,8 +139,8 @@ platform_packages =
 [core_esp32_1_12_2]
 platform                  = espressif32@1.12.4
 
-[core_esp32_2_1_0]
-platform                  = espressif32@2.1.0
+[core_esp32_3_1_0]
+platform                  = espressif32@3.1.0
 
 
 [core_esp32_stage]

--- a/platformio_esp32_envs.ini
+++ b/platformio_esp32_envs.ini
@@ -7,7 +7,7 @@
 
 
 [esp32_common]
-extends                   = common, core_esp32_2_1_0
+extends                   = common, core_esp32_3_1_0
 lib_ignore                = ESP8266WiFi, ESP8266Ping, ESP8266WebServer, ESP8266HTTPUpdateServer, ESP8266mDNS, IRremoteESP8266, ESPEasy_ESP8266Ping, ESP32_ping, HeatpumpIR
 lib_deps                  = https://github.com/TD-er/ESPEasySerial.git#v2.0.5, adafruit/Adafruit ILI9341 @ ^1.5.6,  Adafruit GFX Library, LOLIN_EPD, Adafruit BusIO
 board_build.f_flash       = 80000000L

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -328,15 +328,6 @@ void setup()
 //  progMemMD5check();
   LoadSettings();
 
-  #ifdef HAS_ETHERNET
-  // This ensures, that changing WIFI OR ETHERNET MODE happens properly only after reboot. Changing without reboot would not be a good idea.
-  // This only works after LoadSettings();
-  active_network_medium = Settings.NetworkMedium;
-  log = F("INIT : ETH_WIFI_MODE:");
-  log += toString(active_network_medium);
-  addLog(LOG_LEVEL_INFO, log);
-  #endif
-
   Settings.UseRTOSMultitasking = false; // For now, disable it, we experience heap corruption.
   if (RTC.bootFailedCount > 10 && RTC.bootCounter > 10) {
     byte toDisable = RTC.bootFailedCount - 10;
@@ -348,12 +339,19 @@ void setup()
       toDisable = disableNotification(toDisable);
     }
   }
-  if (!WiFi_AP_Candidates.hasKnownCredentials()) {
-    WiFiEventData.wifiSetup = true;
-    RTC.clearLastWiFi(); // Must scan all channels
-    // Wait until scan has finished to make sure as many as possible are found
-    // We're still in the setup phase, so nothing else is taking resources of the ESP.
-    WifiScan(false); 
+  #ifdef HAS_ETHERNET
+  // This ensures, that changing WIFI OR ETHERNET MODE happens properly only after reboot. Changing without reboot would not be a good idea.
+  // This only works after LoadSettings();
+  setNetworkMedium(Settings.NetworkMedium);
+  #endif
+  if (active_network_medium == NetworkMedium_t::WIFI) {
+    if (!WiFi_AP_Candidates.hasKnownCredentials()) {
+      WiFiEventData.wifiSetup = true;
+      RTC.clearLastWiFi(); // Must scan all channels
+      // Wait until scan has finished to make sure as many as possible are found
+      // We're still in the setup phase, so nothing else is taking resources of the ESP.
+      WifiScan(false); 
+    }
   }
 
 //  setWifiMode(WIFI_STA);
@@ -375,8 +373,9 @@ void setup()
 
   initSerial();
 
-  if (Settings.Build != BUILD)
+  if (Settings.Build != BUILD) {
     BuildFixes();
+  }
 
 
   log = F("INIT : Free RAM:");

--- a/src/src/DataStructs/GpioFactorySettingsStruct.cpp
+++ b/src/src/DataStructs/GpioFactorySettingsStruct.cpp
@@ -13,7 +13,7 @@ GpioFactorySettingsStruct::GpioFactorySettingsStruct(DeviceModel model)
   eth_mdio(DEFAULT_ETH_PIN_MDIO),
   eth_power(DEFAULT_ETH_PIN_POWER),
   eth_clock_mode(DEFAULT_ETH_CLOCK_MODE),
-  active_network_medium(DEFAULT_NETWORK_MEDIUM)
+  network_medium(DEFAULT_NETWORK_MEDIUM)
 
 {
   for (int i = 0; i < 4; ++i) {
@@ -118,7 +118,7 @@ GpioFactorySettingsStruct::GpioFactorySettingsStruct(DeviceModel model)
       eth_mdio              = 18;
       eth_power             = 12;
       eth_clock_mode        = EthClockMode_t::Int_50MHz_GPIO_17_inv;
-      active_network_medium = NetworkMedium_t::Ethernet;
+      network_medium = NetworkMedium_t::Ethernet;
       break;
     case DeviceMode_Olimex_ESP32_EVB:
       button[0] = 34; // BUT1 Button
@@ -134,7 +134,7 @@ GpioFactorySettingsStruct::GpioFactorySettingsStruct(DeviceModel model)
       eth_mdio              = 18;
       eth_power             = -1; // No Ethernet power pin
       eth_clock_mode        = EthClockMode_t::Ext_crystal_osc;
-      active_network_medium = NetworkMedium_t::Ethernet;
+      network_medium = NetworkMedium_t::Ethernet;
       break;
 
     case DeviceMode_Olimex_ESP32_GATEWAY:
@@ -149,7 +149,7 @@ GpioFactorySettingsStruct::GpioFactorySettingsStruct(DeviceModel model)
       eth_mdio              = 18;
       eth_power             = 5;
       eth_clock_mode        = EthClockMode_t::Int_50MHz_GPIO_17_inv;
-      active_network_medium = NetworkMedium_t::Ethernet;
+      network_medium = NetworkMedium_t::Ethernet;
       // Rev A to E:
       // GPIO 5, 17 can be used only if Ethernet functionality is not used
       // GPIO 6, 7, 8, 9, 10, 11 used for internal flash and SD card

--- a/src/src/DataStructs/GpioFactorySettingsStruct.h
+++ b/src/src/DataStructs/GpioFactorySettingsStruct.h
@@ -21,7 +21,7 @@ struct GpioFactorySettingsStruct {
   int8_t          eth_mdio;
   int8_t          eth_power;
   EthClockMode_t  eth_clock_mode;
-  NetworkMedium_t active_network_medium;
+  NetworkMedium_t network_medium;
 };
 
 

--- a/src/src/ESPEasyCore/ESPEasyEth.cpp
+++ b/src/src/ESPEasyCore/ESPEasyEth.cpp
@@ -1,4 +1,4 @@
-#include "ESPEasyEth.h"
+#include "../ESPEasyCore/ESPEasyEth.h"
 
 #ifdef HAS_ETHERNET
 
@@ -61,29 +61,31 @@ bool ethPrepare() {
   char hostname[40];
   safe_strncpy(hostname, NetworkCreateRFCCompliantHostname().c_str(), sizeof(hostname));
   ETH.setHostname(hostname);
-  ETH.config(INADDR_NONE, INADDR_NONE, INADDR_NONE);
+//  ETH.config(INADDR_NONE, INADDR_NONE, INADDR_NONE);
   ethSetupStaticIPconfig();
   return true;
 }
 
 void ethPrintSettings() {
-  String settingsDebugLog;
-  settingsDebugLog.reserve(115);
-  settingsDebugLog += F("Eth Wifi mode: ");
-  settingsDebugLog += toString(active_network_medium);
-  settingsDebugLog += F(" ETH: PHY Type: ");
-  settingsDebugLog += toString(Settings.ETH_Phy_Type);
-  settingsDebugLog += F(" PHY Addr: ");
-  settingsDebugLog += Settings.ETH_Phy_Addr;
-  settingsDebugLog += F(" Eth Clock mode: ");
-  settingsDebugLog += toString(Settings.ETH_Clock_Mode);
-  settingsDebugLog += F(" MDC Pin: ");
-  settingsDebugLog += String(Settings.ETH_Pin_mdc);
-  settingsDebugLog += F(" MIO Pin: ");
-  settingsDebugLog += String(Settings.ETH_Pin_mdio);
-  settingsDebugLog += F(" Power Pin: ");
-  settingsDebugLog += String(Settings.ETH_Pin_power);
-  addLog(LOG_LEVEL_INFO, settingsDebugLog);
+  if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+    String log;
+    log.reserve(115);
+//    log += F("ETH/Wifi mode: ");
+//    log += toString(active_network_medium);
+    log += F("ETH PHY Type: ");
+    log += toString(Settings.ETH_Phy_Type);
+    log += F(" PHY Addr: ");
+    log += Settings.ETH_Phy_Addr;
+    log += F(" Eth Clock mode: ");
+    log += toString(Settings.ETH_Clock_Mode);
+    log += F(" MDC Pin: ");
+    log += String(Settings.ETH_Pin_mdc);
+    log += F(" MIO Pin: ");
+    log += String(Settings.ETH_Pin_mdio);
+    log += F(" Power Pin: ");
+    log += String(Settings.ETH_Pin_power);
+    addLog(LOG_LEVEL_INFO, log);
+  }
 }
 
 uint8_t * ETHMacAddress(uint8_t* mac) {
@@ -103,11 +105,13 @@ bool ETHConnectRelaxed() {
     return false;
   }
   addLog(LOG_LEVEL_INFO, F("After ETH.begin"));
+  /*
   if (!ethPrepare()) {
     // Dead code for now...
     addLog(LOG_LEVEL_ERROR, F("ETH : Could not prepare ETH!"));
     return false;
   }
+  */
   return true;
 }
 

--- a/src/src/ESPEasyCore/ESPEasyNetwork.cpp
+++ b/src/src/ESPEasyCore/ESPEasyNetwork.cpp
@@ -12,21 +12,36 @@
 #include "ETH.h"
 #endif
 
+void setNetworkMedium(NetworkMedium_t medium) {
+  switch (active_network_medium) {
+    case NetworkMedium_t::Ethernet:
+      #ifdef HAS_ETHERNET
+      // FIXME TD-er: How to 'end' ETH?
+//      ETH.end();
+      #endif
+      break;
+    case NetworkMedium_t::WIFI:
+      WiFi.mode(WIFI_OFF);
+      break;
+  }
+  active_network_medium = medium;
+  addLog(LOG_LEVEL_INFO, String(F("Set Network mode: ")) + toString(active_network_medium));
+}
+
+
 /*********************************************************************************************\
    Ethernet or Wifi Support for ESP32 Build flag HAS_ETHERNET
 \*********************************************************************************************/
 void NetworkConnectRelaxed() {
   if (NetworkConnected()) return;
 #ifdef HAS_ETHERNET
-  addLog(LOG_LEVEL_INFO, F("Connect to: "));
-  addLog(LOG_LEVEL_INFO, toString(active_network_medium));
   if(active_network_medium == NetworkMedium_t::Ethernet) {
     if (ETHConnectRelaxed()) {
       return;
     }
     // Failed to start the Ethernet network, probably not present of wrong parameters.
     // So set the runtime active medium to WiFi to try connecting to WiFi or at least start the AP.
-    active_network_medium = NetworkMedium_t::WIFI;
+    setNetworkMedium(NetworkMedium_t::WIFI);
   }
 #endif
   WiFiConnectRelaxed();

--- a/src/src/ESPEasyCore/ESPEasyNetwork.h
+++ b/src/src/ESPEasyCore/ESPEasyNetwork.h
@@ -6,6 +6,8 @@
 #ifndef NETWORK_H
 #define NETWORK_H
 
+void setNetworkMedium(NetworkMedium_t medium);
+
 void NetworkConnectRelaxed();
 bool NetworkConnected();
 void PrepareSend();

--- a/src/src/ESPEasyCore/ESPEasyWiFiEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWiFiEvent.cpp
@@ -8,6 +8,7 @@
 
 #include "../DataTypes/ESPEasyTimeSource.h"
 
+#include "../ESPEasyCore/ESPEasyEth.h"
 #include "../ESPEasyCore/ESPEasy_Log.h"
 #include "../ESPEasyCore/ESPEasyNetwork.h"
 #include "../ESPEasyCore/ESPEasyWifi.h"
@@ -117,11 +118,15 @@ void WiFiEvent(system_event_id_t event, system_event_info_t info) {
       break;
 #ifdef HAS_ETHERNET
     case SYSTEM_EVENT_ETH_START:
-      addLog(LOG_LEVEL_INFO, F("ETH Started"));
+      if (ethPrepare()) {
+        addLog(LOG_LEVEL_INFO, F("ETH Started"));
+      } else {
+        addLog(LOG_LEVEL_ERROR, F("ETH : Could not prepare ETH!"));
+      }
       break;
     case SYSTEM_EVENT_ETH_CONNECTED:
       addLog(LOG_LEVEL_INFO, F("ETH Connected"));
-      eth_connected = true;
+      //eth_connected = true;
       processEthernetConnected();
       break;
     case SYSTEM_EVENT_ETH_GOT_IP:

--- a/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
@@ -470,6 +470,7 @@ void markWiFi_services_initialized() {
 #ifdef HAS_ETHERNET
 
 void processEthernetConnected() {
+  ++WiFiEventData.wifi_reconnects;
   if (Settings.UseRules)
   {
     eventQueue.add(F("ETHERNET#Connected"));

--- a/src/src/Globals/NetworkState.cpp
+++ b/src/src/Globals/NetworkState.cpp
@@ -2,7 +2,8 @@
 
 #include "../../ESPEasy_common.h"
 
-// Ethernet Connectiopn status
+
+// Ethernet Connection status
 NetworkMedium_t active_network_medium = DEFAULT_NETWORK_MEDIUM;
 bool eth_connected = false;
 

--- a/src/src/Helpers/ESPEasy_FactoryDefault.cpp
+++ b/src/src/Helpers/ESPEasy_FactoryDefault.cpp
@@ -203,7 +203,7 @@ void ResetFactory()
   Settings.ETH_Pin_power  = gpio_settings.eth_power;
   Settings.ETH_Phy_Type   = gpio_settings.eth_phytype;
   Settings.ETH_Clock_Mode = gpio_settings.eth_clock_mode;
-  Settings.NetworkMedium  = gpio_settings.active_network_medium;
+  Settings.NetworkMedium  = gpio_settings.network_medium;
 
   /*
           Settings.GlobalSync						= DEFAULT_USE_GLOBAL_SYNC;

--- a/src/src/Helpers/StringProvider.cpp
+++ b/src/src/Helpers/StringProvider.cpp
@@ -161,9 +161,9 @@ String getLabel(LabelType::Enum label) {
     case LabelType::ETH_SPEED:              return F("Eth Speed");
     case LabelType::ETH_STATE:              return F("Eth State");
     case LabelType::ETH_SPEED_STATE:        return F("Eth Speed State");
-    case LabelType::ETH_WIFI_MODE:          return F("Network Type");
     case LabelType::ETH_CONNECTED:          return F("Eth connected");
 #endif // ifdef HAS_ETHERNET
+    case LabelType::ETH_WIFI_MODE:          return F("Network Type");
   }
   return F("MissingString");
 }
@@ -301,9 +301,9 @@ String getValue(LabelType::Enum label) {
     case LabelType::ETH_SPEED:              return eth_connected ? getEthSpeed() : F("No Ethernet");
     case LabelType::ETH_STATE:              return eth_connected ? (ETH.linkUp() ? F("Link Up") : F("Link Down")) : F("No Ethernet");
     case LabelType::ETH_SPEED_STATE:        return eth_connected ? getEthLinkSpeedState() : F("No Ethernet");
-    case LabelType::ETH_WIFI_MODE:          return active_network_medium == NetworkMedium_t::WIFI ? F("WIFI") : F("ETHERNET");
     case LabelType::ETH_CONNECTED:          return eth_connected ? F("CONNECTED") : F("DISCONNECTED"); // 0=disconnected, 1=connected
 #endif // ifdef HAS_ETHERNET
+    case LabelType::ETH_WIFI_MODE:          return active_network_medium == NetworkMedium_t::WIFI ? F("WIFI") : F("ETHERNET");
   }
   return F("MissingString");
 }

--- a/src/src/Helpers/StringProvider.h
+++ b/src/src/Helpers/StringProvider.h
@@ -131,9 +131,9 @@ struct LabelType {
     ETH_SPEED,
     ETH_STATE,
     ETH_SPEED_STATE,
-    ETH_WIFI_MODE,
     ETH_CONNECTED,
 #endif // ifdef HAS_ETHERNET
+    ETH_WIFI_MODE,
   };
 };
 

--- a/src/src/WebServer/RootPage.cpp
+++ b/src/src/WebServer/RootPage.cpp
@@ -151,11 +151,16 @@ void handle_root() {
       addHtml(html);
     }
 
-    addRowLabelValue(LabelType::IP_ADDRESS);
-    addRowLabel(LabelType::WIFI_RSSI);
+#ifdef HAS_ETHERNET
+    addRowLabelValue(LabelType::ETH_WIFI_MODE);
+#endif
 
-    if (NetworkConnected())
+    if (
+      active_network_medium == NetworkMedium_t::WIFI &&
+      NetworkConnected())
     {
+      addRowLabelValue(LabelType::IP_ADDRESS);
+      addRowLabel(LabelType::WIFI_RSSI);
       String html;
       html.reserve(32);
       html += String(WiFi.RSSI());
@@ -166,7 +171,6 @@ void handle_root() {
     }
 
 #ifdef HAS_ETHERNET
-    addRowLabelValue(LabelType::ETH_WIFI_MODE);
     if(active_network_medium == NetworkMedium_t::Ethernet) {
       addRowLabelValue(LabelType::ETH_SPEED_STATE);
       addRowLabelValue(LabelType::ETH_IP_ADDRESS);

--- a/src/src/WebServer/SysInfoPage.cpp
+++ b/src/src/WebServer/SysInfoPage.cpp
@@ -381,50 +381,51 @@ void handle_sysinfo_Ethernet() {
     addRowLabelValue(LabelType::ETH_SPEED);
     addRowLabelValue(LabelType::ETH_DUPLEX);
     addRowLabelValue(LabelType::ETH_MAC);
-    addRowLabelValue(LabelType::ETH_IP_ADDRESS_SUBNET);
-    addRowLabelValue(LabelType::ETH_IP_GATEWAY);
-    addRowLabelValue(LabelType::ETH_IP_DNS);
+//    addRowLabelValue(LabelType::ETH_IP_ADDRESS_SUBNET);
+//    addRowLabelValue(LabelType::ETH_IP_GATEWAY);
+//    addRowLabelValue(LabelType::ETH_IP_DNS);
   }
 }
 
 # endif // ifdef HAS_ETHERNET
 
 void handle_sysinfo_Network() {
-  addTableSeparator(F("Network"), 2, 3, F("Wifi"));
+  addTableSeparator(F("Network"), 2, 3);
 
   # ifdef HAS_ETHERNET
   addRowLabelValue(LabelType::ETH_WIFI_MODE);
   # endif // ifdef HAS_ETHERNET
 
-
-  if (
-    # ifdef HAS_ETHERNET
-    active_network_medium == NetworkMedium_t::WIFI &&
-    # endif // ifdef HAS_ETHERNET
-    NetworkConnected())
-  {
-    addRowLabel(F("Wifi"));
-    {
-      String html;
-      html.reserve(64);
-
-      html += toString(getConnectionProtocol());
-      html += F(" (RSSI ");
-      html += WiFi.RSSI();
-      html += F(" dBm)");
-      addHtml(html);
-    }
-  }
   addRowLabelValue(LabelType::IP_CONFIG);
   addRowLabelValue(LabelType::IP_ADDRESS_SUBNET);
   addRowLabelValue(LabelType::GATEWAY);
   addRowLabelValue(LabelType::CLIENT_IP);
   addRowLabelValue(LabelType::DNS);
   addRowLabelValue(LabelType::ALLOWED_IP_RANGE);
-  addRowLabelValue(LabelType::STA_MAC);
-  addRowLabelValue(LabelType::AP_MAC);
+  addRowLabelValue(LabelType::CONNECTED);
+  addRowLabelValue(LabelType::NUMBER_RECONNECTS);
+
+  addTableSeparator(F("WiFi"), 2, 3, F("Wifi"));
+
+  const bool showWiFiConnectionInfo = 
+    active_network_medium == NetworkMedium_t::WIFI &&
+    NetworkConnected();
+
+  addRowLabel(F("Wifi Connection"));
+  if (showWiFiConnectionInfo)
+  {
+    String html;
+    html.reserve(64);
+
+    html += toString(getConnectionProtocol());
+    html += F(" (RSSI ");
+    html += WiFi.RSSI();
+    html += F(" dBm)");
+    addHtml(html);
+  } else addHtml('-');
 
   addRowLabel(LabelType::SSID);
+  if (showWiFiConnectionInfo)
   {
     String html;
     html.reserve(64);
@@ -434,14 +435,26 @@ void handle_sysinfo_Network() {
     html += WiFi.BSSIDstr();
     html += ')';
     addHtml(html);
+  } else addHtml('-');
+
+  addRowLabel(getLabel(LabelType::CHANNEL));
+  if (showWiFiConnectionInfo) {
+    addHtml(getValue(LabelType::CHANNEL));
+  } else addHtml('-');
+
+  addRowLabel(getLabel(LabelType::ENCRYPTION_TYPE_STA));
+  if (showWiFiConnectionInfo) {
+    addHtml(getValue(LabelType::ENCRYPTION_TYPE_STA));
+  } else addHtml('-');
+
+  if (active_network_medium == NetworkMedium_t::WIFI)
+  {
+    addRowLabel(LabelType::LAST_DISCONNECT_REASON);
+    addHtml(getValue(LabelType::LAST_DISC_REASON_STR));
   }
 
-  addRowLabelValue(LabelType::CHANNEL);
-  addRowLabelValue(LabelType::ENCRYPTION_TYPE_STA);
-  addRowLabelValue(LabelType::CONNECTED);
-  addRowLabel(LabelType::LAST_DISCONNECT_REASON);
-  addHtml(getValue(LabelType::LAST_DISC_REASON_STR));
-  addRowLabelValue(LabelType::NUMBER_RECONNECTS);
+  addRowLabelValue(LabelType::STA_MAC);
+  addRowLabelValue(LabelType::AP_MAC);
 }
 
 void handle_sysinfo_WiFiSettings() {


### PR DESCRIPTION
Fix issues with Ethernet that prevented updating to 3.1.0
Also did some clean-up on sysinfo info that is either irrelevant when using Ethernet or duplicate info.