### PR TITLE
[1M builds] Init config.dat file to 36k size

### DIFF
--- a/src/src/CustomBuild/StorageLayout.h
+++ b/src/src/CustomBuild/StorageLayout.h
@@ -143,9 +143,16 @@
   #  ifndef DAT_OFFSET_CUSTOM_CONTROLLER
   #   define DAT_OFFSET_CUSTOM_CONTROLLER    32768 // each custom controller config = 1k, 4 max.
   #  endif // ifndef DAT_OFFSET_CUSTOM_CONTROLLER
-  #  ifndef CONFIG_FILE_SIZE
-  #   define CONFIG_FILE_SIZE                65536
-  #  endif // ifndef CONFIG_FILE_SIZE
+  #  ifdef LIMIT_BUILD_SIZE
+  // Limit the config size for 1M builds, since their file system is also quite small
+  #   ifndef CONFIG_FILE_SIZE
+  #    define CONFIG_FILE_SIZE               36864 // DAT_OFFSET_CUSTOM_CONTROLLER + 4x DAT_CUSTOM_CONTROLLER_SIZE
+  #   endif // ifndef CONFIG_FILE_SIZE
+  #  else
+  #   ifndef CONFIG_FILE_SIZE
+  #    define CONFIG_FILE_SIZE               65536
+  #   endif // ifndef CONFIG_FILE_SIZE
+  #  endif
   # endif // ifdef USE_NON_STANDARD_24_TASKS
 #endif     // if defined(ESP8266)
 


### PR DESCRIPTION
No need to include the extra zeroes at the end, which may lead to issues on the already small file system of 1M builds.
This will only be trimmed on new files (e.g. when performing a factory default reset)