### PR TITLE
[WiFi] Set max TX power always if forced in settings

### DIFF
--- a/src/_N001_Email.ino
+++ b/src/_N001_Email.ino
@@ -86,7 +86,6 @@ boolean NPlugin_001_send(const NotificationSettingsStruct& notificationsettings,
 	// Use WiFiClient class to create TCP connections
 	WiFiClient client;
 	client.setTimeout(CONTROLLER_CLIENTTIMEOUT_DFLT);
-	PrepareSend();
 	String aHost = notificationsettings.Server;
 	addLog(LOG_LEVEL_DEBUG, String(F("EMAIL: Connecting to ")) + aHost + notificationsettings.Port);
 	if (!connectClient(client, aHost.c_str(), notificationsettings.Port)) {

--- a/src/_P020_Ser2Net.ino
+++ b/src/_P020_Ser2Net.ino
@@ -238,7 +238,6 @@ boolean Plugin_020(byte function, struct EventStruct *event, String& string)
         int timeOut       = RXWait;
         size_t bytes_read = 0;
 
-        PrepareSend();
         while (timeOut > 0)
         {
           while (Serial.available()) {

--- a/src/src/DataStructs/ControllerSettingsStruct.cpp
+++ b/src/src/DataStructs/ControllerSettingsStruct.cpp
@@ -104,7 +104,6 @@ bool ControllerSettingsStruct::checkHostReachable(bool quick) {
   }
   delay(1);       // Make sure the Watchdog will not trigger a reset.
 
-  PrepareSend();
   if (quick && ipSet()) { return true; }
 
   if (UseDNS) {

--- a/src/src/DataStructs/Web_StreamingBuffer.cpp
+++ b/src/src/DataStructs/Web_StreamingBuffer.cpp
@@ -140,7 +140,6 @@ void Web_StreamingBuffer::startStream(bool json, const String& origin) {
   sentBytes    = 0;
   buf          = "";
   
-  PrepareSend();
   if (beforeTXRam < 3000) {
     lowMemorySkip = true;
     web_server.send(200, "text/plain", "Low memory. Cannot display webpage :-(");
@@ -209,7 +208,7 @@ void Web_StreamingBuffer::sendContentBlocking(String& data) {
     beforeTXRam = freeBeforeSend;
   }
   duringTXRam = freeBeforeSend;
-  PrepareSend();
+  
 #if defined(ESP8266) && defined(ARDUINO_ESP8266_RELEASE_2_3_0)
   String size = formatToHex(length) + "\r\n";
 
@@ -249,7 +248,7 @@ void Web_StreamingBuffer::sendHeaderBlocking(bool json, const String& origin) {
   #ifndef BUILD_NO_RAM_TRACKER
   checkRAM(F("sendHeaderBlocking"));
   #endif
-  PrepareSend();
+  
   web_server.client().flush();
   String contenttype;
 

--- a/src/src/ESPEasyCore/Controller.cpp
+++ b/src/src/ESPEasyCore/Controller.cpp
@@ -186,7 +186,7 @@ bool MQTTConnect(controllerIndex_t controller_idx)
   if (MQTTclient.connected()) {
     MQTTclient.disconnect();
   }
-  PrepareSend();
+  
   updateMQTTclient_connected();
 
   //  mqtt = WiFiClient(); // workaround see: https://github.com/esp8266/Arduino/issues/4497#issuecomment-373023864
@@ -361,7 +361,6 @@ bool MQTTCheck(controllerIndex_t controller_idx)
 
     if (MQTTclient_must_send_LWT_connected) {
       if (mqtt_sendLWT) {
-        PrepareSend();
         if (MQTTclient.publish(LWTTopic.c_str(), LWTMessageConnect.c_str(), willRetain)) {
           MQTTclient_must_send_LWT_connected = false;
         }

--- a/src/src/ESPEasyCore/ESPEasyNetwork.cpp
+++ b/src/src/ESPEasyCore/ESPEasyNetwork.cpp
@@ -56,17 +56,6 @@ bool NetworkConnected() {
   return WiFiConnected();
 }
 
-void PrepareSend() {
-  #ifdef HAS_ETHERNET
-  if (active_network_medium == NetworkMedium_t::Ethernet) {
-    return;
-  }
-  #endif
-  if (Settings.UseMaxTXpowerForSending()) {
-    SetWiFiTXpower(30); // Just some max, will be limited in SetWiFiTXpower
-  }
-}
-
 IPAddress NetworkLocalIP() {
   #ifdef HAS_ETHERNET
   if(active_network_medium == NetworkMedium_t::Ethernet) {

--- a/src/src/ESPEasyCore/ESPEasyNetwork.h
+++ b/src/src/ESPEasyCore/ESPEasyNetwork.h
@@ -10,7 +10,6 @@ void setNetworkMedium(NetworkMedium_t medium);
 
 void NetworkConnectRelaxed();
 bool NetworkConnected();
-void PrepareSend();
 IPAddress NetworkLocalIP();
 IPAddress NetworkSubnetMask();
 IPAddress NetworkGatewayIP();

--- a/src/src/ESPEasyCore/ESPEasyWifi.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi.cpp
@@ -409,6 +409,10 @@ void SetWiFiTXpower(float dBm, float rssi) {
     return;
   }
 
+  if (Settings.UseMaxTXpowerForSending()) {
+    dBm = 30; // Just some max, will be limited later
+  }
+
   // Range ESP32  : 2dBm - 20dBm
   // Range ESP8266: 0dBm - 20.5dBm
   float maxTXpwr;

--- a/src/src/Helpers/Networking.cpp
+++ b/src/src/Helpers/Networking.cpp
@@ -1001,7 +1001,6 @@ bool connectClient(WiFiClient& client, IPAddress ip, uint16_t port)
   if (!NetworkConnected()) {
     return false;
   }
-  PrepareSend();
 
   // In case of domain name resolution error result can be negative.
   // https://github.com/esp8266/Arduino/blob/18f643c7e2d6a0da9d26ff2b14c94e6536ab78c1/libraries/Ethernet/src/Dns.cpp#L44
@@ -1030,7 +1029,7 @@ bool resolveHostByName(const char *aHostname, IPAddress& aResult) {
   if (!NetworkConnected()) {
     return false;
   }
-  PrepareSend();
+
 #if defined(ARDUINO_ESP8266_RELEASE_2_3_0) || defined(ESP32)
   bool resolvedIP = WiFi.hostByName(aHostname, aResult) == 1;
 #else // if defined(ARDUINO_ESP8266_RELEASE_2_3_0) || defined(ESP32)
@@ -1082,8 +1081,6 @@ void sendGratuitousARP() {
     return;
   }
 #ifdef SUPPORT_ARP
-
-  PrepareSend();
 
   // See https://github.com/letscontrolit/ESPEasy/issues/2374
   START_TIMER;

--- a/src/src/Helpers/PeriodicalActions.cpp
+++ b/src/src/Helpers/PeriodicalActions.cpp
@@ -293,7 +293,6 @@ void processMQTTdelayQueue() {
 
   if (element == NULL) { return; }
 
-  PrepareSend();
   if (MQTTclient.publish(element->_topic.c_str(), element->_payload.c_str(), element->_retained)) {
     if (WiFiEventData.connectionFailures > 0) {
       --WiFiEventData.connectionFailures;
@@ -358,7 +357,6 @@ void runPeriodicalMQTT() {
   //dont do this in backgroundtasks(), otherwise causes crashes. (https://github.com/letscontrolit/ESPEasy/issues/683)
   controllerIndex_t enabledMqttController = firstEnabledMQTT_ControllerIndex();
   if (validControllerIndex(enabledMqttController)) {
-    PrepareSend();
     if (!MQTTclient.loop()) {
       updateMQTTclient_connected();
       if (MQTTCheck(enabledMqttController)) {

--- a/src/src/Helpers/_CPlugin_Helper.cpp
+++ b/src/src/Helpers/_CPlugin_Helper.cpp
@@ -523,8 +523,6 @@ String send_via_http(const String& logIdentifier,
   // "if you have XXX, send it; or failing that, just give me what you've got."
   http.addHeader(F("Accept"), F("*/*;q=0.1"));
 
-  PrepareSend();
-
   delay(0);
 #if defined(CORE_POST_2_6_0) || defined(ESP32)
   http.begin(client, host, port, uri, false); // HTTP

--- a/src/src/PluginStructs/P044_data_struct.cpp
+++ b/src/src/PluginStructs/P044_data_struct.cpp
@@ -262,7 +262,6 @@ void P044_Task::handleSerialIn(struct EventStruct *event) {
   } while (true);
 
   if (done) {
-    PrepareSend();
     P1GatewayClient.print(serial_buffer);
     P1GatewayClient.flush();
 


### PR DESCRIPTION
The `PrepareSend()` function was a bad design decision.
If "Use max TX pwr" is set, it must be always set.
Otherwise you may end up with the strange situation where SDK generated traffic (e.g. a reply to a ping) is not using the max TX power while ESPEasy-generated traffic is sending at max. TX power.