### PR TITLE
[Ethernet] Proper handling of network events + revert to WiFi

### DIFF
--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -565,16 +565,7 @@ void loop()
 
   updateLoopStats();
 
-  switch (active_network_medium) {
-    case NetworkMedium_t::WIFI:
-      handle_unprocessedWiFiEvents();
-      break;
-    case NetworkMedium_t::Ethernet:
-      if (NetworkConnected()) {
-        updateUDPport();
-      }
-      break;
-  }
+  handle_unprocessedNetworkEvents();
 
   bool firstLoopConnectionsEstablished = NetworkConnected() && firstLoop;
   if (firstLoopConnectionsEstablished) {
@@ -691,10 +682,7 @@ void backgroundtasks()
     return;
   }
   START_TIMER
-  #if defined(FEATURE_ARDUINO_OTA) || defined(FEATURE_MDNS)
-  const bool networkConnected = 
-  #endif
-  NetworkConnected();
+  const bool networkConnected = NetworkConnected();
   runningBackgroundTasks=true;
 
   /*
@@ -712,12 +700,7 @@ void backgroundtasks()
     if (webserverRunning) {
       web_server.handleClient();
     }
-    if (WiFi.getMode() != WIFI_OFF
-    // This makes UDP working for ETHERNET
-    #ifdef HAS_ETHERNET
-                       || eth_connected
-    #endif
-                       ) {
+    if (networkConnected) {
       checkUDP();
     }
   }

--- a/src/src/DataStructs/EthernetEventData.cpp
+++ b/src/src/DataStructs/EthernetEventData.cpp
@@ -1,0 +1,130 @@
+#include "../DataStructs/EthernetEventData.h"
+
+#include "../ESPEasyCore/ESPEasy_Log.h"
+
+// Bit numbers for Eth status
+#define ESPEASY_ETH_CONNECTED               0
+#define ESPEASY_ETH_GOT_IP                  1
+#define ESPEASY_ETH_SERVICES_INITIALIZED    2
+
+bool EthernetEventData_t::EthConnectAllowed() const {
+  if (!ethConnectAttemptNeeded) return false;
+  if (last_eth_connect_attempt_moment.isSet()) {
+    // TODO TD-er: Make this time more dynamic.
+    if (!last_eth_connect_attempt_moment.timeoutReached(10000)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool EthernetEventData_t::unprocessedEthEvents() const {
+  if (processedConnect && processedDisconnect && processedGotIP && processedDHCPTimeout)
+  {
+    return false;
+  }
+  return true;
+}
+
+void EthernetEventData_t::clearAll() {
+  lastDisconnectMoment.clear();
+  lastConnectMoment.clear();
+  lastGetIPmoment.clear();
+  last_eth_connect_attempt_moment.clear();
+
+  setEthDisconnected();
+  lastEthResetMoment.setNow();
+  eth_considered_stable = false;
+
+  // Mark all flags to default to prevent handling old events.
+  processedConnect          = true;
+  processedDisconnect       = true;
+  processedGotIP            = true;
+  processedDHCPTimeout      = true;
+  ethConnectAttemptNeeded  = true;
+}
+
+void EthernetEventData_t::markEthBegin() {
+  setEthDisconnected();
+  lastDisconnectMoment.clear();
+  lastConnectMoment.clear();
+  lastGetIPmoment.clear();
+  last_eth_connect_attempt_moment.setNow();
+  eth_considered_stable = false;
+  ethConnectInProgress  = true;
+  ++eth_connect_attempt;
+}
+
+bool EthernetEventData_t::EthDisconnected() const {
+  return ethStatus == ESPEASY_ETH_DISCONNECTED;
+}
+
+bool EthernetEventData_t::EthGotIP() const {
+  return bitRead(ethStatus, ESPEASY_ETH_GOT_IP);
+}
+
+bool EthernetEventData_t::EthConnected() const {
+  return bitRead(ethStatus, ESPEASY_ETH_CONNECTED);
+}
+
+bool EthernetEventData_t::EthServicesInitialized() const {
+  return bitRead(ethStatus, ESPEASY_ETH_SERVICES_INITIALIZED);
+}
+
+void EthernetEventData_t::setEthDisconnected() {
+  ethStatus = ESPEASY_ETH_DISCONNECTED;
+}
+
+void EthernetEventData_t::setEthGotIP() {
+  bitSet(ethStatus, ESPEASY_ETH_GOT_IP);
+  setEthServicesInitialized();
+}
+
+void EthernetEventData_t::setEthConnected() {
+  bitSet(ethStatus, ESPEASY_ETH_CONNECTED);
+  setEthServicesInitialized();
+}
+
+void EthernetEventData_t::setEthServicesInitialized() {
+  if (!unprocessedEthEvents() && !EthServicesInitialized()) {
+    if (EthGotIP() && EthConnected()) {
+      addLog(LOG_LEVEL_DEBUG, F("Eth : Eth services initialized"));
+      bitSet(ethStatus, ESPEASY_ETH_SERVICES_INITIALIZED);
+      ethConnectInProgress = false;
+    }
+  }
+}
+
+void EthernetEventData_t::markGotIP() {
+  lastGetIPmoment.setNow();
+
+  // Create the 'got IP event' so mark the ethStatus to not have the got IP flag set
+  // This also implies the services are not fully initialized.
+  bitClear(ethStatus, ESPEASY_ETH_GOT_IP);
+  bitClear(ethStatus, ESPEASY_ETH_SERVICES_INITIALIZED);
+  processedGotIP = false;
+}
+
+void EthernetEventData_t::markLostIP() {
+  bitClear(ethStatus, ESPEASY_ETH_GOT_IP);
+  bitClear(ethStatus, ESPEASY_ETH_SERVICES_INITIALIZED);
+}
+
+void EthernetEventData_t::markDisconnect() {
+  lastDisconnectMoment.setNow();
+
+  if (last_eth_connect_attempt_moment.isSet() && !lastConnectMoment.isSet()) {
+    // There was an unsuccessful connection attempt
+    lastConnectedDuration_us = last_eth_connect_attempt_moment.timeDiff(lastDisconnectMoment);
+  } else {
+    lastConnectedDuration_us = lastConnectMoment.timeDiff(lastDisconnectMoment);
+  }
+  setEthDisconnected();
+  processedDisconnect  = false;
+}
+
+void EthernetEventData_t::markConnected() {
+  lastConnectMoment.setNow();
+  processedConnect    = false;
+}
+

--- a/src/src/DataStructs/EthernetEventData.h
+++ b/src/src/DataStructs/EthernetEventData.h
@@ -1,0 +1,72 @@
+#ifndef DATASTRUCTS_ETHERNETEVENTDATA_H
+#define DATASTRUCTS_ETHERNETEVENTDATA_H
+
+#include "../Helpers/LongTermTimer.h"
+
+
+#ifdef ESP32
+# include <esp_event.h>
+
+#endif // ifdef ESP32
+
+#include <IPAddress.h>
+
+
+// EthStatus
+#define ESPEASY_ETH_DISCONNECTED            0
+
+
+struct EthernetEventData_t {
+  bool EthConnectAllowed() const;
+
+  bool unprocessedEthEvents() const;
+
+  void clearAll();
+  void markEthBegin();
+
+  bool EthDisconnected() const;
+  bool EthGotIP() const;
+  bool EthConnected() const;
+  bool EthServicesInitialized() const;
+
+  void setEthDisconnected();
+  void setEthGotIP();
+  void setEthConnected();
+  void setEthServicesInitialized();
+
+
+  void markGotIP();
+  void markLostIP();
+  void markDisconnect();
+  void markConnected();
+
+
+  // Eth related data
+  bool          ethSetup        = false;
+  uint8_t       ethStatus       = ESPEASY_ETH_DISCONNECTED;
+  LongTermTimer last_eth_connect_attempt_moment;
+  unsigned int  eth_connect_attempt   = 0;
+  bool          eth_considered_stable = false;
+  int           eth_reconnects        = -1; // First connection attempt is not a reconnect.
+
+  LongTermTimer           lastConnectMoment;
+  LongTermTimer           lastDisconnectMoment;
+  LongTermTimer           lastEthResetMoment;
+  LongTermTimer           lastGetIPmoment;
+  LongTermTimer::Duration lastConnectedDuration_us = 0ll;
+
+
+  // Semaphore like bools for processing data gathered from Eth events.
+  bool processedConnect          = true;
+  bool processedDisconnect       = true;
+  bool processedGotIP            = true;
+  bool processedDHCPTimeout      = true;
+  bool ethConnectAttemptNeeded  = true;
+  bool ethConnectInProgress     = false;
+
+
+  bool ethInitSuccess            = false;
+  unsigned long connectionFailures = 0;
+};
+
+#endif   // ifndef DATASTRUCTS_ETHERNETEVENTDATA_H

--- a/src/src/DataStructs/WiFiEventData.h
+++ b/src/src/DataStructs/WiFiEventData.h
@@ -93,12 +93,9 @@ struct WiFiEventData_t {
   bool processedScanDone         = true;
   bool wifiConnectAttemptNeeded  = true;
   bool wifiConnectInProgress     = false;
+  bool warnedNoValidWiFiSettings = false;
 
   unsigned long connectionFailures = 0;
-
-  #ifdef ESP32
-  WiFiEventId_t wm_event_id;
-  #endif // ifdef ESP32
 };
 
 #endif   // ifndef DATASTRUCTS_WIFIEVENTDATA_H

--- a/src/src/ESPEasyCore/ESPEasyNetwork.h
+++ b/src/src/ESPEasyCore/ESPEasyNetwork.h
@@ -24,6 +24,12 @@ String WifiSoftAPmacAddress();
 
 void CheckRunningServices();
 
+#ifdef HAS_ETHERNET
+bool EthFullDuplex();
+bool EthLinkUp();
+uint8_t EthLinkSpeed();
+#endif
+
 
 #endif 
 #endif

--- a/src/src/ESPEasyCore/ESPEasyWiFiEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWiFiEvent.cpp
@@ -15,14 +15,12 @@
 #include "../ESPEasyCore/ESPEasyWifi_ProcessEvent.h"
 
 #include "../Globals/ESPEasyWiFiEvent.h"
+#include "../Globals/NetworkState.h"
 #include "../Globals/RTC.h"
 
 #include "../Helpers/ESPEasy_time_calc.h"
 
 
-#ifdef HAS_ETHERNET
-extern bool eth_connected;
-#endif
 
 #ifdef ESP32
 void WiFi_Access_Static_IP::set_use_static_ip(bool enabled) {
@@ -73,8 +71,16 @@ void WiFiEvent(system_event_id_t event, system_event_info_t info) {
       break;
     case SYSTEM_EVENT_STA_LOST_IP:
       // ESP32 station lost IP and the IP is reset to 0
+      #ifdef HAS_ETHERNET
+      if (active_network_medium == NetworkMedium_t::Ethernet) {
+        EthEventData.markLostIP();
+      }
+      else
+      #endif
       WiFiEventData.markLostIP();
-      addLog(LOG_LEVEL_INFO, F("WiFi : Lost IP"));
+      addLog(LOG_LEVEL_INFO, 
+        active_network_medium == NetworkMedium_t::Ethernet ?
+        F("ETH : Lost IP") : F("WiFi : Lost IP"));
       break;
 
     case SYSTEM_EVENT_AP_PROBEREQRECVED:
@@ -119,47 +125,25 @@ void WiFiEvent(system_event_id_t event, system_event_info_t info) {
 #ifdef HAS_ETHERNET
     case SYSTEM_EVENT_ETH_START:
       if (ethPrepare()) {
-        addLog(LOG_LEVEL_INFO, F("ETH Started"));
+        addLog(LOG_LEVEL_INFO, F("ETH  : Started"));
       } else {
-        addLog(LOG_LEVEL_ERROR, F("ETH : Could not prepare ETH!"));
+        addLog(LOG_LEVEL_ERROR, F("ETH  : Could not prepare ETH!"));
       }
       break;
     case SYSTEM_EVENT_ETH_CONNECTED:
-      addLog(LOG_LEVEL_INFO, F("ETH Connected"));
-      //eth_connected = true;
-      processEthernetConnected();
+      addLog(LOG_LEVEL_INFO, F("ETH  : Connected"));
+      EthEventData.markConnected();
       break;
     case SYSTEM_EVENT_ETH_GOT_IP:
-      eth_connected = true;
-      if (loglevelActiveFor(LOG_LEVEL_INFO))
-      {
-        String log = F("ETH MAC: ");
-        log += NetworkMacAddress();
-        log += F(" IPv4: ");
-        log += NetworkLocalIP().toString();
-        log += " (";
-        log += NetworkGetHostname();
-        log += F(") GW: ");
-        log += NetworkGatewayIP().toString();
-        log += F(" SN: ");
-        log += NetworkSubnetMask().toString();
-        if (ETH.fullDuplex()) {
-          log += F(" FULL_DUPLEX");
-        }
-        log += F(" ");
-        log += ETH.linkSpeed();
-        log += F("Mbps");
-        addLog(LOG_LEVEL_INFO, log);
-      }
+      EthEventData.markGotIP();
+      addLog(LOG_LEVEL_INFO, F("ETH  : Got IP"));
       break;
     case SYSTEM_EVENT_ETH_DISCONNECTED:
       addLog(LOG_LEVEL_ERROR, F("ETH Disconnected"));
-      eth_connected = false;
-      processEthernetDisconnected();
+      EthEventData.markDisconnect();
       break;
     case SYSTEM_EVENT_ETH_STOP:
       addLog(LOG_LEVEL_INFO, F("ETH Stopped"));
-      eth_connected = false;
       break;
     case SYSTEM_EVENT_GOT_IP6:
       addLog(LOG_LEVEL_INFO, F("ETH Got IP6"));

--- a/src/src/ESPEasyCore/ESPEasyWifi.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi.cpp
@@ -268,7 +268,10 @@ void AttemptWiFiConnect() {
 // ********************************************************************************
 bool prepareWiFi() {
   if (!WiFi_AP_Candidates.hasKnownCredentials()) {
-    addLog(LOG_LEVEL_ERROR, F("WIFI : No valid wifi settings"));
+    if (!WiFiEventData.warnedNoValidWiFiSettings) {
+      addLog(LOG_LEVEL_ERROR, F("WIFI : No valid wifi settings"));
+      WiFiEventData.warnedNoValidWiFiSettings = true;
+    }
     WiFiEventData.last_wifi_connect_attempt_moment.clear();
     WiFiEventData.wifi_connect_attempt     = 1;
     WiFiEventData.wifiConnectAttemptNeeded = false;
@@ -277,6 +280,7 @@ bool prepareWiFi() {
     setAP(true);
     return false;
   }
+  WiFiEventData.warnedNoValidWiFiSettings = false;
   setSTA(true);
   char hostname[40];
   safe_strncpy(hostname, NetworkCreateRFCCompliantHostname().c_str(), sizeof(hostname));
@@ -382,7 +386,7 @@ void initWiFi()
   setWifiMode(WIFI_OFF);
 
 #if defined(ESP32)
-  WiFiEventData.wm_event_id = WiFi.onEvent(WiFiEvent);
+  wm_event_id = WiFi.onEvent(WiFiEvent);
 #endif
 #ifdef ESP8266
   // WiFi event handlers
@@ -580,7 +584,7 @@ void WifiDisconnect()
 {
   #if defined(ESP32)
   WiFi.disconnect();
-  WiFi.removeEvent(WiFiEventData.wm_event_id);
+  WiFi.removeEvent(wm_event_id);
   #else // if defined(ESP32)
   ETS_UART_INTR_DISABLE();
   wifi_station_disconnect();

--- a/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
@@ -1,5 +1,7 @@
 #include "ESPEasyWifi_ProcessEvent.h"
 
+// FIXME TD-er: Rename this to ESPEasyNetwork_ProcessEvent
+
 #include "../../ESPEasy-Globals.h"
 #include "../ESPEasyCore/ESPEasy_Log.h"
 #include "../ESPEasyCore/ESPEasyNetwork.h"
@@ -30,112 +32,158 @@
 // Called from the loop() to make sure events are processed as soon as possible.
 // These functions are called from Setup() or Loop() and thus may call delay() or yield()
 // ********************************************************************************
-void handle_unprocessedWiFiEvents()
+void handle_unprocessedNetworkEvents()
 {
-  if ((!WiFiEventData.WiFiServicesInitialized()) || WiFiEventData.unprocessedWifiEvents()) {
-    if (WiFi.status() == WL_DISCONNECTED && WiFiEventData.wifiConnectInProgress) {
+#ifdef HAS_ETHERNET
+  // Must process the Ethernet Connected event regardless the active network medium.
+  // It may happen by plugging in the cable while WiFi was active.
+  if (!EthEventData.processedConnect) {
+    #ifndef BUILD_NO_DEBUG
+    addLog(LOG_LEVEL_DEBUG, F("Eth  : Entering processConnect()"));
+    #endif // ifndef BUILD_NO_DEBUG
+    processEthernetConnected();
+  }
+
+  if (active_network_medium == NetworkMedium_t::Ethernet) {
+    if (!EthEventData.EthServicesInitialized() || EthEventData.unprocessedEthEvents())
+    {
+      if (!EthEventData.unprocessedEthEvents() && EthEventData.EthConnectAllowed()) {
+        NetworkConnectRelaxed();
+      }
+ 
+      // Process disconnect events before connect events.
+      if (!EthEventData.processedDisconnect) {
+        #ifndef BUILD_NO_DEBUG
+        addLog(LOG_LEVEL_DEBUG, F("Eth  : Entering processDisconnect()"));
+        #endif // ifndef BUILD_NO_DEBUG
+        processEthernetDisconnected();
+      }
+
+      if (!EthEventData.processedGotIP) {
+        #ifndef BUILD_NO_DEBUG
+        addLog(LOG_LEVEL_DEBUG, F("Eth  : Entering processGotIP()"));
+        #endif // ifndef BUILD_NO_DEBUG
+        processEthernetGotIP();
+      }
+
+      if (!EthEventData.processedDHCPTimeout) {
+        #ifndef BUILD_NO_DEBUG
+        addLog(LOG_LEVEL_DEBUG, F("Eth  : DHCP timeout, Calling disconnect()"));
+        #endif // ifndef BUILD_NO_DEBUG
+        EthEventData.processedDHCPTimeout = true;
+        //WifiDisconnect();
+      }
+    }
+    EthEventData.setEthServicesInitialized();
+  }
+
+#endif
+  if (active_network_medium == NetworkMedium_t::WIFI) {
+    if ((!WiFiEventData.WiFiServicesInitialized()) || WiFiEventData.unprocessedWifiEvents()) {
+      if (WiFi.status() == WL_DISCONNECTED && WiFiEventData.wifiConnectInProgress) {
+        delay(10);
+      }
+
+      // WiFi connection is not yet available, so introduce some extra delays to
+      // help the background tasks managing wifi connections
+      delay(1);
+
+      NetworkConnectRelaxed();
+
+      // Process disconnect events before connect events.
+      if (!WiFiEventData.processedDisconnect) {
+        #ifndef BUILD_NO_DEBUG
+        addLog(LOG_LEVEL_DEBUG, F("WIFI : Entering processDisconnect()"));
+        #endif // ifndef BUILD_NO_DEBUG
+        processDisconnect();
+      }
+
+      if (!WiFiEventData.processedConnect) {
+        #ifndef BUILD_NO_DEBUG
+        addLog(LOG_LEVEL_DEBUG, F("WIFI : Entering processConnect()"));
+        #endif // ifndef BUILD_NO_DEBUG
+        processConnect();
+      }
+
+      if (!WiFiEventData.processedGotIP) {
+        #ifndef BUILD_NO_DEBUG
+        addLog(LOG_LEVEL_DEBUG, F("WIFI : Entering processGotIP()"));
+        #endif // ifndef BUILD_NO_DEBUG
+        processGotIP();
+      }
+
+      if (!WiFiEventData.processedDHCPTimeout) {
+        #ifndef BUILD_NO_DEBUG
+        addLog(LOG_LEVEL_DEBUG, F("WIFI : DHCP timeout, Calling disconnect()"));
+        #endif // ifndef BUILD_NO_DEBUG
+        WiFiEventData.processedDHCPTimeout = true;
+        WifiDisconnect();
+      }
+    }
+    const bool should_be_initialized = (WiFiEventData.WiFiGotIP() && WiFiEventData.WiFiConnected()) || NetworkConnected();
+    if (WiFiEventData.WiFiServicesInitialized() != should_be_initialized)
+    {
+      if (!WiFiEventData.WiFiServicesInitialized()) {
+        markWiFi_services_initialized();
+      }
+    }
+
+    if (WiFiEventData.WiFiDisconnected()) {
+      #ifndef BUILD_NO_DEBUG
+
+      if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+        static LongTermTimer lastDisconnectMoment_log;
+        static uint8_t lastWiFiStatus_log = 0;
+        uint8_t cur_wifi_status = WiFi.status();
+        if (WiFiEventData.lastDisconnectMoment.get() != lastDisconnectMoment_log.get() || 
+            lastWiFiStatus_log != cur_wifi_status) {
+          lastDisconnectMoment_log.set(WiFiEventData.lastDisconnectMoment.get());
+          lastWiFiStatus_log = cur_wifi_status;
+          String wifilog = F("WIFI : Disconnected: WiFi.status() = ");
+          wifilog += ESPeasyWifiStatusToString();
+          wifilog += F(" RSSI: ");
+          wifilog += String(WiFi.RSSI());
+          wifilog += F(" status: ");
+          #ifdef ESP8266
+          station_status_t status = wifi_station_get_connect_status();
+          wifilog += SDKwifiStatusToString(status);
+          #endif
+          #ifdef ESP32
+          wifilog += ArduinoWifiStatusToString(WiFi.status());
+          #endif
+          addLog(LOG_LEVEL_DEBUG, wifilog);
+        }
+      }
+      #endif // ifndef BUILD_NO_DEBUG
+
+      // While connecting to WiFi make sure the device has ample time to do so
       delay(10);
     }
 
-    // WiFi connection is not yet available, so introduce some extra delays to
-    // help the background tasks managing wifi connections
-    delay(1);
+    if (!WiFiEventData.processedDisconnectAPmode) { processDisconnectAPmode(); }
 
-    NetworkConnectRelaxed();
+    if (!WiFiEventData.processedConnectAPmode) { processConnectAPmode(); }
 
-    // Process disconnect events before connect events.
-    if (!WiFiEventData.processedDisconnect) {
-      #ifndef BUILD_NO_DEBUG
-      addLog(LOG_LEVEL_DEBUG, F("WIFI : Entering processDisconnect()"));
-      #endif // ifndef BUILD_NO_DEBUG
-      processDisconnect();
-    }
+    if (WiFiEventData.timerAPoff.isSet()) { processDisableAPmode(); }
 
-    if (!WiFiEventData.processedConnect) {
-      #ifndef BUILD_NO_DEBUG
-      addLog(LOG_LEVEL_DEBUG, F("WIFI : Entering processConnect()"));
-      #endif // ifndef BUILD_NO_DEBUG
-      processConnect();
-    }
+    if (!WiFiEventData.processedScanDone) { processScanDone(); }
 
-    if (!WiFiEventData.processedGotIP) {
-      #ifndef BUILD_NO_DEBUG
-      addLog(LOG_LEVEL_DEBUG, F("WIFI : Entering processGotIP()"));
-      #endif // ifndef BUILD_NO_DEBUG
-      processGotIP();
-    }
+    if (WiFiEventData.wifi_connect_attempt > 0) {
+      // We only want to clear this counter if the connection is currently stable.
+      if (WiFiEventData.WiFiServicesInitialized()) {
+        if (WiFiEventData.lastConnectMoment.isSet() && WiFiEventData.lastConnectMoment.timeoutReached(WIFI_CONNECTION_CONSIDERED_STABLE)) {
+          // Connection considered stable
+          WiFiEventData.wifi_connect_attempt = 0;
+          WiFiEventData.wifi_considered_stable = true;
+          WiFi_AP_Candidates.markCurrentConnectionStable();
 
-    if (!WiFiEventData.processedDHCPTimeout) {
-      #ifndef BUILD_NO_DEBUG
-      addLog(LOG_LEVEL_DEBUG, F("WIFI : DHCP timeout, Calling disconnect()"));
-      #endif // ifndef BUILD_NO_DEBUG
-      WiFiEventData.processedDHCPTimeout = true;
-      WifiDisconnect();
-    }
-  }
-  const bool wifi_should_be_initialized = (WiFiEventData.WiFiGotIP() && WiFiEventData.WiFiConnected()) || NetworkConnected();
-  if (WiFiEventData.WiFiServicesInitialized() != wifi_should_be_initialized)
-  {
-    if (!WiFiEventData.WiFiServicesInitialized()) {
-      markWiFi_services_initialized();
-    }
-  }
-
-  if (WiFiEventData.WiFiDisconnected()) {
-    #ifndef BUILD_NO_DEBUG
-
-    if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
-      static LongTermTimer lastDisconnectMoment_log;
-      static uint8_t lastWiFiStatus_log = 0;
-      uint8_t cur_wifi_status = WiFi.status();
-      if (WiFiEventData.lastDisconnectMoment.get() != lastDisconnectMoment_log.get() || 
-          lastWiFiStatus_log != cur_wifi_status) {
-        lastDisconnectMoment_log.set(WiFiEventData.lastDisconnectMoment.get());
-        lastWiFiStatus_log = cur_wifi_status;
-        String wifilog = F("WIFI : Disconnected: WiFi.status() = ");
-        wifilog += ESPeasyWifiStatusToString();
-        wifilog += F(" RSSI: ");
-        wifilog += String(WiFi.RSSI());
-        wifilog += F(" status: ");
-        #ifdef ESP8266
-        station_status_t status = wifi_station_get_connect_status();
-        wifilog += SDKwifiStatusToString(status);
-        #endif
-        #ifdef ESP32
-        wifilog += ArduinoWifiStatusToString(WiFi.status());
-        #endif
-        addLog(LOG_LEVEL_DEBUG, wifilog);
-      }
-    }
-    #endif // ifndef BUILD_NO_DEBUG
-
-    // While connecting to WiFi make sure the device has ample time to do so
-    delay(10);
-  }
-
-  if (!WiFiEventData.processedDisconnectAPmode) { processDisconnectAPmode(); }
-
-  if (!WiFiEventData.processedConnectAPmode) { processConnectAPmode(); }
-
-  if (WiFiEventData.timerAPoff.isSet()) { processDisableAPmode(); }
-
-  if (!WiFiEventData.processedScanDone) { processScanDone(); }
-
-  if (WiFiEventData.wifi_connect_attempt > 0) {
-    // We only want to clear this counter if the connection is currently stable.
-    if (WiFiEventData.WiFiServicesInitialized()) {
-      if (WiFiEventData.lastConnectMoment.isSet() && WiFiEventData.lastConnectMoment.timeoutReached(WIFI_CONNECTION_CONSIDERED_STABLE)) {
-        // Connection considered stable
-        WiFiEventData.wifi_connect_attempt = 0;
-        WiFiEventData.wifi_considered_stable = true;
-        WiFi_AP_Candidates.markCurrentConnectionStable();
-
-        if (!WiFi.getAutoConnect()) {
-          WiFi.setAutoConnect(true);
-        }
-      } else {
-        if (WiFi.getAutoConnect()) {
-          WiFi.setAutoConnect(false);
+          if (!WiFi.getAutoConnect()) {
+            WiFi.setAutoConnect(true);
+          }
+        } else {
+          if (WiFi.getAutoConnect()) {
+            WiFi.setAutoConnect(false);
+          }
         }
       }
     }
@@ -470,19 +518,95 @@ void markWiFi_services_initialized() {
 #ifdef HAS_ETHERNET
 
 void processEthernetConnected() {
+  if (EthEventData.processedConnect) return;
+  // FIXME TD-er: Must differentiate among reconnects for WiFi and Ethernet.
   ++WiFiEventData.wifi_reconnects;
+  EthEventData.setEthConnected();
+  EthEventData.processedConnect = true;
   if (Settings.UseRules)
   {
-    eventQueue.add(F("ETHERNET#Connected"));
-  }
-  statusLED(true);
+    eventQueue.add(F("Ethernet#LinkUp"));
+  }  
+  setNetworkMedium(Settings.NetworkMedium);
 }
 
 void processEthernetDisconnected() {
+  EthEventData.setEthDisconnected();
+  EthEventData.processedDisconnect = true;
   if (Settings.UseRules)
   {
     eventQueue.add(F("ETHERNET#Disconnected"));
   }
+  setNetworkMedium(NetworkMedium_t::WIFI);
+}
+
+void processEthernetGotIP() {
+  if (EthEventData.processedGotIP) {
+    return;
+  }
+  IPAddress ip = NetworkLocalIP();
+  const IPAddress gw       = NetworkGatewayIP();
+  const IPAddress subnet   = NetworkSubnetMask();
+  const LongTermTimer::Duration dhcp_duration = EthEventData.lastConnectMoment.timeDiff(EthEventData.lastGetIPmoment);
+
+  if (loglevelActiveFor(LOG_LEVEL_INFO))
+  {
+    String log = F("ETH MAC: ");
+    log += NetworkMacAddress();
+    if (useStaticIP()) {
+      log += F("Static IP: ");
+    } else {
+      log += F("DHCP IP: ");
+    }
+    log += NetworkLocalIP().toString();
+    log += " (";
+    log += NetworkGetHostname();
+    log += F(") GW: ");
+    log += NetworkGatewayIP().toString();
+    log += F(" SN: ");
+    log += NetworkSubnetMask().toString();
+    if (EthLinkUp()) {
+      if (EthFullDuplex()) {
+        log += F(" FULL_DUPLEX");
+      }
+      log += F(" ");
+      log += EthLinkSpeed();
+      log += F("Mbps");
+    } else {
+      log += F(" Link Down");
+    }
+    
+    if ((dhcp_duration > 0ll) && (dhcp_duration < 30000000ll)) {
+      // Just log times when they make sense.
+      log += F("   duration: ");
+      log += static_cast<int32_t>(dhcp_duration / 1000);
+      log += F(" ms");
+    }
+
+    addLog(LOG_LEVEL_INFO, log);
+  }
+
+  // First try to get the time, since that may be used in logs
+  if (node_time.systemTimePresent()) {
+    node_time.initTime();
+  }
+#ifdef USES_MQTT
+  mqtt_reconnect_count        = 0;
+  MQTTclient_should_reconnect = true;
+  timermqtt_interval          = 100;
+  Scheduler.setIntervalTimer(ESPEasy_Scheduler::IntervalTimer_e::TIMER_MQTT);
+#endif // USES_MQTT
+  Scheduler.sendGratuitousARP_now();
+
+  if (Settings.UseRules)
+  {
+    eventQueue.add(F("Ethernet#Connected"));
+  }
+  statusLED(true);
+  logConnectionStatus();
+
+  EthEventData.processedGotIP = true;
+  EthEventData.setEthGotIP();
 }
 
 #endif

--- a/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.h
+++ b/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.h
@@ -3,7 +3,7 @@
 
 #include "../../ESPEasy_common.h"
 
-void handle_unprocessedWiFiEvents();
+void handle_unprocessedNetworkEvents();
 void processDisconnect();
 void processConnect();
 void processGotIP();
@@ -16,6 +16,7 @@ void markWiFi_services_initialized();
 #ifdef HAS_ETHERNET
 void processEthernetConnected();
 void processEthernetDisconnected();
+void processEthernetGotIP();
 #endif
 
 #endif //ESPEASYWIFI_PROCESSEVENT_H

--- a/src/src/Globals/ESPEasyWiFiEvent.cpp
+++ b/src/src/Globals/ESPEasyWiFiEvent.cpp
@@ -2,7 +2,7 @@
 
 #include "../../ESPEasy_common.h"
 
-
+// FIXME TD-er: Rename this to ESPEasyNetworkEvent
 
 
 #ifdef ESP8266
@@ -16,3 +16,12 @@ WiFiEventHandler APModeStationDisconnectedHandler;
 #endif // ifdef ESP8266
 
 WiFiEventData_t WiFiEventData;
+
+#ifdef HAS_ETHERNET
+EthernetEventData_t EthEventData;
+#endif
+
+
+#ifdef ESP32
+WiFiEventId_t wm_event_id;
+#endif // ifdef ESP32

--- a/src/src/Globals/ESPEasyWiFiEvent.h
+++ b/src/src/Globals/ESPEasyWiFiEvent.h
@@ -5,7 +5,13 @@
 #include <IPAddress.h>
 #include <stdint.h>
 
+#include "../../ESPEasy_common.h"
+
 #include "../DataStructs/WiFiEventData.h"
+#ifdef HAS_ETHERNET
+#include "../DataStructs/EthernetEventData.h"
+#endif
+
 
 #ifdef ESP32
 # include <esp_event.h>
@@ -30,5 +36,14 @@ extern WiFiEventHandler APModeStationDisconnectedHandler;
 
 
 extern WiFiEventData_t WiFiEventData;
+
+#ifdef HAS_ETHERNET
+extern EthernetEventData_t EthEventData;
+#endif
+
+#ifdef ESP32
+extern WiFiEventId_t wm_event_id;
+#endif // ifdef ESP32
+
 
 #endif // GLOBALS_ESPEASYWIFIEVENT_H

--- a/src/src/Globals/NetworkState.cpp
+++ b/src/src/Globals/NetworkState.cpp
@@ -5,8 +5,6 @@
 
 // Ethernet Connection status
 NetworkMedium_t active_network_medium = DEFAULT_NETWORK_MEDIUM;
-bool eth_connected = false;
-
 
 bool webserverRunning(false);
 bool webserver_init(false);

--- a/src/src/Globals/NetworkState.h
+++ b/src/src/Globals/NetworkState.h
@@ -11,7 +11,6 @@
 
 // Ethernet Connectiopn status
 extern NetworkMedium_t active_network_medium;
-extern bool    eth_connected;
 
 extern bool webserverRunning;
 extern bool webserver_init;

--- a/src/src/Helpers/StringProvider.cpp
+++ b/src/src/Helpers/StringProvider.cpp
@@ -8,6 +8,9 @@
 
 #include "../ESPEasyCore/ESPEasyNetwork.h"
 #include "../ESPEasyCore/ESPEasyWifi.h"
+#ifdef HAS_ETHERNET
+#include "../ESPEasyCore/ESPEasyEth.h"
+#endif
 
 #include "../Globals/ESPEasy_Scheduler.h"
 #include "../Globals/ESPEasy_time.h"
@@ -297,11 +300,11 @@ String getValue(LabelType::Enum label) {
     case LabelType::ETH_IP_GATEWAY:         return NetworkGatewayIP().toString();
     case LabelType::ETH_IP_DNS:             return NetworkDnsIP(0).toString();
     case LabelType::ETH_MAC:                return NetworkMacAddress();
-    case LabelType::ETH_DUPLEX:             return eth_connected ? (ETH.fullDuplex() ? F("Full Duplex") : F("Half Duplex")) : F("No Ethernet");
-    case LabelType::ETH_SPEED:              return eth_connected ? getEthSpeed() : F("No Ethernet");
-    case LabelType::ETH_STATE:              return eth_connected ? (ETH.linkUp() ? F("Link Up") : F("Link Down")) : F("No Ethernet");
-    case LabelType::ETH_SPEED_STATE:        return eth_connected ? getEthLinkSpeedState() : F("No Ethernet");
-    case LabelType::ETH_CONNECTED:          return eth_connected ? F("CONNECTED") : F("DISCONNECTED"); // 0=disconnected, 1=connected
+    case LabelType::ETH_DUPLEX:             return EthLinkUp() ? (EthFullDuplex() ? F("Full Duplex") : F("Half Duplex")) : F("Link Down");
+    case LabelType::ETH_SPEED:              return EthLinkUp() ? getEthSpeed() : F("Link Down");
+    case LabelType::ETH_STATE:              return EthLinkUp() ? F("Link Up") : F("Link Down");
+    case LabelType::ETH_SPEED_STATE:        return EthLinkUp() ? getEthLinkSpeedState() : F("Link Down");
+    case LabelType::ETH_CONNECTED:          return ETHConnected() ? F("CONNECTED") : F("DISCONNECTED"); // 0=disconnected, 1=connected
 #endif // ifdef HAS_ETHERNET
     case LabelType::ETH_WIFI_MODE:          return active_network_medium == NetworkMedium_t::WIFI ? F("WIFI") : F("ETHERNET");
   }
@@ -313,7 +316,7 @@ String getEthSpeed() {
   String result;
 
   result.reserve(7);
-  result += ETH.linkSpeed();
+  result += EthLinkSpeed();
   result += F("Mbps");
   return result;
 }
@@ -323,7 +326,7 @@ String getEthLinkSpeedState() {
 
   result.reserve(29);
 
-  if (ETH.linkUp()) {
+  if (EthLinkUp()) {
     result += getValue(LabelType::ETH_STATE);
     result += ' ';
     result += getValue(LabelType::ETH_DUPLEX);


### PR DESCRIPTION
Ethernet could get into a limbo state where it would not work after some time.
The user could also not use a fall-back to WiFi when Ethernet did not work.

Known issue:
Ethernet disconnect/connect events do not appear to be fired > 2 times.
Probably an issue in the core libraries.
But fallback to Ethernet does seem to work just fine.