### PR TITLE
[JSON] Add extra variables to JSON output

### DIFF
--- a/docs/source/Reference/SystemVariable.rst
+++ b/docs/source/Reference/SystemVariable.rst
@@ -104,6 +104,10 @@ More uses of these system variables can be seen in the rules section and formula
      - 3244
      - Uptime in minutes.
      - Yes
+   * - ``%uptime_ms%``
+     - 3244
+     - Uptime in milliseconds.
+     -
    * - ``%rssi%``
      - -45
      - WiFi signal strength (dBm).

--- a/docs/source/Reference/SystemVariable.rst
+++ b/docs/source/Reference/SystemVariable.rst
@@ -105,7 +105,7 @@ More uses of these system variables can be seen in the rules section and formula
      - Uptime in minutes.
      - Yes
    * - ``%uptime_ms%``
-     - 3244
+     - 2095803
      - Uptime in milliseconds.
      -
    * - ``%rssi%``

--- a/src/src/Helpers/StringProvider.cpp
+++ b/src/src/Helpers/StringProvider.cpp
@@ -169,6 +169,13 @@ String getLabel(LabelType::Enum label) {
     case LabelType::ETH_CONNECTED:          return F("Eth connected");
 #endif // ifdef HAS_ETHERNET
     case LabelType::ETH_WIFI_MODE:          return F("Network Type");
+    case LabelType::SUNRISE:                return F("Sunrise");
+    case LabelType::SUNSET:                 return F("Sunset");
+    case LabelType::ISNTP:                  return F("Use NTP");
+    case LabelType::UPTIME_MS:              return F("Uptime (ms)");
+    case LabelType::TIMEZONE_OFFSET:        return F("Timezone Offset");
+    case LabelType::LATITUDE:               return F("Latitude");
+    case LabelType::LONGITUDE:              return F("Longitude");
   }
   return F("MissingString");
 }
@@ -311,6 +318,13 @@ String getValue(LabelType::Enum label) {
     case LabelType::ETH_CONNECTED:          return ETHConnected() ? F("CONNECTED") : F("DISCONNECTED"); // 0=disconnected, 1=connected
 #endif // ifdef HAS_ETHERNET
     case LabelType::ETH_WIFI_MODE:          return active_network_medium == NetworkMedium_t::WIFI ? F("WIFI") : F("ETHERNET");
+    case LabelType::SUNRISE:                return node_time.getSunriseTimeString(':');
+    case LabelType::SUNSET:                 return node_time.getSunsetTimeString(':');
+    case LabelType::ISNTP:                  return jsonBool(Settings.UseNTP);
+    case LabelType::UPTIME_MS:              return ull2String(getMicros64() / 1000);
+    case LabelType::TIMEZONE_OFFSET:        return String(Settings.TimeZone);
+    case LabelType::LATITUDE:               return String(Settings.Latitude);
+    case LabelType::LONGITUDE:              return String(Settings.Longitude);
   }
   return F("MissingString");
 }

--- a/src/src/Helpers/StringProvider.h
+++ b/src/src/Helpers/StringProvider.h
@@ -136,6 +136,13 @@ struct LabelType {
     ETH_CONNECTED,
 #endif // ifdef HAS_ETHERNET
     ETH_WIFI_MODE,
+    SUNRISE,
+    SUNSET,
+    ISNTP,
+    UPTIME_MS,
+    TIMEZONE_OFFSET,
+    LATITUDE,
+    LONGITUDE,
   };
 };
 

--- a/src/src/Helpers/SystemVariables.cpp
+++ b/src/src/Helpers/SystemVariables.cpp
@@ -166,6 +166,7 @@ void SystemVariables::parseSystemVariables(String& s, boolean useURLencode)
       case UNIXDAY_SEC:       value = String(node_time.getUnixTime() % 86400); break;
       case UNIXTIME:          value = String(node_time.getUnixTime()); break;
       case UPTIME:            value = String(wdcounter / 2); break;
+      case UPTIME_MS:         value = ull2String(getMicros64() / 1000); break;
       #if FEATURE_ADC_VCC
       case VCC:               value = String(vcc); break;
       #else // if FEATURE_ADC_VCC
@@ -323,6 +324,7 @@ String SystemVariables::toString(SystemVariables::Enum enumval)
     case Enum::UNIXDAY_SEC:     return F("%unixday_sec%");
     case Enum::UNIXTIME:        return F("%unixtime%");
     case Enum::UPTIME:          return F("%uptime%");
+    case Enum::UPTIME_MS:       return F("%uptime_ms%");
     case Enum::VCC:             return F("%vcc%");
     case Enum::WI_CH:           return F("%wi_ch%");
     case Enum::UNKNOWN: break;

--- a/src/src/Helpers/SystemVariables.h
+++ b/src/src/Helpers/SystemVariables.h
@@ -77,6 +77,7 @@ public:
     UNIXDAY_SEC,
     UNIXTIME,
     UPTIME,
+    UPTIME_MS,
     VCC,
     WI_CH,
 

--- a/src/src/WebServer/JSON.cpp
+++ b/src/src/WebServer/JSON.cpp
@@ -144,9 +144,11 @@ void handle_json()
       stream_next_json_object_value(LabelType::PLUGIN_COUNT);
       stream_next_json_object_value(LabelType::PLUGIN_DESCRIPTION);
       stream_next_json_object_value(LabelType::LOCAL_TIME);
+      stream_next_json_object_value(LabelType::ISNTP);
       stream_next_json_object_value(LabelType::UNIT_NR);
       stream_next_json_object_value(LabelType::UNIT_NAME);
       stream_next_json_object_value(LabelType::UPTIME);
+      stream_next_json_object_value(LabelType::UPTIME_MS);
       stream_next_json_object_value(LabelType::BOOT_TYPE);
       stream_next_json_object_value(LabelType::RESET_REASON);
 
@@ -162,12 +164,11 @@ void handle_json()
       stream_next_json_object_value(LabelType::HEAP_FRAGMENTATION);
       #endif // ifdef CORE_POST_2_5_0
       stream_next_json_object_value(LabelType::FREE_MEM);
-      String suntime = F("%sunrise%");
-      parseSystemVariables(suntime, false); // Not URL encoded
-      stream_next_json_object_value(F("Sunrise"),suntime);
-      suntime = F("%sunset%");
-      parseSystemVariables(suntime, false); // Not URL encoded
-      stream_last_json_object_value(F("Sunset"),suntime);
+      stream_next_json_object_value(LabelType::SUNRISE);
+      stream_next_json_object_value(LabelType::SUNSET);
+      stream_next_json_object_value(LabelType::TIMEZONE_OFFSET);
+      stream_next_json_object_value(LabelType::LATITUDE);
+      stream_last_json_object_value(LabelType::LONGITUDE);
       addHtml(F(",\n"));
     }
 

--- a/src/src/WebServer/JSON.cpp
+++ b/src/src/WebServer/JSON.cpp
@@ -161,7 +161,15 @@ void handle_json()
       stream_next_json_object_value(LabelType::HEAP_MAX_FREE_BLOCK);
       stream_next_json_object_value(LabelType::HEAP_FRAGMENTATION);
       #endif // ifdef CORE_POST_2_5_0
-      stream_last_json_object_value(LabelType::FREE_MEM);
+      stream_next_json_object_value(LabelType::FREE_MEM);
+      String suntime = F("%sunrise%");
+      parseSystemVariables(suntime, false); // Not URL encoded
+      parseStandardConversions(suntime, false);
+      stream_next_json_object_value(F("Sunrise"),suntime);
+      suntime = F("%sunset%");
+      parseSystemVariables(suntime, false); // Not URL encoded
+      parseStandardConversions(suntime, false);
+      stream_last_json_object_value(F("Sunset"),suntime);
       addHtml(F(",\n"));
     }
 

--- a/src/src/WebServer/JSON.cpp
+++ b/src/src/WebServer/JSON.cpp
@@ -164,11 +164,9 @@ void handle_json()
       stream_next_json_object_value(LabelType::FREE_MEM);
       String suntime = F("%sunrise%");
       parseSystemVariables(suntime, false); // Not URL encoded
-      parseStandardConversions(suntime, false);
       stream_next_json_object_value(F("Sunrise"),suntime);
       suntime = F("%sunset%");
       parseSystemVariables(suntime, false); // Not URL encoded
-      parseStandardConversions(suntime, false);
       stream_last_json_object_value(F("Sunset"),suntime);
       addHtml(F(",\n"));
     }

--- a/src/src/WebServer/SysVarPage.cpp
+++ b/src/src/WebServer/SysVarPage.cpp
@@ -119,6 +119,7 @@ void handle_sysvars() {
   addSysVar_enum_html(SystemVariables::SYSWEEKDAY_S);
   addTableSeparator(F("System"), 3, 3);
   addSysVar_enum_html(SystemVariables::UPTIME);
+  addSysVar_enum_html(SystemVariables::UPTIME_MS);
   addSysVar_enum_html(SystemVariables::UNIXTIME);
   addSysVar_enum_html(SystemVariables::UNIXDAY);
   addSysVar_enum_html(SystemVariables::UNIXDAY_SEC);


### PR DESCRIPTION
Add extra variables to JSON output: (`http://<esp-ip>/json`)
- `%sunrise%`
- `%sunset%`
- `%isntp%`
- `%uptime_ms%` (new system variable)
- Location:
  - Timezone Offset
  - Latitude
  - Longitude

Resolves #3573 