### PR TITLE
Fix Precision issues and initialisation of members in rules

### DIFF
--- a/src/src/ESPEasyCore/ESPEasyRules.cpp
+++ b/src/src/ESPEasyCore/ESPEasyRules.cpp
@@ -457,6 +457,9 @@ bool parse_bitwise_functions(const String& cmd_s_lower, const String& arg1, cons
   }
 
   if (cmd_s_lower.startsWith(F("bit"))) {
+    #define bitSetULL(value, bit) ((value) |= (1ULL << (bit)))
+    #define bitClearULL(value, bit) ((value) &= ~(1ULL << (bit)))
+    #define bitWriteULL(value, bit, bitvalue) (bitvalue ? bitSetULL(value, bit) : bitClearULL(value, bit))
     uint32_t bitnr = 0;
     uint64_t iarg2 = 0;
 
@@ -470,11 +473,11 @@ bool parse_bitwise_functions(const String& cmd_s_lower, const String& arg1, cons
     } else if (cmd_s_lower.equals(F("bitset"))) {
       // Syntax like {bitset:0:122} to set least significant bit of the given nr '122' to '1' => '123'
       result = iarg2;
-      bitSet(result, bitnr);
+      bitSetULL(result, bitnr);
     } else if (cmd_s_lower.equals(F("bitclear"))) {
       // Syntax like {bitclear:0:123} to set least significant bit of the given nr '123' to '0' => '122'
       result = iarg2;
-      bitClear(result, bitnr);
+      bitClearULL(result, bitnr);
     } else if (cmd_s_lower.equals(F("bitwrite"))) {
       uint32_t iarg3 = 0;
 
@@ -482,7 +485,7 @@ bool parse_bitwise_functions(const String& cmd_s_lower, const String& arg1, cons
       if (validUIntFromString(arg3, iarg3)) {
         const int bitvalue = (iarg3 & 1); // Only use the last bit of the given parameter
         result = iarg2;
-        bitWrite(result, bitnr, bitvalue);
+        bitWriteULL(result, bitnr, bitvalue);
       } else {
         // Need 3 parameters, but 3rd one is not a valid uint
         return false;

--- a/src/src/ESPEasyCore/ESPEasyWifi.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi.cpp
@@ -513,10 +513,12 @@ void SetWiFiTXpower(float dBm, float rssi) {
   delay(0);
   #ifndef BUILD_NO_DEBUG
   if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
-    if (WiFiEventData.wifi_TX_pwr != maxTXpwr) {
-      static float last_log = -1;
-      if (WiFiEventData.wifi_TX_pwr != last_log) {
-        last_log = WiFiEventData.wifi_TX_pwr;
+    const int TX_pwr_int = WiFiEventData.wifi_TX_pwr * 4;
+    const int maxTXpwr_int = maxTXpwr * 4;
+    if (TX_pwr_int != maxTXpwr_int) {
+      static int last_log = -1;
+      if (TX_pwr_int != last_log) {
+        last_log = TX_pwr_int;
         String log = F("WiFi : Set TX power to ");
         log += String(dBm, 0);
         log += F("dBm");

--- a/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
@@ -240,13 +240,15 @@ void processConnect() {
   ++WiFiEventData.wifi_reconnects;
 
   if (WiFi_AP_Candidates.getCurrent().isEmergencyFallback) {
-    bool mustResetCredentials = false;
     #ifdef CUSTOM_EMERGENCY_FALLBACK_RESET_CREDENTIALS
-    mustResetCredentials = CUSTOM_EMERGENCY_FALLBACK_RESET_CREDENTIALS;
+    const bool mustResetCredentials = CUSTOM_EMERGENCY_FALLBACK_RESET_CREDENTIALS;
+    #else
+    const bool mustResetCredentials = false;
     #endif
-    bool mustStartAP = false;
     #ifdef CUSTOM_EMERGENCY_FALLBACK_START_AP
-    mustStartAP = CUSTOM_EMERGENCY_FALLBACK_START_AP;
+    const boolmustStartAP = CUSTOM_EMERGENCY_FALLBACK_START_AP;
+    #else
+    const bool mustStartAP = false;
     #endif
     if (mustStartAP) {
       int allowedUptimeMinutes = 10;

--- a/src/src/Helpers/ESPEasy_Storage.cpp
+++ b/src/src/Helpers/ESPEasy_Storage.cpp
@@ -26,7 +26,6 @@
 
 #include "../Helpers/ESPEasyRTC.h"
 #include "../Helpers/ESPEasy_FactoryDefault.h"
-#include "../Helpers/ESPEasy_Storage.h"
 #include "../Helpers/ESPEasy_time_calc.h"
 #include "../Helpers/FS_Helper.h"
 #include "../Helpers/Hardware.h"

--- a/src/src/Helpers/Rules_calculate.cpp
+++ b/src/src/Helpers/Rules_calculate.cpp
@@ -9,6 +9,12 @@
 #include "../Helpers/StringConverter.h"
 
 
+RulesCalculate_t::RulesCalculate_t() {
+  for (int i = 0; i < STACK_SIZE; ++i) {
+    globalstack[i] = 0.0;
+  }
+}
+
 /********************************************************************************************\
    Instance of the RulesCalculate to perform calculations
    These functions are wrapped in a class to

--- a/src/src/Helpers/Rules_calculate.h
+++ b/src/src/Helpers/Rules_calculate.h
@@ -59,7 +59,7 @@ private:
 
   double globalstack[STACK_SIZE];
   double *sp     = globalstack - 1;
-  double *sp_max = &globalstack[STACK_SIZE - 1];
+  const double *sp_max = &globalstack[STACK_SIZE - 1];
 
   // Check if it matches part of a number (identifier)
   // @param oc  Previous character
@@ -98,6 +98,8 @@ private:
   unsigned int op_arg_count(const char c);
 
 public:
+
+  RulesCalculate_t();
 
   CalculateReturnCode doCalculate(const char *input,
                                   double     *result);


### PR DESCRIPTION
Arduino's `bitSet` and `bitClear` macro can only be used on 32 bit ints, but we use it on 64 bit ints.

The `globalStack` in rules was not initialized with zeroes upon construction.
Not sure if it would have lead to bugs, but better safe than sorry.