### PR TITLE
[WiFi] Feed SW watchdog timer on WiFi related actions that may take time

### DIFF
--- a/src/Custom-sample.h
+++ b/src/Custom-sample.h
@@ -40,6 +40,7 @@
 #define DEFAULT_KEY                          "MySuperSecretPassword" // Enter your network WPA key
 #define DEFAULT_SSID2                        ""                      // Enter your fallback network SSID
 #define DEFAULT_KEY2                         ""                      // Enter your fallback network WPA key
+#define DEFAULT_WIFI_INCLUDE_HIDDEN_SSID     false                   // Allow to connect to hidden SSID APs
 #define DEFAULT_USE_STATIC_IP                false                   // (true|false) enabled or disabled static IP
 #define DEFAULT_IP                           "192.168.0.50"          // Enter your IP address
 #define DEFAULT_DNS                          "192.168.0.1"           // Enter your DNS

--- a/src/src/CustomBuild/ESPEasyDefaults.h
+++ b/src/src/CustomBuild/ESPEasyDefaults.h
@@ -48,6 +48,9 @@
 #ifndef DEFAULT_KEY2
 #define DEFAULT_KEY2         ""                 // Enter your fallback Wifi network WPA key
 #endif
+#ifndef DEFAULT_WIFI_INCLUDE_HIDDEN_SSID  
+#define DEFAULT_WIFI_INCLUDE_HIDDEN_SSID false  // Allow to connect to hidden SSID APs
+#endif
 #ifndef DEFAULT_USE_STATIC_IP
 #define DEFAULT_USE_STATIC_IP   false           // (true|false) enabled or disabled static IP
 #endif

--- a/src/src/ESPEasyCore/ESPEasyWifi.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi.cpp
@@ -16,6 +16,7 @@
 #include "../Globals/Settings.h"
 #include "../Globals/WiFi_AP_Candidates.h"
 #include "../Helpers/ESPEasy_time_calc.h"
+#include "../Helpers/Misc.h"
 #include "../Helpers/Networking.h"
 #include "../Helpers/StringConverter.h"
 #include "../Helpers/StringGenerator_WiFi.h"
@@ -366,6 +367,7 @@ void resetWiFi() {
     // Don't reset WiFi too often
     return;
   }
+  FeedSW_watchdog();
   WiFiEventData.clearAll();
   WifiDisconnect();
 
@@ -671,6 +673,7 @@ void WifiScan(bool async, uint8_t channel) {
   while (nrScans > 0) {
     if (!async) {
       WiFi_AP_Candidates.begin_sync_scan();
+      FeedSW_watchdog();
     }
     --nrScans;
     #ifdef ESP8266
@@ -682,6 +685,7 @@ void WifiScan(bool async, uint8_t channel) {
     WiFi.scanNetworks(async, show_hidden, passive, max_ms_per_chan /*, channel */);
     #endif
     if (!async) {
+      FeedSW_watchdog();
       processScanDone();
     }
   }

--- a/src/src/Helpers/ESPEasy_FactoryDefault.cpp
+++ b/src/src/Helpers/ESPEasy_FactoryDefault.cpp
@@ -109,6 +109,7 @@ void ResetFactory()
     str2ip((char *)DEFAULT_GW,     Settings.Gateway);
     str2ip((char *)DEFAULT_SUBNET, Settings.Subnet);
     #endif // if DEFAULT_USE_STATIC_IP
+    Settings.IncludeHiddenSSID(DEFAULT_WIFI_INCLUDE_HIDDEN_SSID);
   }
 
   Settings.clearNotifications();

--- a/src/src/Helpers/Misc.cpp
+++ b/src/src/Helpers/Misc.cpp
@@ -258,6 +258,13 @@ void reboot(ESPEasy_Scheduler::IntendedRebootReason_e reason) {
   #endif // if defined(ESP32)
 }
 
+void FeedSW_watchdog()
+{
+  #ifdef ESP8266
+  ESP.wdtFeed();
+  #endif
+}
+
 void SendValueLogger(taskIndex_t TaskIndex)
 {
 #if !defined(BUILD_NO_DEBUG) || defined(FEATURE_SD)

--- a/src/src/Helpers/Misc.h
+++ b/src/src/Helpers/Misc.h
@@ -122,6 +122,7 @@ void delayedReboot(int rebootDelay, ESPEasy_Scheduler::IntendedRebootReason_e re
 
 void reboot(ESPEasy_Scheduler::IntendedRebootReason_e reason);
 
+void FeedSW_watchdog();
 
 void SendValueLogger(taskIndex_t TaskIndex);
 


### PR DESCRIPTION
Checking network state may sometimes detect the exact limbo states it was written for.
However it may take some time to reset the WiFi if it is in limbo state, but by then the SW watchdog timer may already have reset the node.