### PR TITLE
[ESP32] Add missing lib_deps dependency

### DIFF
--- a/platformio_esp32_envs.ini
+++ b/platformio_esp32_envs.ini
@@ -9,7 +9,7 @@
 [esp32_common]
 extends                   = common, core_esp32_3_2_0
 lib_ignore                = ESP8266WiFi, ESP8266Ping, ESP8266WebServer, ESP8266HTTPUpdateServer, ESP8266mDNS, IRremoteESP8266, ESPEasy_ESP8266Ping, ESP32_ping, HeatpumpIR
-lib_deps                  = https://github.com/TD-er/ESPEasySerial.git#v2.0.5, adafruit/Adafruit ILI9341 @ ^1.5.6,  Adafruit GFX Library, LOLIN_EPD, Adafruit BusIO
+lib_deps                  = https://github.com/TD-er/ESPEasySerial.git#v2.0.5, adafruit/Adafruit ILI9341 @ ^1.5.6,  Adafruit GFX Library, LOLIN_EPD, Adafruit BusIO, SparkFun_VL53L1X
 board_build.f_flash       = 80000000L
 board_build.flash_mode    = dout
 board_upload.maximum_size = 1900544


### PR DESCRIPTION
Missed a dependency, re-enable ESP32 MAX configuration (with VL53L1X plugin) in build