### PR TITLE
Fix CUL reader + WiFi unable to reconnect

### DIFF
--- a/src/src/DataStructs/ControllerSettingsStruct.cpp
+++ b/src/src/DataStructs/ControllerSettingsStruct.cpp
@@ -103,7 +103,7 @@ bool ControllerSettingsStruct::checkHostReachable(bool quick) {
   if (!NetworkConnected(10)) {
     return false; // Not connected, so no use in wasting time to connect to a host.
   }
-  delay(1);       // Make sure the Watchdog will not trigger a reset.
+  delay(0);       // Make sure the Watchdog will not trigger a reset.
 
   if (quick && ipSet()) { return true; }
 

--- a/src/src/DataStructs/WiFi_AP_Candidate.cpp
+++ b/src/src/DataStructs/WiFi_AP_Candidate.cpp
@@ -46,6 +46,16 @@ WiFi_AP_Candidate::WiFi_AP_Candidate(uint8_t networkItem) : index(0) {
   last_seen = millis();
 }
 
+WiFi_AP_Candidate::WiFi_AP_Candidate(const WiFi_AP_Candidate& other)
+: ssid(other.ssid), key(other.key), last_seen(other.last_seen), 
+  rssi(other.rssi), channel(other.channel), index(other.index), 
+  enc_type(other.enc_type), isHidden(other.isHidden), 
+  lowPriority(other.lowPriority), 
+  isEmergencyFallback(other.isEmergencyFallback)
+{
+  setBSSID(other.bssid);
+}
+
 WiFi_AP_Candidate::WiFi_AP_Candidate() {}
 
 bool WiFi_AP_Candidate::operator<(const WiFi_AP_Candidate& other) const {

--- a/src/src/DataStructs/WiFi_AP_Candidate.h
+++ b/src/src/DataStructs/WiFi_AP_Candidate.h
@@ -16,6 +16,8 @@ struct WiFi_AP_Candidate {
   // Construct using index from WiFi scan result
   WiFi_AP_Candidate(uint8_t networkItem);
 
+  WiFi_AP_Candidate(const WiFi_AP_Candidate& other);
+
   // Default constructor
   WiFi_AP_Candidate();
 

--- a/src/src/ESPEasyCore/ESPEasyRules.cpp
+++ b/src/src/ESPEasyCore/ESPEasyRules.cpp
@@ -1460,6 +1460,7 @@ void createRuleEvents(struct EventStruct *event) {
     eventString += F("#");
     eventString += ExtraTaskSettings.TaskDeviceValueNames[0];
     eventString += F("=");
+    eventString += '`';
     if (appendCompleteStringvalue) {
       eventString += event->String2;
     } else {
@@ -1467,6 +1468,7 @@ void createRuleEvents(struct EventStruct *event) {
       eventString += F("...");
       eventString += event->String2.substring(event->String2.length() - 10);
     }
+    eventString += '`';
     eventQueue.addMove(std::move(eventString));    
   } else if (Settings.CombineTaskValues_SingleEvent(event->TaskIndex)) {
     String eventString;

--- a/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
@@ -88,7 +88,7 @@ void handle_unprocessedNetworkEvents()
 
       // WiFi connection is not yet available, so introduce some extra delays to
       // help the background tasks managing wifi connections
-      delay(1);
+      delay(0);
 
       NetworkConnectRelaxed();
 

--- a/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
@@ -222,7 +222,16 @@ void processDisconnect() {
     addLog(LOG_LEVEL_INFO, log);
   }
 
-  if (Settings.WiFiRestart_connection_lost()) {
+
+  bool mustRestartWiFi = Settings.WiFiRestart_connection_lost();
+  if (WiFiEventData.lastConnectedDuration_us > 0 && (WiFiEventData.lastConnectedDuration_us / 1000) < 5000) {
+    mustRestartWiFi = true;
+  }
+
+  if (mustRestartWiFi) {
+    WifiDisconnect(); // Needed or else node may not reconnect reliably.
+    delay(100);
+    setWifiMode(WIFI_OFF);
     initWiFi();
     delay(100);
     if (WiFiEventData.unprocessedWifiEvents()) {

--- a/src/src/Helpers/ESPEasy_Storage.cpp
+++ b/src/src/Helpers/ESPEasy_Storage.cpp
@@ -1184,7 +1184,7 @@ String LoadFromFile(const char *fname, int offset, byte *memAddress, int datasiz
     addLog(LOG_LEVEL_ERROR, log);
     return log;
   }
-  delay(1);
+  delay(0);
   START_TIMER;
   #ifndef BUILD_NO_RAM_TRACKER
   checkRAM(F("LoadFromFile"));
@@ -1196,7 +1196,7 @@ String LoadFromFile(const char *fname, int offset, byte *memAddress, int datasiz
   f.close();
 
   STOP_TIMER(LOADFILE_STATS);
-  delay(1);
+  delay(0);
 
   return String();
 }

--- a/src/src/PluginStructs/P094_data_struct.cpp
+++ b/src/src/PluginStructs/P094_data_struct.cpp
@@ -151,17 +151,16 @@ const String& P094_data_struct::peekSentence() const {
 }
 
 void P094_data_struct::getSentence(String& string, bool appendSysTime) {
+  string = std::move(sentence_part);
+  sentence_part = ""; // FIXME TD-er: Should not be needed as move already cleared it.
   if (appendSysTime) {
     // Unix timestamp = 10 decimals + separator
     if (string.reserve(sentence_part.length() + 11)) {
-      string        = sentence_part;
       string += ';';
       string += node_time.getUnixTime();
     }
-    sentence_part = "";
-  } else {
-    string = std::move(sentence_part);
   }
+  sentence_part.reserve(string.length());
 }
 
 void P094_data_struct::getSentencesReceived(uint32_t& succes, uint32_t& error, uint32_t& length_last) const {


### PR DESCRIPTION
Sometimes the ESP may get in some strange loop where it immediately gets disconnected.
Often with a disconnect reason like "4 way handshake timeout".
This may be impossible for the ESP to get out of, sometimes even a warm reboot (crash) may not help.
The only way to get out of it is a full WiFi disconnect.

The CUL reader plugin erased its message when timestamp needed to be appended.

Plugin with String type output needs to have the event parameter wrapped in quotes or else its content may be considered to be multiple eventvalues if it contains a comma.