### PR TITLE
[ESP32] Revert back to Espressif32 PIO v 2.1.0 due to serial issues

### DIFF
--- a/platformio_core_defs.ini
+++ b/platformio_core_defs.ini
@@ -139,6 +139,9 @@ platform_packages =
 [core_esp32_1_12_2]
 platform                  = espressif32@1.12.4
 
+[core_esp32_2_1_0]
+platform                  = espressif32@2.1.0
+
 [core_esp32_3_2_0]
 platform                  = espressif32@3.2.0
 

--- a/platformio_esp32_envs.ini
+++ b/platformio_esp32_envs.ini
@@ -7,7 +7,7 @@
 
 
 [esp32_common]
-extends                   = common, core_esp32_3_2_0
+extends                   = common, core_esp32_2_1_0
 lib_ignore                = ESP8266WiFi, ESP8266Ping, ESP8266WebServer, ESP8266HTTPUpdateServer, ESP8266mDNS, IRremoteESP8266, ESPEasy_ESP8266Ping, ESP32_ping, HeatpumpIR
 lib_deps                  = https://github.com/TD-er/ESPEasySerial.git#v2.0.5, adafruit/Adafruit ILI9341 @ ^1.5.6,  Adafruit GFX Library, LOLIN_EPD, Adafruit BusIO, VL53L0X @ 1.3.0, SparkFun VL53L1X 4m Laser Distance Sensor @ 1.2.9
 board_build.f_flash       = 80000000L


### PR DESCRIPTION
When calling Serial::begin() (on ESP32) you apparently need to give all parameters or else it may use default parameters (makes no sense!)
Serial::end() may cause a hang or crash -> timing issue

See crash/hang:
- https://github.com/espressif/arduino-esp32/pull/5047
- https://github.com/espressif/arduino-esp32/issues/5004
- https://github.com/espressif/arduino-esp32/commit/81b7c47203b7558cc634ab2b22f966aa4bbc9ce1
- https://github.com/espressif/arduino-esp32/issues/5112
- https://github.com/espressif/arduino-esp32/issues/5032

Switch back to default:
- https://github.com/espressif/arduino-esp32/issues/5026

Since these are all relative new issues, I guess it may be best to revert to this core version.

Symptoms:
A device connected to "Serial1" receives logs sent to "Serial0" after some time and/or fiddling around with settings.