### PR TITLE
[Memory] Use move operator to prevent extra memory allocs

### DIFF
--- a/src/_C001.ino
+++ b/src/_C001.ino
@@ -111,7 +111,7 @@ bool CPlugin_001(CPlugin::Function function, struct EventStruct *event, String& 
           url += mapVccToDomoticz();
             # endif // if FEATURE_ADC_VCC
 
-          success = C001_DelayHandler->addToQueue(C001_queue_element(event->ControllerIndex, event->TaskIndex, url));
+          success = C001_DelayHandler->addToQueue(std::move(C001_queue_element(event->ControllerIndex, event->TaskIndex, std::move(url))));
           Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C001_DELAY_QUEUE,
                                           C001_DelayHandler->getNextScheduleTime());
         }

--- a/src/_C001.ino
+++ b/src/_C001.ino
@@ -111,7 +111,7 @@ bool CPlugin_001(CPlugin::Function function, struct EventStruct *event, String& 
           url += mapVccToDomoticz();
             # endif // if FEATURE_ADC_VCC
 
-          success = C001_DelayHandler->addToQueue(std::move(C001_queue_element(event->ControllerIndex, event->TaskIndex, std::move(url))));
+          success = C001_DelayHandler->addToQueue(C001_queue_element(event->ControllerIndex, event->TaskIndex, std::move(url)));
           Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C001_DELAY_QUEUE,
                                           C001_DelayHandler->getNextScheduleTime());
         }

--- a/src/_C002.ino
+++ b/src/_C002.ino
@@ -267,7 +267,8 @@ bool CPlugin_002(CPlugin::Function function, struct EventStruct *event, String& 
         String pubname = CPlugin_002_pubname;
         parseControllerVariables(pubname, event, false);
 
-        success = MQTTpublish(event->ControllerIndex, event->TaskIndex, pubname.c_str(), json.c_str(), CPlugin_002_mqtt_retainFlag);
+        // Publish using move operator, thus pubname and json are empty after this call
+        success = MQTTpublish(event->ControllerIndex, event->TaskIndex, std::move(pubname), std::move(json), CPlugin_002_mqtt_retainFlag);
       } // if ixd !=0
       else
       {

--- a/src/_C003.ino
+++ b/src/_C003.ino
@@ -56,7 +56,7 @@ bool CPlugin_003(CPlugin::Function function, struct EventStruct *event, String& 
       url    += ",";
       url    += formatUserVarNoCheck(event, 0);
       url    += "\n";
-      success = C003_DelayHandler->addToQueue(C003_queue_element(event->ControllerIndex, event->TaskIndex, url));
+      success = C003_DelayHandler->addToQueue(std::move(C003_queue_element(event->ControllerIndex, event->TaskIndex, std::move(url))));
       Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C003_DELAY_QUEUE, C003_DelayHandler->getNextScheduleTime());
 
       break;

--- a/src/_C003.ino
+++ b/src/_C003.ino
@@ -56,7 +56,7 @@ bool CPlugin_003(CPlugin::Function function, struct EventStruct *event, String& 
       url    += ",";
       url    += formatUserVarNoCheck(event, 0);
       url    += "\n";
-      success = C003_DelayHandler->addToQueue(std::move(C003_queue_element(event->ControllerIndex, event->TaskIndex, std::move(url))));
+      success = C003_DelayHandler->addToQueue(C003_queue_element(event->ControllerIndex, event->TaskIndex, std::move(url)));
       Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C003_DELAY_QUEUE, C003_DelayHandler->getNextScheduleTime());
 
       break;

--- a/src/_C004.ino
+++ b/src/_C004.ino
@@ -67,7 +67,7 @@ bool CPlugin_004(CPlugin::Function function, struct EventStruct *event, String& 
       if (C004_DelayHandler == nullptr) {
         break;
       }
-      success = C004_DelayHandler->addToQueue(std::move(C004_queue_element(event)));
+      success = C004_DelayHandler->addToQueue(C004_queue_element(event));
       Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C004_DELAY_QUEUE, C004_DelayHandler->getNextScheduleTime());
 
       break;

--- a/src/_C004.ino
+++ b/src/_C004.ino
@@ -67,7 +67,7 @@ bool CPlugin_004(CPlugin::Function function, struct EventStruct *event, String& 
       if (C004_DelayHandler == nullptr) {
         break;
       }
-      success = C004_DelayHandler->addToQueue(C004_queue_element(event));
+      success = C004_DelayHandler->addToQueue(std::move(C004_queue_element(event)));
       Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C004_DELAY_QUEUE, C004_DelayHandler->getNextScheduleTime());
 
       break;

--- a/src/_C005.ino
+++ b/src/_C005.ino
@@ -149,14 +149,10 @@ bool CPlugin_005(CPlugin::Function function, struct EventStruct *event, String& 
         String tmppubname = pubname;
         parseSingleControllerVariable(tmppubname, event, x, false);
         String value;
-
-        // Small optimization so we don't try to copy potentially large strings
         if (event->sensorType == Sensor_VType::SENSOR_TYPE_STRING) {
-          MQTTpublish(event->ControllerIndex, event->TaskIndex, tmppubname.c_str(), event->String2.c_str(), mqtt_retainFlag);
           value = event->String2.substring(0, 20); // For the log
         } else {
           value = formatUserVarNoCheck(event, x);
-          MQTTpublish(event->ControllerIndex, event->TaskIndex, tmppubname.c_str(), value.c_str(), mqtt_retainFlag);
         }
 # ifndef BUILD_NO_DEBUG
 
@@ -168,6 +164,14 @@ bool CPlugin_005(CPlugin::Function function, struct EventStruct *event, String& 
           addLog(LOG_LEVEL_DEBUG, log);
         }
 # endif // ifndef BUILD_NO_DEBUG
+
+        // Small optimization so we don't try to copy potentially large strings
+        if (event->sensorType == Sensor_VType::SENSOR_TYPE_STRING) {
+          MQTTpublish(event->ControllerIndex, event->TaskIndex, tmppubname.c_str(), event->String2.c_str(), mqtt_retainFlag);
+        } else {
+          // Publish using move operator, thus tmppubname and value are empty after this call
+          MQTTpublish(event->ControllerIndex, event->TaskIndex, std::move(tmppubname), std::move(value), mqtt_retainFlag);
+        }
       }
       break;
     }

--- a/src/_C007.ino
+++ b/src/_C007.ino
@@ -63,7 +63,7 @@ bool CPlugin_007(CPlugin::Function function, struct EventStruct *event, String& 
         addLog(LOG_LEVEL_ERROR, F("emoncms : Unknown sensortype or too many sensor values"));
         break;
       }
-      success = C007_DelayHandler->addToQueue(std::move(C007_queue_element(event)));
+      success = C007_DelayHandler->addToQueue(C007_queue_element(event));
       Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C007_DELAY_QUEUE, C007_DelayHandler->getNextScheduleTime());
       break;
     }

--- a/src/_C007.ino
+++ b/src/_C007.ino
@@ -63,7 +63,7 @@ bool CPlugin_007(CPlugin::Function function, struct EventStruct *event, String& 
         addLog(LOG_LEVEL_ERROR, F("emoncms : Unknown sensortype or too many sensor values"));
         break;
       }
-      success = C007_DelayHandler->addToQueue(C007_queue_element(event));
+      success = C007_DelayHandler->addToQueue(std::move(C007_queue_element(event)));
       Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C007_DELAY_QUEUE, C007_DelayHandler->getNextScheduleTime());
       break;
     }

--- a/src/_C008.ino
+++ b/src/_C008.ino
@@ -76,7 +76,7 @@ bool CPlugin_008(CPlugin::Function function, struct EventStruct *event, String& 
 
       
       byte valueCount = getValueCountForTask(event->TaskIndex);
-      success = C008_DelayHandler->addToQueue(std::move(C008_queue_element(event, valueCount)));
+      success = C008_DelayHandler->addToQueue(C008_queue_element(event, valueCount));
 
       if (success) {
         // Element was added.

--- a/src/_C008.ino
+++ b/src/_C008.ino
@@ -74,9 +74,9 @@ bool CPlugin_008(CPlugin::Function function, struct EventStruct *event, String& 
         pubname = ControllerSettings.Publish;
       }
 
-      // FIXME TD-er must define a proper move operator
+      
       byte valueCount = getValueCountForTask(event->TaskIndex);
-      success = C008_DelayHandler->addToQueue(C008_queue_element(event, valueCount));
+      success = C008_DelayHandler->addToQueue(std::move(C008_queue_element(event, valueCount)));
 
       if (success) {
         // Element was added.

--- a/src/_C009.ino
+++ b/src/_C009.ino
@@ -77,7 +77,7 @@ bool CPlugin_009(CPlugin::Function function, struct EventStruct *event, String& 
       }
 
       
-      success = C009_DelayHandler->addToQueue(std::move(C009_queue_element(event)));
+      success = C009_DelayHandler->addToQueue(C009_queue_element(event));
       Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C009_DELAY_QUEUE, C009_DelayHandler->getNextScheduleTime());
       break;
     }

--- a/src/_C009.ino
+++ b/src/_C009.ino
@@ -76,8 +76,8 @@ bool CPlugin_009(CPlugin::Function function, struct EventStruct *event, String& 
         break;
       }
 
-      // FIXME TD-er must define a proper move operator
-      success = C009_DelayHandler->addToQueue(C009_queue_element(event));
+      
+      success = C009_DelayHandler->addToQueue(std::move(C009_queue_element(event)));
       Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C009_DELAY_QUEUE, C009_DelayHandler->getNextScheduleTime());
       break;
     }

--- a/src/_C010.ino
+++ b/src/_C010.ino
@@ -95,8 +95,8 @@ bool CPlugin_010(CPlugin::Function function, struct EventStruct *event, String& 
         }
       }
 
-      // FIXME TD-er must define a proper move operator
-      success = C010_DelayHandler->addToQueue(C010_queue_element(element));
+      
+      success = C010_DelayHandler->addToQueue(std::move(element));
       Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C010_DELAY_QUEUE, C010_DelayHandler->getNextScheduleTime());
       break;
     }

--- a/src/_C011.ino
+++ b/src/_C011.ino
@@ -237,7 +237,7 @@ boolean Create_schedule_HTTP_C011(struct EventStruct *event)
   LoadTaskSettings(event->TaskIndex);
 
   // Add a new element to the queue with the minimal payload
-  bool success = C011_DelayHandler->addToQueue(C011_queue_element(event));
+  bool success = C011_DelayHandler->addToQueue(std::move(C011_queue_element(event)));
 
   if (success) {
     // Element was added.

--- a/src/_C011.ino
+++ b/src/_C011.ino
@@ -237,7 +237,7 @@ boolean Create_schedule_HTTP_C011(struct EventStruct *event)
   LoadTaskSettings(event->TaskIndex);
 
   // Add a new element to the queue with the minimal payload
-  bool success = C011_DelayHandler->addToQueue(std::move(C011_queue_element(event)));
+  bool success = C011_DelayHandler->addToQueue(C011_queue_element(event));
 
   if (success) {
     // Element was added.

--- a/src/_C012.ino
+++ b/src/_C012.ino
@@ -74,8 +74,8 @@ bool CPlugin_012(CPlugin::Function function, struct EventStruct *event, String& 
         }
       }
 
-      // FIXME TD-er must define a proper move operator
-      success = C012_DelayHandler->addToQueue(C012_queue_element(element));
+      
+      success = C012_DelayHandler->addToQueue(std::move(element));
       Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C012_DELAY_QUEUE, C012_DelayHandler->getNextScheduleTime());
       break;
     }

--- a/src/_C015.ino
+++ b/src/_C015.ino
@@ -167,8 +167,8 @@ bool CPlugin_015(CPlugin::Function function, struct EventStruct *event, String& 
       // Collect the values at the same run, to make sure all are from the same sample
       byte valueCount = getValueCountForTask(event->TaskIndex);
 
-      // FIXME TD-er must define a proper move operator
-      success = C015_DelayHandler->addToQueue(C015_queue_element(event, valueCount));
+      
+      success = C015_DelayHandler->addToQueue(std::move(C015_queue_element(event, valueCount)));
 
       if (success) {
         // Element was added.

--- a/src/_C015.ino
+++ b/src/_C015.ino
@@ -168,7 +168,7 @@ bool CPlugin_015(CPlugin::Function function, struct EventStruct *event, String& 
       byte valueCount = getValueCountForTask(event->TaskIndex);
 
       
-      success = C015_DelayHandler->addToQueue(std::move(C015_queue_element(event, valueCount)));
+      success = C015_DelayHandler->addToQueue(C015_queue_element(event, valueCount));
 
       if (success) {
         // Element was added.

--- a/src/_C016.ino
+++ b/src/_C016.ino
@@ -108,7 +108,7 @@ bool CPlugin_016(CPlugin::Function function, struct EventStruct *event, String& 
 
               MakeControllerSettings(ControllerSettings);
               LoadControllerSettings(event->ControllerIndex, ControllerSettings);
-              success = C016_DelayHandler->addToQueue(element);
+              success = C016_DelayHandler->addToQueue(std::move(element));
               Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C016_DELAY_QUEUE,
                  C016_DelayHandler->getNextScheduleTime());
        */

--- a/src/_C017.ino
+++ b/src/_C017.ino
@@ -64,8 +64,7 @@ bool CPlugin_017(CPlugin::Function function, struct EventStruct *event, String& 
         break;
       }
 
-      // FIXME TD-er must define a proper move operator
-      success = C017_DelayHandler->addToQueue(C017_queue_element(event));
+      success = C017_DelayHandler->addToQueue(std::move(C017_queue_element(event)));
       Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C017_DELAY_QUEUE, C017_DelayHandler->getNextScheduleTime());
       break;
     }

--- a/src/_C017.ino
+++ b/src/_C017.ino
@@ -64,7 +64,7 @@ bool CPlugin_017(CPlugin::Function function, struct EventStruct *event, String& 
         break;
       }
 
-      success = C017_DelayHandler->addToQueue(std::move(C017_queue_element(event)));
+      success = C017_DelayHandler->addToQueue(C017_queue_element(event));
       Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C017_DELAY_QUEUE, C017_DelayHandler->getNextScheduleTime());
       break;
     }

--- a/src/_C018.ino
+++ b/src/_C018.ino
@@ -745,7 +745,7 @@ bool CPlugin_018(CPlugin::Function function, struct EventStruct *event, String& 
 
       if (C018_data != nullptr) {
         success = C018_DelayHandler->addToQueue(
-          C018_queue_element(event, C018_data->getSampleSetCount(event->TaskIndex)));
+          std::move(C018_queue_element(event, C018_data->getSampleSetCount(event->TaskIndex))));
         Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_C018_DELAY_QUEUE,
                                          C018_DelayHandler->getNextScheduleTime());
 

--- a/src/src/Commands/MQTT.cpp
+++ b/src/src/Commands/MQTT.cpp
@@ -76,6 +76,7 @@ boolean MQTTsubscribe(controllerIndex_t controller_idx, const char* topic, boole
 {
   if (MQTTclient.subscribe(topic)) {
     Scheduler.setIntervalTimerOverride(ESPEasy_Scheduler::IntervalTimer_e::TIMER_MQTT, 10); // Make sure the MQTT is being processed as soon as possible.
+    scheduleNextMQTTdelayQueue();
     String log = F("Subscribed to: ");  log += topic;
     addLog(LOG_LEVEL_INFO, log);
     return true;

--- a/src/src/Commands/Notifications.cpp
+++ b/src/src/Commands/Notifications.cpp
@@ -26,7 +26,7 @@ String Command_Notifications_Notify(struct EventStruct *event, const char* Line)
 				// TempEvent.NotificationProtocolIndex = NotificationProtocolIndex;
 				TempEvent.NotificationIndex = index;
 				TempEvent.String1 = message;
-				Scheduler.schedule_notification_event_timer(NotificationProtocolIndex, NPlugin::Function::NPLUGIN_NOTIFY, &TempEvent);
+				Scheduler.schedule_notification_event_timer(NotificationProtocolIndex, NPlugin::Function::NPLUGIN_NOTIFY, std::move(TempEvent));
 			}
 		}
 	}

--- a/src/src/ControllerQueue/C011_queue_element.cpp
+++ b/src/src/ControllerQueue/C011_queue_element.cpp
@@ -4,19 +4,6 @@
 
 #ifdef USES_C011
 
-C011_queue_element::C011_queue_element() {}
-
-C011_queue_element::C011_queue_element(C011_queue_element&& other)
-  : uri(std::move(other.uri))
-  , HttpMethod(std::move(other.HttpMethod))
-  , header(std::move(other.header))
-  , postStr(std::move(other.postStr))
-  , idx(other.idx)
-  , _timestamp(other._timestamp)
-  , TaskIndex(other.TaskIndex)
-  , controller_idx(other.controller_idx)
-  , sensorType(other.sensorType)
-{}
 
 C011_queue_element::C011_queue_element(const struct EventStruct *event) :
   idx(event->idx),

--- a/src/src/ControllerQueue/C011_queue_element.cpp
+++ b/src/src/ControllerQueue/C011_queue_element.cpp
@@ -6,6 +6,18 @@
 
 C011_queue_element::C011_queue_element() {}
 
+C011_queue_element::C011_queue_element(C011_queue_element&& other)
+  : uri(std::move(other.uri))
+  , HttpMethod(std::move(other.HttpMethod))
+  , header(std::move(other.header))
+  , postStr(std::move(other.postStr))
+  , idx(other.idx)
+  , _timestamp(other._timestamp)
+  , TaskIndex(other.TaskIndex)
+  , controller_idx(other.controller_idx)
+  , sensorType(other.sensorType)
+{}
+
 C011_queue_element::C011_queue_element(const struct EventStruct *event) :
   idx(event->idx),
   TaskIndex(event->TaskIndex),
@@ -14,6 +26,7 @@ C011_queue_element::C011_queue_element(const struct EventStruct *event) :
 
 size_t C011_queue_element::getSize() const {
   size_t total = sizeof(*this);
+
   total += uri.length();
   total += HttpMethod.length();
   total += header.length();
@@ -22,17 +35,16 @@ size_t C011_queue_element::getSize() const {
 }
 
 bool C011_queue_element::isDuplicate(const C011_queue_element& other) const {
-  if (other.controller_idx != controller_idx || 
-      other.TaskIndex != TaskIndex ||
-      other.sensorType != sensorType ||
-      other.idx != idx) {
+  if ((other.controller_idx != controller_idx) ||
+      (other.TaskIndex != TaskIndex) ||
+      (other.sensorType != sensorType) ||
+      (other.idx != idx)) {
     return false;
   }
-  return (other.uri.equals(uri) && 
-          other.HttpMethod.equals(HttpMethod) && 
-          other.header.equals(header) && 
-          other.postStr.equals(postStr));
+  return other.uri.equals(uri) &&
+         other.HttpMethod.equals(HttpMethod) &&
+         other.header.equals(header) &&
+         other.postStr.equals(postStr);
 }
 
-
-#endif
+#endif // ifdef USES_C011

--- a/src/src/ControllerQueue/C011_queue_element.h
+++ b/src/src/ControllerQueue/C011_queue_element.h
@@ -4,6 +4,7 @@
 #include "../../ESPEasy_common.h"
 #include "../CustomBuild/ESPEasyLimits.h"
 #include "../DataStructs/DeviceStruct.h"
+#include "../DataStructs/UnitMessageCount.h"
 #include "../Globals/CPlugins.h"
 #include "../Globals/Plugins.h"
 
@@ -35,6 +36,7 @@ public:
   taskIndex_t TaskIndex            = INVALID_TASK_INDEX;
   controllerIndex_t controller_idx = INVALID_CONTROLLER_INDEX;
   Sensor_VType sensorType          = Sensor_VType::SENSOR_TYPE_NONE;
+  UnitMessageCount_t UnitMessageCount; 
 };
 
 #endif //USES_C011

--- a/src/src/ControllerQueue/C011_queue_element.h
+++ b/src/src/ControllerQueue/C011_queue_element.h
@@ -19,9 +19,11 @@ struct EventStruct;
 class C011_queue_element {
 public:
 
-  C011_queue_element();
+  C011_queue_element() = default;
 
-  C011_queue_element(C011_queue_element&& other);
+  C011_queue_element(C011_queue_element&& other) = default;
+
+  C011_queue_element(const C011_queue_element& other) = delete;
 
   C011_queue_element(const struct EventStruct *event);
 

--- a/src/src/ControllerQueue/C011_queue_element.h
+++ b/src/src/ControllerQueue/C011_queue_element.h
@@ -25,6 +25,8 @@ public:
 
   bool isDuplicate(const C011_queue_element& other) const;
 
+  const UnitMessageCount_t* getUnitMessageCount() const { return nullptr; }
+
   size_t getSize() const;
 
   String uri;
@@ -36,7 +38,6 @@ public:
   taskIndex_t TaskIndex            = INVALID_TASK_INDEX;
   controllerIndex_t controller_idx = INVALID_CONTROLLER_INDEX;
   Sensor_VType sensorType          = Sensor_VType::SENSOR_TYPE_NONE;
-  UnitMessageCount_t UnitMessageCount; 
 };
 
 #endif //USES_C011

--- a/src/src/ControllerQueue/C011_queue_element.h
+++ b/src/src/ControllerQueue/C011_queue_element.h
@@ -21,6 +21,8 @@ public:
 
   C011_queue_element();
 
+  C011_queue_element(C011_queue_element&& other);
+
   C011_queue_element(const struct EventStruct *event);
 
   bool isDuplicate(const C011_queue_element& other) const;

--- a/src/src/ControllerQueue/C015_queue_element.cpp
+++ b/src/src/ControllerQueue/C015_queue_element.cpp
@@ -6,6 +6,17 @@
 
 C015_queue_element::C015_queue_element() {}
 
+C015_queue_element::C015_queue_element(C015_queue_element&& other)
+  : idx(other.idx), _timestamp(other._timestamp), TaskIndex(other.TaskIndex)
+  , controller_idx(other.controller_idx), valuesSent(other.valuesSent)
+  , valueCount(other.valueCount)
+{
+  for (byte i = 0; i < VARS_PER_TASK; ++i) {
+    txt[i]  = std::move(other.txt[i]);
+    vPin[i] = other.vPin[i];
+  }
+}
+
 C015_queue_element::C015_queue_element(const struct EventStruct *event, byte value_count) :
   idx(event->idx),
   TaskIndex(event->TaskIndex),
@@ -28,17 +39,19 @@ size_t C015_queue_element::getSize() const {
 }
 
 bool C015_queue_element::isDuplicate(const C015_queue_element& other) const {
-  if (other.controller_idx != controller_idx || 
-      other.TaskIndex != TaskIndex ||
-      other.sensorType != sensorType ||
-      other.valueCount != valueCount ||
-      other.idx != idx) {
+  if ((other.controller_idx != controller_idx) ||
+      (other.TaskIndex != TaskIndex) ||
+      (other.sensorType != sensorType) ||
+      (other.valueCount != valueCount) ||
+      (other.idx != idx)) {
     return false;
   }
+
   for (byte i = 0; i < VARS_PER_TASK; ++i) {
     if (other.txt[i] != txt[i]) {
       return false;
     }
+
     if (other.vPin[i] != vPin[i]) {
       return false;
     }
@@ -46,5 +59,4 @@ bool C015_queue_element::isDuplicate(const C015_queue_element& other) const {
   return true;
 }
 
-
-#endif
+#endif // ifdef USES_C015

--- a/src/src/ControllerQueue/C015_queue_element.cpp
+++ b/src/src/ControllerQueue/C015_queue_element.cpp
@@ -4,8 +4,6 @@
 
 #ifdef USES_C015
 
-C015_queue_element::C015_queue_element() {}
-
 C015_queue_element::C015_queue_element(C015_queue_element&& other)
   : idx(other.idx), _timestamp(other._timestamp), TaskIndex(other.TaskIndex)
   , controller_idx(other.controller_idx), valuesSent(other.valuesSent)

--- a/src/src/ControllerQueue/C015_queue_element.h
+++ b/src/src/ControllerQueue/C015_queue_element.h
@@ -19,7 +19,9 @@ struct EventStruct;
 class C015_queue_element {
 public:
 
-  C015_queue_element();
+  C015_queue_element() = default;
+
+  C015_queue_element(const C015_queue_element& other) = delete;
 
   C015_queue_element(C015_queue_element&& other);
 

--- a/src/src/ControllerQueue/C015_queue_element.h
+++ b/src/src/ControllerQueue/C015_queue_element.h
@@ -21,6 +21,8 @@ public:
 
   C015_queue_element();
 
+  C015_queue_element(C015_queue_element&& other);
+
   C015_queue_element(const struct EventStruct *event, byte value_count);
 
   bool   checkDone(bool succesfull) const;

--- a/src/src/ControllerQueue/C015_queue_element.h
+++ b/src/src/ControllerQueue/C015_queue_element.h
@@ -29,6 +29,8 @@ public:
 
   bool isDuplicate(const C015_queue_element& other) const;
 
+  const UnitMessageCount_t* getUnitMessageCount() const { return nullptr; }
+
   String txt[VARS_PER_TASK];
   int vPin[VARS_PER_TASK]          = { 0 };
   int idx                          = 0;
@@ -37,7 +39,6 @@ public:
   controllerIndex_t controller_idx = INVALID_CONTROLLER_INDEX;
   mutable byte valuesSent          = 0; // Value must be set by const function checkDone()
   byte valueCount                  = 0;
-  UnitMessageCount_t UnitMessageCount; 
 };
 
 #endif //USES_C015

--- a/src/src/ControllerQueue/C015_queue_element.h
+++ b/src/src/ControllerQueue/C015_queue_element.h
@@ -3,6 +3,7 @@
 
 #include "../../ESPEasy_common.h"
 #include "../CustomBuild/ESPEasyLimits.h"
+#include "../DataStructs/UnitMessageCount.h"
 #include "../Globals/CPlugins.h"
 #include "../Globals/Plugins.h"
 
@@ -36,6 +37,7 @@ public:
   controllerIndex_t controller_idx = INVALID_CONTROLLER_INDEX;
   mutable byte valuesSent          = 0; // Value must be set by const function checkDone()
   byte valueCount                  = 0;
+  UnitMessageCount_t UnitMessageCount; 
 };
 
 #endif //USES_C015

--- a/src/src/ControllerQueue/C016_queue_element.cpp
+++ b/src/src/ControllerQueue/C016_queue_element.cpp
@@ -9,6 +9,18 @@
 C016_queue_element::C016_queue_element() : _timestamp(0), TaskIndex(INVALID_TASK_INDEX), controller_idx(0), sensorType(
     Sensor_VType::SENSOR_TYPE_NONE) {}
 
+C016_queue_element::C016_queue_element(C016_queue_element&& other)
+  : _timestamp(other._timestamp)
+  , TaskIndex(other.TaskIndex)
+  , controller_idx(other.controller_idx)
+  , sensorType(other.sensorType)
+  , valueCount(other.valueCount)
+{
+  for (byte i = 0; i < VARS_PER_TASK; ++i) {
+    values[i] = other.values[i];
+  }
+}
+
 C016_queue_element::C016_queue_element(const struct EventStruct *event, byte value_count, unsigned long unixTime) :
   _timestamp(unixTime),
   TaskIndex(event->TaskIndex),
@@ -30,12 +42,13 @@ size_t C016_queue_element::getSize() const {
 }
 
 bool C016_queue_element::isDuplicate(const C016_queue_element& other) const {
-  if (other.controller_idx != controller_idx || 
-      other.TaskIndex != TaskIndex ||
-      other.sensorType != sensorType ||
-      other.valueCount != valueCount) {
+  if ((other.controller_idx != controller_idx) ||
+      (other.TaskIndex != TaskIndex) ||
+      (other.sensorType != sensorType) ||
+      (other.valueCount != valueCount)) {
     return false;
   }
+
   for (byte i = 0; i < VARS_PER_TASK; ++i) {
     if (other.values[i] != values[i]) {
       return false;
@@ -44,5 +57,4 @@ bool C016_queue_element::isDuplicate(const C016_queue_element& other) const {
   return true;
 }
 
-
-#endif
+#endif // ifdef USES_C016

--- a/src/src/ControllerQueue/C016_queue_element.cpp
+++ b/src/src/ControllerQueue/C016_queue_element.cpp
@@ -44,4 +44,5 @@ bool C016_queue_element::isDuplicate(const C016_queue_element& other) const {
   return true;
 }
 
+
 #endif

--- a/src/src/ControllerQueue/C016_queue_element.h
+++ b/src/src/ControllerQueue/C016_queue_element.h
@@ -31,13 +31,14 @@ public:
 
   bool isDuplicate(const C016_queue_element& other) const;
 
+  const UnitMessageCount_t* getUnitMessageCount() const { return nullptr; }
+
   float values[VARS_PER_TASK] = { 0 };
   unsigned long _timestamp    = 0; // Unix timestamp
   taskIndex_t TaskIndex       = INVALID_TASK_INDEX;
   controllerIndex_t controller_idx = INVALID_CONTROLLER_INDEX;
   Sensor_VType sensorType     = Sensor_VType::SENSOR_TYPE_NONE;
   byte valueCount             = 0;
-  UnitMessageCount_t UnitMessageCount; 
 };
 
 #endif //USES_C016

--- a/src/src/ControllerQueue/C016_queue_element.h
+++ b/src/src/ControllerQueue/C016_queue_element.h
@@ -4,6 +4,7 @@
 #include "../../ESPEasy_common.h"
 #include "../CustomBuild/ESPEasyLimits.h"
 #include "../DataStructs/DeviceStruct.h"
+#include "../DataStructs/UnitMessageCount.h"
 #include "../Globals/Plugins.h"
 
 struct EventStruct;
@@ -36,6 +37,7 @@ public:
   controllerIndex_t controller_idx = INVALID_CONTROLLER_INDEX;
   Sensor_VType sensorType     = Sensor_VType::SENSOR_TYPE_NONE;
   byte valueCount             = 0;
+  UnitMessageCount_t UnitMessageCount; 
 };
 
 #endif //USES_C016

--- a/src/src/ControllerQueue/C016_queue_element.h
+++ b/src/src/ControllerQueue/C016_queue_element.h
@@ -23,6 +23,8 @@ public:
 
   C016_queue_element();
 
+  C016_queue_element(C016_queue_element&& other);
+
   C016_queue_element(const struct EventStruct *event,
                      byte                      value_count,
                      unsigned long             unixTime);

--- a/src/src/ControllerQueue/C018_queue_element.cpp
+++ b/src/src/ControllerQueue/C018_queue_element.cpp
@@ -8,15 +8,6 @@
 
 #ifdef USES_C018
 
-C018_queue_element::C018_queue_element() {}
-
-C018_queue_element::C018_queue_element(C018_queue_element&& other)
-  : packed(std::move(other.packed))
-  , _timestamp(other._timestamp)
-  , TaskIndex(other.TaskIndex)
-  , controller_idx(other.controller_idx)
-{}
-
 C018_queue_element::C018_queue_element(struct EventStruct *event, uint8_t sampleSetCount) :
   TaskIndex(event->TaskIndex),
   controller_idx(event->ControllerIndex)

--- a/src/src/ControllerQueue/C018_queue_element.cpp
+++ b/src/src/ControllerQueue/C018_queue_element.cpp
@@ -10,18 +10,26 @@
 
 C018_queue_element::C018_queue_element() {}
 
+C018_queue_element::C018_queue_element(C018_queue_element&& other)
+  : packed(std::move(other.packed))
+  , _timestamp(other._timestamp)
+  , TaskIndex(other.TaskIndex)
+  , controller_idx(other.controller_idx)
+{}
+
 C018_queue_element::C018_queue_element(struct EventStruct *event, uint8_t sampleSetCount) :
   TaskIndex(event->TaskIndex),
   controller_idx(event->ControllerIndex)
 {
-    #ifdef USES_PACKED_RAW_DATA
+    # ifdef USES_PACKED_RAW_DATA
   packed = getPackedFromPlugin(event, sampleSetCount);
+
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
     String log = F("C018 queue element: ");
     log += packed;
     addLog(LOG_LEVEL_INFO, log);
   }
-    #endif // USES_PACKED_RAW_DATA
+    # endif // USES_PACKED_RAW_DATA
 }
 
 size_t C018_queue_element::getSize() const {
@@ -29,17 +37,12 @@ size_t C018_queue_element::getSize() const {
 }
 
 bool C018_queue_element::isDuplicate(const C018_queue_element& other) const {
-  if (other.controller_idx != controller_idx || 
-      other.TaskIndex != TaskIndex) {
+  if ((other.controller_idx != controller_idx) ||
+      (other.TaskIndex != TaskIndex) ||
+      (other.packed != packed)) {
     return false;
-  }
-  for (byte i = 0; i < VARS_PER_TASK; ++i) {
-    if (other.packed[i] != packed[i]) {
-      return false;
-    }
   }
   return true;
 }
 
-
-#endif
+#endif // ifdef USES_C018

--- a/src/src/ControllerQueue/C018_queue_element.h
+++ b/src/src/ControllerQueue/C018_queue_element.h
@@ -28,11 +28,12 @@ public:
 
   bool isDuplicate(const C018_queue_element& other) const;
 
+  const UnitMessageCount_t* getUnitMessageCount() const { return nullptr; }
+
   String packed;
   unsigned long _timestamp         = millis();
   taskIndex_t TaskIndex            = INVALID_TASK_INDEX;
   controllerIndex_t controller_idx = INVALID_CONTROLLER_INDEX;
-  UnitMessageCount_t UnitMessageCount; 
 };
 
 #endif //USES_C018

--- a/src/src/ControllerQueue/C018_queue_element.h
+++ b/src/src/ControllerQueue/C018_queue_element.h
@@ -19,9 +19,11 @@ struct EventStruct;
 class C018_queue_element {
 public:
 
-  C018_queue_element();
+  C018_queue_element() = default;
 
-  C018_queue_element(C018_queue_element&& other);
+  C018_queue_element(const C018_queue_element& other) = delete;
+
+  C018_queue_element(C018_queue_element&& other) = default;
 
   C018_queue_element(struct EventStruct *event,
                      uint8_t             sampleSetCount);

--- a/src/src/ControllerQueue/C018_queue_element.h
+++ b/src/src/ControllerQueue/C018_queue_element.h
@@ -21,6 +21,8 @@ public:
 
   C018_queue_element();
 
+  C018_queue_element(C018_queue_element&& other);
+
   C018_queue_element(struct EventStruct *event,
                      uint8_t             sampleSetCount);
 

--- a/src/src/ControllerQueue/C018_queue_element.h
+++ b/src/src/ControllerQueue/C018_queue_element.h
@@ -3,6 +3,7 @@
 
 #include "../../ESPEasy_common.h"
 #include "../CustomBuild/ESPEasyLimits.h"
+#include "../DataStructs/UnitMessageCount.h"
 #include "../Globals/CPlugins.h"
 
 
@@ -31,6 +32,7 @@ public:
   unsigned long _timestamp         = millis();
   taskIndex_t TaskIndex            = INVALID_TASK_INDEX;
   controllerIndex_t controller_idx = INVALID_CONTROLLER_INDEX;
+  UnitMessageCount_t UnitMessageCount; 
 };
 
 #endif //USES_C018

--- a/src/src/ControllerQueue/ControllerDelayHandlerStruct.h
+++ b/src/src/ControllerQueue/ControllerDelayHandlerStruct.h
@@ -3,6 +3,7 @@
 
 #include "../DataStructs/ControllerSettingsStruct.h"
 #include "../DataStructs/TimingStats.h"
+#include "../DataStructs/UnitMessageCount.h"
 #include "../ESPEasyCore/ESPEasy_Log.h"
 #include "../Globals/CPlugins.h"
 #include "../Globals/ESPEasy_Scheduler.h"
@@ -103,15 +104,23 @@ struct ControllerDelayHandlerStruct {
     return true;
   }
 
-  // Return true if last element was removed
-  bool removeLastIfDuplicate() {
+  // Return true if message is already present in the queue
+  bool isDuplicate(const T& element) const {
+    // Some controllers may receive duplicate messages, due to lost acknowledgement
+    // This is actually the same message, so this should not be processed.
+    if (!unitLastMessageCount.isNew(element.UnitMessageCount)) {
+      return true;
+    }
+    // The unit message count is still stored to make sure a new one with the same count
+    // is considered a duplicate, even when the queue is empty.
+    unitLastMessageCount.add(element.UnitMessageCount);
+
+    // the setting 'deduplicate' does look at the content of the message and only compares it to messages in the queue.
     if (deduplicate && !sendQueue.empty()) {
-      auto back = sendQueue.back();
       // Use reverse iterator here, as it is more likely a duplicate is added shortly after another.
       auto it = sendQueue.rbegin(); // Same as back()
-      ++it;                         // The last element before back()
       for (; it != sendQueue.rend(); ++it) {
-        if (back.isDuplicate(*it)) {
+        if (element.isDuplicate(*it)) {
 #ifndef BUILD_NO_DEBUG
           if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
             const cpluginID_t cpluginID = getCPluginID_from_ControllerIndex(it->controller_idx);
@@ -120,8 +129,6 @@ struct ControllerDelayHandlerStruct {
             addLog(LOG_LEVEL_DEBUG, log);
           }
 #endif // ifndef BUILD_NO_DEBUG
-
-          sendQueue.pop_back();
           return true;
         }
       }
@@ -130,8 +137,12 @@ struct ControllerDelayHandlerStruct {
   }
 
   // Try to add to the queue, if permitted by "delete_oldest"
-  // Return false when no item was added.
-  bool addToQueue(T&& element, bool checkDuplicate = true) {
+  // Return true when item was added, or skipped as it was considered a duplicate
+  bool addToQueue(T&& element) {
+    if (isDuplicate(element)) {
+      return true;
+    }
+
     if (delete_oldest) {
       // Force add to the queue.
       // If max buffer is reached, the oldest in the queue (first to be served) will be removed.
@@ -139,20 +150,10 @@ struct ControllerDelayHandlerStruct {
         sendQueue.pop_front();
         attempt = 0;
       }
-      sendQueue.emplace_back(element);
-      if (checkDuplicate) {
-        // If message is already present consider adding to be a success.
-        removeLastIfDuplicate();
-      }
-      return true;
     }
 
     if (!queueFull(element)) {
-      sendQueue.emplace_back(element);
-      if (checkDuplicate) {
-        // If message is already present consider adding to be a success.
-        removeLastIfDuplicate();
-      }
+      sendQueue.push_back(element);
       return true;
     }
 #ifndef BUILD_NO_DEBUG
@@ -170,7 +171,7 @@ struct ControllerDelayHandlerStruct {
   // Get the next element.
   // Remove front element when max_retries is reached.
   T* getNext() {
-    if (sendQueue.empty()) { return NULL; }
+    if (sendQueue.empty()) { return nullptr; }
 
     if (attempt > max_retries) {
       sendQueue.pop_front();
@@ -189,7 +190,7 @@ struct ControllerDelayHandlerStruct {
       }
     }
 
-    if (sendQueue.empty()) { return NULL; }
+    if (sendQueue.empty()) { return nullptr; }
     return &sendQueue.front();
   }
 
@@ -239,6 +240,7 @@ struct ControllerDelayHandlerStruct {
   }
 
   std::list<T>  sendQueue;
+  mutable UnitLastMessageCount_map unitLastMessageCount;
   unsigned long lastSend;
   unsigned int  minTimeBetweenMessages;
   unsigned long expire_timeout = 0;
@@ -289,7 +291,7 @@ struct ControllerDelayHandlerStruct {
   void process_c##NNN####M##_delay_queue() {                                                                           \
     if (C##NNN####M##_DelayHandler == nullptr) return;                                                                 \
     C##NNN####M##_queue_element *element(C##NNN####M##_DelayHandler->getNext());                                       \
-    if (element == NULL) return;                                                                                       \
+    if (element == nullptr) return;                                                                                       \
     MakeControllerSettings(ControllerSettings);                                                                        \
     bool ready = true;                                                                                                 \
     if (!AllocatedControllerSettings()) {                                                                              \

--- a/src/src/ControllerQueue/ControllerDelayHandlerStruct.h
+++ b/src/src/ControllerQueue/ControllerDelayHandlerStruct.h
@@ -108,12 +108,12 @@ struct ControllerDelayHandlerStruct {
   bool isDuplicate(const T& element) const {
     // Some controllers may receive duplicate messages, due to lost acknowledgement
     // This is actually the same message, so this should not be processed.
-    if (!unitLastMessageCount.isNew(element.UnitMessageCount)) {
+    if (!unitLastMessageCount.isNew(element.getUnitMessageCount())) {
       return true;
     }
     // The unit message count is still stored to make sure a new one with the same count
     // is considered a duplicate, even when the queue is empty.
-    unitLastMessageCount.add(element.UnitMessageCount);
+    unitLastMessageCount.add(element.getUnitMessageCount());
 
     // the setting 'deduplicate' does look at the content of the message and only compares it to messages in the queue.
     if (deduplicate && !sendQueue.empty()) {

--- a/src/src/ControllerQueue/ControllerDelayHandlerStruct.h
+++ b/src/src/ControllerQueue/ControllerDelayHandlerStruct.h
@@ -153,7 +153,7 @@ struct ControllerDelayHandlerStruct {
     }
 
     if (!queueFull(element)) {
-      sendQueue.push_back(element);
+      sendQueue.push_back(std::move(element));
       return true;
     }
 #ifndef BUILD_NO_DEBUG

--- a/src/src/ControllerQueue/DelayQueueElements.cpp
+++ b/src/src/ControllerQueue/DelayQueueElements.cpp
@@ -3,6 +3,7 @@
 #include "../DataStructs/ControllerSettingsStruct.h"
 #include "../DataStructs/TimingStats.h"
 #include "../Globals/ESPEasy_Scheduler.h"
+#include "../Helpers/PeriodicalActions.h"
 
 #ifdef USES_MQTT
 ControllerDelayHandlerStruct<MQTT_queue_element> *MQTTDelayHandler = nullptr;
@@ -22,6 +23,8 @@ bool init_mqtt_delay_queue(controllerIndex_t ControllerIndex, String& pubname, b
   MQTTDelayHandler->configureControllerSettings(ControllerSettings);
   pubname = ControllerSettings.Publish;
   retainFlag = ControllerSettings.mqtt_retainFlag();
+  Scheduler.setIntervalTimerOverride(ESPEasy_Scheduler::IntervalTimer_e::TIMER_MQTT, 10); // Make sure the MQTT is being processed as soon as possible.
+  scheduleNextMQTTdelayQueue();
   return true;
 }
 

--- a/src/src/ControllerQueue/MQTT_queue_element.cpp
+++ b/src/src/ControllerQueue/MQTT_queue_element.cpp
@@ -3,6 +3,15 @@
 
 MQTT_queue_element::MQTT_queue_element() {}
 
+MQTT_queue_element::MQTT_queue_element(MQTT_queue_element&& other)
+  : _topic(std::move(other._topic)),
+  _payload(std::move(other._payload)),
+  _timestamp(other._timestamp),
+  TaskIndex(other.TaskIndex),
+  controller_idx(other.controller_idx),
+  _retained(other._retained),
+  UnitMessageCount(other.UnitMessageCount) {}
+
 MQTT_queue_element::MQTT_queue_element(int ctrl_idx,
                                        taskIndex_t TaskIndex,
                                        const String& topic, const String& payload, bool retained) :
@@ -11,12 +20,12 @@ MQTT_queue_element::MQTT_queue_element(int ctrl_idx,
   removeEmptyTopics();
 }
 
-MQTT_queue_element::MQTT_queue_element(int           ctrl_idx,
-                                        taskIndex_t   TaskIndex,
-                                        String&&      topic,
-                                        String&&      payload,
-                                        bool          retained)
- :
+MQTT_queue_element::MQTT_queue_element(int         ctrl_idx,
+                                       taskIndex_t TaskIndex,
+                                       String   && topic,
+                                       String   && payload,
+                                       bool        retained)
+  :
   _topic(std::move(topic)), _payload(std::move(payload)), TaskIndex(TaskIndex), controller_idx(ctrl_idx), _retained(retained)
 {
   removeEmptyTopics();
@@ -27,17 +36,11 @@ size_t MQTT_queue_element::getSize() const {
 }
 
 bool MQTT_queue_element::isDuplicate(const MQTT_queue_element& other) const {
-  if (other.controller_idx != controller_idx ||
-      other._retained != _retained) {
+  if ((other.controller_idx != controller_idx) ||
+      (other._retained != _retained) ||
+      other._topic != _topic ||
+      other._payload != _payload) {
     return false;
-  }
-  for (byte i = 0; i < VARS_PER_TASK; ++i) {
-    if (other._topic[i] != _topic[i]) {
-      return false;
-    }
-    if (other._payload[i] != _payload[i]) {
-      return false;
-    }
   }
   return true;
 }

--- a/src/src/ControllerQueue/MQTT_queue_element.cpp
+++ b/src/src/ControllerQueue/MQTT_queue_element.cpp
@@ -8,12 +8,18 @@ MQTT_queue_element::MQTT_queue_element(int ctrl_idx,
                                        const String& topic, const String& payload, bool retained) :
   _topic(topic), _payload(payload), TaskIndex(TaskIndex), controller_idx(ctrl_idx), _retained(retained)
 {
-  // some parts of the topic may have been replaced by empty strings,
-  // or "/status" may have been appended to a topic ending with a "/"
-  // Get rid of "//"
-  while (_topic.indexOf(F("//")) != -1) {
-    _topic.replace(F("//"), F("/"));
-  }
+  removeEmptyTopics();
+}
+
+MQTT_queue_element::MQTT_queue_element(int           ctrl_idx,
+                                        taskIndex_t   TaskIndex,
+                                        String&&      topic,
+                                        String&&      payload,
+                                        bool          retained)
+ :
+  _topic(std::move(topic)), _payload(std::move(payload)), TaskIndex(TaskIndex), controller_idx(ctrl_idx), _retained(retained)
+{
+  removeEmptyTopics();
 }
 
 size_t MQTT_queue_element::getSize() const {
@@ -34,4 +40,13 @@ bool MQTT_queue_element::isDuplicate(const MQTT_queue_element& other) const {
     }
   }
   return true;
+}
+
+void MQTT_queue_element::removeEmptyTopics() {
+  // some parts of the topic may have been replaced by empty strings,
+  // or "/status" may have been appended to a topic ending with a "/"
+  // Get rid of "//"
+  while (_topic.indexOf(F("//")) != -1) {
+    _topic.replace(F("//"), F("/"));
+  }
 }

--- a/src/src/ControllerQueue/MQTT_queue_element.cpp
+++ b/src/src/ControllerQueue/MQTT_queue_element.cpp
@@ -1,17 +1,6 @@
 #include "../ControllerQueue/MQTT_queue_element.h"
 
 
-MQTT_queue_element::MQTT_queue_element() {}
-
-MQTT_queue_element::MQTT_queue_element(MQTT_queue_element&& other)
-  : _topic(std::move(other._topic)),
-  _payload(std::move(other._payload)),
-  _timestamp(other._timestamp),
-  TaskIndex(other.TaskIndex),
-  controller_idx(other.controller_idx),
-  _retained(other._retained),
-  UnitMessageCount(other.UnitMessageCount) {}
-
 MQTT_queue_element::MQTT_queue_element(int ctrl_idx,
                                        taskIndex_t TaskIndex,
                                        const String& topic, const String& payload, bool retained) :

--- a/src/src/ControllerQueue/MQTT_queue_element.h
+++ b/src/src/ControllerQueue/MQTT_queue_element.h
@@ -14,17 +14,19 @@ public:
 
   MQTT_queue_element();
 
+  MQTT_queue_element(MQTT_queue_element&& other);
+
   explicit MQTT_queue_element(int           ctrl_idx,
                               taskIndex_t   TaskIndex,
                               const String& topic,
                               const String& payload,
                               bool          retained);
 
-  explicit MQTT_queue_element(int           ctrl_idx,
-                              taskIndex_t   TaskIndex,
-                              String&&      topic,
-                              String&&      payload,
-                              bool          retained);
+  explicit MQTT_queue_element(int         ctrl_idx,
+                              taskIndex_t TaskIndex,
+                              String   && topic,
+                              String   && payload,
+                              bool        retained);
 
   size_t getSize() const;
 
@@ -41,7 +43,7 @@ public:
   taskIndex_t TaskIndex            = INVALID_TASK_INDEX;
   controllerIndex_t controller_idx = INVALID_CONTROLLER_INDEX;
   bool _retained                   = false;
-  UnitMessageCount_t UnitMessageCount; 
+  UnitMessageCount_t UnitMessageCount;
 };
 
 

--- a/src/src/ControllerQueue/MQTT_queue_element.h
+++ b/src/src/ControllerQueue/MQTT_queue_element.h
@@ -12,9 +12,11 @@
 class MQTT_queue_element {
 public:
 
-  MQTT_queue_element();
+  MQTT_queue_element() = default;
 
-  MQTT_queue_element(MQTT_queue_element&& other);
+  MQTT_queue_element(const MQTT_queue_element& other) = delete;
+  
+  MQTT_queue_element(MQTT_queue_element&& other) = default;
 
   explicit MQTT_queue_element(int           ctrl_idx,
                               taskIndex_t   TaskIndex,

--- a/src/src/ControllerQueue/MQTT_queue_element.h
+++ b/src/src/ControllerQueue/MQTT_queue_element.h
@@ -30,6 +30,9 @@ public:
 
   bool isDuplicate(const MQTT_queue_element& other) const;
 
+  const UnitMessageCount_t* getUnitMessageCount() const { return &UnitMessageCount; }
+  UnitMessageCount_t* getUnitMessageCount() { return &UnitMessageCount; }
+
   void removeEmptyTopics();
 
   String _topic;

--- a/src/src/ControllerQueue/MQTT_queue_element.h
+++ b/src/src/ControllerQueue/MQTT_queue_element.h
@@ -2,6 +2,7 @@
 #define CONTROLLERQUEUE_MQTT_QUEUE_ELEMENT_H
 
 #include "../../ESPEasy_common.h"
+#include "../DataStructs/UnitMessageCount.h"
 #include "../Globals/CPlugins.h"
 
 
@@ -19,9 +20,17 @@ public:
                               const String& payload,
                               bool          retained);
 
+  explicit MQTT_queue_element(int           ctrl_idx,
+                              taskIndex_t   TaskIndex,
+                              String&&      topic,
+                              String&&      payload,
+                              bool          retained);
+
   size_t getSize() const;
 
   bool isDuplicate(const MQTT_queue_element& other) const;
+
+  void removeEmptyTopics();
 
   String _topic;
   String _payload;
@@ -29,6 +38,7 @@ public:
   taskIndex_t TaskIndex            = INVALID_TASK_INDEX;
   controllerIndex_t controller_idx = INVALID_CONTROLLER_INDEX;
   bool _retained                   = false;
+  UnitMessageCount_t UnitMessageCount; 
 };
 
 

--- a/src/src/ControllerQueue/SimpleQueueElement_string_only.cpp
+++ b/src/src/ControllerQueue/SimpleQueueElement_string_only.cpp
@@ -1,10 +1,5 @@
 #include "../ControllerQueue/SimpleQueueElement_string_only.h"
 
-simple_queue_element_string_only::simple_queue_element_string_only() {}
-
-simple_queue_element_string_only::simple_queue_element_string_only(simple_queue_element_string_only&& other)
-  : txt(std::move(other.txt)), _timestamp(other._timestamp), TaskIndex(other.TaskIndex), controller_idx(other.controller_idx)
-{}
 
 simple_queue_element_string_only::simple_queue_element_string_only(int ctrl_idx, taskIndex_t TaskIndex,  String&& req) :
   txt(std::move(req)), TaskIndex(TaskIndex), controller_idx(ctrl_idx) {}

--- a/src/src/ControllerQueue/SimpleQueueElement_string_only.cpp
+++ b/src/src/ControllerQueue/SimpleQueueElement_string_only.cpp
@@ -2,22 +2,22 @@
 
 simple_queue_element_string_only::simple_queue_element_string_only() {}
 
+simple_queue_element_string_only::simple_queue_element_string_only(simple_queue_element_string_only&& other)
+  : txt(std::move(other.txt)), _timestamp(other._timestamp), TaskIndex(other.TaskIndex), controller_idx(other.controller_idx)
+{}
+
 simple_queue_element_string_only::simple_queue_element_string_only(int ctrl_idx, taskIndex_t TaskIndex,  String&& req) :
-   txt(std::move(req)), TaskIndex(TaskIndex), controller_idx(ctrl_idx) {}
+  txt(std::move(req)), TaskIndex(TaskIndex), controller_idx(ctrl_idx) {}
 
 size_t simple_queue_element_string_only::getSize() const {
   return sizeof(*this) + txt.length();
 }
 
 bool simple_queue_element_string_only::isDuplicate(const simple_queue_element_string_only& other) const {
-  if (other.controller_idx != controller_idx || 
-      other.TaskIndex != TaskIndex) {
+  if ((other.controller_idx != controller_idx) ||
+      (other.TaskIndex != TaskIndex) ||
+      (other.txt != txt)) {
     return false;
-  }
-  for (byte i = 0; i < VARS_PER_TASK; ++i) {
-    if (other.txt[i] != txt[i]) {
-      return false;
-    }
   }
   return true;
 }

--- a/src/src/ControllerQueue/SimpleQueueElement_string_only.cpp
+++ b/src/src/ControllerQueue/SimpleQueueElement_string_only.cpp
@@ -2,8 +2,8 @@
 
 simple_queue_element_string_only::simple_queue_element_string_only() {}
 
-simple_queue_element_string_only::simple_queue_element_string_only(int ctrl_idx, taskIndex_t TaskIndex,  const String& req) :
-   txt(req), TaskIndex(TaskIndex), controller_idx(ctrl_idx) {}
+simple_queue_element_string_only::simple_queue_element_string_only(int ctrl_idx, taskIndex_t TaskIndex,  String&& req) :
+   txt(std::move(req)), TaskIndex(TaskIndex), controller_idx(ctrl_idx) {}
 
 size_t simple_queue_element_string_only::getSize() const {
   return sizeof(*this) + txt.length();

--- a/src/src/ControllerQueue/SimpleQueueElement_string_only.h
+++ b/src/src/ControllerQueue/SimpleQueueElement_string_only.h
@@ -14,6 +14,8 @@ public:
 
   simple_queue_element_string_only();
 
+  simple_queue_element_string_only(simple_queue_element_string_only&& other);
+
   explicit simple_queue_element_string_only(int           ctrl_idx,
                                             taskIndex_t   TaskIndex,
                                             String&&      req);

--- a/src/src/ControllerQueue/SimpleQueueElement_string_only.h
+++ b/src/src/ControllerQueue/SimpleQueueElement_string_only.h
@@ -22,12 +22,12 @@ public:
 
   bool isDuplicate(const simple_queue_element_string_only& other) const;
 
+  const UnitMessageCount_t* getUnitMessageCount() const { return nullptr; }
 
   String txt;
   unsigned long _timestamp         = millis();
   taskIndex_t TaskIndex            = INVALID_TASK_INDEX;
   controllerIndex_t controller_idx = INVALID_CONTROLLER_INDEX;
-  UnitMessageCount_t UnitMessageCount; 
 };
 
 

--- a/src/src/ControllerQueue/SimpleQueueElement_string_only.h
+++ b/src/src/ControllerQueue/SimpleQueueElement_string_only.h
@@ -12,9 +12,11 @@
 class simple_queue_element_string_only {
 public:
 
-  simple_queue_element_string_only();
+  simple_queue_element_string_only() = default;
 
-  simple_queue_element_string_only(simple_queue_element_string_only&& other);
+  simple_queue_element_string_only(const simple_queue_element_string_only& other) = delete;
+  
+  simple_queue_element_string_only(simple_queue_element_string_only&& other) = default;
 
   explicit simple_queue_element_string_only(int           ctrl_idx,
                                             taskIndex_t   TaskIndex,

--- a/src/src/ControllerQueue/SimpleQueueElement_string_only.h
+++ b/src/src/ControllerQueue/SimpleQueueElement_string_only.h
@@ -2,6 +2,7 @@
 #define CONTROLLERQUEUE_SIMPLE_QUEUE_ELEMENT_STRING_ONLY_H
 
 #include "../../ESPEasy_common.h"
+#include "../DataStructs/UnitMessageCount.h"
 #include "../Globals/CPlugins.h"
 
 
@@ -15,7 +16,7 @@ public:
 
   explicit simple_queue_element_string_only(int           ctrl_idx,
                                             taskIndex_t   TaskIndex,
-                                            const String& req);
+                                            String&&      req);
 
   size_t getSize() const;
 
@@ -26,6 +27,7 @@ public:
   unsigned long _timestamp         = millis();
   taskIndex_t TaskIndex            = INVALID_TASK_INDEX;
   controllerIndex_t controller_idx = INVALID_CONTROLLER_INDEX;
+  UnitMessageCount_t UnitMessageCount; 
 };
 
 

--- a/src/src/ControllerQueue/queue_element_formatted_uservar.cpp
+++ b/src/src/ControllerQueue/queue_element_formatted_uservar.cpp
@@ -7,6 +7,20 @@
 
 queue_element_formatted_uservar::queue_element_formatted_uservar() {}
 
+queue_element_formatted_uservar::queue_element_formatted_uservar(queue_element_formatted_uservar&& other)
+  :
+  idx(other.idx),
+  _timestamp(other._timestamp),
+  TaskIndex(other.TaskIndex),
+  controller_idx(other.controller_idx),
+  sensorType(other.sensorType),
+  valueCount(other.valueCount)
+{
+  for (size_t i = 0; i < VARS_PER_TASK; ++i) {
+    txt[i] = std::move(other.txt[i]);
+  }
+}
+
 queue_element_formatted_uservar::queue_element_formatted_uservar(EventStruct *event) :
   idx(event->idx),
   TaskIndex(event->TaskIndex),
@@ -14,6 +28,7 @@ queue_element_formatted_uservar::queue_element_formatted_uservar(EventStruct *ev
   sensorType(event->sensorType)
 {
   valueCount = getValueCountForTask(TaskIndex);
+
   for (byte i = 0; i < valueCount; ++i) {
     txt[i] = formatUserVarNoCheck(event, i);
   }
@@ -29,12 +44,13 @@ size_t queue_element_formatted_uservar::getSize() const {
 }
 
 bool queue_element_formatted_uservar::isDuplicate(const queue_element_formatted_uservar& other) const {
-  if (other.controller_idx != controller_idx || 
-      other.TaskIndex != TaskIndex ||
-      other.sensorType != sensorType ||
-      other.valueCount != valueCount) {
+  if ((other.controller_idx != controller_idx) ||
+      (other.TaskIndex != TaskIndex) ||
+      (other.sensorType != sensorType) ||
+      (other.valueCount != valueCount)) {
     return false;
   }
+
   for (byte i = 0; i < VARS_PER_TASK; ++i) {
     if (other.txt[i] != txt[i]) {
       return false;

--- a/src/src/ControllerQueue/queue_element_formatted_uservar.cpp
+++ b/src/src/ControllerQueue/queue_element_formatted_uservar.cpp
@@ -5,8 +5,6 @@
 #include "../../_Plugin_Helper.h"
 
 
-queue_element_formatted_uservar::queue_element_formatted_uservar() {}
-
 queue_element_formatted_uservar::queue_element_formatted_uservar(queue_element_formatted_uservar&& other)
   :
   idx(other.idx),

--- a/src/src/ControllerQueue/queue_element_formatted_uservar.h
+++ b/src/src/ControllerQueue/queue_element_formatted_uservar.h
@@ -17,6 +17,7 @@ class queue_element_formatted_uservar {
 public:
 
   queue_element_formatted_uservar();
+  queue_element_formatted_uservar(queue_element_formatted_uservar&& other);
 
   queue_element_formatted_uservar(struct EventStruct *event);
 

--- a/src/src/ControllerQueue/queue_element_formatted_uservar.h
+++ b/src/src/ControllerQueue/queue_element_formatted_uservar.h
@@ -16,7 +16,8 @@ struct EventStruct;
 class queue_element_formatted_uservar {
 public:
 
-  queue_element_formatted_uservar();
+  queue_element_formatted_uservar() = default;
+  queue_element_formatted_uservar(const queue_element_formatted_uservar& other) = delete;
   queue_element_formatted_uservar(queue_element_formatted_uservar&& other);
 
   queue_element_formatted_uservar(struct EventStruct *event);

--- a/src/src/ControllerQueue/queue_element_formatted_uservar.h
+++ b/src/src/ControllerQueue/queue_element_formatted_uservar.h
@@ -24,6 +24,8 @@ public:
 
   bool isDuplicate(const queue_element_formatted_uservar& other) const;
 
+  const UnitMessageCount_t* getUnitMessageCount() const { return nullptr; }
+
   String txt[VARS_PER_TASK];
   int idx                          = 0;
   unsigned long _timestamp         = millis();
@@ -31,7 +33,6 @@ public:
   controllerIndex_t controller_idx = INVALID_CONTROLLER_INDEX;
   Sensor_VType sensorType          = Sensor_VType::SENSOR_TYPE_NONE;
   byte valueCount                  = 0;
-  UnitMessageCount_t UnitMessageCount; 
 };
 
 #endif // CONTROLLERQUEUE_QUEUE_ELEMENT_FORMATTED_USERVAR_H

--- a/src/src/ControllerQueue/queue_element_formatted_uservar.h
+++ b/src/src/ControllerQueue/queue_element_formatted_uservar.h
@@ -3,6 +3,7 @@
 
 #include "../../ESPEasy_common.h"
 #include "../DataStructs/DeviceStruct.h"
+#include "../DataStructs/UnitMessageCount.h"
 #include "../Globals/CPlugins.h"
 #include "../Globals/Plugins.h"
 
@@ -30,6 +31,7 @@ public:
   controllerIndex_t controller_idx = INVALID_CONTROLLER_INDEX;
   Sensor_VType sensorType          = Sensor_VType::SENSOR_TYPE_NONE;
   byte valueCount                  = 0;
+  UnitMessageCount_t UnitMessageCount; 
 };
 
 #endif // CONTROLLERQUEUE_QUEUE_ELEMENT_FORMATTED_USERVAR_H

--- a/src/src/ControllerQueue/queue_element_single_value_base.cpp
+++ b/src/src/ControllerQueue/queue_element_single_value_base.cpp
@@ -11,18 +11,15 @@ queue_element_single_value_base::queue_element_single_value_base(const struct Ev
   valuesSent(0),
   valueCount(value_count) {}
 
-/*
-queue_element_single_value_base::queue_element_single_value_base(queue_element_single_value_base &&rval)
-: idx(rval.idx), TaskIndex(rval.TaskIndex), 
-  controller_idx(rval.controller_idx), 
+queue_element_single_value_base::queue_element_single_value_base(queue_element_single_value_base&& rval)
+  : idx(rval.idx), _timestamp(rval._timestamp),  TaskIndex(rval.TaskIndex),
+  controller_idx(rval.controller_idx),
   valuesSent(rval.valuesSent), valueCount(rval.valueCount)
 {
   for (byte i = 0; i < VARS_PER_TASK; ++i) {
-    String tmp(std::move(rval.txt[i]));
-    txt[i] = tmp;
+    txt[i] = std::move(rval.txt[i]);
   }
 }
-*/
 
 bool queue_element_single_value_base::checkDone(bool succesfull) const {
   if (succesfull) { ++valuesSent; }
@@ -39,12 +36,13 @@ size_t queue_element_single_value_base::getSize() const {
 }
 
 bool queue_element_single_value_base::isDuplicate(const queue_element_single_value_base& other) const {
-  if (other.controller_idx != controller_idx || 
-      other.TaskIndex != TaskIndex ||
-      other.valueCount != valueCount ||
-      other.idx != idx) {
+  if ((other.controller_idx != controller_idx) ||
+      (other.TaskIndex != TaskIndex) ||
+      (other.valueCount != valueCount) ||
+      (other.idx != idx)) {
     return false;
   }
+
   for (byte i = 0; i < VARS_PER_TASK; ++i) {
     if (other.txt[i] != txt[i]) {
       return false;

--- a/src/src/ControllerQueue/queue_element_single_value_base.cpp
+++ b/src/src/ControllerQueue/queue_element_single_value_base.cpp
@@ -2,8 +2,6 @@
 
 #include "../DataStructs/ESPEasy_EventStruct.h"
 
-queue_element_single_value_base::queue_element_single_value_base() {}
-
 queue_element_single_value_base::queue_element_single_value_base(const struct EventStruct *event, byte value_count) :
   idx(event->idx),
   TaskIndex(event->TaskIndex),

--- a/src/src/ControllerQueue/queue_element_single_value_base.h
+++ b/src/src/ControllerQueue/queue_element_single_value_base.h
@@ -4,6 +4,7 @@
 
 #include "../../ESPEasy_common.h"
 #include "../CustomBuild/ESPEasyLimits.h"
+#include "../DataStructs/UnitMessageCount.h"
 #include "../Globals/CPlugins.h"
 #include "../Globals/Plugins.h"
 
@@ -36,6 +37,7 @@ public:
   controllerIndex_t controller_idx = INVALID_CONTROLLER_INDEX;
   mutable byte valuesSent          = 0; // Value must be set by const function checkDone()
   byte valueCount                  = 0;
+  UnitMessageCount_t UnitMessageCount; 
 };
 
 

--- a/src/src/ControllerQueue/queue_element_single_value_base.h
+++ b/src/src/ControllerQueue/queue_element_single_value_base.h
@@ -22,7 +22,7 @@ public:
   queue_element_single_value_base(const struct EventStruct *event,
                                   byte                      value_count);
 
-//  queue_element_single_value_base(queue_element_single_value_base &&rval);
+  queue_element_single_value_base(queue_element_single_value_base &&rval);
 
   bool   checkDone(bool succesfull) const;
 

--- a/src/src/ControllerQueue/queue_element_single_value_base.h
+++ b/src/src/ControllerQueue/queue_element_single_value_base.h
@@ -30,6 +30,8 @@ public:
 
   bool isDuplicate(const queue_element_single_value_base& other) const;
 
+  const UnitMessageCount_t* getUnitMessageCount() const { return nullptr; }
+
   String txt[VARS_PER_TASK];
   int idx                          = 0;
   unsigned long _timestamp         = millis();
@@ -37,7 +39,6 @@ public:
   controllerIndex_t controller_idx = INVALID_CONTROLLER_INDEX;
   mutable byte valuesSent          = 0; // Value must be set by const function checkDone()
   byte valueCount                  = 0;
-  UnitMessageCount_t UnitMessageCount; 
 };
 
 

--- a/src/src/ControllerQueue/queue_element_single_value_base.h
+++ b/src/src/ControllerQueue/queue_element_single_value_base.h
@@ -17,11 +17,13 @@ struct EventStruct;
 class queue_element_single_value_base {
 public:
 
-  queue_element_single_value_base();
+  queue_element_single_value_base() = default;
 
   queue_element_single_value_base(const struct EventStruct *event,
                                   byte                      value_count);
 
+  queue_element_single_value_base(const queue_element_single_value_base &rval) = delete;
+  
   queue_element_single_value_base(queue_element_single_value_base &&rval);
 
   bool   checkDone(bool succesfull) const;

--- a/src/src/DataStructs/ESPEasy_EventStruct.cpp
+++ b/src/src/DataStructs/ESPEasy_EventStruct.cpp
@@ -14,21 +14,6 @@ EventStruct::EventStruct(taskIndex_t taskIndex) :
   TaskIndex(taskIndex), BaseVarIndex(taskIndex * VARS_PER_TASK) 
 {}
 
-EventStruct::EventStruct(const struct EventStruct& event) :
-  String1(event.String1)
-  , String2(event.String2)
-  , String3(event.String3)
-  , String4(event.String4)
-  , String5(event.String5)
-  , Data(event.Data)
-  , idx(event.idx)
-  , Par1(event.Par1), Par2(event.Par2), Par3(event.Par3), Par4(event.Par4), Par5(event.Par5)
-  , Source(event.Source), TaskIndex(event.TaskIndex), ControllerIndex(event.ControllerIndex)
-  , NotificationIndex(event.NotificationIndex)
-  , BaseVarIndex(event.BaseVarIndex), sensorType(event.sensorType)
-  , OriginTaskIndex(event.OriginTaskIndex)
-{}
-
 EventStruct::EventStruct(struct EventStruct&& event) :
   String1(std::move(event.String1))
   , String2(std::move(event.String2))
@@ -49,20 +34,19 @@ EventStruct::EventStruct(struct EventStruct&& event) :
     event.Par3 = 0;
     event.Par4 = 0;
     event.Par5 = 0;
-    Source            = EventValueSource::Enum::VALUE_SOURCE_NOT_SET;
-    TaskIndex         = INVALID_TASK_INDEX;       
-    ControllerIndex   = INVALID_CONTROLLER_INDEX; 
-    NotificationIndex = INVALID_NOTIFIER_INDEX;   // index position in Settings.Notification, 0-3
-    BaseVarIndex      = 0;
-    sensorType        = Sensor_VType::SENSOR_TYPE_NOT_SET;
-    OriginTaskIndex   = 0;
-
+    event.Source            = EventValueSource::Enum::VALUE_SOURCE_NOT_SET;
+    event.TaskIndex         = INVALID_TASK_INDEX;       
+    event.ControllerIndex   = INVALID_CONTROLLER_INDEX; 
+    event.NotificationIndex = INVALID_NOTIFIER_INDEX;   // index position in Settings.Notification, 0-3
+    event.BaseVarIndex      = 0;
+    event.sensorType        = Sensor_VType::SENSOR_TYPE_NOT_SET;
+    event.OriginTaskIndex   = 0;
   }
 
-EventStruct& EventStruct::operator=(const struct EventStruct& other) {
+void EventStruct::deep_copy(const struct EventStruct& other) {
   // check for self-assignment
   if (&other == this) {
-    return *this;
+    return;
   }
   String1           = other.String1;
   String2           = other.String2;
@@ -83,8 +67,14 @@ EventStruct& EventStruct::operator=(const struct EventStruct& other) {
   BaseVarIndex      = other.BaseVarIndex;
   sensorType        = other.sensorType;
   OriginTaskIndex   = other.OriginTaskIndex;
-  return *this;
 }
+
+void EventStruct::deep_copy(const struct EventStruct* other) {
+  if (other != nullptr) {
+    deep_copy(*other);
+  }
+}
+
 
 EventStruct& EventStruct::operator=(struct EventStruct&& other) {
   // check for self-assignment

--- a/src/src/DataStructs/ESPEasy_EventStruct.cpp
+++ b/src/src/DataStructs/ESPEasy_EventStruct.cpp
@@ -14,59 +14,8 @@ EventStruct::EventStruct(taskIndex_t taskIndex) :
   TaskIndex(taskIndex), BaseVarIndex(taskIndex * VARS_PER_TASK) 
 {}
 
-EventStruct::EventStruct(struct EventStruct&& event) :
-  String1(std::move(event.String1))
-  , String2(std::move(event.String2))
-  , String3(std::move(event.String3))
-  , String4(std::move(event.String4))
-  , String5(std::move(event.String5))
-  , Data(event.Data)
-  , idx(event.idx)
-  , Par1(event.Par1), Par2(event.Par2), Par3(event.Par3), Par4(event.Par4), Par5(event.Par5)
-  , Source(event.Source), TaskIndex(event.TaskIndex), ControllerIndex(event.ControllerIndex)
-  , NotificationIndex(event.NotificationIndex)
-  , BaseVarIndex(event.BaseVarIndex), sensorType(event.sensorType)
-  , OriginTaskIndex(event.OriginTaskIndex) {
-    event.Data = nullptr;
-    event.idx = 0;
-    event.Par1 = 0;
-    event.Par2 = 0;
-    event.Par3 = 0;
-    event.Par4 = 0;
-    event.Par5 = 0;
-    event.Source            = EventValueSource::Enum::VALUE_SOURCE_NOT_SET;
-    event.TaskIndex         = INVALID_TASK_INDEX;       
-    event.ControllerIndex   = INVALID_CONTROLLER_INDEX; 
-    event.NotificationIndex = INVALID_NOTIFIER_INDEX;   // index position in Settings.Notification, 0-3
-    event.BaseVarIndex      = 0;
-    event.sensorType        = Sensor_VType::SENSOR_TYPE_NOT_SET;
-    event.OriginTaskIndex   = 0;
-  }
-
 void EventStruct::deep_copy(const struct EventStruct& other) {
-  // check for self-assignment
-  if (&other == this) {
-    return;
-  }
-  String1           = other.String1;
-  String2           = other.String2;
-  String3           = other.String3;
-  String4           = other.String4;
-  String5           = other.String5;
-  Data              = other.Data;
-  idx               = other.idx;
-  Par1              = other.Par1;
-  Par2              = other.Par2;
-  Par3              = other.Par3;
-  Par4              = other.Par4;
-  Par5              = other.Par5;
-  Source            = other.Source;
-  TaskIndex         = other.TaskIndex;
-  ControllerIndex   = other.ControllerIndex;
-  NotificationIndex = other.NotificationIndex;
-  BaseVarIndex      = other.BaseVarIndex;
-  sensorType        = other.sensorType;
-  OriginTaskIndex   = other.OriginTaskIndex;
+  this->operator=(other);
 }
 
 void EventStruct::deep_copy(const struct EventStruct* other) {
@@ -74,35 +23,6 @@ void EventStruct::deep_copy(const struct EventStruct* other) {
     deep_copy(*other);
   }
 }
-
-
-EventStruct& EventStruct::operator=(struct EventStruct&& other) {
-  // check for self-assignment
-  if (&other == this) {
-    return *this;
-  }
-  String1           = std::move(other.String1);
-  String2           = std::move(other.String2);
-  String3           = std::move(other.String3);
-  String4           = std::move(other.String4);
-  String5           = std::move(other.String5);
-  Data              = other.Data;
-  idx               = other.idx;
-  Par1              = other.Par1;
-  Par2              = other.Par2;
-  Par3              = other.Par3;
-  Par4              = other.Par4;
-  Par5              = other.Par5;
-  Source            = other.Source;
-  TaskIndex         = other.TaskIndex;
-  ControllerIndex   = other.ControllerIndex;
-  NotificationIndex = other.NotificationIndex;
-  BaseVarIndex      = other.BaseVarIndex;
-  sensorType        = other.sensorType;
-  OriginTaskIndex   = other.OriginTaskIndex;
-  return *this;
-}
-
 
 void EventStruct::setTaskIndex(taskIndex_t taskIndex) {
   TaskIndex    = taskIndex;

--- a/src/src/DataStructs/ESPEasy_EventStruct.cpp
+++ b/src/src/DataStructs/ESPEasy_EventStruct.cpp
@@ -29,6 +29,36 @@ EventStruct::EventStruct(const struct EventStruct& event) :
   , OriginTaskIndex(event.OriginTaskIndex)
 {}
 
+EventStruct::EventStruct(struct EventStruct&& event) :
+  String1(std::move(event.String1))
+  , String2(std::move(event.String2))
+  , String3(std::move(event.String3))
+  , String4(std::move(event.String4))
+  , String5(std::move(event.String5))
+  , Data(event.Data)
+  , idx(event.idx)
+  , Par1(event.Par1), Par2(event.Par2), Par3(event.Par3), Par4(event.Par4), Par5(event.Par5)
+  , Source(event.Source), TaskIndex(event.TaskIndex), ControllerIndex(event.ControllerIndex)
+  , NotificationIndex(event.NotificationIndex)
+  , BaseVarIndex(event.BaseVarIndex), sensorType(event.sensorType)
+  , OriginTaskIndex(event.OriginTaskIndex) {
+    event.Data = nullptr;
+    event.idx = 0;
+    event.Par1 = 0;
+    event.Par2 = 0;
+    event.Par3 = 0;
+    event.Par4 = 0;
+    event.Par5 = 0;
+    Source            = EventValueSource::Enum::VALUE_SOURCE_NOT_SET;
+    TaskIndex         = INVALID_TASK_INDEX;       
+    ControllerIndex   = INVALID_CONTROLLER_INDEX; 
+    NotificationIndex = INVALID_NOTIFIER_INDEX;   // index position in Settings.Notification, 0-3
+    BaseVarIndex      = 0;
+    sensorType        = Sensor_VType::SENSOR_TYPE_NOT_SET;
+    OriginTaskIndex   = 0;
+
+  }
+
 EventStruct& EventStruct::operator=(const struct EventStruct& other) {
   // check for self-assignment
   if (&other == this) {
@@ -55,6 +85,34 @@ EventStruct& EventStruct::operator=(const struct EventStruct& other) {
   OriginTaskIndex   = other.OriginTaskIndex;
   return *this;
 }
+
+EventStruct& EventStruct::operator=(struct EventStruct&& other) {
+  // check for self-assignment
+  if (&other == this) {
+    return *this;
+  }
+  String1           = std::move(other.String1);
+  String2           = std::move(other.String2);
+  String3           = std::move(other.String3);
+  String4           = std::move(other.String4);
+  String5           = std::move(other.String5);
+  Data              = other.Data;
+  idx               = other.idx;
+  Par1              = other.Par1;
+  Par2              = other.Par2;
+  Par3              = other.Par3;
+  Par4              = other.Par4;
+  Par5              = other.Par5;
+  Source            = other.Source;
+  TaskIndex         = other.TaskIndex;
+  ControllerIndex   = other.ControllerIndex;
+  NotificationIndex = other.NotificationIndex;
+  BaseVarIndex      = other.BaseVarIndex;
+  sensorType        = other.sensorType;
+  OriginTaskIndex   = other.OriginTaskIndex;
+  return *this;
+}
+
 
 void EventStruct::setTaskIndex(taskIndex_t taskIndex) {
   TaskIndex    = taskIndex;

--- a/src/src/DataStructs/ESPEasy_EventStruct.h
+++ b/src/src/DataStructs/ESPEasy_EventStruct.h
@@ -20,7 +20,9 @@ struct EventStruct
   EventStruct();
   explicit EventStruct(taskIndex_t taskIndex);
   explicit EventStruct(const struct EventStruct& event);
+  explicit EventStruct(struct EventStruct&& event);
   EventStruct& operator=(const struct EventStruct& other);
+  EventStruct& operator=(struct EventStruct&& other);
 
   void setTaskIndex(taskIndex_t taskIndex);
 

--- a/src/src/DataStructs/ESPEasy_EventStruct.h
+++ b/src/src/DataStructs/ESPEasy_EventStruct.h
@@ -14,13 +14,23 @@
 
 /*********************************************************************************************\
 * EventStruct
+* This should not be copied, only moved.
+* When copy is really needed, use deep_copy
 \*********************************************************************************************/
 struct EventStruct
 {
   EventStruct();
+  // Delete the copy constructor
+  EventStruct(const struct EventStruct& event) = delete;
+private:
+  // Hide the copy assignment operator by making it private
+  EventStruct& operator=(const EventStruct&) = default; 
+
+public:
+  EventStruct(struct EventStruct&& event) = default;
+  EventStruct& operator=(struct EventStruct&& other) = default;
+
   explicit EventStruct(taskIndex_t taskIndex);
-  explicit EventStruct(struct EventStruct&& event);
-  EventStruct& operator=(struct EventStruct&& other);
 
   // Explicit deep_copy function to make sure this object is not accidentally copied using the copy-constructor
   // Copy constructor and assignment operator should not be used.

--- a/src/src/DataStructs/ESPEasy_EventStruct.h
+++ b/src/src/DataStructs/ESPEasy_EventStruct.h
@@ -19,10 +19,16 @@ struct EventStruct
 {
   EventStruct();
   explicit EventStruct(taskIndex_t taskIndex);
-  explicit EventStruct(const struct EventStruct& event);
   explicit EventStruct(struct EventStruct&& event);
-  EventStruct& operator=(const struct EventStruct& other);
   EventStruct& operator=(struct EventStruct&& other);
+
+  // Explicit deep_copy function to make sure this object is not accidentally copied using the copy-constructor
+  // Copy constructor and assignment operator should not be used.
+  void deep_copy(const struct EventStruct& other);
+  void deep_copy(const struct EventStruct* other);
+  //  explicit EventStruct(const struct EventStruct& event);
+  //  EventStruct& operator=(const struct EventStruct& other);
+
 
   void setTaskIndex(taskIndex_t taskIndex);
 

--- a/src/src/DataStructs/EthernetEventData.cpp
+++ b/src/src/DataStructs/EthernetEventData.cpp
@@ -108,6 +108,7 @@ void EthernetEventData_t::markGotIP() {
 void EthernetEventData_t::markLostIP() {
   bitClear(ethStatus, ESPEASY_ETH_GOT_IP);
   bitClear(ethStatus, ESPEASY_ETH_SERVICES_INITIALIZED);
+  lastGetIPmoment.clear();
 }
 
 void EthernetEventData_t::markDisconnect() {
@@ -119,6 +120,7 @@ void EthernetEventData_t::markDisconnect() {
   } else {
     lastConnectedDuration_us = lastConnectMoment.timeDiff(lastDisconnectMoment);
   }
+  lastConnectMoment.clear();
   setEthDisconnected();
   processedDisconnect  = false;
 }

--- a/src/src/DataStructs/EventStructCommandWrapper.h
+++ b/src/src/DataStructs/EventStructCommandWrapper.h
@@ -7,7 +7,7 @@
 struct EventStructCommandWrapper {
   EventStructCommandWrapper() : id(0) {}
 
-  EventStructCommandWrapper(unsigned long i, const EventStruct& e) : id(i), event(e) {}
+  EventStructCommandWrapper(unsigned long i, EventStruct&& e) : id(i), event(std::move(e)) {}
 
   unsigned long      id;
   String             cmd;

--- a/src/src/DataStructs/UnitMessageCount.cpp
+++ b/src/src/DataStructs/UnitMessageCount.cpp
@@ -1,0 +1,16 @@
+#include "../DataStructs/UnitMessageCount.h"
+
+bool UnitLastMessageCount_map::isNew(const UnitMessageCount_t& count) const {
+  auto it = _map.find(count.unit);
+
+  if (it != _map.end()) {
+    return it->second != count.count;
+  }
+  return true;
+}
+
+void UnitLastMessageCount_map::add(const UnitMessageCount_t& count) {
+  if ((count.unit != 0) && (count.unit != 255)) {
+    _map[count.unit] = count.count;
+  }
+}

--- a/src/src/DataStructs/UnitMessageCount.cpp
+++ b/src/src/DataStructs/UnitMessageCount.cpp
@@ -1,16 +1,19 @@
 #include "../DataStructs/UnitMessageCount.h"
 
-bool UnitLastMessageCount_map::isNew(const UnitMessageCount_t& count) const {
-  auto it = _map.find(count.unit);
+bool UnitLastMessageCount_map::isNew(const UnitMessageCount_t *count) const {
+  if (count == nullptr) { return true; }
+  auto it = _map.find(count->unit);
 
   if (it != _map.end()) {
-    return it->second != count.count;
+    return it->second != count->count;
   }
   return true;
 }
 
-void UnitLastMessageCount_map::add(const UnitMessageCount_t& count) {
-  if ((count.unit != 0) && (count.unit != 255)) {
-    _map[count.unit] = count.count;
+void UnitLastMessageCount_map::add(const UnitMessageCount_t *count) {
+  if (count == nullptr) { return; }
+
+  if ((count->unit != 0) && (count->unit != 255)) {
+    _map[count->unit] = count->count;
   }
 }

--- a/src/src/DataStructs/UnitMessageCount.h
+++ b/src/src/DataStructs/UnitMessageCount.h
@@ -18,9 +18,9 @@ struct UnitMessageCount_t {
 };
 
 struct UnitLastMessageCount_map {
-  bool isNew(const UnitMessageCount_t& count) const;
+  bool isNew(const UnitMessageCount_t *count) const;
 
-  void add(const UnitMessageCount_t& count);
+  void add(const UnitMessageCount_t *count);
 
 private:
 

--- a/src/src/DataStructs/UnitMessageCount.h
+++ b/src/src/DataStructs/UnitMessageCount.h
@@ -1,0 +1,30 @@
+#ifndef DATASTRUCTS_UNITMESSAGECOUNT_H
+#define DATASTRUCTS_UNITMESSAGECOUNT_H
+
+#include "../../ESPEasy_common.h"
+
+#include <map>
+
+// For deduplication, some controllers may add a unit ID and current counter.
+// This count will wrap around, so it is just to detect if a message is received multiple times.
+// The unit ID is the unit where the message originates from and thus should be kept along when forwarding.
+struct UnitMessageCount_t {
+  UnitMessageCount_t() {}
+
+  UnitMessageCount_t(byte unitnr, byte messageCount) : unit(unitnr), count(messageCount) {}
+
+  byte unit  = 0; // Initialize to "not set"
+  byte count = 0;
+};
+
+struct UnitLastMessageCount_map {
+  bool isNew(const UnitMessageCount_t& count) const;
+
+  void add(const UnitMessageCount_t& count);
+
+private:
+
+  std::map<byte, byte>_map;
+};
+
+#endif // ifndef DATASTRUCTS_UNITMESSAGECOUNT_H

--- a/src/src/DataStructs/WiFiEventData.cpp
+++ b/src/src/DataStructs/WiFiEventData.cpp
@@ -57,6 +57,7 @@ void WiFiEventData_t::clearAll() {
   processedDisconnectAPmode = true;
   processedScanDone         = true;
   wifiConnectAttemptNeeded  = true;
+  wifiConnectInProgress     = false;
   wifi_TX_pwr = 0;
   usedChannel = 0;
 }
@@ -93,7 +94,8 @@ bool WiFiEventData_t::WiFiServicesInitialized() const {
 }
 
 void WiFiEventData_t::setWiFiDisconnected() {
-  wifiStatus = ESPEASY_WIFI_DISCONNECTED;
+  wifiConnectInProgress = false;
+  wifiStatus            = ESPEASY_WIFI_DISCONNECTED;
 }
 
 void WiFiEventData_t::setWiFiGotIP() {

--- a/src/src/DataStructs/WiFiEventData.h
+++ b/src/src/DataStructs/WiFiEventData.h
@@ -101,6 +101,11 @@ struct WiFiEventData_t {
 
   bool performedClearWiFiCredentials = false;
 
+  // processDisconnect() may clear all WiFi settings, resulting in clearing processedDisconnect
+  // This can cause recursion, so a semaphore is needed here.
+  bool processingDisconnect      = false;
+
+
   unsigned long connectionFailures = 0;
 
 

--- a/src/src/ESPEasyCore/Controller.cpp
+++ b/src/src/ESPEasyCore/Controller.cpp
@@ -499,7 +499,21 @@ bool MQTTpublish(controllerIndex_t controller_idx, taskIndex_t taskIndex, const 
   if (MQTT_queueFull(controller_idx)) {
     return false;
   }
-  const bool success = MQTTDelayHandler->addToQueue(MQTT_queue_element(controller_idx, taskIndex, topic, payload, retained));
+  const bool success = MQTTDelayHandler->addToQueue(std::move(MQTT_queue_element(controller_idx, taskIndex, topic, payload, retained)));
+
+  scheduleNextMQTTdelayQueue();
+  return success;
+}
+
+bool MQTTpublish(controllerIndex_t controller_idx, taskIndex_t taskIndex,  String&& topic, String&& payload, bool retained) {
+  if (MQTTDelayHandler == nullptr) {
+    return false;
+  }
+
+  if (MQTT_queueFull(controller_idx)) {
+    return false;
+  }
+  const bool success = MQTTDelayHandler->addToQueue(std::move(MQTT_queue_element(controller_idx, taskIndex, std::move(topic), std::move(payload), retained)));
 
   scheduleNextMQTTdelayQueue();
   return success;

--- a/src/src/ESPEasyCore/Controller.cpp
+++ b/src/src/ESPEasyCore/Controller.cpp
@@ -499,7 +499,7 @@ bool MQTTpublish(controllerIndex_t controller_idx, taskIndex_t taskIndex, const 
   if (MQTT_queueFull(controller_idx)) {
     return false;
   }
-  const bool success = MQTTDelayHandler->addToQueue(std::move(MQTT_queue_element(controller_idx, taskIndex, topic, payload, retained)));
+  const bool success = MQTTDelayHandler->addToQueue(MQTT_queue_element(controller_idx, taskIndex, topic, payload, retained));
 
   scheduleNextMQTTdelayQueue();
   return success;
@@ -513,7 +513,7 @@ bool MQTTpublish(controllerIndex_t controller_idx, taskIndex_t taskIndex,  Strin
   if (MQTT_queueFull(controller_idx)) {
     return false;
   }
-  const bool success = MQTTDelayHandler->addToQueue(std::move(MQTT_queue_element(controller_idx, taskIndex, std::move(topic), std::move(payload), retained)));
+  const bool success = MQTTDelayHandler->addToQueue(MQTT_queue_element(controller_idx, taskIndex, std::move(topic), std::move(payload), retained));
 
   scheduleNextMQTTdelayQueue();
   return success;

--- a/src/src/ESPEasyCore/Controller.h
+++ b/src/src/ESPEasyCore/Controller.h
@@ -61,6 +61,9 @@ bool MQTT_queueFull(controllerIndex_t controller_idx);
 
 bool MQTTpublish(controllerIndex_t controller_idx, taskIndex_t taskIndex,  const char *topic, const char *payload, bool retained);
 
+// Publish using the move operator for topic and message
+bool MQTTpublish(controllerIndex_t controller_idx, taskIndex_t taskIndex,  String&& topic, String&& payload, bool retained);
+
 
 /*********************************************************************************************\
 * Send status info back to channel where request came from

--- a/src/src/ESPEasyCore/ESPEasyEth.cpp
+++ b/src/src/ESPEasyCore/ESPEasyEth.cpp
@@ -136,6 +136,8 @@ bool ETHConnected() {
         }
       }
       return false;
+    } else {
+      setNetworkMedium(NetworkMedium_t::WIFI);
     }
   }
   return false;

--- a/src/src/ESPEasyCore/ESPEasyEth.cpp
+++ b/src/src/ESPEasyCore/ESPEasyEth.cpp
@@ -106,11 +106,39 @@ bool ETHConnectRelaxed() {
     Settings.ETH_Pin_mdio,
     (eth_phy_type_t)Settings.ETH_Phy_Type,
     (eth_clock_mode_t)Settings.ETH_Clock_Mode);
+  if (EthEventData.ethInitSuccess) {
+    EthEventData.ethConnectAttemptNeeded = false;
+  }
   return EthEventData.ethInitSuccess;
 }
 
 bool ETHConnected() {
-  return EthEventData.EthServicesInitialized();
+  if (EthEventData.EthServicesInitialized()) {
+    if (EthLinkUp()) {
+      return true;
+    }
+    // Apparently we missed an event
+    EthEventData.processedDisconnect = false;
+  } else if (EthEventData.ethInitSuccess) {
+    if (EthLinkUp()) {
+      EthEventData.setEthConnected();
+      if (NetworkLocalIP() != IPAddress(0, 0, 0, 0) && 
+          !EthEventData.EthGotIP()) {
+        EthEventData.processedGotIP = false;
+      }
+      if (EthEventData.lastConnectMoment.isSet()) {
+        if (!EthEventData.EthServicesInitialized()) {
+          if (EthEventData.lastConnectMoment.millisPassedSince() > 10000 &&
+              EthEventData.lastGetIPmoment.isSet()) {
+            EthEventData.processedGotIP = false;
+            EthEventData.markLostIP();
+          }
+        }
+      }
+      return false;
+    }
+  }
+  return false;
 }
 
 #endif

--- a/src/src/ESPEasyCore/ESPEasyNetwork.cpp
+++ b/src/src/ESPEasyCore/ESPEasyNetwork.cpp
@@ -196,7 +196,10 @@ String WifiSoftAPmacAddress() {
 
 void CheckRunningServices() {
   set_mDNS();
-  SetWiFiTXpower();
+  if (active_network_medium == NetworkMedium_t::WIFI) 
+  {
+    SetWiFiTXpower();
+  }
 }
 
 #ifdef HAS_ETHERNET

--- a/src/src/ESPEasyCore/ESPEasyNetwork.cpp
+++ b/src/src/ESPEasyCore/ESPEasyNetwork.cpp
@@ -194,6 +194,14 @@ String WifiSoftAPmacAddress() {
     return String(macaddress);
 }
 
+String WifiSTAmacAddress() {
+    uint8_t  mac[]   = { 0, 0, 0, 0, 0, 0 };
+    uint8_t *macread = WiFi.macAddress(mac);
+    char     macaddress[20];
+    formatMAC(macread, macaddress);
+    return String(macaddress);
+}
+
 void CheckRunningServices() {
   set_mDNS();
   if (active_network_medium == NetworkMedium_t::WIFI) 

--- a/src/src/ESPEasyCore/ESPEasyNetwork.cpp
+++ b/src/src/ESPEasyCore/ESPEasyNetwork.cpp
@@ -24,6 +24,9 @@ void setNetworkMedium(NetworkMedium_t new_medium) {
       #ifdef HAS_ETHERNET
       // FIXME TD-er: How to 'end' ETH?
 //      ETH.end();
+      if (new_medium == NetworkMedium_t::WIFI) {
+        WiFiEventData.clearAll();
+      }
       #endif
       break;
     case NetworkMedium_t::WIFI:

--- a/src/src/ESPEasyCore/ESPEasyNetwork.h
+++ b/src/src/ESPEasyCore/ESPEasyNetwork.h
@@ -21,6 +21,7 @@ String NetworkGetHostname();
 String NetworkCreateRFCCompliantHostname(bool force_add_unitnr = false);
 String createRFCCompliantHostname(const String& oldString);
 String WifiSoftAPmacAddress();
+String WifiSTAmacAddress();
 
 void CheckRunningServices();
 

--- a/src/src/ESPEasyCore/ESPEasyWifi.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi.cpp
@@ -631,6 +631,23 @@ bool WiFiScanAllowed() {
     handle_unprocessedNetworkEvents();
   }
   if (WiFiEventData.unprocessedWifiEvents()) {
+    if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
+      String log = F("WiFi : Scan not allowed, unprocessed WiFi events: ");
+      if (!WiFiEventData.processedConnect) {
+        log += F(" conn");
+      }
+      if (!WiFiEventData.processedDisconnect) {
+        log += F(" disconn");
+      }
+      if (!WiFiEventData.processedGotIP) {
+        log += F(" gotIP");
+      }
+      if (!WiFiEventData.processedDHCPTimeout) {
+        log += F(" DHCP_t/o");
+      }
+      
+      addLog(LOG_LEVEL_ERROR, log);
+    }
     return false;
   }
   /*

--- a/src/src/ESPEasyCore/ESPEasyWifi.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi.cpp
@@ -624,6 +624,9 @@ void WiFiScanPeriodical() {
 }
 
 bool WiFiScanAllowed() {
+  if (WiFi_AP_Candidates.scanComplete() == WIFI_SCAN_RUNNING) {
+    return false;
+  }
   if (!WiFiEventData.processedScanDone) { 
     processScanDone(); 
   }
@@ -655,10 +658,8 @@ bool WiFiScanAllowed() {
     return true;
   }
   */
-  if (WiFi_AP_Candidates.scanComplete() <= 0) {
-    return true;
-  }
   if (WiFi_AP_Candidates.getBestCandidate().usable()) {
+    addLog(LOG_LEVEL_ERROR, F("WiFi : Scan not needed, good candidate present"));
     return false;
   }
   if (WiFiEventData.lastDisconnectMoment.isSet() && WiFiEventData.lastDisconnectMoment.millisPassedSince() < WIFI_RECONNECT_WAIT) {

--- a/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
@@ -25,6 +25,7 @@
 #include "../Helpers/Misc.h"
 #include "../Helpers/Network.h"
 #include "../Helpers/Networking.h"
+#include "../Helpers/PeriodicalActions.h"
 #include "../Helpers/Scheduler.h"
 #include "../Helpers/StringConverter.h"
 #include "../Helpers/StringGenerator_WiFi.h"
@@ -37,13 +38,23 @@
 void handle_unprocessedNetworkEvents()
 {
 #ifdef HAS_ETHERNET
-  // Must process the Ethernet Connected event regardless the active network medium.
-  // It may happen by plugging in the cable while WiFi was active.
-  if (!EthEventData.processedConnect) {
-    #ifndef BUILD_NO_DEBUG
-    addLog(LOG_LEVEL_DEBUG, F("Eth  : Entering processConnect()"));
-    #endif // ifndef BUILD_NO_DEBUG
-    processEthernetConnected();
+  if (EthEventData.unprocessedEthEvents()) {
+    // Process disconnect events before connect events.
+    if (!EthEventData.processedDisconnect) {
+      #ifndef BUILD_NO_DEBUG
+      addLog(LOG_LEVEL_DEBUG, F("Eth  : Entering processDisconnect()"));
+      #endif // ifndef BUILD_NO_DEBUG
+      processEthernetDisconnected();
+    }
+
+    // Must process the Ethernet Connected event regardless the active network medium.
+    // It may happen by plugging in the cable while WiFi was active.
+    if (!EthEventData.processedConnect) {
+      #ifndef BUILD_NO_DEBUG
+      addLog(LOG_LEVEL_DEBUG, F("Eth  : Entering processConnect()"));
+      #endif // ifndef BUILD_NO_DEBUG
+      processEthernetConnected();
+    }
   }
 
   if (active_network_medium == NetworkMedium_t::Ethernet) {
@@ -53,14 +64,6 @@ void handle_unprocessedNetworkEvents()
         NetworkConnectRelaxed();
       }
  
-      // Process disconnect events before connect events.
-      if (!EthEventData.processedDisconnect) {
-        #ifndef BUILD_NO_DEBUG
-        addLog(LOG_LEVEL_DEBUG, F("Eth  : Entering processDisconnect()"));
-        #endif // ifndef BUILD_NO_DEBUG
-        processEthernetDisconnected();
-      }
-
       if (!EthEventData.processedGotIP) {
         #ifndef BUILD_NO_DEBUG
         addLog(LOG_LEVEL_DEBUG, F("Eth  : Entering processGotIP()"));
@@ -80,6 +83,16 @@ void handle_unprocessedNetworkEvents()
   }
 
 #endif
+  if (WiFiEventData.unprocessedWifiEvents()) {
+    // Process disconnect events before connect events.
+    if (!WiFiEventData.processedDisconnect) {
+      #ifndef BUILD_NO_DEBUG
+      addLog(LOG_LEVEL_DEBUG, F("WIFI : Entering processDisconnect()"));
+      #endif // ifndef BUILD_NO_DEBUG
+      processDisconnect();
+    }
+  }
+
   if (active_network_medium == NetworkMedium_t::WIFI) {
     if ((!WiFiEventData.WiFiServicesInitialized()) || WiFiEventData.unprocessedWifiEvents()) {
       if (WiFi.status() == WL_DISCONNECTED && WiFiEventData.wifiConnectInProgress) {
@@ -91,14 +104,6 @@ void handle_unprocessedNetworkEvents()
       delay(0);
 
       NetworkConnectRelaxed();
-
-      // Process disconnect events before connect events.
-      if (!WiFiEventData.processedDisconnect) {
-        #ifndef BUILD_NO_DEBUG
-        addLog(LOG_LEVEL_DEBUG, F("WIFI : Entering processDisconnect()"));
-        #endif // ifndef BUILD_NO_DEBUG
-        processDisconnect();
-      }
 
       if (!WiFiEventData.processedConnect) {
         #ifndef BUILD_NO_DEBUG
@@ -198,8 +203,9 @@ void handle_unprocessedNetworkEvents()
 // These functions are called from Setup() or Loop() and thus may call delay() or yield()
 // ********************************************************************************
 void processDisconnect() {
-  if (WiFiEventData.processedDisconnect) { return; }
-  WiFiEventData.processedDisconnect = true;
+  if (WiFiEventData.processedDisconnect || 
+      WiFiEventData.processingDisconnect) { return; }
+  WiFiEventData.processingDisconnect = true;
   WiFiEventData.setWiFiDisconnected();
   WiFiEventData.wifiConnectAttemptNeeded = true;
   delay(100); // FIXME TD-er: See https://github.com/letscontrolit/ESPEasy/issues/1987#issuecomment-451644424
@@ -241,6 +247,8 @@ void processDisconnect() {
     WifiScan(false);
   }
   logConnectionStatus();
+  WiFiEventData.processedDisconnect = true;
+  WiFiEventData.processingDisconnect = false;
 }
 
 void processConnect() {
@@ -390,6 +398,7 @@ void processGotIP() {
   MQTTclient_should_reconnect = true;
   timermqtt_interval          = 100;
   Scheduler.setIntervalTimer(ESPEasy_Scheduler::IntervalTimer_e::TIMER_MQTT);
+  scheduleNextMQTTdelayQueue();
 #endif // USES_MQTT
   Scheduler.sendGratuitousARP_now();
 
@@ -579,11 +588,11 @@ void processEthernetConnected() {
 void processEthernetDisconnected() {
   EthEventData.setEthDisconnected();
   EthEventData.processedDisconnect = true;
+  EthEventData.ethConnectAttemptNeeded = true;
   if (Settings.UseRules)
   {
     eventQueue.add(F("ETHERNET#Disconnected"));
   }
-  setNetworkMedium(NetworkMedium_t::WIFI);
 }
 
 void processEthernetGotIP() {
@@ -597,15 +606,19 @@ void processEthernetGotIP() {
 
   if (loglevelActiveFor(LOG_LEVEL_INFO))
   {
-    String log = F("ETH MAC: ");
+    String log;
+    log.reserve(160);
+    log = F("ETH MAC: ");
     log += NetworkMacAddress();
+    log += ' ';
     if (useStaticIP()) {
-      log += F("Static IP: ");
+      log += F("Static");
     } else {
-      log += F("DHCP IP: ");
+      log += F("DHCP");
     }
+    log += F(" IP: ");
     log += NetworkLocalIP().toString();
-    log += " (";
+    log += F(" (");
     log += NetworkGetHostname();
     log += F(") GW: ");
     log += NetworkGatewayIP().toString();
@@ -615,7 +628,7 @@ void processEthernetGotIP() {
       if (EthFullDuplex()) {
         log += F(" FULL_DUPLEX");
       }
-      log += F(" ");
+      log += ' ';
       log += EthLinkSpeed();
       log += F("Mbps");
     } else {
@@ -641,6 +654,7 @@ void processEthernetGotIP() {
   MQTTclient_should_reconnect = true;
   timermqtt_interval          = 100;
   Scheduler.setIntervalTimer(ESPEasy_Scheduler::IntervalTimer_e::TIMER_MQTT);
+  scheduleNextMQTTdelayQueue();
 #endif // USES_MQTT
   Scheduler.sendGratuitousARP_now();
 
@@ -653,6 +667,7 @@ void processEthernetGotIP() {
 
   EthEventData.processedGotIP = true;
   EthEventData.setEthGotIP();
+  CheckRunningServices();
 }
 
 #endif

--- a/src/src/Globals/Plugins.cpp
+++ b/src/src/Globals/Plugins.cpp
@@ -319,7 +319,7 @@ bool PluginCall(byte Function, struct EventStruct *event, String& str)
     event = &TempEvent;
   }
   else {
-    TempEvent = (*event);
+    TempEvent.deep_copy(*event);
   }
 
   #ifndef BUILD_NO_RAM_TRACKER

--- a/src/src/Helpers/Memory.cpp
+++ b/src/src/Helpers/Memory.cpp
@@ -1,4 +1,4 @@
-#include "Memory.h"
+#include "../Helpers/Memory.h"
 
 
 #ifdef ESP8266
@@ -77,14 +77,15 @@ unsigned long FreeMem(void)
 
 unsigned long getMaxFreeBlock()
 {
-  unsigned long freemem = FreeMem();
-
-  #ifdef CORE_POST_2_5_0
-
+  const unsigned long freemem = FreeMem();
   // computing max free block is a rather extensive operation, so only perform when free memory is already low.
   if (freemem < 6144) {
+  #if  defined(ESP32)
+    return ESP.getMaxAllocHeap();
+  #endif // if  defined(ESP32)
+  #ifdef CORE_POST_2_5_0
     return ESP.getMaxFreeBlockSize();
-  }
   #endif // ifdef CORE_POST_2_5_0
+  }
   return freemem;
 }

--- a/src/src/Helpers/PeriodicalActions.cpp
+++ b/src/src/Helpers/PeriodicalActions.cpp
@@ -254,7 +254,9 @@ void runEach30Seconds()
 
 
 void scheduleNextMQTTdelayQueue() {
-  Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_MQTT_DELAY_QUEUE, MQTTDelayHandler->getNextScheduleTime());
+  if (MQTTDelayHandler != nullptr) {
+    Scheduler.scheduleNextDelayQueue(ESPEasy_Scheduler::IntervalTimer_e::TIMER_MQTT_DELAY_QUEUE, MQTTDelayHandler->getNextScheduleTime());
+  }
 }
 
 void schedule_all_tasks_using_MQTT_controller() {

--- a/src/src/Helpers/PeriodicalActions.cpp
+++ b/src/src/Helpers/PeriodicalActions.cpp
@@ -347,6 +347,7 @@ void updateMQTTclient_connected() {
     timermqtt_interval = 250;
   }
   Scheduler.setIntervalTimer(ESPEasy_Scheduler::IntervalTimer_e::TIMER_MQTT);
+  scheduleNextMQTTdelayQueue();
 }
 
 void runPeriodicalMQTT() {

--- a/src/src/Helpers/PeriodicalActions.cpp
+++ b/src/src/Helpers/PeriodicalActions.cpp
@@ -292,7 +292,7 @@ void processMQTTdelayQueue() {
   START_TIMER;
   MQTT_queue_element *element(MQTTDelayHandler->getNext());
 
-  if (element == NULL) { return; }
+  if (element == nullptr) { return; }
 
   if (MQTTclient.publish(element->_topic.c_str(), element->_payload.c_str(), element->_retained)) {
     if (WiFiEventData.connectionFailures > 0) {

--- a/src/src/Helpers/PeriodicalActions.cpp
+++ b/src/src/Helpers/PeriodicalActions.cpp
@@ -269,7 +269,7 @@ void schedule_all_tasks_using_MQTT_controller() {
         // Schedule a call to each MQTT import plugin to notify the broker connection state
         EventStruct event(task);
         event.Par1 = MQTTclient_connected ? 1 : 0;
-        Scheduler.schedule_plugin_task_event_timer(DeviceIndex, PLUGIN_MQTT_CONNECTION_STATE, &event);
+        Scheduler.schedule_plugin_task_event_timer(DeviceIndex, PLUGIN_MQTT_CONNECTION_STATE, std::move(event));
       }
     }
   }

--- a/src/src/Helpers/Scheduler.cpp
+++ b/src/src/Helpers/Scheduler.cpp
@@ -1000,9 +1000,9 @@ void ESPEasy_Scheduler::process_task_device_timer(unsigned long task_index, unsi
 * Thus only use these when the result is not needed immediately.
 * Proper use case is calling from a callback function, since those cannot use yield() or delay()
 \*********************************************************************************************/
-void ESPEasy_Scheduler::schedule_plugin_task_event_timer(deviceIndex_t DeviceIndex, byte Function, struct EventStruct *event) {
+void ESPEasy_Scheduler::schedule_plugin_task_event_timer(deviceIndex_t DeviceIndex, byte Function, struct EventStruct &&event) {
   if (validDeviceIndex(DeviceIndex)) {
-    schedule_event_timer(PluginPtrType::TaskPlugin, DeviceIndex, Function, event);
+    schedule_event_timer(PluginPtrType::TaskPlugin, DeviceIndex, Function, std::move(event));
   }
 }
 
@@ -1033,9 +1033,9 @@ void ESPEasy_Scheduler::schedule_mqtt_plugin_import_event_timer(deviceIndex_t   
   }
 }
 
-void ESPEasy_Scheduler::schedule_controller_event_timer(protocolIndex_t ProtocolIndex, byte Function, struct EventStruct *event) {
+void ESPEasy_Scheduler::schedule_controller_event_timer(protocolIndex_t ProtocolIndex, byte Function, struct EventStruct &&event) {
   if (validProtocolIndex(ProtocolIndex)) {
-    schedule_event_timer(PluginPtrType::ControllerPlugin, ProtocolIndex, Function, event);
+    schedule_event_timer(PluginPtrType::ControllerPlugin, ProtocolIndex, Function, std::move(event));
   }
 }
 
@@ -1078,16 +1078,16 @@ void ESPEasy_Scheduler::schedule_mqtt_controller_event_timer(protocolIndex_t Pro
   }
 }
 
-void ESPEasy_Scheduler::schedule_notification_event_timer(byte NotificationProtocolIndex, NPlugin::Function Function, struct EventStruct *event) {
-  schedule_event_timer(PluginPtrType::NotificationPlugin, NotificationProtocolIndex, static_cast<byte>(Function), event);
+void ESPEasy_Scheduler::schedule_notification_event_timer(byte NotificationProtocolIndex, NPlugin::Function Function, struct EventStruct &&event) {
+  schedule_event_timer(PluginPtrType::NotificationPlugin, NotificationProtocolIndex, static_cast<byte>(Function), std::move(event));
 }
 
-void ESPEasy_Scheduler::schedule_event_timer(PluginPtrType ptr_type, byte Index, byte Function, struct EventStruct *event) {
+void ESPEasy_Scheduler::schedule_event_timer(PluginPtrType ptr_type, byte Index, byte Function, struct EventStruct &&event) {
   const unsigned long mixedId = createSystemEventMixedId(ptr_type, Index, Function);
 
   //  EventStructCommandWrapper eventWrapper(mixedId, *event);
   //  ScheduledEventQueue.push_back(eventWrapper);
-  ScheduledEventQueue.emplace_back(mixedId, *event);
+  ScheduledEventQueue.emplace_back(mixedId, std::move(event));
 }
 
 void ESPEasy_Scheduler::process_system_event_queue() {

--- a/src/src/Helpers/Scheduler.h
+++ b/src/src/Helpers/Scheduler.h
@@ -230,9 +230,11 @@ public:
   * Thus only use these when the result is not needed immediately.
   * Proper use case is calling from a callback function, since those cannot use yield() or delay()
   \*********************************************************************************************/
+
+  // Note: event will be moved
   void schedule_plugin_task_event_timer(deviceIndex_t       DeviceIndex,
                                         byte                Function,
-                                        struct EventStruct *event);
+                                        struct EventStruct &&event);
 
   void schedule_mqtt_plugin_import_event_timer(deviceIndex_t   DeviceIndex,
                                                taskIndex_t     TaskIndex,
@@ -242,9 +244,10 @@ public:
                                                unsigned int    length);
 
 
+  // Note: the event will be moved
   void schedule_controller_event_timer(protocolIndex_t     ProtocolIndex,
                                        byte                Function,
-                                       struct EventStruct *event);
+                                       struct EventStruct &&event);
 
   void schedule_mqtt_controller_event_timer(protocolIndex_t ProtocolIndex,
                                             CPlugin::Function Function,
@@ -252,9 +255,10 @@ public:
                                             byte           *b_payload,
                                             unsigned int    length);
 
+  // Note: The event will be moved
   void schedule_notification_event_timer(byte                NotificationProtocolIndex,
                                          NPlugin::Function   Function,
-                                         struct EventStruct *event);
+                                         struct EventStruct &&event);
 
 
   static unsigned long createSystemEventMixedId(PluginPtrType ptr_type,
@@ -264,10 +268,11 @@ public:
                                                 byte          Index,
                                                 byte          Function);
 
+  // Note, the event will be moved
   void schedule_event_timer(PluginPtrType       ptr_type,
                             byte                Index,
                             byte                Function,
-                            struct EventStruct *event);
+                            struct EventStruct &&event);
 
   void process_system_event_queue();
 

--- a/src/src/Helpers/StringConverter.cpp
+++ b/src/src/Helpers/StringConverter.cpp
@@ -237,6 +237,7 @@ void addNewLine(String& line) {
    Format a value to the set number of decimals
 \*********************************************************************************************/
 String doFormatUserVar(struct EventStruct *event, byte rel_index, bool mustCheck, bool& isvalid) {
+  if (event == nullptr) return "";
   isvalid = true;
 
   const deviceIndex_t DeviceIndex = getDeviceIndex_from_TaskIndex(event->TaskIndex);
@@ -249,7 +250,8 @@ String doFormatUserVar(struct EventStruct *event, byte rel_index, bool mustCheck
   {
     // First try to format using the plugin specific formatting.
     String result;
-    EventStruct tempEvent(*event);
+    EventStruct tempEvent;
+    tempEvent.deep_copy(event);
     tempEvent.idx = rel_index;
     PluginCall(PLUGIN_FORMAT_USERVAR, &tempEvent, result);
     if (result.length() > 0) {

--- a/src/src/Helpers/StringProvider.cpp
+++ b/src/src/Helpers/StringProvider.cpp
@@ -254,7 +254,7 @@ String getValue(LabelType::Enum label) {
     case LabelType::DNS_1:                  return NetworkDnsIP(0).toString();
     case LabelType::DNS_2:                  return NetworkDnsIP(1).toString();
     case LabelType::ALLOWED_IP_RANGE:       return describeAllowedIPrange();
-    case LabelType::STA_MAC:                return NetworkMacAddress();
+    case LabelType::STA_MAC:                return WifiSTAmacAddress();
     case LabelType::AP_MAC:                 return WifiSoftAPmacAddress();
     case LabelType::SSID:                   return WiFi.SSID();
     case LabelType::BSSID:                  return WiFi.BSSIDstr();

--- a/src/src/WebServer/NotificationPage.cpp
+++ b/src/src/WebServer/NotificationPage.cpp
@@ -92,7 +92,7 @@ void handle_notifications() {
       {
         // TempEvent.NotificationProtocolIndex = NotificationProtocolIndex;
         TempEvent.NotificationIndex = notificationindex;
-        Scheduler.schedule_notification_event_timer(NotificationProtocolIndex, NPlugin::Function::NPLUGIN_NOTIFY, &TempEvent);
+        Scheduler.schedule_notification_event_timer(NotificationProtocolIndex, NPlugin::Function::NPLUGIN_NOTIFY, std::move(TempEvent));
       }
     }
   }

--- a/src/src/WebServer/RootPage.cpp
+++ b/src/src/WebServer/RootPage.cpp
@@ -198,9 +198,7 @@ void handle_root() {
       addRowLabelValue(LabelType::ETH_WIFI_MODE);
   #endif
 
-      if (
-        active_network_medium == NetworkMedium_t::WIFI &&
-        NetworkConnected())
+      if (!WiFiEventData.WiFiDisconnected())
       {
         addRowLabelValue(LabelType::IP_ADDRESS);
         addRowLabel(LabelType::WIFI_RSSI);

--- a/src/src/WebServer/SysInfoPage.cpp
+++ b/src/src/WebServer/SysInfoPage.cpp
@@ -17,6 +17,7 @@
 
 #include "../Globals/CRCValues.h"
 #include "../Globals/ESPEasy_time.h"
+#include "../Globals/ESPEasyWiFiEvent.h"
 #include "../Globals/NetworkState.h"
 #include "../Globals/RTC.h"
 
@@ -416,11 +417,10 @@ void handle_sysinfo_Network() {
 
   addTableSeparator(F("WiFi"), 2, 3, F("Wifi"));
 
-  const bool showWiFiConnectionInfo = 
-    active_network_medium == NetworkMedium_t::WIFI &&
-    NetworkConnected();
+  const bool showWiFiConnectionInfo = !WiFiEventData.WiFiDisconnected();
 
-  addRowLabel(F("Wifi Connection"));
+
+  addRowLabel(LabelType::WIFI_CONNECTION);
   if (showWiFiConnectionInfo)
   {
     String html;


### PR DESCRIPTION
For the controller queue messages, as well as EventStruct (and some more) the generated code was often using a copy constructor instead of the move operator.
This would lead to lots of memory allocations which are not needed.

For the EventStruct and the controller queue element structs there are only move constructors and no copy constructors.
C++ only can generate copy-constructor and move constructor if no user defined move constructor or move assignment operator is present.
So by manually creating one, and not having a copy-constructor and/or assignment operator, you can make sure those copy constructors are not generated and unknowingly used instead of the move operator.

For the EventStruct you still need to copy the struct in a few places, so for those I added a `deep_copy` function so the user must perform an explicit deepcopy and no longer an unintentional one.

There is still a lot to gain, as we still have lots and lots of functions where non-trivial objects are copied instead of moved (e.g. return value of a function)
But for now, the structs with potentially the largest memory blocks are moved instead of copied.

Also fixed the deduplication check on a number of controllers as those were a buggy due to copy/paste without proper checking.