### PR TITLE
[LoRaWAN TTN] Fix controller not setting SF or FP & add ADR (#3630)

### DIFF
--- a/dist/Release_notes.txt
+++ b/dist/Release_notes.txt
@@ -2785,7 +2785,7 @@ Release date: Tue Aug 13 04:00:10 CEST 2019
 Gijs Noorlander (21):
       [TTN] Add RN2483-Arduino-Library
       [TTN] Skeleton for C018 TTN RN2xx3 controller
-      [RN2384 lib] Only use const String& in function parameters
+      [RN2483 lib] Only use const String& in function parameters
       [LoRa plugin] Use separate object for C018 data
       [LoRa TTN] Create special interface for LoRa TTN controller
       [Controller page] Restructure Controller rendering page

--- a/docs/source/Controller/C018.rst
+++ b/docs/source/Controller/C018.rst
@@ -54,7 +54,7 @@ This layer is called LoRaWAN.
 There are several modules available:
 
 - RFM95  & SX127x.  These are LoRa modules which needs to have the LoRaWAN stack implemented in software
-- Microchip RN2384/RN2903. These are the modules supported in this controller. They have the full LoRaWAN stack present in the module.
+- Microchip RN2483/RN2903. These are the modules supported in this controller. They have the full LoRaWAN stack present in the module.
 
 
 Nodes, Gateways, Application
@@ -128,7 +128,7 @@ Prerequisites:
 
 - An user account on the TTN network.
 - A TTN gateway in range to send data to (and receive data from)
-- Microchip RN2384 or RN2903 LoRaWAN module connected to a node running ESPeasy. (UART connection)
+- Microchip RN2483 or RN2903 LoRaWAN module connected to a node running ESPeasy. (UART connection)
 
 On the TTN network:
 - Create an application

--- a/docs/source/Controller/_controller_substitutions.repl
+++ b/docs/source/Controller/_controller_substitutions.repl
@@ -184,6 +184,6 @@
 .. |C018_github| replace:: C018.ino
 .. _C018_github: https://github.com/letscontrolit/ESPEasy/blob/mega/src/_C018.ino
 .. |C018_usedby| replace:: `.`
-.. |C018_shortinfo| replace:: `Controller for the LoRaWAN/TTN network supporting RN2384 (434/868 MHz) and RN2903 (915 MHz)`
+.. |C018_shortinfo| replace:: `Controller for the LoRaWAN/TTN network supporting RN2483 (434/868 MHz) and RN2903 (915 MHz)`
 .. |C018_maintainer| replace:: `TD-er`
 .. |C018_compileinfo| replace:: `.`

--- a/lib/RN2483-Arduino-Library/library.properties
+++ b/lib/RN2483-Arduino-Library/library.properties
@@ -1,5 +1,5 @@
 name=RN2xx3 Arduino Library
-version=1.0.1
+version=1.0.2
 author=JP Meijers
 maintainer=JP Meijers <arduino+rn2483@jpmeijers.com>
 sentence=A library to communicate using the RN2483 and RN2903 module.

--- a/lib/RN2483-Arduino-Library/src/rn2xx3.cpp
+++ b/lib/RN2483-Arduino-Library/src/rn2xx3.cpp
@@ -97,6 +97,11 @@ bool rn2xx3::setSF(uint8_t sf)
   return _rn2xx3_handler.setSF(sf);
 }
 
+bool rn2xx3::setAdaptiveDataRate(bool enabled)
+{
+  return _rn2xx3_handler.setAdaptiveDataRate(enabled);
+}
+
 bool rn2xx3::init()
 {
   return _rn2xx3_handler.init();
@@ -196,12 +201,18 @@ int rn2xx3::getVbat()
 
 String rn2xx3::getDataRate()
 {
+  int dr;
+  int sf = _rn2xx3_handler.getSF(dr);
   String output;
 
-  output.reserve(9);
-  output  = sendRawCommand(F("radio get sf"));
-  output += "bw";
-  output += _rn2xx3_handler.readIntValue(F("radio get bw"));
+  output.reserve(24);
+  output  = F("sf:");
+  output += sf;
+  output += F(" dr:");
+  output += dr;
+
+  output += F(" ADR: ");
+  output += sendRawCommand(F("mac get adr"));
   return output;
 }
 

--- a/lib/RN2483-Arduino-Library/src/rn2xx3.h
+++ b/lib/RN2483-Arduino-Library/src/rn2xx3.h
@@ -88,6 +88,8 @@ public:
 
   bool   setSF(uint8_t sf);
 
+  bool   setAdaptiveDataRate(bool enabled);
+
   /*
    * Initialise the RN2xx3 and join the LoRa network (if applicable).
    * This function can only be called after calling initABP() or initOTAA().

--- a/lib/RN2483-Arduino-Library/src/rn2xx3_handler.h
+++ b/lib/RN2483-Arduino-Library/src/rn2xx3_handler.h
@@ -119,6 +119,7 @@ public:
                                              uint8_t port = 1);
 
   bool setSF(uint8_t sf);
+  uint8_t getSF(int& dr);
 
 
   /*
@@ -264,6 +265,7 @@ private:
   uint16_t _max_received_length = 0;
 
 
+  RN2xx3_datatypes::Firmware _firmware = RN2xx3_datatypes::Firmware::unknown;
   RN2xx3_datatypes::Model _moduleType = RN2xx3_datatypes::Model::RN_NA;
   RN2xx3_datatypes::Freq_plan _fp     = RN2xx3_datatypes::Freq_plan::TTN_EU;
   uint8_t _sf                         = 7;

--- a/src/_C018.ino
+++ b/src/_C018.ino
@@ -159,6 +159,15 @@ struct C018_data_struct {
     return res;
   }
 
+  bool setAdaptiveDataRate(bool enabled) {
+    if (!isInitialized()) { return false; }
+    bool res = myLora->setAdaptiveDataRate(enabled);
+
+    C018_logError(F("setAdaptiveDataRate()"));
+    return res;
+  }
+
+
   bool initOTAA(const String& AppEUI = "", const String& AppKey = "", const String& DevEUI = "") {
     if (myLora == nullptr) { return false; }
     bool success = myLora->initOTAA(AppEUI, AppKey, DevEUI);
@@ -321,7 +330,7 @@ private:
     //    String error = myLora->getLastError();
 
     if (error.length() > 0) {
-      String log = F("RN2384: ");
+      String log = F("RN2483: ");
       log += command;
       log += ": ";
       log += error;
@@ -460,6 +469,7 @@ struct C018_ConfigStruct
   uint8_t       joinmethod                                      = C018_USE_OTAA;
   uint8_t       serialPort                                      = 0;
   uint8_t       stackVersion                                    = RN2xx3_datatypes::TTN_stack_version::TTN_v2;
+  uint8_t       adr                                             = 0;
 };
 
 
@@ -551,6 +561,7 @@ bool CPlugin_018(CPlugin::Function function, struct EventStruct *event, String& 
       uint8_t frequencyplan;
       uint8_t joinmethod;
       uint8_t stackVersion;
+      uint8_t adr;
 
       {
         // Keep this object in a small scope so we can destruct it as soon as possible again.
@@ -569,6 +580,7 @@ bool CPlugin_018(CPlugin::Function function, struct EventStruct *event, String& 
         frequencyplan = customConfig->frequencyplan;
         joinmethod    = customConfig->joinmethod;
         stackVersion  = customConfig->stackVersion;
+        adr           = customConfig->adr;
 
         {
           addFormTextBox(F("Device EUI"), F("deveui"), customConfig->DeviceEUI, C018_DEVICE_EUI_LEN - 1);
@@ -618,6 +630,7 @@ bool CPlugin_018(CPlugin::Function function, struct EventStruct *event, String& 
       }
 
       addFormNumericBox(F("Spread Factor"), F("sf"), sf, 7, 12);
+      addFormCheckBox(F("Adaptive Data Rate (ADR)"), F("adr"), adr);
 
 
       addTableSeparator(F("Serial Port Configuration"), 2, 3);
@@ -667,6 +680,9 @@ bool CPlugin_018(CPlugin::Function function, struct EventStruct *event, String& 
         addRowLabel(F("Sample Set Counter"));
         addHtmlInt(C018_data->getSampleSetCount());
 
+        addRowLabel(F("Data Rate"));
+        addHtml(C018_data->getDataRate());        
+
         {
           RN2xx3_status status = C018_data->getStatus();
 
@@ -707,6 +723,7 @@ bool CPlugin_018(CPlugin::Function function, struct EventStruct *event, String& 
         customConfig->frequencyplan = getFormItemInt(F("frequencyplan"), customConfig->frequencyplan);
         customConfig->joinmethod    = getFormItemInt(F("joinmethod"), customConfig->joinmethod);
         customConfig->stackVersion  = getFormItemInt(F("ttnstack"), customConfig->stackVersion);
+        customConfig->adr           = isFormItemChecked(F("adr"));
         serialHelper_webformSave(customConfig->serialPort, customConfig->rxpin, customConfig->txpin);
         SaveCustomControllerSettings(event->ControllerIndex, (byte *)customConfig.get(), sizeof(C018_ConfigStruct));
       }
@@ -796,6 +813,15 @@ bool C018_init(struct EventStruct *event) {
   taskIndex_t  SampleSetInitiator = INVALID_TASK_INDEX;
   unsigned int Port               = 0;
 
+  // Check if the object is already created.
+  // If so, delete it to make sure the module is initialized according to the full set parameters.
+  if (C018_data != nullptr) {
+    C018_data->reset();
+    delete C018_data;
+    C018_data = nullptr;
+  }
+
+
   if (C018_data == nullptr) {
     C018_data = new (std::nothrow) C018_data_struct;
 
@@ -835,6 +861,12 @@ bool C018_init(struct EventStruct *event) {
   }
 
   C018_data->setFrequencyPlan(static_cast<RN2xx3_datatypes::Freq_plan>(customConfig->frequencyplan));
+  if (!C018_data->setSF(customConfig->sf)) {
+    return false;
+  }
+  if (!C018_data->setAdaptiveDataRate(customConfig->adr != 0)) {
+    return false;
+  }
 
   if (customConfig->joinmethod == C018_USE_OTAA) {
     String log = F("OTAA: AppEUI: ");
@@ -854,10 +886,6 @@ bool C018_init(struct EventStruct *event) {
     if (!C018_data->initABP(customConfig->DeviceAddr, customConfig->AppSessionKey, customConfig->NetworkSessionKey)) {
       return false;
     }
-  }
-
-  if (!C018_data->setSF(customConfig->sf)) {
-    return false;
   }
 
   if (!C018_data->setTTNstack(static_cast<RN2xx3_datatypes::TTN_stack_version>(customConfig->stackVersion))) {


### PR DESCRIPTION
Fixes: #3630

- Add checkbox for enable/disable ADR (Adaptive Data Rate)
- Fix not being able to set Frequency Plan (FP)
- Fix not being able to set Spreading Factor (SF)