### PR TITLE
[Commands] Enable LogEntry to log for other level than INFO #3312

### DIFF
--- a/docs/source/Plugin/P000_commands.repl
+++ b/docs/source/Plugin/P000_commands.repl
@@ -203,7 +203,16 @@
     :red:`Internal`","
     Add string to log
 
-    ``LogEntry,<string>``"
+    ``LogEntry,<string>[,<level>]``
+    
+    ``<level>`` is optional and can be any of these (numeric) values:
+    
+    - 1 = ERROR
+    - 2 = INFO (default)
+    - 3 = DEBUG
+    - 4 = DEBUG_DEV
+    
+    When a ``<level>`` is provided, it will be present in the log output if the 'Tolerant last parameter' Advanced setting is enabled."
     "
     LogPortStatus","
     :red:`Internal`","

--- a/src/src/Commands/Diagnostic.cpp
+++ b/src/src/Commands/Diagnostic.cpp
@@ -158,7 +158,7 @@ String Command_Debug(struct EventStruct *event, const char *Line)
 
 String Command_logentry(struct EventStruct *event, const char *Line)
 {
-  int level = LOG_LEVEL_INFO;
+  byte level = LOG_LEVEL_INFO;
   // An extra optional parameter to set log level.
   if (event->Par2 > LOG_LEVEL_NONE && event->Par2 <= LOG_LEVEL_DEBUG_MORE) { level = event->Par2; }
   addLog(level, tolerantParseStringKeepCase(Line, 2));

--- a/src/src/Commands/Diagnostic.cpp
+++ b/src/src/Commands/Diagnostic.cpp
@@ -158,8 +158,10 @@ String Command_Debug(struct EventStruct *event, const char *Line)
 
 String Command_logentry(struct EventStruct *event, const char *Line)
 {
-  // FIXME TD-er: Add an extra optional parameter to set log level.
-  addLog(LOG_LEVEL_INFO, tolerantParseStringKeepCase(Line, 2));
+  int level = LOG_LEVEL_INFO;
+  // An extra optional parameter to set log level.
+  if (event->Par2 > LOG_LEVEL_NONE && event->Par2 <= LOG_LEVEL_DEBUG_MORE) { level = event->Par2; }
+  addLog(level, tolerantParseStringKeepCase(Line, 2));
   return return_command_success();
 }
 

--- a/src/src/Commands/InternalCommands.cpp
+++ b/src/src/Commands/InternalCommands.cpp
@@ -258,7 +258,7 @@ bool executeInternalCommand(command_case_data & data)
     case 'l': {
       COMMAND_CASE_A(            "let", Command_Rules_Let,         2); // Rules.h
       COMMAND_CASE_A(           "load", Command_Settings_Load,     0); // Settings.h
-      COMMAND_CASE_A(       "logentry", Command_logentry,          1); // Diagnostic.h
+      COMMAND_CASE_A(       "logentry", Command_logentry,         -1); // Diagnostic.h
       COMMAND_CASE_A(   "looptimerset", Command_Loop_Timer_Set,    3); // Timers.h
       COMMAND_CASE_A("looptimerset_ms", Command_Loop_Timer_Set_ms, 3); // Timers.h
       COMMAND_CASE_A(      "longpulse", Command_GPIO_LongPulse,    3);    // GPIO.h


### PR DESCRIPTION
Adds an optional 'level' argument at the end of the `LogEntry,<text_to_log>[,<level>]` command, so would look like: `LogEntry,"some logging text",1` will log this at ERROR level (1).
The log entry will include the level at the end if the 'Tolerant last parameter' Advanced setting is enabled.
Checks are in place to only accept normal log levels, ERROR (1), INFO (2), DEBUG (3), DEBUG_MORE (4). Not supported: DEBUG_DEV (9).

TODO:
- [x] Documentation update

Resolves #3312 