### PR TITLE
[MQTT] Check MQTT status before sending

### DIFF
--- a/lib/pubsubclient/src/PubSubClient.h
+++ b/lib/pubsubclient/src/PubSubClient.h
@@ -37,6 +37,15 @@
 #define MQTT_SOCKET_TIMEOUT 15
 #endif
 
+// ESP32_CONNECTION_TIMEOUT : Specific case for ESP32, we need to manually provide timeout as default (-1) leads to WDT reset (after 5 seconds).
+// By default (4500 milliseconds) 4,5 seconds to avoid reaching 5s default watchdog reset time.
+// This is multiplied in WiFiClient.cpp (part of arduino-esp32) by 1000 inside [WiFiClient::connect] method.
+// ESP8266 Arduino framework in contrast has fixed 5000ms timeout. No need to define it manually here.
+// See: https://github.com/knolleary/pubsubclient/pull/842
+#ifndef ESP32_CONNECTION_TIMEOUT
+#define ESP32_CONNECTION_TIMEOUT 4500
+#endif
+
 // MQTT_MAX_TRANSFER_SIZE : limit how much data is passed to the network client
 //  in each write call. Needed for the Arduino Wifi Shield. Leave undefined to
 //  pass the entire MQTT packet in each write call.

--- a/src/src/ESPEasyCore/Controller.cpp
+++ b/src/src/ESPEasyCore/Controller.cpp
@@ -1,4 +1,4 @@
-#include "Controller.h"
+#include "../ESPEasyCore/Controller.h"
 
 #include "../../ESPEasy_common.h"
 #include "../../ESPEasy-Globals.h"

--- a/src/src/Helpers/PeriodicalActions.cpp
+++ b/src/src/Helpers/PeriodicalActions.cpp
@@ -295,7 +295,7 @@ void processMQTTdelayQueue() {
   if (MQTTDelayHandler == nullptr) {
     return;
   }
-  updateMQTTclient_connected();
+  runPeriodicalMQTT(); // Update MQTT connected state.
   if (!MQTTclient_connected) {
     scheduleNextMQTTdelayQueue();
     return;

--- a/src/src/Helpers/PeriodicalActions.cpp
+++ b/src/src/Helpers/PeriodicalActions.cpp
@@ -292,7 +292,12 @@ void schedule_all_tasks_using_MQTT_controller() {
 }
 
 void processMQTTdelayQueue() {
-  if (MQTTDelayHandler == nullptr || !MQTTclient_connected) {
+  if (MQTTDelayHandler == nullptr) {
+    return;
+  }
+  updateMQTTclient_connected();
+  if (!MQTTclient_connected) {
+    scheduleNextMQTTdelayQueue();
     return;
   }
 

--- a/src/src/Helpers/Scheduler.cpp
+++ b/src/src/Helpers/Scheduler.cpp
@@ -1,4 +1,4 @@
-#include "Scheduler.h"
+#include "../Helpers/Scheduler.h"
 
 #include "../../ESPEasy_common.h"
 
@@ -19,9 +19,7 @@
 #include "../Helpers/PortStatus.h"
 
 
-//#define TIMER_ID_SHIFT    28   // Must be decreased as soon as timers below reach 15
-
-#define TIMER_ID_SHIFT    28   // Must be decreased as soon as timers below reach 15
+#define TIMER_ID_SHIFT       28   // Must be decreased as soon as timers below reach 15
 #define SYSTEM_EVENT_QUEUE   0 // Not really a timer.
 #define CONST_INTERVAL_TIMER 1
 #define PLUGIN_TASK_TIMER    2


### PR DESCRIPTION
Extra check/update of MQTT connected status before trying to send messages to the broker from the queue.
Based on the symptoms described here https://github.com/letscontrolit/ESPEasy/issues/2684#issuecomment-843183136 by @ghtester
