### PR TITLE
[WiFi] Fix issue where WiFi could not scan to reconnect

### DIFF
--- a/src/src/ESPEasyCore/ESPEasyWifi.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi.cpp
@@ -662,10 +662,15 @@ bool WiFiScanAllowed() {
     return true;
   }
   */
-  if (WiFi_AP_Candidates.getBestCandidate().usable()) {
+  WiFi_AP_Candidates.purge_expired();
+  if (WiFiEventData.wifiConnectInProgress) {
+    return false;
+  }
+  if (NetworkConnected() && WiFi_AP_Candidates.getBestCandidate().usable()) {
     addLog(LOG_LEVEL_ERROR, F("WiFi : Scan not needed, good candidate present"));
     return false;
   }
+
   if (WiFiEventData.lastDisconnectMoment.isSet() && WiFiEventData.lastDisconnectMoment.millisPassedSince() < WIFI_RECONNECT_WAIT) {
     if (!NetworkConnected()) {
       return true;

--- a/src/src/ESPEasyCore/ESPEasy_setup.cpp
+++ b/src/src/ESPEasyCore/ESPEasy_setup.cpp
@@ -225,6 +225,7 @@ void ESPEasy_setup()
   #endif // ifdef HAS_ETHERNET
 
   if (active_network_medium == NetworkMedium_t::WIFI) {
+    WiFi_AP_Candidates.load_knownCredentials();
     if (!WiFi_AP_Candidates.hasKnownCredentials()) {
       WiFiEventData.wifiSetup = true;
       RTC.clearLastWiFi(); // Must scan all channels
@@ -234,7 +235,9 @@ void ESPEasy_setup()
       WiFiEventData.lastScanMoment.clear();
     }
 
-    // Start an extra async scan so we can continue, but we may find more APs by scanning twice.
+    // Always perform WiFi scan
+    // It appears reconnecting from RTC may take just as long to be able to send first packet as performing a scan first and then connect.
+    // Perhaps the WiFi radio needs some time to stabilize first?
     WifiScan(true);
   }
 

--- a/src/src/Helpers/WiFi_AP_CandidatesList.cpp
+++ b/src/src/Helpers/WiFi_AP_CandidatesList.cpp
@@ -53,6 +53,7 @@ void WiFi_AP_CandidatesList::load_knownCredentials() {
     }
   }
   loadCandidatesFromScanned();
+  addFromRTC();
 }
 
 void WiFi_AP_CandidatesList::clearCache() {


### PR DESCRIPTION
As reported by a number of users since the latest mega-20210503 build.

- Reconnect after reboot may take forever
- Reconnect when WiFi connection lost may take forever.
- Cannot perform WiFi scan