### PR TITLE
[Build] Re-enable RTTTL in TESTING where it fits

### DIFF
--- a/platformio_esp32_envs.ini
+++ b/platformio_esp32_envs.ini
@@ -59,6 +59,7 @@ platform                  = ${esp32_common.platform}
 build_flags               = ${esp32_common.build_flags}  
                             -DFEATURE_ARDUINO_OTA
                             -DPLUGIN_SET_TEST_ESP32
+                            -DTESTING_USE_RTTTL
 board                     = esp32dev
 extra_scripts             = ${esp32_common.extra_scripts}
 
@@ -68,6 +69,7 @@ platform                  = ${esp32_common.platform}
 build_flags               = ${esp32_common.build_flags}  
                             -DFEATURE_ARDUINO_OTA
                             -DPLUGIN_SET_TEST_B_ESP32
+                            -DTESTING_USE_RTTTL
 board                     = esp32dev
 extra_scripts             = ${esp32_common.extra_scripts}
 
@@ -77,6 +79,7 @@ platform                  = ${esp32_common.platform}
 build_flags               = ${esp32_common.build_flags}  
                             -DFEATURE_ARDUINO_OTA
                             -DPLUGIN_SET_TEST_C_ESP32
+                            -DTESTING_USE_RTTTL
 board                     = esp32dev
 extra_scripts             = ${esp32_common.extra_scripts}
 
@@ -86,6 +89,7 @@ platform                  = ${esp32_common.platform}
 build_flags               = ${esp32_common.build_flags}  
                             -DFEATURE_ARDUINO_OTA
                             -DPLUGIN_SET_TEST_D_ESP32
+                            -DTESTING_USE_RTTTL
 board                     = esp32dev
 extra_scripts             = ${esp32_common.extra_scripts}
 
@@ -96,6 +100,7 @@ platform                  = ${esp32_common.platform}
 build_flags               = ${esp32_common.build_flags}
                             -DFEATURE_ARDUINO_OTA
                             -DPLUGIN_SET_TEST_ESP32
+                            -DTESTING_USE_RTTTL
 board                     = esp-wrover-kit
 upload_protocol           = ftdi
 debug_tool                = ftdi
@@ -108,6 +113,7 @@ platform                  = ${esp32_common.platform}
 build_flags               = ${esp32_common.build_flags}
                             -DFEATURE_ARDUINO_OTA
                             -DPLUGIN_SET_TEST_B_ESP32
+                            -DTESTING_USE_RTTTL
 board                     = esp-wrover-kit
 upload_protocol           = ftdi
 debug_tool                = ftdi
@@ -120,6 +126,7 @@ platform                  = ${esp32_common.platform}
 build_flags               = ${esp32_common.build_flags}
                             -DFEATURE_ARDUINO_OTA
                             -DPLUGIN_SET_TEST_C_ESP32
+                            -DTESTING_USE_RTTTL
 board                     = esp-wrover-kit
 upload_protocol           = ftdi
 debug_tool                = ftdi
@@ -132,6 +139,7 @@ platform                  = ${esp32_common.platform}
 build_flags               = ${esp32_common.build_flags}
                             -DFEATURE_ARDUINO_OTA
                             -DPLUGIN_SET_TEST_D_ESP32
+                            -DTESTING_USE_RTTTL
 board                     = esp-wrover-kit
 upload_protocol           = ftdi
 debug_tool                = ftdi
@@ -145,6 +153,7 @@ build_flags               = ${esp32_common.build_flags}
 ;                            -DFEATURE_ARDUINO_OTA
                             -DPLUGIN_SET_TEST_ESP32
 ;                            -DUSES_P096
+                            -DTESTING_USE_RTTTL
 board                     = lolin_d32_pro
 extra_scripts             = ${esp32_common.extra_scripts}
 
@@ -155,6 +164,7 @@ build_flags               = ${esp32_common.build_flags}
 ;                            -DFEATURE_ARDUINO_OTA
                             -DPLUGIN_SET_TEST_B_ESP32
                             -DUSES_P096
+                            -DTESTING_USE_RTTTL
 board                     = lolin_d32_pro
 extra_scripts             = ${esp32_common.extra_scripts}
 
@@ -165,6 +175,7 @@ build_flags               = ${esp32_common.build_flags}
 ;                            -DFEATURE_ARDUINO_OTA
                             -DPLUGIN_SET_TEST_C_ESP32
 ;                            -DUSES_P096
+                            -DTESTING_USE_RTTTL
 board                     = lolin_d32_pro
 extra_scripts             = ${esp32_common.extra_scripts}
 
@@ -175,6 +186,7 @@ build_flags               = ${esp32_common.build_flags}
 ;                            -DFEATURE_ARDUINO_OTA
                             -DPLUGIN_SET_TEST_D_ESP32
                             -DUSES_P096
+                            -DTESTING_USE_RTTTL
 board                     = lolin_d32_pro
 extra_scripts             = ${esp32_common.extra_scripts}
 
@@ -183,24 +195,28 @@ extends                   = env:test_A_ESP32_4M316k
 lib_ignore                = AS_BH1750, ${esp32_always.lib_ignore}, ESP32_ping
 build_flags               = ${esp32_common.build_flags}
                             -DPLUGIN_BUILD_NORMAL_IRext
+                            -DTESTING_USE_RTTTL
 
 [env:test_B_ESP32_IRExt_4M316k]
 extends                   = env:test_B_ESP32_4M316k
 lib_ignore                = AS_BH1750, ${esp32_always.lib_ignore}, ESP32_ping
 build_flags               = ${esp32_common.build_flags}
                             -DPLUGIN_BUILD_NORMAL_IRext
+                            -DTESTING_USE_RTTTL
 
 [env:test_C_ESP32_IRExt_4M316k]
 extends                   = env:test_C_ESP32_4M316k
 lib_ignore                = AS_BH1750, ${esp32_always.lib_ignore}, ESP32_ping
 build_flags               = ${esp32_common.build_flags}
                             -DPLUGIN_BUILD_NORMAL_IRext
+                            -DTESTING_USE_RTTTL
 
 [env:test_D_ESP32_IRExt_4M316k]
 extends                   = env:test_D_ESP32_4M316k
 lib_ignore                = AS_BH1750, ${esp32_always.lib_ignore}, ESP32_ping
 build_flags               = ${esp32_common.build_flags}
                             -DPLUGIN_BUILD_NORMAL_IRext
+                            -DTESTING_USE_RTTTL
 
 [env:energy_ESP32_4M316k]
 extends                   = esp32_common
@@ -238,42 +254,50 @@ build_flags               = ${env:normal_ESP32_4M316k.build_flags} -DHAS_ETHERNE
 extends                   = env:test_A_ESP32_4M316k
 platform                  = ${env:test_A_ESP32_4M316k.platform}
 build_flags               = ${env:test_A_ESP32_4M316k.build_flags} -DHAS_ETHERNET
+                            -DTESTING_USE_RTTTL
 
 [env:test_B_ESP32_4M316k_ETH]
 extends                   = env:test_B_ESP32_4M316k
 platform                  = ${env:test_B_ESP32_4M316k.platform}
 build_flags               = ${env:test_B_ESP32_4M316k.build_flags} -DHAS_ETHERNET
+                            -DTESTING_USE_RTTTL
 
 [env:test_C_ESP32_4M316k_ETH]
 extends                   = env:test_C_ESP32_4M316k
 platform                  = ${env:test_C_ESP32_4M316k.platform}
 build_flags               = ${env:test_C_ESP32_4M316k.build_flags} -DHAS_ETHERNET
+                            -DTESTING_USE_RTTTL
 
 [env:test_D_ESP32_4M316k_ETH]
 extends                   = env:test_D_ESP32_4M316k
 platform                  = ${env:test_D_ESP32_4M316k.platform}
 build_flags               = ${env:test_D_ESP32_4M316k.build_flags} -DHAS_ETHERNET
+                            -DTESTING_USE_RTTTL
 
 
 [env:test_A_ESP32-wrover-kit_4M316k_ETH]
 extends                   = env:test_A_ESP32-wrover-kit_4M316k
 platform                  = ${env:test_A_ESP32-wrover-kit_4M316k.platform}
 build_flags               = ${env:test_A_ESP32-wrover-kit_4M316k.build_flags} -DHAS_ETHERNET
+                            -DTESTING_USE_RTTTL
 
 [env:test_B_ESP32-wrover-kit_4M316k_ETH]
 extends                   = env:test_B_ESP32-wrover-kit_4M316k
 platform                  = ${env:test_B_ESP32-wrover-kit_4M316k.platform}
 build_flags               = ${env:test_B_ESP32-wrover-kit_4M316k.build_flags} -DHAS_ETHERNET
+                            -DTESTING_USE_RTTTL
 
 [env:test_C_ESP32-wrover-kit_4M316k_ETH]
 extends                   = env:test_C_ESP32-wrover-kit_4M316k
 platform                  = ${env:test_C_ESP32-wrover-kit_4M316k.platform}
 build_flags               = ${env:test_C_ESP32-wrover-kit_4M316k.build_flags} -DHAS_ETHERNET
+                            -DTESTING_USE_RTTTL
 
 [env:test_D_ESP32-wrover-kit_4M316k_ETH]
 extends                   = env:test_D_ESP32-wrover-kit_4M316k
 platform                  = ${env:test_D_ESP32-wrover-kit_4M316k.platform}
 build_flags               = ${env:test_D_ESP32-wrover-kit_4M316k.build_flags} -DHAS_ETHERNET
+                            -DTESTING_USE_RTTTL
 
 
 ; A Lolin D32 PRO with 16MB Flash, allowing 4MB sketch size, and file storage using the default (SPIFFS) filesystem

--- a/platformio_esp82xx_envs.ini
+++ b/platformio_esp82xx_envs.ini
@@ -394,6 +394,7 @@ platform                  = ${testing.platform}
 platform_packages         = ${testing.platform_packages}
 build_flags               = ${testing.build_flags}
                             ${esp8266_4M1M.build_flags}
+                            -DTESTING_USE_RTTTL
 
 [env:test_B_ESP8266_4M1M]
 extends                   = esp8266_4M1M
@@ -410,6 +411,7 @@ platform_packages         = ${testing.platform_packages}
 build_flags               = ${testing.build_flags}
                             ${esp8266_4M1M.build_flags}
                             -DPLUGIN_BUILD_TESTING_C
+                            -DTESTING_USE_RTTTL
 
 [env:test_D_ESP8266_4M1M]
 extends                   = esp8266_4M1M
@@ -418,6 +420,7 @@ platform_packages         = ${testing.platform_packages}
 build_flags               = ${testing.build_flags}
                             ${esp8266_4M1M.build_flags}
                             -DPLUGIN_BUILD_TESTING_D
+                            -DTESTING_USE_RTTTL
 
 
 ; TEST: 4096k version + FEATURE_ADC_VCC ----------
@@ -428,6 +431,7 @@ platform_packages         = ${testing.platform_packages}
 build_flags               = ${testing.build_flags}
                             ${esp8266_4M1M.build_flags}
                             -DFEATURE_ADC_VCC=true
+                            -DTESTING_USE_RTTTL
 
 [env:test_B_ESP8266_4M1M_VCC]
 extends                   = esp8266_4M1M
@@ -446,6 +450,7 @@ build_flags               = ${testing.build_flags}
                             ${esp8266_4M1M.build_flags}
                             -DFEATURE_ADC_VCC=true
                             -DPLUGIN_BUILD_TESTING_C
+                            -DTESTING_USE_RTTTL
 
 [env:test_D_ESP8266_4M1M_VCC]
 extends                   = esp8266_4M1M
@@ -455,6 +460,7 @@ build_flags               = ${testing.build_flags}
                             ${esp8266_4M1M.build_flags}
                             -DFEATURE_ADC_VCC=true
                             -DPLUGIN_BUILD_TESTING_D
+                            -DTESTING_USE_RTTTL
 
 [env:test_A_alt_wifi_ESP8266_4M1M_VCC]
 extends                   = esp8266_4M1M
@@ -514,6 +520,7 @@ platform_packages         = ${testing_beta.platform_packages}
 build_flags               = ${testing_beta.build_flags}
                             ${esp8266_4M1M.build_flags}
                             -DLIMIT_BUILD_SIZE
+                            -DTESTING_USE_RTTTL
 
 [env:test_B_beta_ESP8266_4M1M]
 extends                   = esp8266_4M1M
@@ -532,6 +539,7 @@ build_flags               = ${testing_beta.build_flags}
                             ${esp8266_4M1M.build_flags}
                             -DLIMIT_BUILD_SIZE
                             -DPLUGIN_BUILD_TESTING_C
+                            -DTESTING_USE_RTTTL
 
 [env:test_D_beta_ESP8266_4M1M]
 extends                   = esp8266_4M1M
@@ -541,6 +549,7 @@ build_flags               = ${testing_beta.build_flags}
                             ${esp8266_4M1M.build_flags}
                             -DLIMIT_BUILD_SIZE
                             -DPLUGIN_BUILD_TESTING_D
+                            -DTESTING_USE_RTTTL
 
 ; Test: 16M version -- LittleFS --------------
 ; LittleFS is determined by using "LittleFS" in the pio env name
@@ -571,6 +580,7 @@ build_flags               = ${testing_beta.build_flags}
                             ${esp8266_16M.build_flags} 
                             -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22y
                             -DPLUGIN_BUILD_TESTING_C
+                            -DTESTING_USE_RTTTL
 lib_ignore                = ESP32_ping, ESP32WebServer, ServoESP32, ESP32HTTPUpdateServer, IRremoteESP8266, HeatpumpIR
 
 [env:test_D_beta_ESP8266_16M_LittleFS]
@@ -581,6 +591,7 @@ build_flags               = ${testing_beta.build_flags}
                             ${esp8266_16M.build_flags} 
                             -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22y
                             -DPLUGIN_BUILD_TESTING_D
+                            -DTESTING_USE_RTTTL
 lib_ignore                = ESP32_ping, ESP32WebServer, ServoESP32, ESP32HTTPUpdateServer, IRremoteESP8266, HeatpumpIR
 
 

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -1690,6 +1690,11 @@ To create/register a plugin, you have to :
   #endif
 #endif
 
-
+// Here we can re-enable specific features in the TESTING sets as we have created some space there by splitting them up
+#if defined(TESTING_USE_RTTTL) && (defined(PLUGIN_SET_TESTING_A) || defined(PLUGIN_SET_TESTING_B) || defined(PLUGIN_SET_TESTING_C) || defined(PLUGIN_SET_TESTING_D))
+  #ifndef USE_RTTTL
+    #define USE_RTTTL
+  #endif
+#endif
 
 #endif // DEFINE_PLUGIN_SETS_H


### PR DESCRIPTION
Re-enables the `rtttl` command in the TESTING builds where it fits.
Mostly TEST_B ESP8266 builds don't fit, and also not in `alt_wifi` and `beta` versions of the Arduino libraries.

Resolves #3651 