### PR TITLE
[WebServer] Optimize serving flash strings

### DIFF
--- a/platformio_esp82xx_base.ini
+++ b/platformio_esp82xx_base.ini
@@ -53,7 +53,7 @@ board_build.f_cpu         = 80000000L
 build_flags               = ${debug_flags.build_flags} ${mqtt_flags.build_flags} -DHTTPCLIENT_1_1_COMPATIBLE=0
 build_unflags             = -DDEBUG_ESP_PORT
 lib_deps                  = https://github.com/TD-er/ESPEasySerial.git#v2.0.5, adafruit/Adafruit ILI9341 @ ^1.5.6, Adafruit GFX Library, LOLIN_EPD, Adafruit BusIO, bblanchon/ArduinoJson @ ^6.17.2, VL53L0X @ 1.3.0, SparkFun VL53L1X 4m Laser Distance Sensor @ 1.2.9, td-er/RABurton ESP8266 Mutex @ ^1.0.2, td-er/SparkFun MAX1704x Fuel Gauge Arduino Library @ ^1.0.1
-lib_ignore                = ${esp82xx_defaults.lib_ignore}, IRremoteESP8266, HeatpumpIR, SD(esp8266), SDFS, LittleFS(esp8266), ServoESP32
+lib_ignore                = ${esp82xx_defaults.lib_ignore}, IRremoteESP8266, HeatpumpIR, LittleFS(esp8266), ServoESP32
 board                     = esp12e
 monitor_filters           = esp8266_exception_decoder
 
@@ -68,20 +68,20 @@ monitor_filters           = esp8266_exception_decoder
 platform                  = ${regular_platform.platform}
 platform_packages         = ${regular_platform.platform_packages}
 build_flags               = ${regular_platform.build_flags}
-lib_ignore                = ${regular_platform.lib_ignore}
+lib_ignore                = ${regular_platform.lib_ignore} SD(esp8266), SDFS
 
 [normal_alt_wifi]
 platform                  = ${regular_platform_alt_wifi.platform}
 platform_packages         = ${regular_platform_alt_wifi.platform_packages}
 build_flags               = ${regular_platform_alt_wifi.build_flags}
-lib_ignore                = ${regular_platform_alt_wifi.lib_ignore}
+lib_ignore                = ${regular_platform_alt_wifi.lib_ignore} SD(esp8266), SDFS
 
 
 [normal_beta]
 platform                  = ${beta_platform.platform}
 platform_packages         = ${beta_platform.platform_packages}
 build_flags               = ${beta_platform.build_flags}
-lib_ignore                = ${beta_platform.lib_ignore}
+lib_ignore                = ${beta_platform.lib_ignore} SD(esp8266), SDFS
 
 
 ;;; TEST  *************************************************************

--- a/src/_C001.ino
+++ b/src/_C001.ino
@@ -152,7 +152,8 @@ bool do_process_c001_delay_queue(int controller_number, const C001_queue_element
   String request = create_http_request_auth(controller_number, element.controller_idx, ControllerSettings, F("GET"), element.txt);
 
 # ifndef BUILD_NO_DEBUG
-  addLog(LOG_LEVEL_DEBUG, element.txt);
+  if (loglevelActiveFor(LOG_LEVEL_DEBUG))
+    addLog(LOG_LEVEL_DEBUG, element.txt);
 # endif // ifndef BUILD_NO_DEBUG
   return send_via_http(controller_number, client, request, ControllerSettings.MustCheckReply);
 }

--- a/src/_C002.ino
+++ b/src/_C002.ino
@@ -185,9 +185,11 @@ bool CPlugin_002(CPlugin::Function function, struct EventStruct *event, String& 
       {
         String json = serializeDomoticzJson(event);
 # ifndef BUILD_NO_DEBUG
-        String log = F("MQTT : ");
-        log += json;
-        addLog(LOG_LEVEL_DEBUG, log);
+        if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+          String log = F("MQTT : ");
+          log += json;
+          addLog(LOG_LEVEL_DEBUG, log);
+        }
 # endif // ifndef BUILD_NO_DEBUG
 
         String pubname = CPlugin_002_pubname;

--- a/src/_C008.ino
+++ b/src/_C008.ino
@@ -99,7 +99,8 @@ bool CPlugin_008(CPlugin::Function function, struct EventStruct *event, String& 
             parseSingleControllerVariable(element.txt[x], event, x, true);
             element.txt[x].replace(F("%value%"), formattedValue);
 # ifndef BUILD_NO_DEBUG
-            addLog(LOG_LEVEL_DEBUG_MORE, element.txt[x]);
+            if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE))
+              addLog(LOG_LEVEL_DEBUG_MORE, element.txt[x]);
 # endif // ifndef BUILD_NO_DEBUG
           }
         }

--- a/src/_C008.ino
+++ b/src/_C008.ino
@@ -132,7 +132,7 @@ bool do_process_c008_delay_queue(int controller_number, const C008_queue_element
 
 bool do_process_c008_delay_queue(int controller_number, const C008_queue_element& element, ControllerSettingsStruct& ControllerSettings) {
 // *INDENT-ON*
-  while (element.txt[element.valuesSent] == "") {
+  while (element.txt[element.valuesSent].isEmpty()) {
     // A non valid value, which we are not going to send.
     // Increase sent counter until a valid value is found.
     if (element.checkDone(true)) {

--- a/src/_C010.ino
+++ b/src/_C010.ino
@@ -125,7 +125,7 @@ bool do_process_c010_delay_queue(int controller_number, const C010_queue_element
 
 bool do_process_c010_delay_queue(int controller_number, const C010_queue_element& element, ControllerSettingsStruct& ControllerSettings) {
 // *INDENT-ON*
-  while (element.txt[element.valuesSent] == "") {
+  while (element.txt[element.valuesSent].isEmpty()) {
     // A non valid value, which we are not going to send.
     // Increase sent counter until a valid value is found.
     if (element.checkDone(true)) {

--- a/src/_C010.ino
+++ b/src/_C010.ino
@@ -90,7 +90,8 @@ bool CPlugin_010(CPlugin::Function function, struct EventStruct *event, String& 
             element.txt[x] = tmppubname;
             parseSingleControllerVariable(element.txt[x], event, x, false);
             element.txt[x].replace(F("%value%"), formattedValue);
-            addLog(LOG_LEVEL_DEBUG_MORE, element.txt[x]);
+            if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE))
+              addLog(LOG_LEVEL_DEBUG_MORE, element.txt[x]);
           }
         }
       }

--- a/src/_C011.ino
+++ b/src/_C011.ino
@@ -334,19 +334,25 @@ void ReplaceTokenByValue(String& s, struct EventStruct *event, bool sendBinary)
   // write?db=testdb&type=%1%%vname1%%/1%%2%;%vname2%%/2%%3%;%vname3%%/3%%4%;%vname4%%/4%&value=%1%%val1%%/1%%2%;%val2%%/2%%3%;%val3%%/3%%4%;%val4%%/4%
   //	%1%%vname1%,Standort=%tskname% Wert=%val1%%/1%%2%%LF%%vname2%,Standort=%tskname% Wert=%val2%%/2%%3%%LF%%vname3%,Standort=%tskname%
   //  Wert=%val3%%/3%%4%%LF%%vname4%,Standort=%tskname% Wert=%val4%%/4%
-  addLog(LOG_LEVEL_DEBUG_MORE, F("HTTP before parsing: "));
-  addLog(LOG_LEVEL_DEBUG_MORE, s);
+  if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE)) {
+    addLog(LOG_LEVEL_DEBUG_MORE, F("HTTP before parsing: "));
+    addLog(LOG_LEVEL_DEBUG_MORE, s);
+  }
   const byte valueCount = getValueCountForTask(event->TaskIndex);
 
   DeleteNotNeededValues(s, valueCount);
 
-  addLog(LOG_LEVEL_DEBUG_MORE, F("HTTP after parsing: "));
-  addLog(LOG_LEVEL_DEBUG_MORE, s);
+  if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE)) {
+    addLog(LOG_LEVEL_DEBUG_MORE, F("HTTP after parsing: "));
+    addLog(LOG_LEVEL_DEBUG_MORE, s);
+  }
 
   parseControllerVariables(s, event, !sendBinary);
 
-  addLog(LOG_LEVEL_DEBUG_MORE, F("HTTP after replacements: "));
-  addLog(LOG_LEVEL_DEBUG_MORE, s);
+  if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE)) {
+    addLog(LOG_LEVEL_DEBUG_MORE, F("HTTP after replacements: "));
+    addLog(LOG_LEVEL_DEBUG_MORE, s);
+  }
 }
 
 #endif // ifdef USES_C011

--- a/src/_C012.ino
+++ b/src/_C012.ino
@@ -70,7 +70,8 @@ bool CPlugin_012(CPlugin::Function function, struct EventStruct *event, String& 
           element.txt[x] += event->idx + x;
           element.txt[x] += F("?value=");
           element.txt[x] += formattedValue;
-          addLog(LOG_LEVEL_DEBUG_MORE, element.txt[x]);
+          if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE))
+            addLog(LOG_LEVEL_DEBUG_MORE, element.txt[x]);
         }
       }
 

--- a/src/_C012.ino
+++ b/src/_C012.ino
@@ -104,7 +104,7 @@ bool do_process_c012_delay_queue(int controller_number, const C012_queue_element
 
 bool do_process_c012_delay_queue(int controller_number, const C012_queue_element& element, ControllerSettingsStruct& ControllerSettings) {
 // *INDENT-ON*
-  while (element.txt[element.valuesSent] == "") {
+  while (element.txt[element.valuesSent].isEmpty()) {
     // A non valid value, which we are not going to send.
     // Increase sent counter until a valid value is found.
     if (element.checkDone(true)) {

--- a/src/_C014.ino
+++ b/src/_C014.ino
@@ -378,7 +378,7 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
                                     break;
                           }
                           CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), ExtraTaskSettings.TaskDeviceValueNames[varNr], "/$datatype", valueName.c_str(), errorCounter);
-                          if (unitName!="") CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), ExtraTaskSettings.TaskDeviceValueNames[varNr], "/$format", unitName.c_str(), errorCounter);
+                          if (!unitName.isEmpty()) CPlugin_014_sendMQTTnode(nodename, deviceName.c_str(), ExtraTaskSettings.TaskDeviceValueNames[varNr], "/$format", unitName.c_str(), errorCounter);
                           nodeCount++;
                         }
                       }
@@ -437,7 +437,7 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
                     }
                   }
                 }
-                if (valuesList!="")
+                if (!valuesList.isEmpty())
                 {
                   // only add device to list if it has nodes!
                   // $name	Device → Controller	Friendly name of the Node	Yes	Yes
@@ -612,7 +612,7 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
                       if (Settings.TaskDevicePluginConfig[taskIndex][valueNr]==4) { // Enumeration parameter, find Number of item. PLUGIN_086_VALUE_ENUM
                         String enumList = ExtraTaskSettings.TaskDeviceFormula[taskVarIndex];
                         int i = 1;
-                        while (parseString(enumList,i)!="") { // lookup result in enum List
+                        while (!parseString(enumList,i).isEmpty()) { // lookup result in enum List
                           if (parseString(enumList,i)==event->String2) break;
                           i++;
                         }
@@ -770,7 +770,7 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
           addLog(LOG_LEVEL_DEBUG, log);
         } */
         success = false;
-        if (string!="") {
+        if (!string.isEmpty()) {
           String commandName = parseString(string, 1); // could not find a way to get the command out of the event structure.
           if (commandName == F("gpio")) //!ToDo : As gpio is like any other plugin commands should be integrated below!
           {

--- a/src/_C015.ino
+++ b/src/_C015.ino
@@ -392,7 +392,7 @@ String Command_Blynk_Set_c015(struct EventStruct *event, const char *Line) {
 
   String data = parseString(Line, 3);
 
-  if (data.length() == 0) {
+  if (data.isEmpty()) {
     String err = F("Skip sending empty data to blynk vPin ");
     err += vPin;
     return err;

--- a/src/_C015.ino
+++ b/src/_C015.ino
@@ -193,25 +193,29 @@ bool CPlugin_015(CPlugin::Function function, struct EventStruct *event, String& 
           valueFullName += valueName;
           String vPinNumberStr = valueName.substring(1, 4);
           int    vPinNumber    = vPinNumberStr.toInt();
-          String log           = F(C015_LOG_PREFIX);
-          log += Blynk.connected() ? F("(online): ") : F("(offline): ");
 
-          if ((vPinNumber > 0) && (vPinNumber < 256)) {
-            log += F("send ");
-            log += valueFullName;
-            log += F(" = ");
-            log += formattedValue;
-            log += F(" to blynk pin v");
-            log += vPinNumber;
-          }
-          else {
+          if (!(vPinNumber > 0) && (vPinNumber < 256)) {
             vPinNumber = -1;
-            log       += F("error got vPin number for ");
-            log       += valueFullName;
-            log       += F(", got not valid value: ");
-            log       += vPinNumberStr;
           }
-          addLog(LOG_LEVEL_INFO, log);
+          if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+            String log           = F(C015_LOG_PREFIX);
+            log += Blynk.connected() ? F("(online): ") : F("(offline): ");
+
+            if ((vPinNumber > 0) && (vPinNumber < 256)) {
+              log += F("send ");
+              log += valueFullName;
+              log += F(" = ");
+              log += formattedValue;
+              log += F(" to blynk pin v");
+              log += vPinNumber;
+            } else {
+              log += F("error got vPin number for ");
+              log += valueFullName;
+              log += F(", got not valid value: ");
+              log += vPinNumberStr;
+            }
+            addLog(LOG_LEVEL_INFO, log);
+          }
           element.vPin[x] = vPinNumber;
           element.txt[x]  = formattedValue;
         }
@@ -286,11 +290,15 @@ boolean Blynk_keep_connection_c015(int controllerIndex, ControllerSettingsStruct
     LoadCustomControllerSettings(controllerIndex, (byte *)&thumbprint, sizeof(thumbprint));
 
     if (strlen(thumbprint) != 59) {
-      addLog(LOG_LEVEL_INFO, C015_LOG_PREFIX "Saved thumprint value is not correct:");
-      addLog(LOG_LEVEL_INFO, thumbprint);
+      if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+        addLog(LOG_LEVEL_INFO, F(C015_LOG_PREFIX "Saved thumprint value is not correct:"));
+        addLog(LOG_LEVEL_INFO, thumbprint);
+      }
       strcpy(thumbprint, CPLUGIN_015_DEFAULT_THUMBPRINT);
-      addLog(LOG_LEVEL_INFO, C015_LOG_PREFIX "using default one:");
-      addLog(LOG_LEVEL_INFO, thumbprint);
+      if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+        addLog(LOG_LEVEL_INFO, F(C015_LOG_PREFIX "using default one:"));
+        addLog(LOG_LEVEL_INFO, thumbprint);
+      }
     }
     # endif // ifdef CPLUGIN_015_SSL
 
@@ -390,12 +398,14 @@ String Command_Blynk_Set_c015(struct EventStruct *event, const char *Line) {
     return err;
   }
 
-  String log = F(C015_LOG_PREFIX "(online): send blynk pin v");
+  if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+    String log = F(C015_LOG_PREFIX "(online): send blynk pin v");
 
-  log += vPin;
-  log += F(" = ");
-  log += data;
-  addLog(LOG_LEVEL_INFO, log);
+    log += vPin;
+    log += F(" = ");
+    log += data;
+    addLog(LOG_LEVEL_INFO, log);
+  }
 
   Blynk.virtualWrite(vPin, data);
   return return_command_success();

--- a/src/_C015.ino
+++ b/src/_C015.ino
@@ -307,7 +307,7 @@ boolean Blynk_keep_connection_c015(int controllerIndex, ControllerSettingsStruct
     if (ControllerSettings.UseDNS) {
       String hostName = ControllerSettings.getHost();
 
-      if (hostName.length() != 0) {
+      if (!hostName.isEmpty()) {
         log += F("Connecting to custom blynk server ");
         log += ControllerSettings.getHostPortString();
         Blynk.config(auth.c_str(),

--- a/src/_C018.ino
+++ b/src/_C018.ino
@@ -257,7 +257,7 @@ struct C018_data_struct {
   // Cached data, only changing occasionally.
 
   String getDevaddr() {
-    if (cacheDevAddr.length() == 0)
+    if (cacheDevAddr.isEmpty())
     {
       updateCacheOnInit();
     }
@@ -265,7 +265,7 @@ struct C018_data_struct {
   }
 
   String hweui() {
-    if (cacheHWEUI.length() == 0) {
+    if (cacheHWEUI.isEmpty()) {
       if (isInitialized()) {
         cacheHWEUI = myLora->hweui();
       }
@@ -274,7 +274,7 @@ struct C018_data_struct {
   }
 
   String sysver() {
-    if (cacheSysVer.length() == 0) {
+    if (cacheSysVer.isEmpty()) {
       if (isInitialized()) {
         cacheSysVer = myLora->sysver();
       }

--- a/src/_C018.ino
+++ b/src/_C018.ino
@@ -325,16 +325,18 @@ struct C018_data_struct {
 private:
 
   void C018_logError(const String& command) const {
-    String error = myLora->peekLastError();
+    if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+      String error = myLora->peekLastError();
 
-    //    String error = myLora->getLastError();
+      //    String error = myLora->getLastError();
 
-    if (error.length() > 0) {
-      String log = F("RN2483: ");
-      log += command;
-      log += ": ";
-      log += error;
-      addLog(LOG_LEVEL_INFO, log);
+      if (error.length() > 0) {
+        String log = F("RN2483: ");
+        log += command;
+        log += ": ";
+        log += error;
+        addLog(LOG_LEVEL_INFO, log);
+      }
     }
   }
 
@@ -869,14 +871,16 @@ bool C018_init(struct EventStruct *event) {
   }
 
   if (customConfig->joinmethod == C018_USE_OTAA) {
-    String log = F("OTAA: AppEUI: ");
-    log += AppEUI;
-    log += F(" AppKey: ");
-    log += AppKey;
-    log += F(" DevEUI: ");
-    log += customConfig->DeviceEUI;
+    if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+      String log = F("OTAA: AppEUI: ");
+      log += AppEUI;
+      log += F(" AppKey: ");
+      log += AppKey;
+      log += F(" DevEUI: ");
+      log += customConfig->DeviceEUI;
 
-    addLog(LOG_LEVEL_INFO, log);
+      addLog(LOG_LEVEL_INFO, log);
+    }
 
     if (!C018_data->initOTAA(AppEUI, AppKey, customConfig->DeviceEUI)) {
       return false;

--- a/src/_N001_Email.ino
+++ b/src/_N001_Email.ino
@@ -96,9 +96,11 @@ boolean NPlugin_001_send(const NotificationSettingsStruct& notificationsettings,
 	WiFiClient client;
 	client.setTimeout(CONTROLLER_CLIENTTIMEOUT_DFLT);
 	String aHost = notificationsettings.Server;
-	addLog(LOG_LEVEL_DEBUG, String(F("EMAIL: Connecting to ")) + aHost + notificationsettings.Port);
+	if (loglevelActiveFor(LOG_LEVEL_DEBUG))
+		addLog(LOG_LEVEL_DEBUG, String(F("EMAIL: Connecting to ")) + aHost + notificationsettings.Port);
 	if (!connectClient(client, aHost.c_str(), notificationsettings.Port, CONTROLLER_CLIENTTIMEOUT_DFLT)) {
-		addLog(LOG_LEVEL_ERROR, String(F("EMAIL: Error connecting to ")) + aHost + notificationsettings.Port);
+		if (loglevelActiveFor(LOG_LEVEL_ERROR))
+			addLog(LOG_LEVEL_ERROR, String(F("EMAIL: Error connecting to ")) + aHost + notificationsettings.Port);
 		myStatus = false;
 	}else {
 		String mailheader = F(
@@ -154,7 +156,8 @@ boolean NPlugin_001_send(const NotificationSettingsStruct& notificationsettings,
 			while (nextAddressAvailable) {
 				String mailFound = F("Email: To ");
 				mailFound += emailTo;
-				addLog(LOG_LEVEL_INFO, mailFound);
+				if (loglevelActiveFor(LOG_LEVEL_INFO))
+					addLog(LOG_LEVEL_INFO, mailFound);
 				if (!NPlugin_001_MTA(client, String(F("RCPT TO:<")) + emailTo + ">", F("250 "))) break;
 				++i;
 				nextAddressAvailable = getNextMailAddress(notificationsettings.Receiver, emailTo, i);
@@ -173,9 +176,11 @@ boolean NPlugin_001_send(const NotificationSettingsStruct& notificationsettings,
 		if (myStatus == true) {
 			addLog(LOG_LEVEL_INFO, F("EMAIL: Connection Closed Successfully"));
 		}else {
-			String log = F("EMAIL: Connection Closed With Error. Used header: ");
-			log += mailheader;
-			addLog(LOG_LEVEL_ERROR, log);
+			if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
+				String log = F("EMAIL: Connection Closed With Error. Used header: ");
+				log += mailheader;
+				addLog(LOG_LEVEL_ERROR, log);
+			}
 		}
 	}
 	return myStatus;
@@ -202,7 +207,8 @@ boolean NPlugin_001_Auth(WiFiClient& client, const String& user, const String& p
 
 boolean NPlugin_001_MTA(WiFiClient& client, const String& aStr, const String &aWaitForPattern)
 {
-	addLog(LOG_LEVEL_DEBUG, aStr);
+	if (loglevelActiveFor(LOG_LEVEL_DEBUG))
+		addLog(LOG_LEVEL_DEBUG, aStr);
 
 	if (aStr.length()) client.println(aStr);
 
@@ -211,9 +217,11 @@ boolean NPlugin_001_MTA(WiFiClient& client, const String& aStr, const String &aW
 	backgroundtasks();
 	while (true) {
 		if (timeOutReached(timer)) {
-			String log = F("NPlugin_001_MTA: timeout. ");
-			log += aStr;
-			addLog(LOG_LEVEL_ERROR, log);
+			if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
+				String log = F("NPlugin_001_MTA: timeout. ");
+				log += aStr;
+				addLog(LOG_LEVEL_ERROR, log);
+			}
 			return false;
 		}
 
@@ -223,7 +231,8 @@ boolean NPlugin_001_MTA(WiFiClient& client, const String& aStr, const String &aW
 		String line;
 		safeReadStringUntil(client, line, '\n');
 
-		addLog(LOG_LEVEL_DEBUG, line);
+        if (loglevelActiveFor(LOG_LEVEL_DEBUG))
+			addLog(LOG_LEVEL_DEBUG, line);
 
 		if (line.indexOf(aWaitForPattern) >= 0) {
 			return true;

--- a/src/_N001_Email.ino
+++ b/src/_N001_Email.ino
@@ -190,7 +190,7 @@ boolean NPlugin_001_send(const NotificationSettingsStruct& notificationsettings,
 
 boolean NPlugin_001_Auth(WiFiClient& client, const String& user, const String& pass)
 {
-	if (user.length() == 0 || pass.length() == 0) {
+	if (user.isEmpty() || pass.isEmpty()) {
 		// No user/password given.
 		return true;
 	}

--- a/src/_P003_Pulse.ino
+++ b/src/_P003_Pulse.ino
@@ -394,7 +394,7 @@ boolean Plugin_003(byte function, struct EventStruct *event, String& string)
           //       i = increase the log level for regular statstic logs to "info"
 
           String subcommand = parseString(string, 2);
-          if (subcommand == F("i") || subcommand == F("r") || subcommand == "") {
+          if (subcommand == F("i") || subcommand == F("r") || subcommand.isEmpty()) {
             doStatisticLogging(event->TaskIndex, F("P003+"), P003_PULSE_STATS_ADHOC_LOG_LEVEL);
             doTimingLogging(event->TaskIndex, F("P003+"), P003_PULSE_STATS_ADHOC_LOG_LEVEL);
             if (subcommand == F("i")) P003_StatsLogLevel[event->TaskIndex] = LOG_LEVEL_INFO;

--- a/src/_P007_PCF8591.ino
+++ b/src/_P007_PCF8591.ino
@@ -65,9 +65,11 @@ boolean Plugin_007(byte function, struct EventStruct *event, String& string)
       {
         Wire.read();                                       // Read older value first (stored in chip)
         UserVar[event->BaseVarIndex] = (float)Wire.read(); // now read actual value and store into Nodo var
-        String log = F("PCF  : Analog value: ");
-        log += formatUserVarNoCheck(event->TaskIndex, 0);
-        addLog(LOG_LEVEL_INFO, log);
+        if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+          String log = F("PCF  : Analog value: ");
+          log += formatUserVarNoCheck(event->TaskIndex, 0);
+          addLog(LOG_LEVEL_INFO, log);
+        }
         success = true;
       }
       break;

--- a/src/_P008_RFID.ino
+++ b/src/_P008_RFID.ino
@@ -144,9 +144,11 @@ boolean Plugin_008(byte function, struct EventStruct *event, String& string)
               Plugin_008_timeoutCount++;
               if (Plugin_008_timeoutCount > 5)
               {
-                String log = F("RFID : reset bits: ");
-                log += Plugin_008_bitCount;
-                addLog(LOG_LEVEL_INFO, log );
+                if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+                  String log = F("RFID : reset bits: ");
+                  log += Plugin_008_bitCount;
+                  addLog(LOG_LEVEL_INFO, log );
+                }
                 // reset after ~5 sec
                 Plugin_008_keyBuffer = 0;
                 Plugin_008_bitCount = 0;

--- a/src/_P009_MCP.ino
+++ b/src/_P009_MCP.ino
@@ -203,7 +203,11 @@ boolean Plugin_009(byte function, struct EventStruct *event, String& string)
         // read and store current state to prevent switching at boot time
         // "state" could be -1, 0 or 1
         newStatus.state                          = GPIO_MCP_Read(CONFIG_PORT);
-addLog(LOG_LEVEL_INFO,"MCP INIT="+String(newStatus.state));        
+        if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+          String log = F("MCP INIT=");
+          log += newStatus.state;
+          addLog(LOG_LEVEL_INFO,log);
+        }
         newStatus.output                         = newStatus.state;
         (newStatus.state == -1) ? newStatus.mode = PIN_MODE_OFFLINE : newStatus.mode = PIN_MODE_INPUT_PULLUP; // @giig1967g: if it is in the
                                                                                                               // device list we assume it's

--- a/src/_P010_BH1750.ino
+++ b/src/_P010_BH1750.ino
@@ -123,13 +123,15 @@ boolean Plugin_010(byte function, struct EventStruct *event, String& string)
 
       if (lux != -1) {
         UserVar[event->BaseVarIndex] = lux;
-        String log = F("BH1750 Address: 0x");
-        log += String(address, HEX);
-        log += F(" Mode: 0x");
-        log += String(mode);
-        log += F(" : Light intensity: ");
-        log += formatUserVarNoCheck(event->TaskIndex, 0);
-        addLog(LOG_LEVEL_INFO, log);
+        if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+          String log = F("BH1750 Address: 0x");
+          log += String(address, HEX);
+          log += F(" Mode: 0x");
+          log += String(mode);
+          log += F(" : Light intensity: ");
+          log += formatUserVarNoCheck(event->TaskIndex, 0);
+          addLog(LOG_LEVEL_INFO, log);
+        }
         success = true;
       }
       break;

--- a/src/_P013_HCSR04.ino
+++ b/src/_P013_HCSR04.ino
@@ -170,43 +170,48 @@ boolean Plugin_013(byte function, struct EventStruct *event, String& string)
         P_013_sensordefs[event->TaskIndex] =
           std::shared_ptr<NewPingESP8266> (new NewPingESP8266(Plugin_013_TRIG_Pin, Plugin_013_IRQ_Pin, max_distance_cm));
 
-        String log = F("ULTRASONIC : TaskNr: ");
-        log += event->TaskIndex +1;
-        log += F(" TrigPin: ");
-        log += Plugin_013_TRIG_Pin;
-        log += F(" IRQ_Pin: ");
-        log += Plugin_013_IRQ_Pin;
-        log += F(" max dist ");
-        log += (measuringUnit == UNIT_CM) ? F("[cm]: ") : F("[inch]: ");
-        log += max_distance;
-        log += F(" max echo: ");
-        log += P_013_sensordefs[event->TaskIndex]->getMaxEchoTime();
-        log += F(" Filter: ");
-        if (filterType == FILTER_NONE)
-          log += F("none");
-        else
-          if (filterType == FILTER_MEDIAN) {
-            log += F("Median size: ");
-            log += filterSize;
-          }
+        if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+          String log = F("ULTRASONIC : TaskNr: ");
+          log += event->TaskIndex +1;
+          log += F(" TrigPin: ");
+          log += Plugin_013_TRIG_Pin;
+          log += F(" IRQ_Pin: ");
+          log += Plugin_013_IRQ_Pin;
+          log += F(" max dist ");
+          log += (measuringUnit == UNIT_CM) ? F("[cm]: ") : F("[inch]: ");
+          log += max_distance;
+          log += F(" max echo: ");
+          log += P_013_sensordefs[event->TaskIndex]->getMaxEchoTime();
+          log += F(" Filter: ");
+          if (filterType == FILTER_NONE)
+            log += F("none");
           else
-            log += F("invalid!");
-        log += F(" nr_tasks: ");
-        log += P_013_sensordefs.size();
-        addLog(LOG_LEVEL_INFO, log);
+            if (filterType == FILTER_MEDIAN) {
+              log += F("Median size: ");
+              log += filterSize;
+            }
+            else
+              log += F("invalid!");
+          log += F(" nr_tasks: ");
+          log += P_013_sensordefs.size();
+          addLog(LOG_LEVEL_INFO, log);
+        }
 
-        unsigned long tmpmillis = millis();
-        unsigned long tmpmicros = micros();
-        delay(100);
-        long millispassed = timePassedSince(tmpmillis);
-        long microspassed = usecPassedSince(tmpmicros);
+        if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+          // FIXME TD-er: What kind of nonsense code is this?
+          unsigned long tmpmillis = millis();
+          unsigned long tmpmicros = micros();
+          delay(100);
+          long millispassed = timePassedSince(tmpmillis);
+          long microspassed = usecPassedSince(tmpmicros);
 
-        log = F("ULTRASONIC : micros() test: ");
-        log += millispassed;
-        log += F(" msec, ");
-        log += microspassed;
-        log += F(" usec, ");
-        addLog(LOG_LEVEL_INFO, log);
+          String log = F("ULTRASONIC : micros() test: ");
+          log += millispassed;
+          log += F(" msec, ");
+          log += microspassed;
+          log += F(" usec, ");
+          addLog(LOG_LEVEL_INFO, log);
+        }
 
         success = true;
         break;
@@ -262,11 +267,13 @@ boolean Plugin_013(byte function, struct EventStruct *event, String& string)
               state = 1;
             if (state != switchstate[event->TaskIndex])
             {
-              String log = F("ULTRASONIC : TaskNr: ");
-              log += event->TaskIndex +1;
-              log += F(" state: ");
-              log += state;
-              addLog(LOG_LEVEL_INFO,log);
+              if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+                String log = F("ULTRASONIC : TaskNr: ");
+                log += event->TaskIndex +1;
+                log += F(" state: ");
+                log += state;
+                addLog(LOG_LEVEL_INFO,log);
+              }
               switchstate[event->TaskIndex] = state;
               UserVar[event->BaseVarIndex] = state;
               event->sensorType = Sensor_VType::SENSOR_TYPE_SWITCH;
@@ -314,7 +321,7 @@ float Plugin_013_read(taskIndex_t taskIndex)
       echoTime = (P_013_sensordefs[taskIndex])->ping_median(filterSize, max_distance_cm);
       break;
     default:
-      addLog(LOG_LEVEL_INFO, F("invalid Filter Type setting!"));
+      addLog(LOG_LEVEL_ERROR, F("invalid Filter Type setting!"));
   }
 
   if (measuringUnit == UNIT_CM)

--- a/src/_P014_SI7021.ino
+++ b/src/_P014_SI7021.ino
@@ -152,7 +152,7 @@ struct P014_data_struct : public PluginTaskData_base {
       {
         // Still waiting for data
         // Should be handled in the loop()
-        addLog(LOG_LEVEL_INFO, F("SI7021 : Read Error !"));
+        addLog(LOG_LEVEL_ERROR, F("SI7021 : Read Error !"));
         break;
       }
 
@@ -287,7 +287,7 @@ struct P014_data_struct : public PluginTaskData_base {
 
     // Check CRC of data received
     if (checkCRC(raw, checksum) != 0) {
-      addLog(LOG_LEVEL_INFO, F("SI7021 : checksum error!"));
+      addLog(LOG_LEVEL_ERROR, F("SI7021 : checksum error!"));
       return -1;
     }
 

--- a/src/_P016_IR.ino
+++ b/src/_P016_IR.ino
@@ -481,7 +481,7 @@ boolean Plugin_016(byte function, struct EventStruct *event, String &string)
       state.clock = -1;
 
       String description = IRAcUtils::resultAcToString(&results);
-      if (description != "") {
+      if (!description.isEmpty()) {
         if (loglevelActiveFor(LOG_LEVEL_INFO)) {
           // If we got a human-readable description of the message, display it.
           String log;

--- a/src/_P016_IR.ino
+++ b/src/_P016_IR.ino
@@ -172,8 +172,10 @@ boolean Plugin_016(byte function, struct EventStruct *event, String &string)
     if (irReceiver == 0 && irPin != -1)
     {
 
-      addLog(LOG_LEVEL_INFO, F("INIT: IR RX"));
-      addLog(LOG_LEVEL_INFO, String(F("IR lib Version: ")) + _IRREMOTEESP8266_VERSION_);
+      if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+        addLog(LOG_LEVEL_INFO, F("INIT: IR RX"));
+        addLog(LOG_LEVEL_INFO, F("IR lib Version: " _IRREMOTEESP8266_VERSION_));
+      }
       irReceiver = new IRrecv(irPin, kCaptureBufferSize, P016_TIMEOUT, true);
       irReceiver->setUnknownThreshold(kMinUnknownSize); // Ignore messages with less than minimum on or off pulses.
       irReceiver->enableIRIn();                         // Start the receiver
@@ -405,10 +407,14 @@ boolean Plugin_016(byte function, struct EventStruct *event, String &string)
         output += F("\",\"bits\":");
         output += uint64ToString(results.bits);
         output += '}';
-        String Log = F("IRSEND,\'");
-        Log += output;
-        Log += "\'";
-        addLog(LOG_LEVEL_INFO, Log); //JSON representation of the command
+        if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+          String Log;
+          Log.reserve(10 + output.length());
+          Log = F("IRSEND,\'");
+          Log += output;
+          Log += '\'';
+          addLog(LOG_LEVEL_INFO, Log); //JSON representation of the command
+        }
         event->String2 = output;
 
         // Check if this is a code we have a command for or we have to add
@@ -475,8 +481,16 @@ boolean Plugin_016(byte function, struct EventStruct *event, String &string)
       state.clock = -1;
 
       String description = IRAcUtils::resultAcToString(&results);
-      if (description != "")
-        addLog(LOG_LEVEL_INFO, String(F("AC State: ")) + description); // If we got a human-readable description of the message, display it.
+      if (description != "") {
+        if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+          // If we got a human-readable description of the message, display it.
+          String log;
+          log.reserve(10 + description.length());
+          log = F("AC State: ");
+          log += description;
+          addLog(LOG_LEVEL_INFO, log); 
+        }
+      }
       if (IRac::isProtocolSupported(results.decode_type))              //Check If there is a replayable AC state and show the JSON command that can be send
       {
         IRAcUtils::decodeToState(&results, &state);
@@ -517,7 +531,15 @@ boolean Plugin_016(byte function, struct EventStruct *event, String &string)
         output="";
         serializeJson(doc, output);
         event->String2 = output;
-        addLog(LOG_LEVEL_INFO, String(F("IRSENDAC,'")) + output+ '\''); //Show the command that the user can put to replay the AC state with P035
+        if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+          //Show the command that the user can put to replay the AC state with P035
+          String log;
+          log.reserve(12 + output.length());
+          log = F("IRSENDAC,'");
+          log += output;
+          log += '\'';
+          addLog(LOG_LEVEL_INFO, log); 
+        }
       }
 #endif // P016_P035_Extended_AC
     if (P016_SEND_IR_TO_CONTROLLER)  sendData(event);
@@ -674,14 +696,15 @@ boolean displayRawToReadableB32Hex(String &outputStr, decode_results results)
     iOut = storeB32Hex(out, iOut, tmOut[d++]);
 
   out[iOut] = 0;
-  String line = F("IRSEND,RAW2,");
-  line += out;
-  line += F(",38,");
-  line += uint64ToString(div[0], 10);
-  line += ',';
-  line += uint64ToString(div[1], 10);
-  addLog(LOG_LEVEL_INFO, line);
-  outputStr = line;
+  
+  outputStr.reserve(32 + iOut);
+  outputStr = F("IRSEND,RAW2,");
+  outputStr += out;
+  outputStr += F(",38,");
+  outputStr += uint64ToString(div[0], 10);
+  outputStr += ',';
+  outputStr += uint64ToString(div[1], 10);
+  addLog(LOG_LEVEL_INFO, outputStr);
   return true;
 }
 

--- a/src/_P017_PN532.ino
+++ b/src/_P017_PN532.ino
@@ -158,9 +158,11 @@ boolean Plugin_017(byte function, struct EventStruct *event, String& string)
         if (error == 1)
         {
           errorCount++;
-          String log = F("PN532: Read error: ");
-          log += errorCount;
-          addLog(LOG_LEVEL_ERROR, log);
+          if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
+            String log = F("PN532: Read error: ");
+            log += errorCount;
+            addLog(LOG_LEVEL_ERROR, log);
+          }
         }
         else {
           errorCount = 0;
@@ -221,9 +223,11 @@ boolean Plugin_017_Init(int8_t resetPin)
 {
   if (resetPin != -1)
   {
-    String log = F("PN532: Reset on pin: ");
-    log += resetPin;
-    addLog(LOG_LEVEL_INFO, log);
+    if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+      String log = F("PN532: Reset on pin: ");
+      log += resetPin;
+      addLog(LOG_LEVEL_INFO, log);
+    }
     pinMode(resetPin, OUTPUT);
     digitalWrite(resetPin, LOW);
     delay(100);
@@ -239,13 +243,15 @@ boolean Plugin_017_Init(int8_t resetPin)
   uint32_t versiondata = getFirmwareVersion();
 
   if (versiondata) {
-    String log = F("PN532: Found chip PN5");
-    log += String((versiondata >> 24) & 0xFF, HEX);
-    log += F(" FW: ");
-    log += String((versiondata >> 16) & 0xFF, HEX);
-    log += '.';
-    log += String((versiondata >> 8) & 0xFF, HEX);
-    addLog(LOG_LEVEL_INFO, log);
+    if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+      String log = F("PN532: Found chip PN5");
+      log += String((versiondata >> 24) & 0xFF, HEX);
+      log += F(" FW: ");
+      log += String((versiondata >> 16) & 0xFF, HEX);
+      log += '.';
+      log += String((versiondata >> 8) & 0xFF, HEX);
+      addLog(LOG_LEVEL_INFO, log);
+    }
   }
   else {
     return false;

--- a/src/_P018_Dust.ino
+++ b/src/_P018_Dust.ino
@@ -84,9 +84,11 @@ boolean Plugin_018(byte function, struct EventStruct *event, String& string)
         }
         interrupts();
         UserVar[event->BaseVarIndex] = (float)value;
-        String log = F("GPY  : Dust value: ");
-        log += value;
-        addLog(LOG_LEVEL_INFO, log);
+        if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+          String log = F("GPY  : Dust value: ");
+          log += value;
+          addLog(LOG_LEVEL_INFO, log);
+        }
         success = true;
         break;
       }

--- a/src/_P021_Level.ino
+++ b/src/_P021_Level.ino
@@ -133,9 +133,11 @@ boolean Plugin_021(byte function, struct EventStruct *event, String& string)
           state = 0;
         if (state != switchstate[event->TaskIndex])
         {
-          String log = F("LEVEL: State ");
-          log += state;
-          addLog(LOG_LEVEL_INFO, log);
+          if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+            String log = F("LEVEL: State ");
+            log += state;
+            addLog(LOG_LEVEL_INFO, log);
+          }
           switchstate[event->TaskIndex] = state;
           digitalWrite(CONFIG_PIN1,state);
           UserVar[event->BaseVarIndex] = state;

--- a/src/_P022_PCA9685.ino
+++ b/src/_P022_PCA9685.ino
@@ -208,6 +208,8 @@ boolean Plugin_022(byte function, struct EventStruct *event, String& string)
       if ((command == F("pcapwm")) || (instanceCommand && (command == F("pwm"))))
       {
         success = true;
+
+        // "log" is also sent along with the SendStatusOnlyIfNeeded
         log     = F("PCA 0x");
         log    += String(address, HEX);
         log    += F(": PWM ");
@@ -236,17 +238,23 @@ boolean Plugin_022(byte function, struct EventStruct *event, String& string)
             newStatus.state   = event->Par2;
             savePortStatus(key, newStatus);
 
-            addLog(LOG_LEVEL_INFO, log);
+            if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+              addLog(LOG_LEVEL_INFO, log);
+            }
 
             // SendStatus(event, getPinStateJSON(SEARCH_PIN_STATE, PLUGIN_ID_022, event->Par1, log, 0));
             SendStatusOnlyIfNeeded(event, SEARCH_PIN_STATE, key, log, 0);
           }
           else {
-            addLog(LOG_LEVEL_ERROR, log + F(" the pwm value ") + String(event->Par2) + F(" is invalid value."));
+            if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
+              addLog(LOG_LEVEL_ERROR, log + F(" the pwm value ") + String(event->Par2) + F(" is invalid value."));
+            }
           }
         }
         else {
-          addLog(LOG_LEVEL_ERROR, log + F(" is invalid value."));
+          if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
+            addLog(LOG_LEVEL_ERROR, log + F(" is invalid value."));
+          }
         }
       }
 

--- a/src/_P025_ADS1115.ino
+++ b/src/_P025_ADS1115.ino
@@ -165,9 +165,13 @@ boolean Plugin_025(byte function, struct EventStruct *event, String& string)
 
       if (nullptr != P025_data) {
         const int16_t value = P025_data->read();
-        String log          = F("ADS1115 : Analog value: ");
         UserVar[event->BaseVarIndex] = (float)value;
-        log                         += value;
+
+        String log;
+        if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+          log  = F("ADS1115 : Analog value: ");
+          log += value;
+        }
 
         if (PCONFIG(3)) // Calibration?
         {
@@ -180,15 +184,18 @@ boolean Plugin_025(byte function, struct EventStruct *event, String& string)
           {
             float normalized = (float)(value - adc1) / (float)(adc2 - adc1);
             UserVar[event->BaseVarIndex] = normalized * (out2 - out1) + out1;
-
-            log += ' ';
-            log += formatUserVarNoCheck(event->TaskIndex, 0);
+            if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+              log += ' ';
+              log += formatUserVarNoCheck(event->TaskIndex, 0);
+            }
           }
         }
 
         // TEST log += F(" @0x");
         // TEST log += String(config, 16);
-        addLog(LOG_LEVEL_DEBUG, log);
+        if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+          addLog(LOG_LEVEL_DEBUG, log);
+        }
         success = true;
       }
       break;

--- a/src/_P026_Sysinfo.ino
+++ b/src/_P026_Sysinfo.ino
@@ -162,7 +162,9 @@ boolean Plugin_026(byte function, struct EventStruct *event, String& string)
       }
 
       if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-        String log = F("SYS  : ");
+        String log;
+        log.reserve(7 * (P026_NR_OUTPUT_VALUES + 1));
+        log = F("SYS  : ");
 
         for (int i = 0; i < P026_NR_OUTPUT_VALUES; ++i) {
           if (i != 0) {

--- a/src/_P027_INA219.ino
+++ b/src/_P027_INA219.ino
@@ -102,32 +102,40 @@ boolean Plugin_027(byte function, struct EventStruct *event, String& string)
         static_cast<P027_data_struct *>(getPluginTaskData(event->TaskIndex));
 
       if (nullptr != P027_data) {
-        String log = F("INA219 0x");
-        log += String(i2caddr, HEX);
-        log += F(" setting Range to: ");
+        const bool mustLog = loglevelActiveFor(LOG_LEVEL_INFO);
+        String log;
+        if (mustLog) {
+          log = F("INA219 0x");
+          log += String(i2caddr, HEX);
+          log += F(" setting Range to: ");
+        }
 
         switch (PCONFIG(0))
         {
           case 0:
           {
-            log += F("32V, 2A");
+            if (mustLog)
+              log += F("32V, 2A");
             P027_data->setCalibration_32V_2A();
             break;
           }
           case 1:
           {
-            log += F("32V, 1A");
+            if (mustLog)
+              log += F("32V, 1A");
             P027_data->setCalibration_32V_1A();
             break;
           }
           case 2:
           {
-            log += F("16V, 400mA");
+            if (mustLog)
+              log += F("16V, 400mA");
             P027_data->setCalibration_16V_400mA();
             break;
           }
         }
-        addLog(LOG_LEVEL_INFO, log);
+        if (mustLog)
+          addLog(LOG_LEVEL_INFO, log);
         success = true;
       }
       break;
@@ -151,8 +159,12 @@ boolean Plugin_027(byte function, struct EventStruct *event, String& string)
         UserVar[event->BaseVarIndex + 1] = current;
         UserVar[event->BaseVarIndex + 2] = power;
 
-        String log = F("INA219 0x");
-        log += String(P027_I2C_ADDR, HEX);
+        const bool mustLog = loglevelActiveFor(LOG_LEVEL_INFO);
+        String log;
+        if (mustLog) {
+          log = F("INA219 0x");
+          log += String(P027_I2C_ADDR, HEX);
+        }
 
         // for backward compability we allow the user to select if only one measurement should be returned
         // or all 3 measurement at once
@@ -162,24 +174,30 @@ boolean Plugin_027(byte function, struct EventStruct *event, String& string)
           {
             event->sensorType            = Sensor_VType::SENSOR_TYPE_SINGLE;
             UserVar[event->BaseVarIndex] = voltage;
-            log                         += F(": Voltage: ");
-            log                         += voltage;
+            if (mustLog) {
+              log                         += F(": Voltage: ");
+              log                         += voltage;
+            }
             break;
           }
           case 1:
           {
             event->sensorType            = Sensor_VType::SENSOR_TYPE_SINGLE;
             UserVar[event->BaseVarIndex] = current;
-            log                         += F(" Current: ");
-            log                         += current;
+            if (mustLog) {
+              log                         += F(" Current: ");
+              log                         += current;
+            }
             break;
           }
           case 2:
           {
             event->sensorType            = Sensor_VType::SENSOR_TYPE_SINGLE;
             UserVar[event->BaseVarIndex] = power;
-            log                         += F(" Power: ");
-            log                         += power;
+            if (mustLog) {
+              log                         += F(" Power: ");
+              log                         += power;
+            }
             break;
           }
           case 3:
@@ -188,17 +206,19 @@ boolean Plugin_027(byte function, struct EventStruct *event, String& string)
             UserVar[event->BaseVarIndex]     = voltage;
             UserVar[event->BaseVarIndex + 1] = current;
             UserVar[event->BaseVarIndex + 2] = power;
-            log                             += F(": Voltage: ");
-            log                             += voltage;
-            log                             += F(" Current: ");
-            log                             += current;
-            log                             += F(" Power: ");
-            log                             += power;
+            if (mustLog) {
+              log                             += F(": Voltage: ");
+              log                             += voltage;
+              log                             += F(" Current: ");
+              log                             += current;
+              log                             += F(" Power: ");
+              log                             += power;
+            }
             break;
           }
         }
-
-        addLog(LOG_LEVEL_INFO, log);
+        if (mustLog)
+          addLog(LOG_LEVEL_INFO, log);
         success = true;
       }
       break;

--- a/src/_P031_SHT1X.ino
+++ b/src/_P031_SHT1X.ino
@@ -368,15 +368,17 @@ boolean Plugin_031(byte function, struct EventStruct *event, String& string)
             P031_data->startMeasurement();
           } else if (P031_data->hasError()) {
             // Log error
-            switch (P031_data->state) {
-              case P031_COMMAND_NO_ACK:
-                addLog(LOG_LEVEL_ERROR, F("SHT1X : Sensor did not ACK command"));
-                break;
-              case P031_NO_DATA:
-                addLog(LOG_LEVEL_ERROR, F("SHT1X : Data not ready"));
-                break;
-              default:
-                break;
+            if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
+              switch (P031_data->state) {
+                case P031_COMMAND_NO_ACK:
+                  addLog(LOG_LEVEL_ERROR, F("SHT1X : Sensor did not ACK command"));
+                  break;
+                case P031_NO_DATA:
+                  addLog(LOG_LEVEL_ERROR, F("SHT1X : Data not ready"));
+                  break;
+                default:
+                  break;
+              }
             }
             P031_data->state = P031_IDLE;
           }

--- a/src/_P035_IRTX.ino
+++ b/src/_P035_IRTX.ino
@@ -270,7 +270,7 @@ bool handle_AC_IRremote(const String &irData) {
 bool handleRawRaw2Encoding(const String &cmd) {
   bool raw=true;
   String IrType = parseString(cmd, 2);
-  if (IrType.length() == 0) return false;
+  if (IrType.isEmpty()) return false;
 
   if (IrType.equalsIgnoreCase(F("RAW"))) raw = true;
   else if (IrType.equalsIgnoreCase(F("RAW2")))  raw = false;

--- a/src/_P035_IRTX.ino
+++ b/src/_P035_IRTX.ino
@@ -101,9 +101,11 @@ boolean Plugin_035(byte function, struct EventStruct *event, String &command)
         int irPin = CONFIG_PIN1;
         if (Plugin_035_irSender == 0 && irPin != -1)
         {
-          addLog(LOG_LEVEL_INFO, F("INIT: IR TX"));
-          addLog(LOG_LEVEL_INFO, String(F("IR lib Version: ")) + _IRREMOTEESP8266_VERSION_);
-          addLog(LOG_LEVEL_INFO, String(F("Supported Protocols by IRSEND: ")) + listProtocols());
+          if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+            addLog(LOG_LEVEL_INFO, F("INIT: IR TX"));
+            addLog(LOG_LEVEL_INFO, F("IR lib Version: " _IRREMOTEESP8266_VERSION_));
+            addLog(LOG_LEVEL_INFO, String(F("Supported Protocols by IRSEND: ")) + listProtocols());
+          }
           Plugin_035_irSender = new IRsend(irPin);
           Plugin_035_irSender->begin(); // Start the sender
         }
@@ -117,8 +119,10 @@ boolean Plugin_035(byte function, struct EventStruct *event, String &command)
 #ifdef P016_P035_Extended_AC
         if (Plugin_035_commonAc == nullptr && irPin != -1)
         {
-          addLog(LOG_LEVEL_INFO, F("INIT AC: IR TX"));
-          addLog(LOG_LEVEL_INFO, String(F("Supported Protocols by IRSENDAC: ")) + listACProtocols());
+          if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+            addLog(LOG_LEVEL_INFO, F("INIT AC: IR TX"));
+            addLog(LOG_LEVEL_INFO, String(F("Supported Protocols by IRSENDAC: ")) + listACProtocols());
+          }
           Plugin_035_commonAc = new (std::nothrow) IRac(irPin);
         }
         if (Plugin_035_commonAc != nullptr && irPin == -1)
@@ -209,14 +213,16 @@ bool handle_AC_IRremote(const String &irData) {
   DeserializationError error = deserializeJson(doc, irData);         // Deserialize the JSON document
   if (error)         // Test if parsing succeeds.
   {
-    addLog(LOG_LEVEL_INFO, String(F("IRTX: Deserialize Json failed: ")) + error.c_str());
+    if (loglevelActiveFor(LOG_LEVEL_INFO))
+      addLog(LOG_LEVEL_INFO, String(F("IRTX: Deserialize Json failed: ")) + error.c_str());
     return false; //do not continue with sending the signal.
   }
   String sprotocol = doc[F("protocol")];
   st.protocol = strToDecodeType(sprotocol.c_str());
   if (!IRac::isProtocolSupported(st.protocol)) //Check if we support the protocol
   {
-    addLog(LOG_LEVEL_INFO, String(F("IRTX: Protocol not supported:")) + sprotocol);
+    if (loglevelActiveFor(LOG_LEVEL_INFO))
+      addLog(LOG_LEVEL_INFO, String(F("IRTX: Protocol not supported:")) + sprotocol);
     return false; //do not continue with sending of the signal.
   }
 

--- a/src/_P037_MQTTImport.ino
+++ b/src/_P037_MQTTImport.ino
@@ -154,7 +154,7 @@ boolean Plugin_037(byte function, struct EventStruct *event, String& string)
         {
           String subscriptionTopic = deviceTemplate[x];
           subscriptionTopic.trim();
-          if (subscriptionTopic.length() == 0) continue;							// skip blank subscriptions
+          if (subscriptionTopic.isEmpty()) continue;							// skip blank subscriptions
 
           // Now check if the incoming topic matches one of our subscriptions
           parseSystemVariables(subscriptionTopic, false);
@@ -261,7 +261,7 @@ bool MQTTSubscribe_037(struct EventStruct *event)
 // Check to see if Topic matches the MQTT subscription
 //
 bool MQTTCheckSubscription_037(const String& Topic, const String& Subscription) {
-  if (Topic.length() == 0 || Subscription.length() == 0)  {
+  if (Topic.isEmpty() || Subscription.isEmpty())  {
     return false;
   }
 

--- a/src/_P037_MQTTImport.ino
+++ b/src/_P037_MQTTImport.ino
@@ -163,14 +163,18 @@ boolean Plugin_037(byte function, struct EventStruct *event, String& string)
             // FIXME TD-er: It may be useful to generate events with string values.
             float floatPayload;
             if (!string2float(event->String2, floatPayload)) {
-              String log = F("IMPT : Bad Import MQTT Command ");
-              log += event->String1;
-              addLog(LOG_LEVEL_ERROR, log);
-              log = F("ERR  : Illegal Payload ");
-              log += event->String2;
-              log += ' ';
-              log += getTaskDeviceName(event->TaskIndex);
-              addLog(LOG_LEVEL_INFO, log);
+              if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
+                String log = F("IMPT : Bad Import MQTT Command ");
+                log += event->String1;
+                addLog(LOG_LEVEL_ERROR, log);
+              }
+              if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+                String log = F("ERR  : Illegal Payload ");
+                log += event->String2;
+                log += ' ';
+                log += getTaskDeviceName(event->TaskIndex);
+                addLog(LOG_LEVEL_INFO, log);
+              }
               success = false;
               break;
             }
@@ -245,8 +249,8 @@ bool MQTTSubscribe_037(struct EventStruct *event)
           String log = F("IMPT : Error subscribing to ");
           log += subscribeTo;
           addLog(LOG_LEVEL_ERROR, log);
-          return false;
         }
+        return false;
       }
     }
   }

--- a/src/_P042_Candle.ino
+++ b/src/_P042_Candle.ino
@@ -196,7 +196,7 @@ boolean Plugin_042(byte function, struct EventStruct *event, String& string)
         // http://jscolor.com/examples/
         addHtml(F("<TR><TD>Color:<TD><input class=\"jscolor {onFineChange:'update(this)'}\" value='"));
         addHtml(hexvalue);
-        addHtml("'>");
+        addHtml(F("'>"));
         addFormNumericBox(F("RGB Color"), F("web_RGB_Red"), PCONFIG(0), 0, 255);
         addNumericBox(F("web_RGB_Green"), PCONFIG(1), 0, 255);
         addNumericBox(F("web_RGB_Blue"), PCONFIG(2), 0, 255);

--- a/src/_P042_Candle.ino
+++ b/src/_P042_Candle.ino
@@ -409,7 +409,7 @@ boolean Plugin_042(byte function, struct EventStruct *event, String& string)
           String val_Color = tmpString.substring(idx2+1, idx3);
           String val_Bright = tmpString.substring(idx3+1, idx4);
 
-          if (val_Type != "") {
+          if (!val_Type.isEmpty()) {
              if (val_Type.toInt() > -1 && val_Type.toInt() < 8) {
                 PCONFIG(4) = val_Type.toInt();     // Type
                 Candle_type = (SimType)PCONFIG(4);
@@ -423,7 +423,7 @@ boolean Plugin_042(byte function, struct EventStruct *event, String& string)
              }
           }
 
-          if (val_Bright != "") {
+          if (!val_Bright.isEmpty()) {
              if (val_Bright.toInt() > -1 && val_Bright.toInt() < 256) {
                 PCONFIG(3) = val_Bright.toInt();     // Brightness
                 Candle_bright = PCONFIG(3);
@@ -437,7 +437,7 @@ boolean Plugin_042(byte function, struct EventStruct *event, String& string)
              }
           }
 
-          if (val_Color != "") {
+          if (!val_Color.isEmpty()) {
             long number = strtol( &val_Color[0], NULL, 16);
             // Split RGB to r, g, b values
             byte r = number >> 16;

--- a/src/_P042_Candle.ino
+++ b/src/_P042_Candle.ino
@@ -277,9 +277,14 @@ boolean Plugin_042(byte function, struct EventStruct *event, String& string)
           SetPixelsBlack();
           Candle_pixels->setBrightness(Candle_bright);
           Candle_pixels->begin();
-          String log = F("CAND : Init WS2812 Pin : ");
-          log += CONFIG_PIN1;
-          addLog(LOG_LEVEL_DEBUG, log);
+
+          #ifndef BUILD_NO_DEBUG
+          if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+            String log = F("CAND : Init WS2812 Pin : ");
+            log += CONFIG_PIN1;
+            addLog(LOG_LEVEL_DEBUG, log);
+          }
+          #endif
         }
 
         success = true;
@@ -408,9 +413,13 @@ boolean Plugin_042(byte function, struct EventStruct *event, String& string)
              if (val_Type.toInt() > -1 && val_Type.toInt() < 8) {
                 PCONFIG(4) = val_Type.toInt();     // Type
                 Candle_type = (SimType)PCONFIG(4);
-                String log = F("CAND : CMD - Type : ");
-                log += val_Type;
-                addLog(LOG_LEVEL_DEBUG, log);
+                #ifndef BUILD_NO_DEBUG
+                if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+                  String log = F("CAND : CMD - Type : ");
+                  log += val_Type;
+                  addLog(LOG_LEVEL_DEBUG, log);
+                }
+                #endif
              }
           }
 
@@ -418,9 +427,13 @@ boolean Plugin_042(byte function, struct EventStruct *event, String& string)
              if (val_Bright.toInt() > -1 && val_Bright.toInt() < 256) {
                 PCONFIG(3) = val_Bright.toInt();     // Brightness
                 Candle_bright = PCONFIG(3);
-                String log = F("CAND : CMD - Bright : ");
-                log += val_Bright;
-                addLog(LOG_LEVEL_DEBUG, log);
+                #ifndef BUILD_NO_DEBUG
+                if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+                  String log = F("CAND : CMD - Bright : ");
+                  log += val_Bright;
+                  addLog(LOG_LEVEL_DEBUG, log);
+                }
+                #endif
              }
           }
 
@@ -440,17 +453,23 @@ boolean Plugin_042(byte function, struct EventStruct *event, String& string)
             PCONFIG(5) = 1;
             Candle_color = (ColorType)PCONFIG(5);   // ColorType (ColorSelected)
 
-            String log = F("CAND : CMD - R ");
-            log += r;
-            log += F(" G ");
-            log += g;
-            log += F(" B ");
-            log += b;
-            addLog(LOG_LEVEL_DEBUG, log);
+            #ifndef BUILD_NO_DEBUG
+            if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+              String log = F("CAND : CMD - R ");
+              log += r;
+              log += F(" G ");
+              log += g;
+              log += F(" B ");
+              log += b;
+              addLog(LOG_LEVEL_DEBUG, log);
+            }
+            #endif
           } else {
             PCONFIG(5) = 0;
             Candle_color = (ColorType)PCONFIG(5);   // ColorType (ColorDefault)
+            #ifndef BUILD_NO_DEBUG
             addLog(LOG_LEVEL_DEBUG, F("CAND : CMD - Color : DEFAULT"));
+            #endif
           }
 
           //SaveTaskSettings(event->TaskIndex);

--- a/src/_P043_ClkOutput.ino
+++ b/src/_P043_ClkOutput.ino
@@ -69,7 +69,7 @@ boolean Plugin_043(byte function, struct EventStruct *event, String& string)
 //          addHtml(timeLong2String(ExtraTaskSettings.TaskDevicePluginConfigLong[x]));
 //          addHtml("'>");
 
-          addHtml(" ");
+          addHtml(' ');
           byte choice = ExtraTaskSettings.TaskDevicePluginConfig[x];
           addSelector(String(F("p043_state")) + (x), 3, options, NULL, NULL, choice);
         }

--- a/src/_P043_ClkOutput.ino
+++ b/src/_P043_ClkOutput.ino
@@ -118,9 +118,11 @@ boolean Plugin_043(byte function, struct EventStruct *event, String& string)
               pinMode(CONFIG_PIN1, OUTPUT);
               digitalWrite(CONFIG_PIN1, state);
               UserVar[event->BaseVarIndex] = state;
-              String log = F("TCLK : State ");
-              log += state;
-              addLog(LOG_LEVEL_INFO, log);
+              if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+                String log = F("TCLK : State ");
+                log += state;
+                addLog(LOG_LEVEL_INFO, log);
+              }
               sendData(event);
             }
           }

--- a/src/_P044_P1WifiGateway.ino
+++ b/src/_P044_P1WifiGateway.ino
@@ -127,10 +127,14 @@ boolean Plugin_044(byte function, struct EventStruct *event, String& string)
 
         task->blinkLED();
         if (P044_BAUDRATE == 115200) {
+          #ifndef BUILD_NO_DEBUG
           addLog(LOG_LEVEL_DEBUG, F("P1   : DSMR version 4 meter, CRC on"));
+          #endif
           task->CRCcheck = true;
         } else {
+          #ifndef BUILD_NO_DEBUG
           addLog(LOG_LEVEL_DEBUG, F("P1   : DSMR version 4 meter, CRC off"));
+          #endif
           task->CRCcheck = false;
         }
 

--- a/src/_P047_i2c-soil-moisture-sensor.ino
+++ b/src/_P047_i2c-soil-moisture-sensor.ino
@@ -127,7 +127,9 @@ boolean Plugin_047(byte function, struct EventStruct *event, String& string)
         // wake sensor
         Plugin_047_getVersion(P047_I2C_ADDR);
         delayBackground(20);
+        #ifndef BUILD_NO_DEBUG
         addLog(LOG_LEVEL_DEBUG, F("SoilMoisture->wake"));
+        #endif
       }
 
       uint8_t sensorVersion = 0;
@@ -149,8 +151,10 @@ boolean Plugin_047(byte function, struct EventStruct *event, String& string)
 
       // check if we want to change the sensor address
       if (P047_CHANGE_ADDR) {
-        addLog(LOG_LEVEL_INFO, String(F("SoilMoisture: Change Address: 0x")) + String(P047_I2C_ADDR, HEX) + String(F("->0x")) +
+        if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+          addLog(LOG_LEVEL_INFO, String(F("SoilMoisture: Change Address: 0x")) + String(P047_I2C_ADDR, HEX) + String(F("->0x")) +
                String(P047_NEW_ADDR, HEX));
+        }
 
         if (Plugin_047_setAddress(P047_I2C_ADDR, P047_NEW_ADDR)) {
           P047_I2C_ADDR = P047_NEW_ADDR;
@@ -179,28 +183,32 @@ boolean Plugin_047(byte function, struct EventStruct *event, String& string)
         UserVar[event->BaseVarIndex + 1] = moisture;
         UserVar[event->BaseVarIndex + 2] = light;
 
-        String log = F("SoilMoisture: Address: 0x");
-        log += String(P047_I2C_ADDR, HEX);
+        if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+          String log = F("SoilMoisture: Address: 0x");
+          log += String(P047_I2C_ADDR, HEX);
 
-        if (P047_CHECK_VERSION) {
-          log += F(" Version: 0x");
-          log += String(sensorVersion, HEX);
+          if (P047_CHECK_VERSION) {
+            log += F(" Version: 0x");
+            log += String(sensorVersion, HEX);
+          }
+          addLog(LOG_LEVEL_INFO, log);
+          log  = F("SoilMoisture: Temperature: ");
+          log += temperature;
+          addLog(LOG_LEVEL_INFO, log);
+          log  = F("SoilMoisture: Moisture: ");
+          log += moisture;
+          addLog(LOG_LEVEL_INFO, log);
+          log  = F("SoilMoisture: Light: ");
+          log += light;
+          addLog(LOG_LEVEL_INFO, log);
         }
-        addLog(LOG_LEVEL_INFO, log);
-        log  = F("SoilMoisture: Temperature: ");
-        log += temperature;
-        addLog(LOG_LEVEL_INFO, log);
-        log  = F("SoilMoisture: Moisture: ");
-        log += moisture;
-        addLog(LOG_LEVEL_INFO, log);
-        log  = F("SoilMoisture: Light: ");
-        log += light;
-        addLog(LOG_LEVEL_INFO, log);
 
         if (P047_SENSOR_SLEEP) {
           // send sensor to sleep
           I2C_write8(P047_I2C_ADDR, SOILMOISTURESENSOR_SLEEP);
+          #ifndef BUILD_NO_DEBUG
           addLog(LOG_LEVEL_DEBUG, F("SoilMoisture->sleep"));
+          #endif
         }
         success = true;
         break;

--- a/src/_P048_Motorshield_v2.ino
+++ b/src/_P048_Motorshield_v2.ino
@@ -128,9 +128,13 @@ boolean Plugin_048(byte function, struct EventStruct *event, String& string) {
 
         // Create the motor shield object with the default I2C address
         AFMS = Adafruit_MotorShield(Plugin_048_MotorShield_address);
-        String log = F("MotorShield: Address: 0x");
-        log += String(Plugin_048_MotorShield_address, HEX);
-        addLog(LOG_LEVEL_DEBUG, log);
+        #ifndef BUILD_NO_DEBUG
+        if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+          String log = F("MotorShield: Address: 0x");
+          log += String(Plugin_048_MotorShield_address, HEX);
+          addLog(LOG_LEVEL_DEBUG, log);
+        }
+        #endif
 
         if (param1.equalsIgnoreCase(F("DCMotor"))) {
           if (param2_is_int && (p2_int > 0) && (p2_int < 5))
@@ -206,6 +210,7 @@ boolean Plugin_048(byte function, struct EventStruct *event, String& string) {
             myStepper = AFMS.getStepper(Plugin_048_MotorStepsPerRevolution, p2_int);
             myStepper->setSpeed(Plugin_048_StepperSpeed);
 
+            #ifndef BUILD_NO_DEBUG
             if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE)) {
               String log = F("MotorShield: StepsPerRevolution: ");
               log += String(Plugin_048_MotorStepsPerRevolution);
@@ -213,6 +218,7 @@ boolean Plugin_048(byte function, struct EventStruct *event, String& string) {
               log += String(Plugin_048_StepperSpeed);
               addLog(LOG_LEVEL_DEBUG_MORE, log);
             }
+            #endif
 
             if (param3.equalsIgnoreCase(F("Forward")))
             {

--- a/src/_P049_MHZ19.ino
+++ b/src/_P049_MHZ19.ino
@@ -570,18 +570,23 @@ boolean Plugin_049(byte function, struct EventStruct *event, String& string)
       float u           = 0;
 
       if (P049_data->read_ppm(ppm, temp, s, u)) {
-        String log = F("MHZ19: ");
+        const bool mustLog = loglevelActiveFor(LOG_LEVEL_INFO);
+        String log;
+        if (mustLog)
+          log = F("MHZ19: ");
 
         // During (and only ever at) sensor boot, 'u' is reported as 15000
         // We log but don't process readings during that time
         if (approximatelyEqual(u, 15000)) {
-          log += F("Bootup detected! ");
+          if (mustLog)
+            log += F("Bootup detected! ");
 
           if (P049_data->ABC_Disable) {
             // After bootup of the sensor the ABC will be enabled.
             // Thus only actively disable after bootup.
             P049_data->ABC_MustApply = true;
-            log                     += F("Will disable ABC when bootup complete. ");
+            if (mustLog)
+              log                     += F("Will disable ABC when bootup complete. ");
           }
           success = false;
 
@@ -614,16 +619,18 @@ boolean Plugin_049(byte function, struct EventStruct *event, String& string)
           }
         }
 
-        // Log values in all cases
-        log += F("PPM value: ");
-        log += ppm;
-        log += F(" Temp/S/U values: ");
-        log += temp;
-        log += '/';
-        log += s;
-        log += '/';
-        log += u;
-        addLog(LOG_LEVEL_INFO, log);
+        if (mustLog) {
+          // Log values in all cases
+          log += F("PPM value: ");
+          log += ppm;
+          log += F(" Temp/S/U values: ");
+          log += temp;
+          log += '/';
+          log += s;
+          log += '/';
+          log += u;
+          addLog(LOG_LEVEL_INFO, log);
+        }
         break;
 
         // #ifdef ENABLE_DETECTION_RANGE_COMMANDS

--- a/src/_P049_MHZ19.ino
+++ b/src/_P049_MHZ19.ino
@@ -705,7 +705,7 @@ void P049_html_show_stats(struct EventStruct *event) {
   switch (P049_data->getDetectedDevice()) {
     case MHZ19_A: addHtml(F("MH-Z19A")); break;
     case MHZ19_B: addHtml(F("MH-Z19B")); break;
-    default: addHtml("---"); break;
+    default: addHtml(F("---")); break;
   }
 }
 

--- a/src/_P050_TCS34725.ino
+++ b/src/_P050_TCS34725.ino
@@ -426,7 +426,7 @@ boolean Plugin_050(byte function, struct EventStruct *event, String& string)
                 RuleEvent = EMPTY_STRING;
                 break;
               }
-              if (RuleEvent.length() != 0) {
+              if (!RuleEvent.isEmpty()) {
                 eventQueue.add(RuleEvent);
               }
             }
@@ -462,7 +462,7 @@ boolean Plugin_050(byte function, struct EventStruct *event, String& string)
               RuleEvent = EMPTY_STRING;
               break;
             }
-            if (RuleEvent.length() != 0) {
+            if (!RuleEvent.isEmpty()) {
               eventQueue.add(RuleEvent);
             }
           }

--- a/src/_P050_TCS34725.ino
+++ b/src/_P050_TCS34725.ino
@@ -334,27 +334,29 @@ boolean Plugin_050(byte function, struct EventStruct *event, String& string)
         }
         UserVar[event->BaseVarIndex + 3] = value4;
 
-        String log = F("TCS34725: ");
-        switch (PCONFIG(3)) {
-          case 0:
-          case 1:
-            log += F("Color Temp (K): ");
-            break;
-          case 2:
-            log += F("Lux : ");
-            break;
-          case 3:
-            log += F("Clear : ");
-            break;
+        if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+          String log = F("TCS34725: ");
+          switch (PCONFIG(3)) {
+            case 0:
+            case 1:
+              log += F("Color Temp (K): ");
+              break;
+            case 2:
+              log += F("Lux : ");
+              break;
+            case 3:
+              log += F("Clear : ");
+              break;
+          }
+          log += formatUserVarNoCheck(event->TaskIndex, 3);
+          log += F(" R: ");
+          log += formatUserVarNoCheck(event->TaskIndex, 0);
+          log += F(" G: ");
+          log += formatUserVarNoCheck(event->TaskIndex, 1);
+          log += F(" B: ");
+          log += formatUserVarNoCheck(event->TaskIndex, 2);
+          addLog(LOG_LEVEL_INFO, log);
         }
-        log += formatUserVarNoCheck(event->TaskIndex, 3);
-        log += F(" R: ");
-        log += formatUserVarNoCheck(event->TaskIndex, 0);
-        log += F(" G: ");
-        log += formatUserVarNoCheck(event->TaskIndex, 1);
-        log += F(" B: ");
-        log += formatUserVarNoCheck(event->TaskIndex, 2);
-        addLog(LOG_LEVEL_INFO, log);
 
 #ifdef P050_OPTION_RGB_EVENTS
         // First RGB events

--- a/src/_P050_TCS34725.ino
+++ b/src/_P050_TCS34725.ino
@@ -172,7 +172,11 @@ boolean Plugin_050(byte function, struct EventStruct *event, String& string)
             addRowLabel(RGB.substring(i, i + 1));
             String id = F("p050_cal_");
             for (int j = 0; j < 3; j++) {
-              addHtml(String(static_cast<char>('a' + i)) + String(F("<sub>")) + String(j + 1) + String(F("</sub>")) + ':');
+              addHtml(String(static_cast<char>('a' + i)));
+              addHtml(F("<sub>"));
+              addHtmlInt(j + 1);
+              addHtml(F("</sub>"));
+              addHtml(':');
               addFloatNumberBox(id + static_cast<char>('a' + i) + '_' + String(j), P050_data->TransformationSettings.matrix[i][j], -255.999f, 255.999f);
             }
           }

--- a/src/_P055_Chiming.ino
+++ b/src/_P055_Chiming.ino
@@ -427,7 +427,7 @@ boolean Plugin_055_IsEmptyFIFO()
 
 void Plugin_055_AddStringFIFO(const String& param)
 {
-  if (param.length() == 0)
+  if (param.isEmpty())
     return;
 
   byte i = 0;

--- a/src/_P075_Nextion.ino
+++ b/src/_P075_Nextion.ino
@@ -217,7 +217,7 @@ boolean Plugin_075(byte function, struct EventStruct *event, String& string)
           SaveCustomTaskSettings(event->TaskIndex, (byte*)&deviceTemplate, sizeof(deviceTemplate));
         }
 
-        if(getTaskDeviceName(event->TaskIndex) == "") {         // Check to see if user entered device name.
+        if(getTaskDeviceName(event->TaskIndex).isEmpty()) {         // Check to see if user entered device name.
             strcpy(ExtraTaskSettings.TaskDeviceName,PLUGIN_DEFAULT_NAME); // Name missing, populate default name.
         }
 //        PCONFIG(0) = isFormItemChecked(F("AdvHwSerial"));

--- a/src/_P079_Wemos_Motorshield.ino
+++ b/src/_P079_Wemos_Motorshield.ino
@@ -242,7 +242,7 @@ boolean Plugin_079(byte function, struct EventStruct *event, String& string)
         String paramDirection = parseString(tmpString, 3); // Direction, Forward/Backward/Stop
         String paramSpeed     = parseString(tmpString, 4); // Speed, 0-100
 
-        if ((paramMotor == "") && (paramDirection == "") && (paramSpeed == "")) {
+        if ((paramMotor.isEmpty()) && (paramDirection.isEmpty()) && (paramSpeed.isEmpty())) {
           switch (Plugin_079_MotorShield_type) {
             case P079_BoardType::WemosMotorshield:
             # ifdef VERBOSE_P079
@@ -277,7 +277,7 @@ boolean Plugin_079(byte function, struct EventStruct *event, String& string)
             motor_number = paramMotor.toInt();
           }
           else {
-            if (paramMotor == "") {
+            if (paramMotor.isEmpty()) {
               paramMotor = '?';
             }
             motor_number = 0;
@@ -305,7 +305,7 @@ boolean Plugin_079(byte function, struct EventStruct *event, String& string)
             parse_error    = true;
           }
 
-          if (paramSpeed == "") {
+          if (paramSpeed.isEmpty()) {
             switch (motor_dir) {
               case MOTOR_STATES::MOTOR_STOP:
               case MOTOR_STATES::MOTOR_STBY:

--- a/src/_P079_Wemos_Motorshield.ino
+++ b/src/_P079_Wemos_Motorshield.ino
@@ -178,7 +178,7 @@ boolean Plugin_079(byte function, struct EventStruct *event, String& string)
       }
 
 
-      if (getTaskDeviceName(event->TaskIndex).length() == 0) {                    // Check to see if user entered device name.
+      if (getTaskDeviceName(event->TaskIndex).isEmpty()) {                    // Check to see if user entered device name.
         switch (Plugin_079_MotorShield_type) {
           case P079_BoardType::WemosMotorshield:
             safe_strncpy(ExtraTaskSettings.TaskDeviceName, F(PLUGIN_DEF_NAME1_079), sizeof(ExtraTaskSettings.TaskDeviceName)); // Name missing, populate default name.

--- a/src/_P082_GPS.ino
+++ b/src/_P082_GPS.ino
@@ -505,7 +505,7 @@ void P082_html_show_satStats(struct EventStruct *event, bool tracked, bool onlyG
           label.reserve(32);
 
           if (onlyGPS) {
-            label = "GPS";
+            label = F("GPS");
           } else {
             label = F("Other");
           }
@@ -518,14 +518,14 @@ void P082_html_show_satStats(struct EventStruct *event, bool tracked, bool onlyG
           }
           addRowLabel(label);
         } else {
-          addHtml(", ");
+          addHtml(F(", "));
         }
         addHtmlInt(id);
 
         if (tracked) {
-          addHtml(" (");
+          addHtml(F(" ("));
           addHtmlInt(snr);
-          addHtml(")");
+          addHtml(')');
         }
       }
     }
@@ -594,7 +594,7 @@ void P082_html_show_stats(struct EventStruct *event) {
     dateTime = node_time.addSeconds(dateTime, (age / 1000), false);
     addHtml(ESPEasy_time::getDateTimeString(dateTime));
   } else {
-    addHtml(F("-"));
+    addHtml('-');
   }
 
   addRowLabel(F("Distance Travelled"));

--- a/src/_P086_Homie.ino
+++ b/src/_P086_Homie.ino
@@ -233,7 +233,7 @@ boolean Plugin_086(byte function, struct EventStruct *event, String& string)
             switch (Settings.TaskDevicePluginConfig[event->TaskIndex][taskVarIndex]) {
               case PLUGIN_086_VALUE_INTEGER:
               case PLUGIN_086_VALUE_FLOAT:
-                if (parameter!="") {
+                if (!parameter.isEmpty()) {
                   if (string2float(parameter,floatValue)) {
                     if (loglevelActiveFor(LOG_LEVEL_INFO)) {
                       log += F(" integer/float set to ");
@@ -285,7 +285,7 @@ boolean Plugin_086(byte function, struct EventStruct *event, String& string)
               case PLUGIN_086_VALUE_ENUM:
                 enumList = ExtraTaskSettings.TaskDeviceFormula[taskVarIndex];
                 i = 1;
-                while (parseString(enumList,i)!="") { // lookup result in enum List
+                while (!parseString(enumList,i).isEmpty()) { // lookup result in enum List
                   if (parseString(enumList,i)==parameter) {
                     floatValue = i;
                     break;

--- a/src/_P087_SerialProxy.ino
+++ b/src/_P087_SerialProxy.ino
@@ -373,7 +373,7 @@ void P087_html_show_stats(struct EventStruct *event) {
     chksumStats += error;
     addHtml(chksumStats);
     addRowLabel(F("Length Last Sentence"));
-    addHtml(String(length_last));
+    addHtmlInt(length_last);
   }
 }
 

--- a/src/_P092_DLbus.ino
+++ b/src/_P092_DLbus.ino
@@ -59,21 +59,21 @@
 
 \**************************************************/
 
-#include "src/PluginStructs/P092_data_struct.h"
+# include "src/PluginStructs/P092_data_struct.h"
 
-#include "src/ESPEasyCore/ESPEasyNetwork.h"
+# include "src/ESPEasyCore/ESPEasyNetwork.h"
 
-#define PLUGIN_092
-#define PLUGIN_ID_092         92
+# define PLUGIN_092
+# define PLUGIN_ID_092         92
 
 // #define PLUGIN_092_DEBUG    // additional debug messages in the log
-#define PLUGIN_NAME_092       "Heating - DL-Bus (Technische Alternative)  [TESTING]"
-#define PLUGIN_VALUENAME1_092 "Value"
+# define PLUGIN_NAME_092       "Heating - DL-Bus (Technische Alternative)  [TESTING]"
+# define PLUGIN_VALUENAME1_092 "Value"
 
 // global values needed for all tasks
-uint8_t  P092_Last_DLB_Pin;             // check if DL bus pin has been changed by one task -> change requires new init because of interrupt
-boolean P092_init = false;              // P092_data_struct can be initialized only once, even if several tasks running
-P092_data_struct *P092_data = nullptr;  // pointer to P092_data_struct, must be the same for all tasks
+uint8_t P092_Last_DLB_Pin;             // check if DL bus pin has been changed by one task -> change requires new init because of interrupt
+boolean P092_init           = false;   // P092_data_struct can be initialized only once, even if several tasks running
+P092_data_struct *P092_data = nullptr; // pointer to P092_data_struct, must be the same for all tasks
 
 boolean Plugin_092(uint8_t function, struct EventStruct *event, String& string)
 {
@@ -118,7 +118,8 @@ boolean Plugin_092(uint8_t function, struct EventStruct *event, String& string)
     case PLUGIN_WEBFORM_LOAD:
     {
       {
-        uint8_t choice = PCONFIG(2);  // Input mode
+        uint8_t choice = PCONFIG(2); // Input mode
+
         if (choice == 0) {
           // pinmode was never set -> use default settings (as it was before)
           if ((PCONFIG(0) == 6133) || (PCONFIG(0) == 6132)) {
@@ -130,15 +131,15 @@ boolean Plugin_092(uint8_t function, struct EventStruct *event, String& string)
             choice = static_cast<uint8_t>(eP092pinmode::ePPM_InputPullUp);
           }
         }
-#ifdef INPUT_PULLDOWN
+# ifdef INPUT_PULLDOWN
         int Opcount = 3;
-#else
+# else // ifdef INPUT_PULLDOWN
         int Opcount = 2;
-#endif
-        const __FlashStringHelper *  options[3];
-        options[0] = F("Input");
-        options[1] = F("Input pullup");
-        options[2] = F("Input pulldown");
+# endif // ifdef INPUT_PULLDOWN
+        const __FlashStringHelper *options[3];
+        options[0]          = F("Input");
+        options[1]          = F("Input pullup");
+        options[2]          = F("Input pulldown");
         int optionValues[3] =
         { static_cast<int>(eP092pinmode::ePPM_Input),
           static_cast<int>(eP092pinmode::ePPM_InputPullUp),
@@ -146,8 +147,8 @@ boolean Plugin_092(uint8_t function, struct EventStruct *event, String& string)
         addFormSelector(F("Pin mode"), F("p092_pinmode"), Opcount, options, optionValues, choice);
       }
       {
-        const __FlashStringHelper * Devices[P092_DLbus_DeviceCount] = { F("ESR21"), F("UVR31"), F("UVR1611"), F("UVR 61-3 (up to v8.2)"), F(
-                                                           "UVR 61-3 (v8.3 or higher)") };
+        const __FlashStringHelper *Devices[P092_DLbus_DeviceCount] = { F("ESR21"), F("UVR31"), F("UVR1611"), F("UVR 61-3 (up to v8.2)"), F(
+                                                                         "UVR 61-3 (v8.3 or higher)") };
         const int DevTypes[P092_DLbus_DeviceCount] = { 21, 31, 1611, 6132, 6133 };
 
         addFormSelector(F("DL-Bus Type"), F("p092_dlbtype"), P092_DLbus_DeviceCount, Devices, DevTypes, NULL, PCONFIG(0), true);
@@ -167,7 +168,7 @@ boolean Plugin_092(uint8_t function, struct EventStruct *event, String& string)
           6, // F("Heat power (kW)")
           7  // F("Heat meter (MWh)")
         };
-        const __FlashStringHelper * Options[P092_DLbus_OptionCount] = {
+        const __FlashStringHelper *Options[P092_DLbus_OptionCount] = {
           F("None"),
           F("Sensor"),
           F("Ext. sensor"),
@@ -302,13 +303,13 @@ boolean Plugin_092(uint8_t function, struct EventStruct *event, String& string)
 
         if (P092_data->DLbus_Data->IsISRset) {
           // interrupt was already attached to P092_DLB_Pin
-          P092_data->DLbus_Data->IsISRset = false;  //to ensure that a new interrupt is attached in P092_data->init()
+          P092_data->DLbus_Data->IsISRset = false; // to ensure that a new interrupt is attached in P092_data->init()
           detachInterrupt(digitalPinToInterrupt(P092_data->DLbus_Data->ISR_DLB_Pin));
           addLog(LOG_LEVEL_INFO, F("P092_save: detachInterrupt"));
         }
       }
 
-#ifdef PLUGIN_092_DEBUG
+# ifdef PLUGIN_092_DEBUG
 
       if (loglevelActiveFor(LOG_LEVEL_INFO)) {
         String log = F("PLUGIN_WEBFORM_SAVE :");
@@ -379,7 +380,7 @@ boolean Plugin_092(uint8_t function, struct EventStruct *event, String& string)
         log += P092_data->P092_DataSettings.IdxCRC;
         addLog(LOG_LEVEL_INFO, log);
       }
-#endif // PLUGIN_092_DEBUG
+# endif // PLUGIN_092_DEBUG
       UserVar[event->BaseVarIndex] = NAN;
       success                      = true;
       break;
@@ -387,9 +388,12 @@ boolean Plugin_092(uint8_t function, struct EventStruct *event, String& string)
 
     case PLUGIN_INIT:
     {
-      String log = F("PLUGIN_092_INIT Task:");
-      log += event->TaskIndex;
-      addLog(LOG_LEVEL_INFO, log);
+      if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+        String log = F("PLUGIN_092_INIT Task:");
+        log += event->TaskIndex;
+        addLog(LOG_LEVEL_INFO, log);
+      }
+
       if (P092_init) {
         addLog(LOG_LEVEL_INFO, F("INIT -> Already done!"));
       }
@@ -408,20 +412,20 @@ boolean Plugin_092(uint8_t function, struct EventStruct *event, String& string)
         else {
           addLog(LOG_LEVEL_INFO, F("P092_data_struct -> Already created"));
         }
-          P092_data_struct *P092_data =
-            static_cast<P092_data_struct *>(getPluginTaskData(event->TaskIndex));
+        P092_data_struct *P092_data =
+          static_cast<P092_data_struct *>(getPluginTaskData(event->TaskIndex));
 
-            addLog(LOG_LEVEL_INFO, F("Init P092_data_struct ..."));
+        addLog(LOG_LEVEL_INFO, F("Init P092_data_struct ..."));
 
         if (!P092_data->init(CONFIG_PIN1, PCONFIG(0), eP092pinmode PCONFIG(2))) {
-              addLog(LOG_LEVEL_ERROR, F("## P092_init: Error DL-Bus: Class not initialized!"));
-              clearPluginTaskData(event->TaskIndex);
-              return false;
-            }
+          addLog(LOG_LEVEL_ERROR, F("## P092_init: Error DL-Bus: Class not initialized!"));
+          clearPluginTaskData(event->TaskIndex);
+          return false;
+        }
 
-            P092_init       = true;
-          }
-      
+        P092_init = true;
+      }
+
       success                      = true;
       UserVar[event->BaseVarIndex] = NAN;
       break;
@@ -467,9 +471,11 @@ boolean Plugin_092(uint8_t function, struct EventStruct *event, String& string)
 
         if (success) {
           P092_data->P092_LastReceived = millis();
-          String log = F("Received data OK TI:");
-          log += event->TaskIndex;
-          addLog(LOG_LEVEL_INFO, log);
+          if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+            String log = F("Received data OK TI:");
+            log += event->TaskIndex;
+            addLog(LOG_LEVEL_INFO, log);
+          }
         }
         P092_data->P092_ReceivedOK = success;
       }
@@ -479,7 +485,7 @@ boolean Plugin_092(uint8_t function, struct EventStruct *event, String& string)
 
       if ((P092_data->DLbus_Data->IsNoData == false) &&
           ((P092_data->P092_ReceivedOK == false) ||
-          (timePassedSince(P092_data->P092_LastReceived) > (static_cast<long>(Settings.TaskDeviceTimer[event->TaskIndex] * 1000 / 2))))) {
+           (timePassedSince(P092_data->P092_LastReceived) > (static_cast<long>(Settings.TaskDeviceTimer[event->TaskIndex] * 1000 / 2))))) {
         P092_data->Plugin_092_StartReceiving(event->TaskIndex);
         success = true;
       }
@@ -488,9 +494,11 @@ boolean Plugin_092(uint8_t function, struct EventStruct *event, String& string)
 
     case PLUGIN_READ:
     {
-      String log = F("PLUGIN_092_READ Task:");
-      log += event->TaskIndex;
-      addLog(LOG_LEVEL_INFO, log);
+      if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+        String log = F("PLUGIN_092_READ Task:");
+        log += event->TaskIndex;
+        addLog(LOG_LEVEL_INFO, log);
+      }
 
       if (!NetworkConnected()) {
         // too busy for DLbus while wifi connect is running
@@ -509,12 +517,14 @@ boolean Plugin_092(uint8_t function, struct EventStruct *event, String& string)
       }
 
       if (P092_data->DLbus_Data->ISR_DLB_Pin != CONFIG_PIN1) {
-        String log = F("## P092_read: Error DL-Bus: Device Pin setting not correct!");
-        log += F(" DLB_Pin:");
-        log += P092_data->DLbus_Data->ISR_DLB_Pin;
-        log += F(" Setting:");
-        log += CONFIG_PIN1;
-        addLog(LOG_LEVEL_ERROR, log);
+        if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
+          String log = F("## P092_read: Error DL-Bus: Device Pin setting not correct!");
+          log += F(" DLB_Pin:");
+          log += P092_data->DLbus_Data->ISR_DLB_Pin;
+          log += F(" Setting:");
+          log += CONFIG_PIN1;
+          addLog(LOG_LEVEL_ERROR, log);
+        }
         return false;
       }
 

--- a/src/_P094_CULReader.ino
+++ b/src/_P094_CULReader.ino
@@ -456,15 +456,13 @@ void P094_html_show_stats(struct EventStruct *event) {
 
   {
     addRowLabel(F("Sentences (pass/fail)"));
-    String   chksumStats;
     uint32_t success, error, length_last;
     P094_data->getSentencesReceived(success, error, length_last);
-    chksumStats  = success;
-    chksumStats += '/';
-    chksumStats += error;
-    addHtml(chksumStats);
+    addHtmlInt(success);
+    addHtml('/');
+    addHtmlInt(error);
     addRowLabel(F("Length Last Sentence"));
-    addHtml(String(length_last));
+    addHtmlInt(length_last);
   }
 }
 

--- a/src/_P101_WakeOnLan.ino
+++ b/src/_P101_WakeOnLan.ino
@@ -320,15 +320,15 @@ boolean Plugin_101(byte function, struct EventStruct *event, String& string)
         String paramPort = parseString(tmpString, 4); // UDP Port (optional)
 
         // Populate Parameters with default settings when missing from command line.
-        if (paramMac == "") {                         // Missing from command line, use default setting.
+        if (paramMac.isEmpty()) {                         // Missing from command line, use default setting.
           paramMac = macString;
         }
 
-        if (paramIp == "") { // Missing from command line, use default setting.
+        if (paramIp.isEmpty()) { // Missing from command line, use default setting.
           paramIp = ipString;
         }
 
-        if (paramPort == "") {
+        if (paramPort.isEmpty()) {
           int portNumber = UDP_PORT_P101; // Get default Port from user settings.
           paramPort = portNumber;
         }
@@ -422,7 +422,7 @@ uint8_t safeName(taskIndex_t index) {
 
   devName.toLowerCase();
 
-  if (devName == "") {
+  if (devName.isEmpty()) {
     safeCode = NAME_MISSING;
   }
 

--- a/src/_Plugin_Helper.cpp
+++ b/src/_Plugin_Helper.cpp
@@ -54,6 +54,8 @@ void initPluginTaskData(taskIndex_t taskIndex, PluginTaskData_base *data) {
   if (Settings.TaskDeviceEnabled[taskIndex]) {
     Plugin_task_data[taskIndex]                     = data;
     Plugin_task_data[taskIndex]->_taskdata_pluginID = Settings.TaskDeviceNumber[taskIndex];
+  } else if (data != nullptr) {
+    delete data;
   }
 }
 

--- a/src/__Plugin.ino
+++ b/src/__Plugin.ino
@@ -1,6 +1,9 @@
+#include "ESPEasy_common.h"
+
 #include "src/Globals/Plugins.h"
 #include "src/Globals/Settings.h"
-#include "ESPEasy_common.h"
+
+#include "src/Helpers/Misc.h"
 
 
 // ********************************************************************************
@@ -17,7 +20,6 @@
 
 void PluginInit(void)
 {
-  DeviceIndex_to_Plugin_id.resize(PLUGIN_MAX + 1); // INVALID_DEVICE_INDEX may be used as index for this array.
   DeviceIndex_to_Plugin_id[PLUGIN_MAX] = INVALID_PLUGIN_ID;
   // Clear pointer table for all plugins
   for (deviceIndex_t x = 0; x < PLUGIN_MAX; x++)
@@ -1048,6 +1050,10 @@ void PluginInit(void)
   ADDPLUGIN(255)
 #endif
 
+#ifndef BUILD_NO_RAM_TRACKER
+  logMemUsageAfter(F("ADDPLUGIN(...)"));
+#endif
+
   String dummy;
   PluginCall(PLUGIN_DEVICE_ADD, nullptr, dummy);
     // Set all not supported plugins to disabled.
@@ -1057,7 +1063,15 @@ void PluginInit(void)
     }
   }
 
+#ifndef BUILD_NO_RAM_TRACKER
+  logMemUsageAfter(F("PLUGIN_DEVICE_ADD"));
+#endif
+
   PluginCall(PLUGIN_INIT_ALL, nullptr, dummy);
+#ifndef BUILD_NO_RAM_TRACKER
+  logMemUsageAfter(F("PLUGIN_INIT_ALL"));
+#endif
+
   sortDeviceIndexArray(); // Used in device selector dropdown.
 }
 

--- a/src/src/Commands/Blynk.cpp
+++ b/src/src/Commands/Blynk.cpp
@@ -85,7 +85,7 @@ bool Blynk_get(const String& command, controllerIndex_t controllerIndex, float *
     pass = getControllerPass(controllerIndex, ControllerSettings);
     ClientTimeout = ControllerSettings.ClientTimeout;
 
-    if (pass.length() == 0) {
+    if (pass.isEmpty()) {
       addLog(LOG_LEVEL_ERROR, F("Blynk : No password set"));
       return false;
     }

--- a/src/src/Commands/GPIO.cpp
+++ b/src/src/Commands/GPIO.cpp
@@ -652,7 +652,7 @@ range_pattern_helper_data range_pattern_helper_shared(pluginID_t plugin, struct 
     data.logPrefix += F("GPIORange");
   }
   data.valid  = false;
-  data.isMask = parseString(Line, 5).length() != 0;
+  data.isMask = !parseString(Line, 5).isEmpty();
 
   if (data.isMask) {
     data.mask  = event->Par4 & ((1 << data.numBytes * 8) - 1);

--- a/src/src/Commands/InternalCommands.cpp
+++ b/src/src/Commands/InternalCommands.cpp
@@ -70,7 +70,7 @@ bool checkNrArguments(const char *cmd, const char *Line, int nrArguments) {
             } else {
               parameter = parseStringKeepCase(Line, i + 1);
             }
-            done = parameter.length() == 0;
+            done = parameter.isEmpty();
 
             if (!done) {
               if (i <= nrArguments) {

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -1569,9 +1569,6 @@ To create/register a plugin, you have to :
   #ifdef USES_P076
     #undef USES_P076   // HWL8012   in POW r1
   #endif
-  #ifdef USES_P092
-    #undef USES_P092   // DL-Bus
-  #endif
   #ifdef USES_P093
     #undef USES_P093   // Mitsubishi Heat Pump
   #endif

--- a/src/src/DataStructs/RTC_cache_handler_struct.cpp
+++ b/src/src/DataStructs/RTC_cache_handler_struct.cpp
@@ -77,7 +77,7 @@ bool RTC_cache_handler_struct::peek(uint8_t *data, unsigned int size) {
         fname = createCacheFilename(peekfilenr);
       }
 
-      if (fname.length() == 0) { return false; }
+      if (fname.isEmpty()) { return false; }
       fp = tryOpenFile(fname, "r");
     }
 

--- a/src/src/DataStructs/Web_StreamingBuffer.cpp
+++ b/src/src/DataStructs/Web_StreamingBuffer.cpp
@@ -203,7 +203,12 @@ void Web_StreamingBuffer::endStream() {
     if (buf.length() > 0) { sendContentBlocking(buf); }
     buf.clear();
     sendContentBlocking(buf);
+    #ifdef ESP8266
     web_server.client().flush(100);
+    #endif
+    #ifdef ESP32
+    web_server.client().flush();
+    #endif
     finalRam = ESP.getFreeHeap();
 
     /*

--- a/src/src/DataStructs/Web_StreamingBuffer.cpp
+++ b/src/src/DataStructs/Web_StreamingBuffer.cpp
@@ -22,6 +22,7 @@ Web_StreamingBuffer::Web_StreamingBuffer(void) : lowMemorySkip(false),
   buf.clear();
 }
 
+/*
 Web_StreamingBuffer Web_StreamingBuffer::operator=(String& a)                 {
   flush(); return addString(a);
 }
@@ -29,8 +30,13 @@ Web_StreamingBuffer Web_StreamingBuffer::operator=(String& a)                 {
 Web_StreamingBuffer Web_StreamingBuffer::operator=(const String& a)           {
   flush(); return addString(a);
 }
+*/
 
 Web_StreamingBuffer Web_StreamingBuffer::operator+=(char a)                   {
+  if (CHUNKED_BUFFER_SIZE > (this->buf.length() + 1)) {
+    this->buf += a;
+    return *this;
+  }
   return addString(String(a));
 }
 
@@ -131,10 +137,10 @@ void Web_StreamingBuffer::flush() {
   }
 }
 
-void Web_StreamingBuffer::checkFull(void) {
+void Web_StreamingBuffer::checkFull() {
   if (lowMemorySkip) { this->buf.clear(); }
 
-  if (this->buf.length() > CHUNKED_BUFFER_SIZE) {
+  if (this->buf.length() >= CHUNKED_BUFFER_SIZE) {
     trackTotalMem();
     sendContentBlocking(this->buf);
   }
@@ -187,7 +193,7 @@ void Web_StreamingBuffer::trackCoreMem() {
   }
 }
 
-void Web_StreamingBuffer::endStream(void) {
+void Web_StreamingBuffer::endStream() {
   if (!lowMemorySkip) {
     if (buf.length() > 0) { sendContentBlocking(buf); }
     buf.clear();

--- a/src/src/DataStructs/Web_StreamingBuffer.cpp
+++ b/src/src/DataStructs/Web_StreamingBuffer.cpp
@@ -55,6 +55,14 @@ Web_StreamingBuffer Web_StreamingBuffer::operator+=(const String& a)          {
 }
 
 Web_StreamingBuffer Web_StreamingBuffer::operator+=(PGM_P str) {
+  return addFlashString(str);
+}
+
+Web_StreamingBuffer Web_StreamingBuffer::operator+=(const __FlashStringHelper* str) {
+  return addFlashString((PGM_P)str);
+}
+
+Web_StreamingBuffer Web_StreamingBuffer::addFlashString(PGM_P str) {
   ++flashStringCalls;
 
   if (!str) { return *this; // return if the pointer is void

--- a/src/src/DataStructs/Web_StreamingBuffer.h
+++ b/src/src/DataStructs/Web_StreamingBuffer.h
@@ -35,8 +35,8 @@ public:
 
   Web_StreamingBuffer(void);
 
-  Web_StreamingBuffer operator=(String& a);
-  Web_StreamingBuffer operator=(const String& a);
+//  Web_StreamingBuffer operator=(String& a);
+//  Web_StreamingBuffer operator=(const String& a);
   Web_StreamingBuffer operator+=(char a);
   Web_StreamingBuffer operator+=(long unsigned int a);
   Web_StreamingBuffer operator+=(float a);
@@ -53,7 +53,7 @@ public:
 public:
   void flush();
 
-  void checkFull(void);
+  void checkFull();
 
   void startStream();
 
@@ -71,7 +71,7 @@ public:
 
   void trackCoreMem();
 
-  void endStream(void);
+  void endStream();
 
 private: 
 

--- a/src/src/DataStructs/Web_StreamingBuffer.h
+++ b/src/src/DataStructs/Web_StreamingBuffer.h
@@ -44,8 +44,13 @@ public:
   Web_StreamingBuffer operator+=(uint32_t a);
   Web_StreamingBuffer operator+=(const String& a);
   Web_StreamingBuffer operator+=(PGM_P str);
+  Web_StreamingBuffer operator+=(const __FlashStringHelper* str);
+
+//private:
+  Web_StreamingBuffer addFlashString(PGM_P str);
   Web_StreamingBuffer addString(const String& a);
 
+public:
   void flush();
 
   void checkFull(void);

--- a/src/src/DataStructs/WiFi_AP_Candidate.cpp
+++ b/src/src/DataStructs/WiFi_AP_Candidate.cpp
@@ -42,7 +42,7 @@ WiFi_AP_Candidate::WiFi_AP_Candidate(uint8_t networkItem) : index(0) {
   isHidden = WiFi.isHidden(networkItem);
   #endif // ifdef ESP8266
   #ifdef ESP32
-  isHidden = ssid.length() == 0;
+  isHidden = ssid.isEmpty();
   #endif // ifdef ESP32
   last_seen = millis();
 }
@@ -108,7 +108,7 @@ void WiFi_AP_Candidate::setBSSID(const uint8_t *bssid_c) {
 
 bool WiFi_AP_Candidate::usable() const {
   // Allow for empty pass
-  // if (key.length() == 0) return false;
+  // if (key.isEmpty()) return false;
   if (isEmergencyFallback) {
     int allowedUptimeMinutes = 10;
     #ifdef CUSTOM_EMERGENCY_FALLBACK_ALLOW_MINUTES_UPTIME
@@ -121,7 +121,7 @@ bool WiFi_AP_Candidate::usable() const {
       return false;
     }
   }
-  if (!isHidden && (ssid.length() == 0)) { return false; }
+  if (!isHidden && (ssid.isEmpty())) { return false; }
   return true;
 }
 

--- a/src/src/ESPEasyCore/Controller.cpp
+++ b/src/src/ESPEasyCore/Controller.cpp
@@ -279,7 +279,7 @@ bool MQTTConnect(controllerIndex_t controller_idx)
 String getMQTTclientID(const ControllerSettingsStruct& ControllerSettings) {
   String clientid = ControllerSettings.ClientID;
 
-  if (clientid.length() == 0) {
+  if (clientid.isEmpty()) {
     // Try to generate some default
     clientid = F(CONTROLLER_DEFAULT_CLIENTID);
   }
@@ -380,7 +380,7 @@ String getLWT_topic(const ControllerSettingsStruct& ControllerSettings) {
   if (ControllerSettings.mqtt_sendLWT()) {
     LWTTopic = ControllerSettings.MQTTLwtTopic;
 
-    if (LWTTopic.length() == 0)
+    if (LWTTopic.isEmpty())
     {
       LWTTopic  = ControllerSettings.Subscribe;
       LWTTopic += F("/LWT");
@@ -397,7 +397,7 @@ String getLWT_messageConnect(const ControllerSettingsStruct& ControllerSettings)
   if (ControllerSettings.mqtt_sendLWT()) {
     LWTMessageConnect = ControllerSettings.LWTMessageConnect;
 
-    if (LWTMessageConnect.length() == 0) {
+    if (LWTMessageConnect.isEmpty()) {
       LWTMessageConnect = F(DEFAULT_MQTT_LWT_CONNECT_MESSAGE);
     }
     parseSystemVariables(LWTMessageConnect, false);
@@ -411,7 +411,7 @@ String getLWT_messageDisconnect(const ControllerSettingsStruct& ControllerSettin
   if (ControllerSettings.mqtt_sendLWT()) {
     LWTMessageDisconnect = ControllerSettings.LWTMessageDisconnect;
 
-    if (LWTMessageDisconnect.length() == 0) {
+    if (LWTMessageDisconnect.isEmpty()) {
       LWTMessageDisconnect = F(DEFAULT_MQTT_LWT_DISCONNECT_MESSAGE);
     }
     parseSystemVariables(LWTMessageDisconnect, false);
@@ -448,7 +448,7 @@ bool SourceNeedsStatusUpdate(EventValueSource::Enum eventSource)
 
 void SendStatus(struct EventStruct *event, const String& status)
 {
-  if (status.length() == 0) { return; }
+  if (status.isEmpty()) { return; }
 
   switch (event->Source)
   {

--- a/src/src/ESPEasyCore/ESPEasyRules.cpp
+++ b/src/src/ESPEasyCore/ESPEasyRules.cpp
@@ -619,7 +619,7 @@ void parse_string_commands(String& line) {
         replacement = String(uval);
       }
 
-      if (replacement.length() == 0) {
+      if (replacement.isEmpty()) {
         // part in braces is not a supported command.
         // replace the {} with other characters to mask the braces so we can continue parsing.
         // We have to unmask then after we're finished.

--- a/src/src/ESPEasyCore/ESPEasy_Log.cpp
+++ b/src/src/ESPEasyCore/ESPEasy_Log.cpp
@@ -206,11 +206,13 @@ void addToLog(byte logLevel, const char *line)
   if (loglevelActiveFor(LOG_TO_SERIAL, logLevel)) {
     addToSerialBuffer(String(millis()));
     addToSerialBuffer(F(" : "));
-    String loglevelDisplayString = getLogLevelDisplayString(logLevel);
-    while (loglevelDisplayString.length() < 6) {
-      loglevelDisplayString += ' ';
+    {
+      String loglevelDisplayString = getLogLevelDisplayString(logLevel);
+      while (loglevelDisplayString.length() < 6) {
+        loglevelDisplayString += ' ';
+      }
+      addToSerialBuffer(loglevelDisplayString);
     }
-    addToSerialBuffer(loglevelDisplayString);
     addToSerialBuffer(F(" : "));
     addToSerialBuffer(line);
     addNewlineToSerialBuffer();

--- a/src/src/ESPEasyCore/ESPEasy_setup.cpp
+++ b/src/src/ESPEasyCore/ESPEasy_setup.cpp
@@ -128,6 +128,10 @@ void ESPEasy_setup()
   // serialPrint("\n\n\nBOOOTTT\n\n\n");
 
   initLog();
+  #ifndef BUILD_NO_RAM_TRACKER
+  logMemUsageAfter(F("initLog()"));
+  #endif
+
 
   if (SpiffsSectors() < 32)
   {
@@ -140,68 +144,81 @@ void ESPEasy_setup()
 
   emergencyReset();
 
-  String log = F("\n\n\rINIT : Booting version: ");
-  log += getValue(LabelType::GIT_BUILD);
-  log += " (";
-  log += getSystemLibraryString();
-  log += ')';
-  addLog(LOG_LEVEL_INFO, log);
-  log  = F("INIT : Free RAM:");
-  log += FreeMem();
-  addLog(LOG_LEVEL_INFO, log);
+  if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+    String log = F("\n\n\rINIT : Booting version: ");
+    log += getValue(LabelType::GIT_BUILD);
+    log += " (";
+    log += getSystemLibraryString();
+    log += ')';
+    addLog(LOG_LEVEL_INFO, log);
+    log  = F("INIT : Free RAM:");
+    log += FreeMem();
+    addLog(LOG_LEVEL_INFO, log);
+  }
 
   readBootCause();
 
-  log  = F("INIT : ");
-  log += getLastBootCauseString();
-
-  if (readFromRTC())
   {
-    RTC.bootFailedCount++;
-    RTC.bootCounter++;
-    lastMixedSchedulerId_beforereboot = RTC.lastMixedSchedulerId;
-    readUserVarFromRTC();
+    String log  = F("INIT : ");
+    log += getLastBootCauseString();
 
-    if (RTC.deepSleepState != 1)
+    if (readFromRTC())
     {
-      node_time.restoreLastKnownUnixTime(RTC.lastSysTime, RTC.deepSleepState);
+      RTC.bootFailedCount++;
+      RTC.bootCounter++;
+      lastMixedSchedulerId_beforereboot = RTC.lastMixedSchedulerId;
+      readUserVarFromRTC();
+
+      if (RTC.deepSleepState != 1)
+      {
+        node_time.restoreLastKnownUnixTime(RTC.lastSysTime, RTC.deepSleepState);
+      }
+
+      log += F(" #");
+      log += RTC.bootCounter;
+
+      #ifndef BUILD_NO_DEBUG
+      log += F(" Last Action before Reboot: ");
+      log += ESPEasy_Scheduler::decodeSchedulerId(lastMixedSchedulerId_beforereboot);
+      log += F(" Last systime: ");
+      log += RTC.lastSysTime;
+      #endif // ifndef BUILD_NO_DEBUG
     }
 
-    log += F(" #");
-    log += RTC.bootCounter;
+    // cold boot (RTC memory empty)
+    else
+    {
+      initRTC();
 
-    #ifndef BUILD_NO_DEBUG
-    log += F(" Last Action before Reboot: ");
-    log += ESPEasy_Scheduler::decodeSchedulerId(lastMixedSchedulerId_beforereboot);
-    log += F(" Last systime: ");
-    log += RTC.lastSysTime;
-    #endif // ifndef BUILD_NO_DEBUG
-  }
-
-  // cold boot (RTC memory empty)
-  else
-  {
-    initRTC();
-
-    // cold boot situation
-    if (lastBootCause == BOOT_CAUSE_MANUAL_REBOOT) { // only set this if not set earlier during boot stage.
-      lastBootCause = BOOT_CAUSE_COLD_BOOT;
+      // cold boot situation
+      if (lastBootCause == BOOT_CAUSE_MANUAL_REBOOT) { // only set this if not set earlier during boot stage.
+        lastBootCause = BOOT_CAUSE_COLD_BOOT;
+      }
+      log = F("INIT : Cold Boot");
     }
-    log = F("INIT : Cold Boot");
+
+    log += F(" - Restart Reason: ");
+    log += getResetReasonString();
+
+    RTC.deepSleepState = 0;
+    saveToRTC();
+
+    addLog(LOG_LEVEL_INFO, log);
   }
-
-  log += F(" - Restart Reason: ");
-  log += getResetReasonString();
-
-  RTC.deepSleepState = 0;
-  saveToRTC();
-
-  addLog(LOG_LEVEL_INFO, log);
+  #ifndef BUILD_NO_RAM_TRACKER
+  logMemUsageAfter(F("RTC init"));
+  #endif
 
   fileSystemCheck();
+  #ifndef BUILD_NO_RAM_TRACKER
+  logMemUsageAfter(F("fileSystemCheck()"));
+  #endif
 
   //  progMemMD5check();
   LoadSettings();
+  #ifndef BUILD_NO_RAM_TRACKER
+  logMemUsageAfter(F("LoadSettings()"));
+  #endif
 
   Settings.UseRTOSMultitasking = false; // For now, disable it, we experience heap corruption.
 
@@ -240,9 +257,17 @@ void ESPEasy_setup()
     // Perhaps the WiFi radio needs some time to stabilize first?
     WifiScan(true);
   }
+  #ifndef BUILD_NO_RAM_TRACKER
+  logMemUsageAfter(F("WifiScan()"));
+  #endif
+
 
   //  setWifiMode(WIFI_STA);
   checkRuleSets();
+  #ifndef BUILD_NO_RAM_TRACKER
+  logMemUsageAfter(F("checkRuleSets()"));
+  #endif
+
 
   // if different version, eeprom settings structure has changed. Full Reset needed
   // on a fresh ESP module eeprom values are set to 255. Version results into -1 (signed int)
@@ -259,15 +284,20 @@ void ESPEasy_setup()
   }
 
   initSerial();
+  #ifndef BUILD_NO_RAM_TRACKER
+  logMemUsageAfter(F("initSerial()"));
+  #endif
+
 
   if (Settings.Build != BUILD) {
     BuildFixes();
   }
 
-
-  log  = F("INIT : Free RAM:");
-  log += FreeMem();
-  addLog(LOG_LEVEL_INFO, log);
+  if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+    String log  = F("INIT : Free RAM:");
+    log += FreeMem();
+    addLog(LOG_LEVEL_INFO, log);
+  }
 
   if (Settings.UseSerial && (Settings.SerialLogLevel >= LOG_LEVEL_DEBUG_MORE)) {
     Serial.setDebugOutput(true);
@@ -277,28 +307,47 @@ void ESPEasy_setup()
   checkRAM(F("hardwareInit"));
   #endif // ifndef BUILD_NO_RAM_TRACKER
   hardwareInit();
+  #ifndef BUILD_NO_RAM_TRACKER
+  logMemUsageAfter(F("hardwareInit()"));
+  #endif
+
 
   timermqtt_interval      = 250; // Interval for checking MQTT
   timerAwakeFromDeepSleep = millis();
   CPluginInit();
+  #ifndef BUILD_NO_RAM_TRACKER
+  logMemUsageAfter(F("CPluginInit()"));
+  #endif
   #ifdef USES_NOTIFIER
   NPluginInit();
+  #ifndef BUILD_NO_RAM_TRACKER
+  logMemUsageAfter(F("NPluginInit()"));
+  #endif
   #endif // ifdef USES_NOTIFIER
+
   PluginInit();
-  log  = F("INFO : Plugins: ");
-  log += deviceCount + 1;
-  log += ' ';
-  log += getPluginDescriptionString();
-  log += " (";
-  log += getSystemLibraryString();
-  log += ')';
-  addLog(LOG_LEVEL_INFO, log);
+  #ifndef BUILD_NO_RAM_TRACKER
+  logMemUsageAfter(F("PluginInit()"));
+  #endif
+  if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+    String log  = F("INFO : Plugins: ");
+    log += deviceCount + 1;
+    log += ' ';
+    log += getPluginDescriptionString();
+    log += " (";
+    log += getSystemLibraryString();
+    log += ')';
+    addLog(LOG_LEVEL_INFO, log);
+  }
 
   if (deviceCount + 1 >= PLUGIN_MAX) {
     addLog(LOG_LEVEL_ERROR, String(F("Programming error! - Increase PLUGIN_MAX (")) + deviceCount + ')');
   }
 
   clearAllCaches();
+  #ifndef BUILD_NO_RAM_TRACKER
+  logMemUsageAfter(F("clearAllCaches()"));
+  #endif
 
   if (Settings.UseRules && isDeepSleepEnabled())
   {
@@ -314,8 +363,15 @@ void ESPEasy_setup()
   }
 
   NetworkConnectRelaxed();
+  #ifndef BUILD_NO_RAM_TRACKER
+  logMemUsageAfter(F("NetworkConnectRelaxed()"));
+  #endif
 
   setWebserverRunning(true);
+  #ifndef BUILD_NO_RAM_TRACKER
+  logMemUsageAfter(F("setWebserverRunning()"));
+  #endif
+
 
   #ifdef FEATURE_REPORTING
   ReportStatus();
@@ -323,26 +379,41 @@ void ESPEasy_setup()
 
   #ifdef FEATURE_ARDUINO_OTA
   ArduinoOTAInit();
+  #ifndef BUILD_NO_RAM_TRACKER
+  logMemUsageAfter(F("ArduinoOTAInit()"));
+  #endif
   #endif // ifdef FEATURE_ARDUINO_OTA
 
   if (node_time.systemTimePresent()) {
     node_time.initTime();
+    #ifndef BUILD_NO_RAM_TRACKER
+    logMemUsageAfter(F("node_time.initTime()"));
+    #endif
   }
 
   if (Settings.UseRules)
   {
     String event = F("System#Boot");
     rulesProcessing(event); // TD-er: Process events in the setup() now.
+    #ifndef BUILD_NO_RAM_TRACKER
+    logMemUsageAfter(F("rulesProcessing(System#Boot)"));
+    #endif
   }
 
   writeDefaultCSS();
+  #ifndef BUILD_NO_RAM_TRACKER
+  logMemUsageAfter(F("writeDefaultCSS()"));
+  #endif
+
 
   UseRTOSMultitasking = Settings.UseRTOSMultitasking;
   #ifdef USE_RTOS_MULTITASKING
 
   if (UseRTOSMultitasking) {
-    log = F("RTOS : Launching tasks");
-    addLog(LOG_LEVEL_INFO, log);
+    if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+      String log = F("RTOS : Launching tasks");
+      addLog(LOG_LEVEL_INFO, log);
+    }
     xTaskCreatePinnedToCore(RTOS_TaskServers, "RTOS_TaskServers", 16384, NULL, 1, NULL, 1);
     xTaskCreatePinnedToCore(RTOS_TaskSerial,  "RTOS_TaskSerial",  8192,  NULL, 1, NULL, 1);
     xTaskCreatePinnedToCore(RTOS_Task10ps,    "RTOS_Task10ps",    8192,  NULL, 1, NULL, 1);
@@ -366,4 +437,8 @@ void ESPEasy_setup()
   Scheduler.setIntervalTimerOverride(ESPEasy_Scheduler::IntervalTimer_e::TIMER_30SEC,      1333); // timer for watchdog once per 30 sec
   Scheduler.setIntervalTimerOverride(ESPEasy_Scheduler::IntervalTimer_e::TIMER_MQTT,       88);   // timer for interaction with MQTT
   Scheduler.setIntervalTimerOverride(ESPEasy_Scheduler::IntervalTimer_e::TIMER_STATISTICS, 2222);
+  #ifndef BUILD_NO_RAM_TRACKER
+  logMemUsageAfter(F("Scheduler.setIntervalTimerOverride"));
+  #endif
+
 }

--- a/src/src/Globals/CPlugins.h
+++ b/src/src/Globals/CPlugins.h
@@ -52,7 +52,8 @@ controllerIndex_t findFirstEnabledControllerWithId(cpluginID_t cpluginid);
 extern std::map<cpluginID_t, protocolIndex_t> CPlugin_id_to_ProtocolIndex;
 
 // Vector to match a "ProtocolIndex" to a controller ID.
-extern std::vector<cpluginID_t> ProtocolIndex_to_CPlugin_id;
+// INVALID_CONTROLLER_INDEX may be used as index for this array.
+extern cpluginID_t ProtocolIndex_to_CPlugin_id[CPLUGIN_MAX + 1];
 
 
 bool validProtocolIndex(protocolIndex_t index);
@@ -75,6 +76,8 @@ protocolIndex_t getProtocolIndex(cpluginID_t cpluginID);
 
 String          getCPluginNameFromProtocolIndex(protocolIndex_t ProtocolIndex);
 String          getCPluginNameFromCPluginID(cpluginID_t cpluginID);
+
+bool            addCPlugin(cpluginID_t cpluginID, protocolIndex_t x);
 
 
 #endif // GLOBALS_CPLUGIN_H

--- a/src/src/Globals/Plugins.h
+++ b/src/src/Globals/Plugins.h
@@ -50,12 +50,12 @@ extern boolean (*Plugin_ptr[PLUGIN_MAX])(byte,
                                          struct EventStruct *,
                                          String&);
 
+// Vector to match a "DeviceIndex" to a plugin ID.
+// INVALID_DEVICE_INDEX may be used as index for this array, thus one larger
+extern pluginID_t DeviceIndex_to_Plugin_id[PLUGIN_MAX + 1];
 
 // Map to match a plugin ID to a "DeviceIndex"
 extern std::map<pluginID_t, deviceIndex_t> Plugin_id_to_DeviceIndex;
-
-// Vector to match a "DeviceIndex" to a plugin ID.
-extern std::vector<pluginID_t> DeviceIndex_to_Plugin_id;
 
 // Vector containing "DeviceIndex" alfabetically sorted.
 extern std::vector<deviceIndex_t> DeviceIndex_sorted;

--- a/src/src/Globals/Protocol.cpp
+++ b/src/src/Globals/Protocol.cpp
@@ -1,4 +1,4 @@
 #include "../Globals/Protocol.h"
 
-ProtocolVector Protocol;
+ProtocolStruct Protocol[CPLUGIN_MAX];
 int protocolCount = -1;

--- a/src/src/Globals/Protocol.h
+++ b/src/src/Globals/Protocol.h
@@ -3,7 +3,9 @@
 
 #include "../DataStructs/ProtocolStruct.h"
 
-extern ProtocolVector Protocol;
+#include "../CustomBuild/ESPEasyLimits.h"
+
+extern ProtocolStruct Protocol[CPLUGIN_MAX];
 extern int protocolCount;
 
 #endif // GLOBALS_PROTOCOL_H

--- a/src/src/Helpers/ESPEasy_Storage.cpp
+++ b/src/src/Helpers/ESPEasy_Storage.cpp
@@ -129,7 +129,7 @@ bool fileExists(const String& fname) {
 fs::File tryOpenFile(const String& fname, const String& mode) {
   START_TIMER;
   fs::File f;
-  if (fname.length() == 0 || fname.equals(F("/"))) {
+  if (fname.isEmpty() || fname.equals(F("/"))) {
     return f;
   }
 
@@ -754,7 +754,7 @@ String SaveTaskSettings(taskIndex_t TaskIndex)
                           (byte *)&ExtraTaskSettings,
                           sizeof(struct ExtraTaskSettingsStruct));
 
-  if (err.length() == 0) {
+  if (err.isEmpty()) {
     err = checkTaskSettings(TaskIndex);
   }
   return err;

--- a/src/src/Helpers/ESPEasy_Storage.cpp
+++ b/src/src/Helpers/ESPEasy_Storage.cpp
@@ -635,7 +635,7 @@ String LoadStringArray(SettingsType::Enum settingsType, int index, String string
     readPos += bufferSize;
   }
 
-  if ((tmpString.length() != 0) && (stringCount < nrStrings)) {
+  if ((!tmpString.isEmpty()) && (stringCount < nrStrings)) {
     result              += F("Incomplete custom settings for index ");
     result              += (index + 1);
     strings[stringCount] = tmpString;

--- a/src/src/Helpers/ESPEasy_checks.cpp
+++ b/src/src/Helpers/ESPEasy_checks.cpp
@@ -167,7 +167,7 @@ bool SettingsCheck(String& error) {
 
   #endif
 
-  return error.length() == 0;
+  return error.isEmpty();
 }
 
 #include "Numerical.h"
@@ -187,7 +187,7 @@ String checkTaskSettings(taskIndex_t taskIndex) {
   if (isNumerical(deviceName, detectedType)) {
     return F("Invalid name. Should not be numeric.");
   }
-  if (deviceName.length() == 0) {
+  if (deviceName.isEmpty()) {
     if (Settings.TaskDeviceEnabled[taskIndex]) {
       // Decide what to do here, for now give a warning when task is enabled.
       return F("Warning: Task Device Name is empty. It is adviced to give tasks an unique name");

--- a/src/src/Helpers/Hardware.cpp
+++ b/src/src/Helpers/Hardware.cpp
@@ -153,6 +153,7 @@ void hardwareInit()
     }
     else
     {
+      SD.end();
       addLog(LOG_LEVEL_ERROR, F("SD   : Init failed"));
     }
   }

--- a/src/src/Helpers/Misc.cpp
+++ b/src/src/Helpers/Misc.cpp
@@ -443,3 +443,30 @@ int getLoopCountPerSec() {
 int getUptimeMinutes() {
   return wdcounter / 2;
 }
+
+#ifndef BUILD_NO_RAM_TRACKER
+void logMemUsageAfter(const __FlashStringHelper * function, int value) {
+  // Store free memory in an int, as subtracting may sometimes result in negative value.
+  // The recorded used memory is not an exact value, as background (or interrupt) tasks may also allocate or free heap memory.
+  static int last_freemem = ESP.getFreeHeap();
+  const int freemem_end = ESP.getFreeHeap();
+  if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+    String log;
+    log.reserve(128);
+    log  = F("After ");
+    log += function;
+    if (value >= 0) {
+      log += value;
+    }
+    while (log.length() < 30) log += ' ';
+    log += F("Free mem after: ");
+    log += freemem_end;
+    while (log.length() < 55) log += ' ';
+    log += F("diff: ");
+    log += last_freemem - freemem_end;
+    addLog(LOG_LEVEL_DEBUG, log);
+  }
+
+  last_freemem = freemem_end;
+}
+#endif

--- a/src/src/Helpers/Misc.cpp
+++ b/src/src/Helpers/Misc.cpp
@@ -38,7 +38,7 @@ bool remoteConfig(struct EventStruct *event, const String& string)
       // tolerantParseStringKeepCase(Line, 4);
       String configCommand = parseStringToEndKeepCase(string, 4);
 
-      if ((configTaskName.length() == 0) || (configCommand.length() == 0)) {
+      if ((configTaskName.isEmpty()) || (configCommand.isEmpty())) {
         return success; // TD-er: Should this be return false?
       }
       taskIndex_t index = findTaskIndexByName(configTaskName);

--- a/src/src/Helpers/Misc.h
+++ b/src/src/Helpers/Misc.h
@@ -177,5 +177,9 @@ int getLoopCountPerSec();
 
 int getUptimeMinutes();
 
+#ifndef BUILD_NO_RAM_TRACKER
+void logMemUsageAfter(const __FlashStringHelper * function, int value = -1);
+#endif
+
 
 #endif // ifndef HELPERS_MISC_H

--- a/src/src/Helpers/Networking.cpp
+++ b/src/src/Helpers/Networking.cpp
@@ -1174,9 +1174,9 @@ bool downloadFile(const String& url, String file_save, const String& user, const
   uint16_t port;
   String   uri = splitURL(url, host, port, file);
 
-  if (file_save.length() == 0) {
+  if (file_save.isEmpty()) {
     file_save = file;
-  } else if ((file.length() == 0) && uri.endsWith("/")) {
+  } else if ((file.isEmpty()) && uri.endsWith("/")) {
     // file = file_save;
     uri += file_save;
   }
@@ -1192,7 +1192,7 @@ bool downloadFile(const String& url, String file_save, const String& user, const
     addLog(LOG_LEVEL_ERROR, log);
   }
 
-  if (file_save.length() == 0) {
+  if (file_save.isEmpty()) {
     error = F("Empty filename");
     addLog(LOG_LEVEL_ERROR, error);
     return false;

--- a/src/src/Helpers/Rules_calculate.cpp
+++ b/src/src/Helpers/Rules_calculate.cpp
@@ -485,7 +485,7 @@ CalculateReturnCode RulesCalculate_t::doCalculate(const char *input, double *res
 void preProcessReplace(String& input, UnaryOperator op) {
   String find = toString(op);
 
-  if (find.length() == 0) { return; }
+  if (find.isEmpty()) { return; }
   find += '('; // Add opening parenthesis.
 
   const String replace = String(static_cast<char>(op)) + '(';

--- a/src/src/Helpers/Scheduler.cpp
+++ b/src/src/Helpers/Scheduler.cpp
@@ -1103,8 +1103,10 @@ void ESPEasy_Scheduler::process_system_event_queue() {
 
   switch (ptr_type) {
     case PluginPtrType::TaskPlugin:
-      LoadTaskSettings(ScheduledEventQueue.front().event.TaskIndex);
-      Plugin_ptr[Index](Function, &ScheduledEventQueue.front().event, tmpString);
+      if (validDeviceIndex(Index)) {
+        LoadTaskSettings(ScheduledEventQueue.front().event.TaskIndex);
+        Plugin_ptr[Index](Function, &ScheduledEventQueue.front().event, tmpString);
+      }
       break;
     case PluginPtrType::ControllerPlugin:
       CPluginCall(Index, static_cast<CPlugin::Function>(Function), &ScheduledEventQueue.front().event, tmpString);

--- a/src/src/Helpers/StringConverter.cpp
+++ b/src/src/Helpers/StringConverter.cpp
@@ -415,7 +415,7 @@ String to_json_object_value(const String& object, const String& value) {
   wrap_String(object, F("\""), result);
   result += F(":");
 
-  if (value.length() == 0) {
+  if (value.isEmpty()) {
     // Empty string
     result += F("\"\"");
     return result;
@@ -918,7 +918,7 @@ bool getConvertArgumentString(const String& marker,
 
   argumentString = s.substring(startIndexArgument, endIndex);
 
-  if (argumentString.length() == 0) { return false; }
+  if (argumentString.isEmpty()) { return false; }
   ++endIndex; // Must also strip ')' from the original string.
   return true;
 }

--- a/src/src/Helpers/StringParser.cpp
+++ b/src/src/Helpers/StringParser.cpp
@@ -107,7 +107,7 @@ String parseTemplate_padded(String& tmpString, byte minimal_lineSize, bool useUR
 
         if (deviceName.equals(F("int"))) {
           nr_decimals = 0;
-        } else if (format.length() != 0)
+        } else if (!format.isEmpty())
         {
           // There is some formatting here, so do not throw away decimals
           trimTrailingZeros = false;
@@ -550,7 +550,7 @@ taskIndex_t findTaskIndexByName(const String& deviceName)
     if (Settings.TaskDeviceEnabled[taskIndex]) {
       String taskDeviceName = getTaskDeviceName(taskIndex);
 
-      if (taskDeviceName.length() != 0)
+      if (!taskDeviceName.isEmpty())
       {
         // Use entered taskDeviceName can have any case, so compare case insensitive.
         if (deviceName.equalsIgnoreCase(taskDeviceName))

--- a/src/src/Helpers/WebServer_commandHelper.cpp
+++ b/src/src/Helpers/WebServer_commandHelper.cpp
@@ -12,7 +12,7 @@ HandledWebCommand_result handle_command_from_web(EventValueSource::Enum source, 
 {
   if (!clientIPallowed()) { return HandledWebCommand_result::IP_not_allowed; }
   webrequest.trim();
-  if (webrequest.length() == 0) { return HandledWebCommand_result::NoCommand; }
+  if (webrequest.isEmpty()) { return HandledWebCommand_result::NoCommand; }
 
   addLog(LOG_LEVEL_INFO,  String(F("HTTP: ")) + webrequest);
   webrequest = parseTemplate(webrequest);

--- a/src/src/Helpers/_CPlugin_Helper.cpp
+++ b/src/src/Helpers/_CPlugin_Helper.cpp
@@ -93,7 +93,7 @@ bool safeReadStringUntil(Stream     & input,
 String get_auth_header(const String& user, const String& pass) {
   String authHeader = "";
 
-  if ((user.length() != 0) && (pass.length() != 0)) {
+  if ((!user.isEmpty()) && (!pass.isEmpty())) {
     String auth = user;
     auth       += ":";
     auth       += pass;
@@ -634,6 +634,6 @@ void setControllerPass(controllerIndex_t controller_idx, const ControllerSetting
 
 bool hasControllerCredentialsSet(controllerIndex_t controller_idx, const ControllerSettingsStruct& ControllerSettings)
 {
-  return getControllerUser(controller_idx, ControllerSettings).length() != 0 &&
-         getControllerPass(controller_idx, ControllerSettings).length() != 0;
+  return !getControllerUser(controller_idx, ControllerSettings).isEmpty() &&
+         !getControllerPass(controller_idx, ControllerSettings).isEmpty();
 }

--- a/src/src/PluginStructs/P036_data_struct.h
+++ b/src/src/PluginStructs/P036_data_struct.h
@@ -80,32 +80,32 @@ enum class eP036pinmode {
 
 typedef struct {
   String   LineContent;       // content
+  int      CurrentLeft = 0;   // current left pix position
+  float    dPix        = 0.0f; // pix change per scroll time (100ms)
+  float    fPixSum     = 0.0f; // pix sum while scrolling (100ms)
   uint16_t LastWidth   = 0;   // width of last line in pix
   uint16_t Width       = 0;   // width in pix
   uint8_t  Height      = 0;   // Height in Pix
   uint8_t  ypos        = 0;   // y position in pix
-  int      CurrentLeft = 0;   // current left pix position
-  float    dPix        = 0.0f; // pix change per scroll time (100ms)
-  float    fPixSum     = 0.0f; // pix sum while scrolling (100ms)
 } tScrollLine;
 
 typedef struct {
-  const char *Font  = nullptr; // font for this line setting
-  uint8_t     Space = 0;       // space in pix between lines for this line setting
-  uint16_t    wait  = 0;       // waiting time before scrolling
   tScrollLine Line[P36_MAX_LinesPerPage];
+  const char *Font  = nullptr; // font for this line setting
+  uint16_t    wait  = 0;       // waiting time before scrolling
+  uint8_t     Space = 0;       // space in pix between lines for this line setting
 } tScrollingLines;
 
 typedef struct {
-  uint8_t     Scrolling                  = 0;       // 0=Ready, 1=Scrolling
-  const char *Font                       = nullptr; // font for this line setting
-  uint8_t     dPix                       = 0;       // pix change per scroll time (25ms)
-  int         dPixSum                    = 0;       // act pix change
-  uint8_t     linesPerFrame              = 0;       // the number of lines in each frame
-  int         ypos[P36_MAX_LinesPerPage] = { 0 };   // ypos contains the heights of the various lines - this depends on the font and the
-                                                    // number of lines
   String LineIn[P36_MAX_LinesPerPage];
   String LineOut[P36_MAX_LinesPerPage];
+  int         ypos[P36_MAX_LinesPerPage] = { 0 };   // ypos contains the heights of the various lines - this depends on the font and the
+                                                    // number of lines
+  int         dPixSum                    = 0;       // act pix change
+  const char *Font                       = nullptr; // font for this line setting
+  uint8_t     Scrolling                  = 0;       // 0=Ready, 1=Scrolling
+  uint8_t     dPix                       = 0;       // pix change per scroll time (25ms)
+  uint8_t     linesPerFrame              = 0;       // the number of lines in each frame
 } tScrollingPages;
 
 typedef struct {
@@ -123,8 +123,8 @@ typedef struct {
 } tFontSizes;
 
 typedef struct {
-  uint8_t     Top;      // top in pix for this line setting
   const char *fontData; // font for this line setting
+  uint8_t     Top;      // top in pix for this line setting
   uint8_t     Height;   // font height in pix
   uint8_t     Space;    // space in pix between lines for this line setting
 } tFontSettings;
@@ -228,8 +228,8 @@ struct P036_data_struct : public PluginTaskData_base {
 
   // display
   p036_resolution  disp_resolution   = p036_resolution::pix128x64;
-  bool             bLineScrollEnabled = false;
   uint8_t          TopLineOffset      = 0; // Offset for top line, used for rotated image while using displays < P36_MaxDisplayHeight lines
+  bool             bLineScrollEnabled = false;
   // Display button
   bool    ButtonState     = false;         // button not touched
   uint8_t ButtonLastState = 0;             // Last state checked (debouncing in progress)
@@ -237,12 +237,12 @@ struct P036_data_struct : public PluginTaskData_base {
   uint8_t RepeatCounter   = 0;             // Repeat delay counter when holding button pressed
   uint8_t displayTimer    = 0;             // counter for display OFF
   // frame header
-  bool           bHideHeader = false;
-  bool           bHideFooter = false;
-  bool           bAlternativHeader = false;
   uint16_t       HeaderCount       = 0;
   eHeaderContent HeaderContent = eHeaderContent::eSSID;
   eHeaderContent HeaderContentAlternative = eHeaderContent::eSSID;
+  bool           bHideHeader = false;
+  bool           bHideFooter = false;
+  bool           bAlternativHeader = false;
 
   // frames
   uint8_t MaxFramesToDisplay    = 0;    // total number of frames to display

--- a/src/src/PluginStructs/P087_data_struct.cpp
+++ b/src/src/PluginStructs/P087_data_struct.cpp
@@ -288,7 +288,7 @@ bool P087_data_struct::matchRegexp(String& received) const {
         for (uint8_t n = 0; n < P087_NR_FILTERS; ++n) {
           unsigned int lines_index = n * 3 + P087_FIRST_FILTER_POS + 2;
 
-          if ((capture_index[n] == capture_vector[i].first) && (_lines[lines_index].length() != 0)) {
+          if ((capture_index[n] == capture_vector[i].first) && !(_lines[lines_index].isEmpty())) {
             String log;
             log.reserve(32);
             log  = F("P087: Index: ");

--- a/src/src/PluginStructs/P087_data_struct.cpp
+++ b/src/src/PluginStructs/P087_data_struct.cpp
@@ -41,7 +41,7 @@ void P087_data_struct::post_init() {
   for (uint8_t i = 0; i < P87_MAX_CAPTURE_INDEX; ++i) {
     capture_index_used[i] = false;
   }
-  regex_empty = _lines[P087_REGEX_POS].length() == 0;
+  regex_empty = _lines[P087_REGEX_POS].isEmpty();
   String log = F("P087_post_init:");
 
   for (uint8_t i = 0; i < P087_NR_FILTERS; ++i) {
@@ -143,7 +143,7 @@ bool P087_data_struct::loop() {
 
 bool P087_data_struct::getSentence(String& string) {
   string        = last_sentence;
-  if (string.length() == 0) {
+  if (string.isEmpty()) {
     return false;
   }
   last_sentence = "";

--- a/src/src/PluginStructs/P092_data_struct.cpp
+++ b/src/src/PluginStructs/P092_data_struct.cpp
@@ -630,9 +630,11 @@ void P092_data_struct::Plugin_092_StartReceiving(taskIndex_t taskindex) {
   DLbus_Data->StartReceiving();
   uint32_t start = millis();
 
-  String log = F("P092_receiving ... TaskIndex:");
-  log += taskindex;
-  addLog(LOG_LEVEL_INFO, log);
+  if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+    String log = F("P092_receiving ... TaskIndex:");
+    log += taskindex;
+    addLog(LOG_LEVEL_INFO, log);
+  }
 
   while ((timePassedSince(start) < 100) && (DLbus_Data->ISR_PulseCount == 0)) {
     // wait for first pulse received (timeout 100ms)

--- a/src/src/PluginStructs/P099_data_struct.cpp
+++ b/src/src/PluginStructs/P099_data_struct.cpp
@@ -220,7 +220,7 @@ bool P099_data_struct::isValidAndTouchedTouchObject(uint16_t x, uint16_t y, Stri
  * Checks if the name doesn't exceed the max. length.
  */
 bool P099_data_struct::setTouchObjectState(String touchObject, bool state, uint8_t checkObjectCount) {
-  if (touchObject.length() == 0 || touchObject.substring(0, 1) == F("_")) return false;
+  if (touchObject.isEmpty() || touchObject.substring(0, 1) == F("_")) return false;
   String findObject = (state ? F("_") : F("")); // When enabling, try to find a disabled object
   findObject += touchObject;
   String thisObject;

--- a/src/src/Static/WebStaticData.cpp
+++ b/src/src/Static/WebStaticData.cpp
@@ -23,7 +23,7 @@ void serve_CSS() {
     addHtml(F("<style>"));
 
     // Send CSS in chunks
-    TXBuffer += DATA_ESPEASY_DEFAULT_MIN_CSS;
+    TXBuffer.addFlashString((PGM_P)FPSTR(DATA_ESPEASY_DEFAULT_MIN_CSS));
     addHtml(F("</style>"));
     return;
     #endif
@@ -80,32 +80,32 @@ void serve_JS(JSfiles_e JSfile) {
         switch (JSfile) {
           case JSfiles_e::UpdateSensorValuesDevicePage:
             #ifdef WEBSERVER_DEVICES
-            TXBuffer += DATA_UPDATE_SENSOR_VALUES_DEVICE_PAGE_JS;
+            TXBuffer.addFlashString((PGM_P)FPSTR(DATA_UPDATE_SENSOR_VALUES_DEVICE_PAGE_JS));
             #endif
             break;
           case JSfiles_e::FetchAndParseLog:
             #ifdef WEBSERVER_LOG
-            TXBuffer += DATA_FETCH_AND_PARSE_LOG_JS;
+            TXBuffer.addFlashString((PGM_P)FPSTR(DATA_FETCH_AND_PARSE_LOG_JS));
             #endif
             break;
           case JSfiles_e::SaveRulesFile:
             #ifdef WEBSERVER_RULES
-            TXBuffer += jsSaveRules;
+            TXBuffer.addFlashString((PGM_P)FPSTR(jsSaveRules));
             #endif
             break;
           case JSfiles_e::GitHubClipboard:
             #ifdef WEBSERVER_GITHUB_COPY
-            TXBuffer += DATA_GITHUB_CLIPBOARD_JS;
+            TXBuffer.addFlashString((PGM_P)FPSTR(DATA_GITHUB_CLIPBOARD_JS));
             #endif
             break;
           case JSfiles_e::Reboot:
-            TXBuffer += DATA_REBOOT_JS;
+            TXBuffer.addFlashString((PGM_P)FPSTR(DATA_REBOOT_JS));
             break;
           case JSfiles_e::Toasting:
-            TXBuffer += jsToastMessageBegin;
+            TXBuffer.addFlashString((PGM_P)FPSTR(jsToastMessageBegin));
             // we can push custom messages here in future releases...
             addHtml(F("Submitted"));
-            TXBuffer += jsToastMessageEnd;
+            TXBuffer.addFlashString((PGM_P)FPSTR(jsToastMessageEnd));
             break;
 
         }

--- a/src/src/WebServer/AdvancedConfigPage.cpp
+++ b/src/src/WebServer/AdvancedConfigPage.cpp
@@ -35,7 +35,7 @@ void handle_advanced() {
   TXBuffer.startStream();
   sendHeadandTail_stdtemplate();
 
-  if (webArg(F("edit")).length() != 0)
+  if (!webArg(F("edit")).isEmpty())
   {
 //    Settings.MessageDelay_unused = getFormItemInt(F("messagedelay"));
     Settings.IP_Octet     = webArg(F("ip")).toInt();

--- a/src/src/WebServer/CacheControllerPages.cpp
+++ b/src/src/WebServer/CacheControllerPages.cpp
@@ -40,9 +40,9 @@ void handle_dumpcache() {
     LoadTaskSettings(i);
 
     for (int j = 0; j < VARS_PER_TASK; ++j) {
-      addHtml(";");
+      addHtml(';');
       addHtml(ExtraTaskSettings.TaskDeviceName);
-      addHtml("#");
+      addHtml('#');
       addHtml(ExtraTaskSettings.TaskDeviceValueNames[j]);
     }
   }
@@ -101,9 +101,9 @@ void handle_cache_json() {
 
   //     addHtml(F("UNIX timestamp;contr. idx;sensortype;taskindex;value count"));
   stream_to_json_value(F("UNIX timestamp"));
-  addHtml(",");
+  addHtml(',');
   stream_to_json_value(F("UTC timestamp"));
-  addHtml(",");
+  addHtml(',');
   stream_to_json_value(F("task index"));
 
   for (taskIndex_t i = 0; i < TASKS_MAX; ++i) {
@@ -113,7 +113,7 @@ void handle_cache_json() {
       String label = ExtraTaskSettings.TaskDeviceName;
       label += '#';
       label += ExtraTaskSettings.TaskDeviceValueNames[j];
-      addHtml(",");
+      addHtml(',');
       stream_to_json_value(label);
     }
   }
@@ -128,7 +128,7 @@ void handle_cache_json() {
 
     if (currentFile.length() > 0) {
       if (filenr != 0) {
-        addHtml(",");
+        addHtml(',');
       }
       stream_to_json_value(currentFile);
       ++filenr;

--- a/src/src/WebServer/ControllerPage.cpp
+++ b/src/src/WebServer/ControllerPage.cpp
@@ -243,7 +243,7 @@ void handle_controllers_ShowAllControllersTable()
           String hostDescription;
           CPluginCall(ProtocolIndex, CPlugin::Function::CPLUGIN_WEBFORM_SHOW_HOST_CONFIG, 0, hostDescription);
 
-          if (hostDescription.length() != 0) {
+          if (!hostDescription.isEmpty()) {
             addHtml(hostDescription);
           } else {
             addHtml(ControllerSettings.getHost());

--- a/src/src/WebServer/DevicesPage.cpp
+++ b/src/src/WebServer/DevicesPage.cpp
@@ -314,7 +314,7 @@ void handle_devices_CopySubmittedSettings(taskIndex_t taskIndex, pluginID_t task
 
         // Restore the settings that were already set by the user
         for (byte i = 0; i < VARS_PER_TASK; ++i) {
-          if (oldNames[i].length() != 0) {
+          if (!oldNames[i].isEmpty()) {
             safe_strncpy(ExtraTaskSettings.TaskDeviceValueNames[i], oldNames[i], sizeof(ExtraTaskSettings.TaskDeviceValueNames[i]));
             ExtraTaskSettings.TaskDeviceValueDecimals[i] = oldNrDec[i];
           }

--- a/src/src/WebServer/FactoryResetPage.cpp
+++ b/src/src/WebServer/FactoryResetPage.cpp
@@ -181,7 +181,7 @@ void handle_factoryreset_json() {
     error = SaveSettings();
   }
 
-  if (error.length() == 0) {
+  if (error.isEmpty()) {
     error = F("ok");
   }
 

--- a/src/src/WebServer/FileList.cpp
+++ b/src/src/WebServer/FileList.cpp
@@ -55,7 +55,7 @@ void handle_filelist_json() {
   }
   int endIdx = startIdx + pageSize - 1;
 
-  addHtml("[{");
+  addHtml(F("[{"));
   bool firstentry = true;
   # if defined(ESP32)
   File root  = ESPEASY_FS.open("/");
@@ -72,7 +72,7 @@ void handle_filelist_json() {
         if (firstentry) {
           firstentry = false;
         } else {
-          addHtml(",{");
+          addHtml(F(",{"));
         }
         stream_next_json_object_value(F("fileName"), String(file.name()));
         stream_next_json_object_value(F("index"),    String(startIdx));
@@ -99,7 +99,7 @@ void handle_filelist_json() {
     if (firstentry) {
       firstentry = false;
     } else {
-      addHtml(",{");
+      addHtml(F(",{"));
     }
 
     stream_next_json_object_value(F("fileName"), String(dir.fileName()));
@@ -124,7 +124,7 @@ void handle_filelist_json() {
   }
 
   # endif // if defined(ESP8266)
-  addHtml("]");
+  addHtml(']');
   TXBuffer.endStream();
 }
 

--- a/src/src/WebServer/HTML_wrappers.cpp
+++ b/src/src/WebServer/HTML_wrappers.cpp
@@ -75,7 +75,7 @@ void html_TR_TD_height(int height) {
   html_TR();
 
   addHtml(F("<TD HEIGHT=\""));
-  addHtml(String(height));
+  addHtmlInt(height);
   addHtml(F("\">"));
 }
 
@@ -99,7 +99,7 @@ void html_copyText_TD() {
   ++copyTextCounter;
 
   addHtml(F("<TD id='copyText_"));
-  addHtml(String(copyTextCounter));
+  addHtmlInt(copyTextCounter);
   addHtml(F("'>"));
 }
 
@@ -201,7 +201,7 @@ void html_table_header(const String& label, const String& helpButton, const Stri
 
   if (width > 0) {
     addHtml(F(" style='width:"));
-    addHtml(String(width));
+    addHtmlInt(width);
     addHtml(F("px;'"));
   }
   addHtml('>');

--- a/src/src/WebServer/HTML_wrappers.cpp
+++ b/src/src/WebServer/HTML_wrappers.cpp
@@ -326,7 +326,7 @@ void addHtml(const char& html) {
 }
 
 void addHtml(const __FlashStringHelper * html) {
-  TXBuffer += html;
+  TXBuffer.addFlashString((PGM_P)html);
 }
 
 void addHtml(const String& html) {

--- a/src/src/WebServer/HardwarePage.cpp
+++ b/src/src/WebServer/HardwarePage.cpp
@@ -82,7 +82,7 @@ void handle_hardware() {
     }
     String error = SaveSettings();
     addHtmlError(error);
-    if (error.length() == 0) {
+    if (error.isEmpty()) {
       // Apply I2C settings.
       initI2C();
     }

--- a/src/src/WebServer/I2C_Scanner.cpp
+++ b/src/src/WebServer/I2C_Scanner.cpp
@@ -72,7 +72,7 @@ int scanI2CbusForDevices_json( // Utility function for scanning the I2C bus for 
               int newpos = description.indexOf(',', pos);
 
               if (pos != 0) {
-                addHtml(",");
+                addHtml(',');
               }
 
               if (newpos == -1) {
@@ -91,7 +91,7 @@ int scanI2CbusForDevices_json( // Utility function for scanning the I2C bus for 
           nDevices++;
         }
         json_close();
-        addHtml("\n");
+        addHtml('\n');
       }
 #ifdef FEATURE_I2CMULTIPLEXER
     }

--- a/src/src/WebServer/JSON.cpp
+++ b/src/src/WebServer/JSON.cpp
@@ -556,7 +556,7 @@ void stream_to_json_value(const String& value) {
   bool isNum  = isNumerical(value, detectedType);
   bool isBool = (Settings.JSONBoolWithoutQuotes() && ((value.equalsIgnoreCase(F("true")) || value.equalsIgnoreCase(F("false")))));
 
-  if (!isBool && ((value.length() == 0) || !isNum || mustConsiderAsString(detectedType))) {
+  if (!isBool && ((value.isEmpty()) || !isNum || mustConsiderAsString(detectedType))) {
     // Either empty, not a numerical or a BIN/HEX notation.
     addHtml('\"');
     if ((value.indexOf('\n') != -1) || (value.indexOf('\r') != -1) || (value.indexOf('"') != -1)) {

--- a/src/src/WebServer/JSON.cpp
+++ b/src/src/WebServer/JSON.cpp
@@ -117,9 +117,9 @@ void handle_json()
   bool showTaskDetails     = true;
   bool showNodes           = true;
   {
-    String view = webArg("view");
+    const String view = webArg("view");
 
-    if (view.length() != 0) {
+    if (!view.isEmpty()) {
       if (view == F("sensorupdate")) {
         showSystem = false;
         showWifi   = false;

--- a/src/src/WebServer/JSON.cpp
+++ b/src/src/WebServer/JSON.cpp
@@ -266,7 +266,7 @@ void handle_json()
         if (it->second.ip[0] != 0)
         {
           if (comma_between) {
-            addHtml(",");
+            addHtml(',');
           } else {
             comma_between = true;
             addHtml(F("\"nodes\":[\n")); // open json array if >0 nodes
@@ -428,9 +428,9 @@ void handle_json()
       stream_last_json_object_value(F("TaskNumber"), String(TaskIndex + 1));
 
       if (TaskIndex != lastActiveTaskIndex) {
-        addHtml(",");
+        addHtml(',');
       }
-      addHtml("\n");
+      addHtml('\n');
     }
   }
 

--- a/src/src/WebServer/Log.cpp
+++ b/src/src/WebServer/Log.cpp
@@ -57,7 +57,7 @@ void handle_log_JSON() {
 
     for (byte i = 0; i < LOG_LEVEL_NRELEMENTS; ++i) {
       if (i != 0) {
-        addHtml(",");
+        addHtml(',');
       }
       addHtml('{');
       int loglevel;

--- a/src/src/WebServer/Markup.cpp
+++ b/src/src/WebServer/Markup.cpp
@@ -285,7 +285,7 @@ void addRowLabel(const String& label, const String& id)
     html_TR_TD();
   }
 
-  if (label.length() != 0) {
+  if (!label.isEmpty()) {
     addHtml(label);
     addHtml(':');
   }

--- a/src/src/WebServer/Markup.cpp
+++ b/src/src/WebServer/Markup.cpp
@@ -241,6 +241,13 @@ void addUnit(const String& unit)
   addHtml(']');
 }
 
+void addUnit(char unit)
+{
+  addHtml(F(" ["));
+  addHtml(unit);
+  addHtml(']');
+}
+
 void addRowLabel_tr_id(const __FlashStringHelper * label, const __FlashStringHelper * id)
 {
   addRowLabel_tr_id(String(label), String(id));

--- a/src/src/WebServer/Markup.cpp
+++ b/src/src/WebServer/Markup.cpp
@@ -332,13 +332,13 @@ void addRowLabelValue_copy(LabelType::Enum label) {
 void addTableSeparator(const __FlashStringHelper *label, int colspan, int h_size)
 {
     addHtml(F("<TR><TD colspan="));
-    addHtml(String(colspan));
+    addHtmlInt(colspan);
     addHtml(F("><H"));
-    addHtml(String(h_size));
+    addHtmlInt(h_size);
     addHtml('>');
     addHtml(label);
     addHtml(F("</H"));
-    addHtml(String(h_size));
+    addHtmlInt(h_size);
     addHtml(F("></TD></TR>"));
 }
 

--- a/src/src/WebServer/Markup.h
+++ b/src/src/WebServer/Markup.h
@@ -80,6 +80,7 @@ void addSelector_Foot();
 
 void addUnit(const __FlashStringHelper * unit);
 void addUnit(const String& unit);
+void addUnit(char unit);
 
 void addRowLabel_tr_id(const __FlashStringHelper * label, const __FlashStringHelper * id);
 void addRowLabel_tr_id(const __FlashStringHelper * label, const String& id);

--- a/src/src/WebServer/Markup_Buttons.cpp
+++ b/src/src/WebServer/Markup_Buttons.cpp
@@ -107,7 +107,7 @@ void addDeleteButton(const String& url, const String& label)
 void addWideButton(const __FlashStringHelper * url, const __FlashStringHelper * label) {
   html_add_wide_button_prefix(EMPTY_STRING, true);
   addHtml(url);
-  addHtml("'>");
+  addHtml(F("'>"));
   addHtml(label);
   addHtml(F("</a>"));
 }
@@ -188,7 +188,7 @@ void addCopyButton(const String& value, const String& delimiter, const String& n
   addHtmlAttribute(F("onclick"), F("setClipboard()"));
   addHtml('>');
   addHtml(name);
-  addHtml(" (");
+  addHtml(F(" ("));
   html_copyText_marker();
   addHtml(F(")</button>"));
 }

--- a/src/src/WebServer/Markup_Buttons.cpp
+++ b/src/src/WebServer/Markup_Buttons.cpp
@@ -176,11 +176,11 @@ void addSubmitButton(const String& value, const String& name, const String& clas
 // add copy to clipboard button
 void addCopyButton(const String& value, const String& delimiter, const String& name)
 {
-  TXBuffer += jsClipboardCopyPart1;
+  TXBuffer.addFlashString((PGM_P)FPSTR(jsClipboardCopyPart1));
   addHtml(value);
-  TXBuffer += jsClipboardCopyPart2;
+  TXBuffer.addFlashString((PGM_P)FPSTR(jsClipboardCopyPart2));
   addHtml(delimiter);
-  TXBuffer += jsClipboardCopyPart3;
+  TXBuffer.addFlashString((PGM_P)FPSTR(jsClipboardCopyPart3));
 
   // Fix HTML
   addHtml(F("<button "));

--- a/src/src/WebServer/Markup_Forms.cpp
+++ b/src/src/WebServer/Markup_Forms.cpp
@@ -176,7 +176,7 @@ void addFormPasswordBox(const String& label, const String& id, const String& pas
   addHtmlAttribute(F("type"),      F("password"));
   addHtmlAttribute(F("name"),      id);
   addHtmlAttribute(F("maxlength"), maxlength);
-  addHtmlAttribute(F("value"),     (password.length() == 0) ? F("") : F("*****"));
+  addHtmlAttribute(F("value"),     (password.isEmpty()) ? F("") : F("*****"));
   addHtml('>');
 }
 
@@ -409,7 +409,7 @@ int getFormItemInt(const String& key, int defaultValue) {
 
 bool getCheckWebserverArg_int(const String& key, int& value) {
   const String valueStr = webArg(key);
-  if (valueStr.length() == 0) return false;
+  if (valueStr.isEmpty()) return false;
   return validIntFromString(valueStr, value);
 }
 

--- a/src/src/WebServer/Markup_Forms.cpp
+++ b/src/src/WebServer/Markup_Forms.cpp
@@ -487,7 +487,7 @@ float getFormItemFloat(const LabelType::Enum& id)
 
 bool isFormItem(const String& id)
 {
-  return webArg(id).length() != 0;
+  return !webArg(id).isEmpty();
 }
 
 void copyFormPassword(const String& id, char *pPassword, int maxlength)

--- a/src/src/WebServer/SetupPage.cpp
+++ b/src/src/WebServer/SetupPage.cpp
@@ -84,7 +84,7 @@ void handle_setup() {
         String password;
         bool passwordGiven = getFormPassword(F("pass"), password);
         if (passwordGiven) {
-          passwordGiven = password.length() != 0;
+          passwordGiven = !password.isEmpty();
         }
         const bool emptyPassAllowed = isFormItemChecked(F("emptypass"));
         const bool performRescan = web_server.hasArg(F("performrescan"));
@@ -93,14 +93,14 @@ void handle_setup() {
           WifiScan(false);
         }
 
-        if (other.length() != 0)
+        if (!other.isEmpty())
         {
           ssid = other;
         }
 
         if (!performRescan) {
           // if ssid config not set and params are both provided
-          if ((status == HANDLE_SETUP_SCAN_STAGE) && (ssid.length() != 0) /*&& strcasecmp(SecuritySettings.WifiSSID, "ssid") == 0 */)
+          if ((status == HANDLE_SETUP_SCAN_STAGE) && (!ssid.isEmpty()) /*&& strcasecmp(SecuritySettings.WifiSSID, "ssid") == 0 */)
           {
             if (clearButtonPressed) {
               addHtmlError(F("Warning: Need to confirm to clear WiFi credentials"));

--- a/src/src/WebServer/SysInfoPage.cpp
+++ b/src/src/WebServer/SysInfoPage.cpp
@@ -426,7 +426,7 @@ void handle_sysinfo_Network() {
   {
     addHtml(toString(getConnectionProtocol()));
     addHtml(F(" (RSSI "));
-    addHtml(String(WiFi.RSSI()));
+    addHtmlInt(WiFi.RSSI());
     addHtml(F(" dBm)"));
   } else addHtml('-');
 

--- a/src/src/WebServer/SysInfoPage.cpp
+++ b/src/src/WebServer/SysInfoPage.cpp
@@ -354,7 +354,7 @@ void handle_sysinfo_memory() {
 # endif // if defined(CORE_POST_2_5_0) || defined(ESP32)
 # if defined(CORE_POST_2_5_0)
   addRowLabelValue(LabelType::HEAP_FRAGMENTATION);
-  addHtml("%");
+  addHtml('%');
 # endif // ifdef CORE_POST_2_5_0
 
 
@@ -489,13 +489,13 @@ void handle_sysinfo_Firmware() {
   addTableSeparator(F("Firmware"), 2, 3);
 
   addRowLabelValue_copy(LabelType::BUILD_DESC);
-  addHtml(" ");
+  addHtml(' ');
   addHtml(F(BUILD_NOTES));
 
   addRowLabelValue_copy(LabelType::SYSTEM_LIBRARIES);
   addRowLabelValue_copy(LabelType::GIT_BUILD);
   addRowLabelValue_copy(LabelType::PLUGIN_COUNT);
-  addHtml(" ");
+  addHtml(' ');
   addHtml(getPluginDescriptionString());
 
   addRowLabel(F("Build Origin"));
@@ -592,7 +592,7 @@ void handle_sysinfo_Storage() {
       } else {
         addHtml(F(HTML_SYMBOL_WARNING));
       }
-      addHtml(")");
+      addHtml(')');
     }
     addHtml(F(" Device: "));
     uint32_t flashDevice = (flashChipId & 0xFF00) | ((flashChipId >> 16) & 0xFF);

--- a/src/src/WebServer/WebServer.cpp
+++ b/src/src/WebServer/WebServer.cpp
@@ -1065,7 +1065,7 @@ void createSvgTextElement(const String& text, float textXoffset, float textYoffs
   addHtml(toString(textXoffset, 2));
   addHtml(F("\" y=\""));
   addHtml(toString(textYoffset, 2));
-  addHtml("\">");
+  addHtml(F("\">"));
   addHtml(text);
   addHtml(F("</tspan>\n</text>"));
 }

--- a/src/src/WebServer/WebServer.cpp
+++ b/src/src/WebServer/WebServer.cpp
@@ -145,22 +145,25 @@ void sendHeadandTail(const String& tmplName, boolean Tail, boolean rebooting) {
     lastWeb = millis();
 
     if (Tail) {
-      addHtml(pageTemplate.substring(
-                11 +                                      // Size of "{{content}}"
-                pageTemplate.indexOf(F("{{content}}")))); // advance beyond content key
+      int pos = pageTemplate.indexOf(F("{{content}}"));
+      if (pos >= 0) {
+        pos += 11; // Size of "{{content}}"
+        const int length = pageTemplate.length();
+        // Prevent copy'ing the string, just stream directly to the buffer.
+        for (int i = pos; i < length; ++i) {
+          addHtml(pageTemplate[i]);
+        }
+      }
     } else {
       int indexStart = 0;
       int indexEnd   = 0;
       int readPos    = 0; // Position of data sent to TXBuffer
       String varName;     // , varValue;
-      String meta;
-
-      if (rebooting) {
-        meta = F("<meta http-equiv='refresh' content='10 url=/'>");
-      }
 
       while ((indexStart = pageTemplate.indexOf(F("{{"), indexStart)) >= 0) {
-        addHtml(pageTemplate.substring(readPos, indexStart));
+        for (int i = readPos; i < indexStart; ++i) {
+          addHtml(pageTemplate[i]);
+        }
         readPos = indexStart;
 
         if ((indexEnd = pageTemplate.indexOf(F("}}"), indexStart)) > 0) {
@@ -175,7 +178,9 @@ void sendHeadandTail(const String& tmplName, boolean Tail, boolean rebooting) {
             getErrorNotifications();
           }
           else if (varName == F("meta")) {
-            addHtml(meta);
+            if (rebooting) {
+              addHtml(F("<meta http-equiv='refresh' content='10 url=/'>"));
+            }
           }
           else {
             getWebPageTemplateVar(varName);
@@ -450,14 +455,14 @@ void setWebserverRunning(bool state) {
 
 void getWebPageTemplateDefault(const String& tmplName, String& tmpl)
 {
-  static size_t expectedSize = 579;
-
-  tmpl.reserve(expectedSize);
   const bool addJS   = true;
   const bool addMeta = true;
 
   if (tmplName == F("TmplAP"))
   {
+    static size_t expectedSize = 200;
+
+    tmpl.reserve(expectedSize);
     getWebPageTemplateDefaultHead(tmpl, !addMeta, !addJS);
 
     #ifndef WEBPAGE_TEMPLATE_AP_HEADER
@@ -470,35 +475,53 @@ void getWebPageTemplateDefault(const String& tmplName, String& tmpl)
     tmpl += F("</header>");
     getWebPageTemplateDefaultContentSection(tmpl);
     getWebPageTemplateDefaultFooter(tmpl);
+    if (tmpl.length() > expectedSize) {
+      expectedSize = tmpl.length();
+    }
   }
   else if (tmplName == F("TmplMsg"))
   {
+    static size_t expectedSize = 200;
+
+    tmpl.reserve(expectedSize);
     getWebPageTemplateDefaultHead(tmpl, !addMeta, !addJS);
     tmpl += F("<body>");
     getWebPageTemplateDefaultHeader(tmpl, F("{{name}}"), false);
     getWebPageTemplateDefaultContentSection(tmpl);
     getWebPageTemplateDefaultFooter(tmpl);
+    if (tmpl.length() > expectedSize) {
+      expectedSize = tmpl.length();
+    }
   }
   else if (tmplName == F("TmplDsh"))
   {
+    static size_t expectedSize = 200;
+
+    tmpl.reserve(expectedSize);
     getWebPageTemplateDefaultHead(tmpl, !addMeta, addJS);
     tmpl += F(
       "<body>"
       "{{content}}"
       "</body></html>"
       );
+    if (tmpl.length() > expectedSize) {
+      expectedSize = tmpl.length();
+    }
   }
   else // all other template names e.g. TmplStd
   {
+    static size_t expectedSize = 200;
+
+    tmpl.reserve(expectedSize);
     getWebPageTemplateDefaultHead(tmpl, addMeta, addJS);
     tmpl += F("<body class='bodymenu'>"
               "<span class='message' id='rbtmsg'></span>");
     getWebPageTemplateDefaultHeader(tmpl, F("{{name}} {{logo}}"), true);
     getWebPageTemplateDefaultContentSection(tmpl);
     getWebPageTemplateDefaultFooter(tmpl);
-  }
-  if (tmpl.length() > expectedSize) {
-    expectedSize = tmpl.length();
+    if (tmpl.length() > expectedSize) {
+      expectedSize = tmpl.length();
+    }
   }
 //  addLog(LOG_LEVEL_INFO, String(F("tmpl.length(): ")) + String(tmpl.length()));
 }
@@ -866,7 +889,7 @@ void addTaskSelect(const String& name,  taskIndex_t choice)
 
     {
       addHtml(F("<option value='"));
-      addHtml(String(x));
+      addHtmlInt(x);
       addHtml('\'');
 
       if (choice == x) {
@@ -879,7 +902,7 @@ void addTaskSelect(const String& name,  taskIndex_t choice)
     }
     {
       addHtml('>');
-      addHtml(String(x + 1));
+      addHtmlInt(x + 1);
       addHtml(F(" - "));
       addHtml(deviceName);
       addHtml(F(" - "));
@@ -911,7 +934,7 @@ void addTaskValueSelect(const String& name, int choice, taskIndex_t TaskIndex)
   for (byte x = 0; x < valueCount; x++)
   {
     addHtml(F("<option value='"));
-    addHtml(String(x));
+    addHtmlInt(x);
     addHtml('\'');
 
     if (choice == x) {
@@ -982,22 +1005,16 @@ String getControllerSymbol(byte index)
    }
  */
 void addSVG_param(const String& key, float value) {
-  String value_str = String(value, 2);
-
-  addSVG_param(key, value_str);
+  addSVG_param(key, String(value, 2));
 }
 
 void addSVG_param(const String& key, const String& value) {
-  String html;
-
-  html.reserve(8 + key.length() + value.length());
-  html += ' ';
-  html += key;
-  html += '=';
-  html += '\"';
-  html += value;
-  html += '\"';
-  addHtml(html);
+  addHtml(' ');
+  addHtml(key);
+  addHtml('=');
+  addHtml('\"');
+  addHtml(value);
+  addHtml('\"');
 }
 
 void createSvgRect_noStroke(const __FlashStringHelper * classname, unsigned int fillColor, float xoffset, float yoffset, float width, float height, float rx, float ry) {
@@ -1037,22 +1054,18 @@ void createSvgHorRectPath(unsigned int color, int xoffset, int yoffset, int size
   float width = SVG_BAR_WIDTH * size / range;
 
   if (width < 2) { width = 2; }
-  String html;
-
-  html.reserve(96);
-  html += formatToHex(color, F("<path fill=\"#"));
-  html += F("\" d=\"M");
-  html += toString(SVG_BAR_WIDTH * xoffset / range, 2);
-  html += ' ';
-  html += yoffset;
-  html += 'h';
-  html += toString(width, 2);
-  html += 'v';
-  html += height;
-  html += 'H';
-  html += toString(SVG_BAR_WIDTH * xoffset / range, 2);
-  html += F("z\"/>\n");
-  addHtml(html);
+  addHtml(formatToHex(color, F("<path fill=\"#")));
+  addHtml(F("\" d=\"M"));
+  addHtml(toString(SVG_BAR_WIDTH * xoffset / range, 2));
+  addHtml(' ');
+  addHtmlInt(yoffset);
+  addHtml('h');
+  addHtml(toString(width, 2));
+  addHtml('v');
+  addHtmlInt(height);
+  addHtml('H');
+  addHtml(toString(SVG_BAR_WIDTH * xoffset / range, 2));
+  addHtml(F("z\"/>\n"));
 }
 
 void createSvgTextElement(const String& text, float textXoffset, float textYoffset) {
@@ -1078,20 +1091,16 @@ void write_SVG_image_header(int width, int height) {
 }
 
 void write_SVG_image_header(int width, int height, bool useViewbox) {
-  String html;
-
-  html.reserve(128);
-  html += F("<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"");
-  html += width;
-  html += F("\" height=\"");
-  html += height;
-  html += F("\" version=\"1.1\"");
+  addHtml(F("<svg xmlns=\"http://www.w3.org/2000/svg\" width=\""));
+  addHtmlInt(width);
+  addHtml(F("\" height=\""));
+  addHtmlInt(height);
+  addHtml(F("\" version=\"1.1\""));
 
   if (useViewbox) {
-    html += F(" viewBox=\"0 0 100 100\"");
+    addHtml(F(" viewBox=\"0 0 100 100\""));
   }
-  html += '>';
-  addHtml(html);
+  addHtml('>');
 }
 
 /*

--- a/src/src/WebServer/WebServer.cpp
+++ b/src/src/WebServer/WebServer.cpp
@@ -1032,7 +1032,7 @@ void createSvgRect(const String& classname,
                    float        rx,
                    float        ry) {
   addHtml(F("<rect"));
-  if (classname.length() != 0) {
+  if (!classname.isEmpty()) {
     addSVG_param(F("class"), classname);
   }
   addSVG_param(F("fill"), formatToHex(fillColor, F("#")));

--- a/src/src/WebServer/login.cpp
+++ b/src/src/WebServer/login.cpp
@@ -44,7 +44,7 @@ void handle_login() {
   html_end_table();
   html_end_form();
 
-  if (webrequest.length() != 0)
+  if (!webrequest.isEmpty())
   {
     char command[80];
     command[0] = 0;

--- a/tools/pio/pre_custom_esp82xx.py
+++ b/tools/pio/pre_custom_esp82xx.py
@@ -24,7 +24,7 @@ else:
   custom_defines=[
     "-DCONTROLLER_SET_ALL",
     "-DNOTIFIER_SET_NONE",
-#    "-DPLUGIN_BUILD_NORMAL",
+    "-DPLUGIN_BUILD_NONE",
     "-DUSES_P001",  # Switch
     "-DUSES_P002",  # ADC
     "-DUSES_P003",  # Generic Pulse Counter
@@ -49,7 +49,7 @@ else:
     "-DUSES_P106",  # BME680
 #    "-DUSES_P107",  # SI1145 UV index
 
-    "-DUSES_C016",  # Cache Controller
+#    "-DUSES_C016",  # Cache Controller
     "-DUSES_C018",  # TTN/RN2483
 #   "-DUSES_C015",  # Blynk
 


### PR DESCRIPTION
Make sure all flash strings are served by not copying it.

Mainly to deal with the memory issues reported by @ghtester and @clumsy-stefan  since https://github.com/letscontrolit/ESPEasy/pull/3655
The main change of that PR is to serve flash strings where possible, so low free memory may be related to this change.