### PR TITLE
[CaptivePortal] Fix root page redirect when connected via LAN

### DIFF
--- a/src/src/WebServer/WebServer.cpp
+++ b/src/src/WebServer/WebServer.cpp
@@ -261,7 +261,7 @@ size_t streamFile_htmlEscape(const String& fileName)
 bool captivePortal() {
   const bool fromAP = web_server.client().localIP() == apIP;
   const bool hasWiFiCredentials = SecuritySettings.hasWiFiCredentials();
-  if (hasWiFiCredentials && !fromAP) {
+  if (hasWiFiCredentials || !fromAP) {
     return false;
   }
   if (!isIP(web_server.hostHeader()) && web_server.hostHeader() != (NetworkGetHostname() + F(".local"))) {


### PR DESCRIPTION
Use case: Connected via LAN, then you don't need WiFi credentials.
However in this use case the client gets redirected to the local IP.
Still not a real problem, unless you got connected through a VPN.... Ooopsie