### PR TITLE
[ESP32] Fix PWM not cleared when changing pin mode (#3671)

### DIFF
--- a/src/src/Commands/GPIO.cpp
+++ b/src/src/Commands/GPIO.cpp
@@ -535,6 +535,18 @@ void createAndSetPortStatus_Mode_State(uint32_t key, byte newMode, int8_t newSta
 {
   // WARNING: operator [] creates an entry in the map if key does not exist
 
+  #ifdef ESP32
+  switch (newMode) {
+    case PIN_MODE_PWM:
+    case PIN_MODE_SERVO:
+      break;
+    default:
+      checkAndClearPWM(key);
+      break;
+  }
+  #endif
+
+
   // If it doesn't exist, it is now created.
   globalMapPortStatus[key].mode = newMode;
   auto it = globalMapPortStatus.find(key);

--- a/src/src/Helpers/Hardware.cpp
+++ b/src/src/Helpers/Hardware.cpp
@@ -36,6 +36,9 @@ void hardwareInit()
     const bool serialPinConflict = (Settings.UseSerial && (gpio == 1 || gpio == 3));
     if (!serialPinConflict) {
       const uint32_t key = createKey(1, gpio);
+      #ifdef ESP32
+      checkAndClearPWM(key);
+      #endif
       if (getGpioPullResistor(gpio, hasPullUp, hasPullDown)) {
         const PinBootState bootState = Settings.getPinBootState(gpio);
         if (bootState != PinBootState::Default_state) {
@@ -1191,11 +1194,11 @@ bool set_Gpio_PWM(int gpio, uint32_t dutyCycle, uint32_t fadeDuration_ms, uint32
   pinMode(gpio, OUTPUT);
         #endif // if defined(ESP8266)
 
+  #if defined(ESP8266)
   if ((frequency > 0) && (frequency <= 40000)) {
-        #if defined(ESP8266)
     analogWriteFreq(frequency);
-        #endif // if defined(ESP8266)
   }
+  #endif // if defined(ESP8266)
 
   if (fadeDuration_ms != 0)
   {
@@ -1220,7 +1223,7 @@ bool set_Gpio_PWM(int gpio, uint32_t dutyCycle, uint32_t fadeDuration_ms, uint32
       analogWrite(gpio, new_value);
             #endif // if defined(ESP8266)
             #if defined(ESP32)
-      analogWriteESP32(gpio, new_value);
+      frequency = analogWriteESP32(gpio, dutyCycle, frequency);
             #endif // if defined(ESP32)
       delay(1);
     }

--- a/src/src/Helpers/Hardware.cpp
+++ b/src/src/Helpers/Hardware.cpp
@@ -1223,7 +1223,7 @@ bool set_Gpio_PWM(int gpio, uint32_t dutyCycle, uint32_t fadeDuration_ms, uint32
       analogWrite(gpio, new_value);
             #endif // if defined(ESP8266)
             #if defined(ESP32)
-      frequency = analogWriteESP32(gpio, dutyCycle, frequency);
+      frequency = analogWriteESP32(gpio, new_value, frequency);
             #endif // if defined(ESP32)
       delay(1);
     }

--- a/src/src/Helpers/PortStatus.cpp
+++ b/src/src/Helpers/PortStatus.cpp
@@ -6,6 +6,27 @@
 #include "../../ESPEasy-Globals.h"
 
 
+#ifdef ESP32
+
+#include "../Helpers/Hardware.h"
+
+void checkAndClearPWM(uint32_t key) {
+  if (existPortStatus(key)) {
+    switch (globalMapPortStatus[key].mode) {
+      case PIN_MODE_PWM:
+      case PIN_MODE_SERVO:
+        {
+          const uint16_t port = getPortFromKey(key);
+          analogWriteESP32(port, 0);
+        }
+        break;
+    }
+  }
+}
+
+#endif
+
+
 /**********************************************************
 *                                                         *
 * Helper Functions for managing the status data structure *
@@ -14,9 +35,24 @@
 void savePortStatus(uint32_t key, struct portStatusStruct& tempStatus) {
   // FIXME TD-er: task and monitor are unsigned, should we only check for == ????
   if ((tempStatus.task <= 0) && (tempStatus.monitor <= 0) && (tempStatus.command <= 0)) {
+    #ifdef ESP32
+    checkAndClearPWM(key);
+    #endif
+
     globalMapPortStatus.erase(key);
   }
   else {
+    #ifdef ESP32
+    switch (tempStatus.mode) {
+      case PIN_MODE_PWM:
+      case PIN_MODE_SERVO:
+        break;
+      default:
+        checkAndClearPWM(key);
+        break;
+    }
+    #endif
+
     globalMapPortStatus[key] = tempStatus;
   }
 }
@@ -33,6 +69,10 @@ void removeTaskFromPort(uint32_t key) {
     if ((it->second.task <= 0) && (it->second.monitor <= 0) && (it->second.command <= 0) &&
         (it->second.init <= 0)) {
       // erase using the key, so the iterator can be const
+      #ifdef ESP32
+      checkAndClearPWM(key);
+      #endif
+
       globalMapPortStatus.erase(key);
     }
   }
@@ -46,6 +86,10 @@ void removeMonitorFromPort(uint32_t key) {
     if ((it->second.task <= 0) && (it->second.monitor <= 0) && (it->second.command <= 0) &&
         (it->second.init <= 0)) {
       // erase using the key, so the iterator can be const
+      #ifdef ESP32
+      checkAndClearPWM(key);
+      #endif
+
       globalMapPortStatus.erase(key);
     }
   }

--- a/src/src/Helpers/PortStatus.h
+++ b/src/src/Helpers/PortStatus.h
@@ -6,6 +6,12 @@
 #include "../DataStructs/PortStatusStruct.h"
 #include "../Globals/Plugins.h"
 
+
+#ifdef ESP32
+void checkAndClearPWM(uint32_t key);
+#endif
+
+
 /**********************************************************
 *                                                         *
 * Helper Functions for managing the status data structure *


### PR DESCRIPTION
The ESP32 does use the hardware PWM timer.
So when we change the port state to something other than PWM (or servo) the hardware timer must be detached from the GPIO.

Fixes: #3671

