### PR TITLE
[Deep Sleep] Revert default deep sleep call & make it optional

### DIFF
--- a/docs/source/Tools/Tools.rst
+++ b/docs/source/Tools/Tools.rst
@@ -195,6 +195,21 @@ JSON bool output without quotes
 
 ESPEasy JSON output has always used quoted bool values, ``"true"`` and ``"false"``, that are in fact string values. According to JSON standards, bool values should be ``true`` and ``false``, so this setting selects what type of bool values will be emitted. As existing functionality is to be left unaltered/backward compatible as much as possible, by default this setting is unchecked.
 
+
+Deep Sleep Alternative
+^^^^^^^^^^^^^^^^^^^^^^
+
+Added: 2021-06-07
+
+On some ESP8266 boards deep sleep does consume quite a lot compared to the stated 20 uA by Espressif.
+For those boards it may be beneficial to use alternative code to set the WiFi radio in such a mode that allows the ESP to really enter deep sleep.
+However, on older boards like the ESP12E or ESP12F, this alternative code prevents the ESP to wake up at all.
+
+This option is only available for ESP82xx boards.
+
+Default: disabled.
+
+
 Use SSDP
 ^^^^^^^^
 

--- a/src/ESPEasy.ino
+++ b/src/ESPEasy.ino
@@ -130,7 +130,11 @@ void preinit() {
   // No global object methods or C++ exceptions can be called in here!
   // The below is a static class method, which is similar to a function, so it's ok.
   ESP8266WiFiClass::preinitWiFiOff();
-  system_phy_set_powerup_option(RF_NO_CAL);
+
+  // Prevent RF calibration on power up.
+  // TD-er: disabled on 2021-06-07 as it may cause several issues with some boards.
+  // It cannot be made a setting as we can't read anything of our own settings.
+//  system_phy_set_powerup_option(RF_NO_CAL);
 }
 
 #endif // ifdef CORE_POST_2_5_0

--- a/src/src/DataStructs/SettingsStruct.cpp
+++ b/src/src/DataStructs/SettingsStruct.cpp
@@ -205,6 +205,17 @@ void SettingsStruct_tmpl<N_TASKS>::DoNotStartAP(bool value) {
   bitWrite(VariousBits1, 17, value);
 }
 
+
+template<unsigned int N_TASKS>
+bool SettingsStruct_tmpl<N_TASKS>::UseAlternativeDeepSleep() const {
+  return bitRead(VariousBits1, 18);
+}
+
+template<unsigned int N_TASKS>
+void SettingsStruct_tmpl<N_TASKS>::UseAlternativeDeepSleep(bool value) {
+  bitWrite(VariousBits1, 18, value);
+}
+
 template<unsigned int N_TASKS>
 void SettingsStruct_tmpl<N_TASKS>::validate() {
   if (UDPPort > 65535) { UDPPort = 0; }

--- a/src/src/DataStructs/SettingsStruct.h
+++ b/src/src/DataStructs/SettingsStruct.h
@@ -118,6 +118,10 @@ class SettingsStruct_tmpl
   bool DoNotStartAP() const;
   void DoNotStartAP(bool value);
 
+  bool UseAlternativeDeepSleep() const;
+  void UseAlternativeDeepSleep(bool value);
+
+
   void validate();
 
   bool networkSettingsEmpty() const;

--- a/src/src/Helpers/DeepSleep.cpp
+++ b/src/src/Helpers/DeepSleep.cpp
@@ -131,37 +131,40 @@ void deepSleepStart(int dsdelay)
     deepSleep_usec = ESP.deepSleepMax();
   }
 
-  // See: https://github.com/esp8266/Arduino/issues/6318#issuecomment-711389479
-  #include "c_types.h"
-  // system_phy_set_powerup_option:
-  // 1 = RF initialization only calibrate VDD33 and Tx power which will take about 18 ms
-  // 2 = RF initialization only calibrate VDD33 which will take about 2 ms
-  system_phy_set_powerup_option(2); // calibrate only 2ms;
-  system_deep_sleep_set_option(static_cast<int>(WAKE_RF_DEFAULT));
-  uint32_t*RT= (uint32_t *)0x60000700;
-  uint32 t_us = 1.31 * deepSleep_usec;
-  {
-    RT[4] = 0;
-    *RT = 0;
-    RT[1]=100;
-    RT[3] = 0x10010;
-    RT[6] = 8;
-    RT[17] = 4;
-    RT[2] = 1<<20;
-    ets_delay_us(10);
-    RT[1]=t_us>>3;
-    RT[3] = 0x640C8;
-    RT[4]= 0;
-    RT[6] = 0x18;
-    RT[16] = 0x7F;
-    RT[17] = 0x20;
-    RT[39] = 0x11;
-    RT[40] = 0x03;
-    RT[2] |= 1<<20;
-    __asm volatile ("waiti 0");
+  if (Settings.UseAlternativeDeepSleep()) {
+    // See: https://github.com/esp8266/Arduino/issues/6318#issuecomment-711389479
+    #include "c_types.h"
+    // system_phy_set_powerup_option:
+    // 1 = RF initialization only calibrate VDD33 and Tx power which will take about 18 ms
+    // 2 = RF initialization only calibrate VDD33 which will take about 2 ms
+    system_phy_set_powerup_option(2); // calibrate only 2ms;
+    system_deep_sleep_set_option(static_cast<int>(WAKE_RF_DEFAULT));
+    uint32_t*RT= (uint32_t *)0x60000700;
+    uint32 t_us = 1.31 * deepSleep_usec;
+    {
+      RT[4] = 0;
+      *RT = 0;
+      RT[1]=100;
+      RT[3] = 0x10010;
+      RT[6] = 8;
+      RT[17] = 4;
+      RT[2] = 1<<20;
+      ets_delay_us(10);
+      RT[1]=t_us>>3;
+      RT[3] = 0x640C8;
+      RT[4]= 0;
+      RT[6] = 0x18;
+      RT[16] = 0x7F;
+      RT[17] = 0x20;
+      RT[39] = 0x11;
+      RT[40] = 0x03;
+      RT[2] |= 1<<20;
+      __asm volatile ("waiti 0");
+    }
+    yield();
+  } else {
+    ESP.deepSleepInstant(deepSleep_usec, WAKE_RF_DEFAULT);
   }
-  yield();
-  // ESP.deepSleepInstant(deepSleep_usec, WAKE_RF_DEFAULT);
     # else // if defined(CORE_POST_2_5_0)
 
   if ((dsdelay > 4294) || (dsdelay < 0)) {

--- a/src/src/Helpers/StringProvider.cpp
+++ b/src/src/Helpers/StringProvider.cpp
@@ -76,6 +76,7 @@ const __FlashStringHelper * getLabel(LabelType::Enum label) {
 
     case LabelType::BOOT_TYPE:              return F("Last Boot Cause");
     case LabelType::BOOT_COUNT:             return F("Boot Count");
+    case LabelType::DEEP_SLEEP_ALTERNATIVE_CALL: return F("Deep Sleep Alternative");
     case LabelType::RESET_REASON:           return F("Reset Reason");
     case LabelType::LAST_TASK_BEFORE_REBOOT: return F("Last Action before Reboot");
     case LabelType::SW_WD_COUNT:            return F("SW WD count");
@@ -240,6 +241,7 @@ String getValue(LabelType::Enum label) {
 
     case LabelType::BOOT_TYPE:              return getLastBootCauseString();
     case LabelType::BOOT_COUNT:             break;
+    case LabelType::DEEP_SLEEP_ALTERNATIVE_CALL: return jsonBool(Settings.UseAlternativeDeepSleep());
     case LabelType::RESET_REASON:           return getResetReasonString();
     case LabelType::LAST_TASK_BEFORE_REBOOT: return ESPEasy_Scheduler::decodeSchedulerId(lastMixedSchedulerId_beforereboot);
     case LabelType::SW_WD_COUNT:            return String(sw_watchdog_callback_count);

--- a/src/src/Helpers/StringProvider.h
+++ b/src/src/Helpers/StringProvider.h
@@ -51,6 +51,7 @@ struct LabelType {
     BOOT_TYPE,               // Cold boot
     BOOT_COUNT,              // 0
     RESET_REASON,            // Software/System restart
+    DEEP_SLEEP_ALTERNATIVE_CALL,
     LAST_TASK_BEFORE_REBOOT, // Last scheduled task.
     SW_WD_COUNT,
 

--- a/src/src/WebServer/AdvancedConfigPage.cpp
+++ b/src/src/WebServer/AdvancedConfigPage.cpp
@@ -98,6 +98,9 @@ void handle_advanced() {
     Settings.NumberExtraWiFiScans = getFormItemInt(LabelType::WIFI_NR_EXTRA_SCANS);
     Settings.PeriodicalScanWiFi(isFormItemChecked(LabelType::WIFI_PERIODICAL_SCAN));
     Settings.JSONBoolWithoutQuotes(isFormItemChecked(F("json_bool_with_quotes")));
+    #ifdef ESP8266
+    Settings.UseAlternativeDeepSleep(isFormItemChecked(LabelType::DEEP_SLEEP_ALTERNATIVE_CALL));
+    #endif
 
     addHtmlError(SaveSettings());
 
@@ -199,6 +202,10 @@ void handle_advanced() {
   #endif // if defined(ESP32)
 
   addFormCheckBox(F("JSON bool output without quotes"), F("json_bool_with_quotes"), Settings.JSONBoolWithoutQuotes());
+  #ifdef ESP8266
+  addFormCheckBox(LabelType::DEEP_SLEEP_ALTERNATIVE_CALL, Settings.UseAlternativeDeepSleep());
+  #endif
+
 
   #ifdef USES_SSDP
   addFormCheckBox_disabled(F("Use SSDP"), F("usessdp"), Settings.UseSSDP);


### PR DESCRIPTION
Reverting this commit for default behaviour: https://github.com/letscontrolit/ESPEasy/commit/c70e54c03e99776dedc705a452066bc63cc60374

Fixes: #3638