### PR TITLE
[DeepSleep] Turn off WiFi before DeepSleep + limit max. deepsleep

### DIFF
--- a/docs/source/Tools/Tools.rst
+++ b/docs/source/Tools/Tools.rst
@@ -448,6 +448,27 @@ Also it is yet unknown if it does have a negative impact on overall WiFi perform
 During a scan the node is listening on a different channel, so it may not respond to requests sent to it for roughly a 1.6 seconds.
 
 
+Use Last Connected AP from RTC
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Added: 2021-06-20
+
+The last used (stable) connection is stored in RTC memory.
+This will survive a reboot (and deep sleep) as long as the unit remains powered.
+
+On WiFi reconnect, the stored last active connection is tried first.
+This can reduce the time needed to reconnect on a reboot, or when waking from deep sleep.
+
+Side effect is that if a node cannot see the stronger configured AP when connecting, it may never try to connect to the stronger AP as on reconnect the last used is tried first.
+
+Especially on mesh networks this appears to cause a lot of instability, therefore this is now made an optional feature.
+
+This is no new functionality, as it was present before and also enabled by default.
+
+New default value since 2021-06-20: unchecked
+
+
+
 Show JSON
 =========
 

--- a/src/src/DataStructs/SettingsStruct.cpp
+++ b/src/src/DataStructs/SettingsStruct.cpp
@@ -217,6 +217,17 @@ void SettingsStruct_tmpl<N_TASKS>::UseAlternativeDeepSleep(bool value) {
 }
 
 template<unsigned int N_TASKS>
+bool SettingsStruct_tmpl<N_TASKS>::UseLastWiFiFromRTC() const {
+  return bitRead(VariousBits1, 19);
+}
+
+template<unsigned int N_TASKS>
+void SettingsStruct_tmpl<N_TASKS>::UseLastWiFiFromRTC(bool value) {
+  bitWrite(VariousBits1, 19, value);
+}
+
+
+template<unsigned int N_TASKS>
 void SettingsStruct_tmpl<N_TASKS>::validate() {
   if (UDPPort > 65535) { UDPPort = 0; }
 

--- a/src/src/DataStructs/SettingsStruct.h
+++ b/src/src/DataStructs/SettingsStruct.h
@@ -121,6 +121,8 @@ class SettingsStruct_tmpl
   bool UseAlternativeDeepSleep() const;
   void UseAlternativeDeepSleep(bool value);
 
+  bool UseLastWiFiFromRTC() const;
+  void UseLastWiFiFromRTC(bool value);
 
   void validate();
 

--- a/src/src/ESPEasyCore/ESPEasy_backgroundtasks.cpp
+++ b/src/src/ESPEasyCore/ESPEasy_backgroundtasks.cpp
@@ -40,7 +40,11 @@ void backgroundtasks()
     return;
   }
   START_TIMER
+  #ifdef FEATURE_MDNS
   const bool networkConnected = NetworkConnected();
+  #else
+  NetworkConnected();
+  #endif
 
   runningBackgroundTasks = true;
 

--- a/src/src/Helpers/PeriodicalActions.cpp
+++ b/src/src/Helpers/PeriodicalActions.cpp
@@ -483,6 +483,7 @@ void prepareShutdown(ESPEasy_Scheduler::IntendedRebootReason_e reason)
   process_serialWriteBuffer();
   flushAndDisconnectAllClients();
   saveUserVarToRTC();
+  setWifiMode(WIFI_OFF);
   ESPEASY_FS.end();
   delay(100); // give the node time to flush all before reboot or sleep
   node_time.now();

--- a/src/src/Helpers/StringProvider.cpp
+++ b/src/src/Helpers/StringProvider.cpp
@@ -53,6 +53,7 @@ const __FlashStringHelper * getLabel(LabelType::Enum label) {
     case LabelType::WIFI_SEND_AT_MAX_TX_PWR:return F("Send With Max TX Power");
     case LabelType::WIFI_NR_EXTRA_SCANS:    return F("Extra WiFi scan loops");
     case LabelType::WIFI_PERIODICAL_SCAN:   return F("Periodical Scan WiFi");
+    case LabelType::WIFI_USE_LAST_CONN_FROM_RTC: return F("Use Last Connected AP from RTC");
 
     case LabelType::FREE_MEM:               return F("Free RAM");
     case LabelType::FREE_STACK:             return F("Free Stack");
@@ -215,6 +216,7 @@ String getValue(LabelType::Enum label) {
     case LabelType::WIFI_SEND_AT_MAX_TX_PWR:return jsonBool(Settings.UseMaxTXpowerForSending());
     case LabelType::WIFI_NR_EXTRA_SCANS:    return String(Settings.NumberExtraWiFiScans);
     case LabelType::WIFI_PERIODICAL_SCAN:   return jsonBool(Settings.PeriodicalScanWiFi());
+    case LabelType::WIFI_USE_LAST_CONN_FROM_RTC: return jsonBool(Settings.UseLastWiFiFromRTC());
 
     case LabelType::FREE_MEM:               return String(ESP.getFreeHeap());
     case LabelType::FREE_STACK:             return String(getCurrentFreeStack());

--- a/src/src/Helpers/StringProvider.h
+++ b/src/src/Helpers/StringProvider.h
@@ -27,6 +27,7 @@ struct LabelType {
     WIFI_SEND_AT_MAX_TX_PWR,
     WIFI_NR_EXTRA_SCANS,
     WIFI_PERIODICAL_SCAN,
+    WIFI_USE_LAST_CONN_FROM_RTC,
 
     FREE_MEM,            // 9876
     FREE_STACK,          // 3456

--- a/src/src/Helpers/WiFi_AP_CandidatesList.cpp
+++ b/src/src/Helpers/WiFi_AP_CandidatesList.cpp
@@ -288,7 +288,7 @@ void WiFi_AP_CandidatesList::loadCandidatesFromScanned() {
 }
 
 void WiFi_AP_CandidatesList::addFromRTC() {
-  if (!RTC.lastWiFi_set()) { return; }
+  if (!Settings.UseLastWiFiFromRTC() || !RTC.lastWiFi_set()) { return; }
 
   if (SettingsIndexMatchCustomCredentials(RTC.lastWiFiSettingsIndex)) 
   { 

--- a/src/src/WebServer/AdvancedConfigPage.cpp
+++ b/src/src/WebServer/AdvancedConfigPage.cpp
@@ -97,6 +97,7 @@ void handle_advanced() {
     Settings.UseMaxTXpowerForSending(isFormItemChecked(LabelType::WIFI_SEND_AT_MAX_TX_PWR));
     Settings.NumberExtraWiFiScans = getFormItemInt(LabelType::WIFI_NR_EXTRA_SCANS);
     Settings.PeriodicalScanWiFi(isFormItemChecked(LabelType::WIFI_PERIODICAL_SCAN));
+    Settings.UseLastWiFiFromRTC(isFormItemChecked(LabelType::WIFI_USE_LAST_CONN_FROM_RTC));
     Settings.JSONBoolWithoutQuotes(isFormItemChecked(F("json_bool_with_quotes")));
     #ifdef ESP8266
     Settings.UseAlternativeDeepSleep(isFormItemChecked(LabelType::DEEP_SLEEP_ALTERNATIVE_CALL));
@@ -256,6 +257,7 @@ void handle_advanced() {
     addFormNote(note);
   }
   addFormCheckBox(LabelType::WIFI_PERIODICAL_SCAN, Settings.PeriodicalScanWiFi());
+  addFormCheckBox(LabelType::WIFI_USE_LAST_CONN_FROM_RTC, Settings.UseLastWiFiFromRTC());
 
 
 

--- a/src/src/WebServer/JSON.cpp
+++ b/src/src/WebServer/JSON.cpp
@@ -224,6 +224,7 @@ void handle_json()
         LabelType::WIFI_SEND_AT_MAX_TX_PWR,
         LabelType::WIFI_NR_EXTRA_SCANS,
         LabelType::WIFI_PERIODICAL_SCAN,
+        LabelType::WIFI_USE_LAST_CONN_FROM_RTC,
         LabelType::WIFI_RSSI,
 
 

--- a/src/src/WebServer/SysInfoPage.cpp
+++ b/src/src/WebServer/SysInfoPage.cpp
@@ -483,6 +483,7 @@ void handle_sysinfo_WiFiSettings() {
   addRowLabelValue(LabelType::WIFI_SEND_AT_MAX_TX_PWR);
   addRowLabelValue(LabelType::WIFI_NR_EXTRA_SCANS);
   addRowLabelValue(LabelType::WIFI_PERIODICAL_SCAN);
+  addRowLabelValue(LabelType::WIFI_USE_LAST_CONN_FROM_RTC);
 }
 
 void handle_sysinfo_Firmware() {


### PR DESCRIPTION
By browsing through deep sleep issues on esp8266/Arduino (example: https://github.com/esp8266/Arduino/issues/4969#issuecomment-703259665 ) I noticed a few recurring things in all comments:

- Max deep sleep time is unreliable and changes
- Instant deep sleep (which we call) does expect WiFi to be off
- deepSleep() does turn off WiFi safely. (whatever that means)

So I tried to mitigate these all by reducing the max. deep sleep time by roughly 5% and turn off WiFi ourselves and calling the deepSleep() function.

Also discussed on [the forum](https://www.letscontrolit.com/forum/viewtopic.php?f=4&t=8576&p=53344#p53344)