### PR TITLE
Reduce build size (PSTR alignment) & memory usage web server

### DIFF
--- a/platformio_core_defs.ini
+++ b/platformio_core_defs.ini
@@ -55,6 +55,8 @@ build_flags               = ${esp82xx_2_5_x.build_flags}
                             -O2
                             -DBEARSSL_SSL_BASIC
                             -DCORE_POST_2_6_0 
+                            ; remove the 4-bytes alignment for PSTR()
+                            -DPSTR_ALIGN=1
 lib_ignore                = ${esp82xx_defaults.lib_ignore}
 
 

--- a/src/src/DataStructs/Web_StreamingBuffer.cpp
+++ b/src/src/DataStructs/Web_StreamingBuffer.cpp
@@ -23,16 +23,16 @@ Web_StreamingBuffer::Web_StreamingBuffer(void) : lowMemorySkip(false),
 }
 
 /*
-Web_StreamingBuffer Web_StreamingBuffer::operator=(String& a)                 {
+Web_StreamingBuffer& Web_StreamingBuffer::operator=(String& a)                 {
   flush(); return addString(a);
 }
 
-Web_StreamingBuffer Web_StreamingBuffer::operator=(const String& a)           {
+Web_StreamingBuffer& Web_StreamingBuffer::operator=(const String& a)           {
   flush(); return addString(a);
 }
 */
 
-Web_StreamingBuffer Web_StreamingBuffer::operator+=(char a)                   {
+Web_StreamingBuffer& Web_StreamingBuffer::operator+=(char a)                   {
   if (CHUNKED_BUFFER_SIZE > (this->buf.length() + 1)) {
     this->buf += a;
     return *this;
@@ -40,35 +40,35 @@ Web_StreamingBuffer Web_StreamingBuffer::operator+=(char a)                   {
   return addString(String(a));
 }
 
-Web_StreamingBuffer Web_StreamingBuffer::operator+=(long unsigned int a)     {
+Web_StreamingBuffer& Web_StreamingBuffer::operator+=(long unsigned int a)     {
   return addString(String(a));
 }
 
-Web_StreamingBuffer Web_StreamingBuffer::operator+=(float a)                  {
+Web_StreamingBuffer& Web_StreamingBuffer::operator+=(float a)                  {
   return addString(String(a));
 }
 
-Web_StreamingBuffer Web_StreamingBuffer::operator+=(int a)                    {
+Web_StreamingBuffer& Web_StreamingBuffer::operator+=(int a)                    {
   return addString(String(a));
 }
 
-Web_StreamingBuffer Web_StreamingBuffer::operator+=(uint32_t a)               {
+Web_StreamingBuffer& Web_StreamingBuffer::operator+=(uint32_t a)               {
   return addString(String(a));
 }
 
-Web_StreamingBuffer Web_StreamingBuffer::operator+=(const String& a)          {
+Web_StreamingBuffer& Web_StreamingBuffer::operator+=(const String& a)          {
   return addString(a);
 }
 
-Web_StreamingBuffer Web_StreamingBuffer::operator+=(PGM_P str) {
+Web_StreamingBuffer& Web_StreamingBuffer::operator+=(PGM_P str) {
   return addFlashString(str);
 }
 
-Web_StreamingBuffer Web_StreamingBuffer::operator+=(const __FlashStringHelper* str) {
+Web_StreamingBuffer& Web_StreamingBuffer::operator+=(const __FlashStringHelper* str) {
   return addFlashString((PGM_P)str);
 }
 
-Web_StreamingBuffer Web_StreamingBuffer::addFlashString(PGM_P str) {
+Web_StreamingBuffer& Web_StreamingBuffer::addFlashString(PGM_P str) {
   ++flashStringCalls;
 
   if (!str) { return *this; // return if the pointer is void
@@ -108,7 +108,7 @@ Web_StreamingBuffer Web_StreamingBuffer::addFlashString(PGM_P str) {
   return *this;
 }
 
-Web_StreamingBuffer Web_StreamingBuffer::addString(const String& a) {
+Web_StreamingBuffer& Web_StreamingBuffer::addString(const String& a) {
   if (lowMemorySkip) { return *this; }
   int flush_step = CHUNKED_BUFFER_SIZE - this->buf.length();
 

--- a/src/src/DataStructs/Web_StreamingBuffer.h
+++ b/src/src/DataStructs/Web_StreamingBuffer.h
@@ -35,20 +35,20 @@ public:
 
   Web_StreamingBuffer(void);
 
-//  Web_StreamingBuffer operator=(String& a);
-//  Web_StreamingBuffer operator=(const String& a);
-  Web_StreamingBuffer operator+=(char a);
-  Web_StreamingBuffer operator+=(long unsigned int a);
-  Web_StreamingBuffer operator+=(float a);
-  Web_StreamingBuffer operator+=(int a);
-  Web_StreamingBuffer operator+=(uint32_t a);
-  Web_StreamingBuffer operator+=(const String& a);
-  Web_StreamingBuffer operator+=(PGM_P str);
-  Web_StreamingBuffer operator+=(const __FlashStringHelper* str);
+//  Web_StreamingBuffer& operator=(String& a);
+//  Web_StreamingBuffer& operator=(const String& a);
+  Web_StreamingBuffer& operator+=(char a);
+  Web_StreamingBuffer& operator+=(long unsigned int a);
+  Web_StreamingBuffer& operator+=(float a);
+  Web_StreamingBuffer& operator+=(int a);
+  Web_StreamingBuffer& operator+=(uint32_t a);
+  Web_StreamingBuffer& operator+=(const String& a);
+  Web_StreamingBuffer& operator+=(PGM_P str);
+  Web_StreamingBuffer& operator+=(const __FlashStringHelper* str);
 
 //private:
-  Web_StreamingBuffer addFlashString(PGM_P str);
-  Web_StreamingBuffer addString(const String& a);
+  Web_StreamingBuffer& addFlashString(PGM_P str);
+  Web_StreamingBuffer& addString(const String& a);
 
 public:
   void flush();


### PR DESCRIPTION
- Fix unneeded copy of object when serving data(#3693)
- Flash strings were 4-byte aligned.

The last one does shave a few kB from the build size.
Built on Windows, both core 2.7.4 minimal OTA builds should fit again.

The fix in serving chunked transfers does prevent a lot of unneeded copy operations, reducing memory usage and making response quite a bit more snappy.