### PR TITLE
[ESP32 Eth] Make sure DHCP server is NOT running

### DIFF
--- a/src/src/ESPEasyCore/ESPEasyEth.cpp
+++ b/src/src/ESPEasyCore/ESPEasyEth.cpp
@@ -120,12 +120,14 @@ bool ETHConnectRelaxed() {
 bool ETHConnected() {
   if (EthEventData.EthServicesInitialized()) {
     if (EthLinkUp()) {
+      stop_eth_dhcps();
       return true;
     }
     // Apparently we missed an event
     EthEventData.processedDisconnect = false;
   } else if (EthEventData.ethInitSuccess) {
     if (EthLinkUp()) {
+      stop_eth_dhcps();
       EthEventData.setEthConnected();
       if (NetworkLocalIP() != IPAddress(0, 0, 0, 0) && 
           !EthEventData.EthGotIP()) {

--- a/src/src/ESPEasyCore/ESPEasyNetwork.cpp
+++ b/src/src/ESPEasyCore/ESPEasyNetwork.cpp
@@ -213,4 +213,19 @@ uint8_t EthLinkSpeed()
     return ETH.linkSpeed();
   return 0;
 }
+
+
+void stop_eth_dhcps() {
+  esp_err_t err = tcpip_adapter_dhcps_stop(TCPIP_ADAPTER_IF_ETH);
+  if(err != ESP_OK && err != ESP_ERR_TCPIP_ADAPTER_DHCP_ALREADY_STOPPED){
+/*
+    if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
+      String log = F("ETH   : DHCP server could not be stopped! Error: ");
+      log += err;
+      addLog(LOG_LEVEL_ERROR, log);
+    }
+*/
+  }
+}
+
 #endif

--- a/src/src/ESPEasyCore/ESPEasyNetwork.h
+++ b/src/src/ESPEasyCore/ESPEasyNetwork.h
@@ -30,6 +30,7 @@ void CheckRunningServices();
 bool EthFullDuplex();
 bool EthLinkUp();
 uint8_t EthLinkSpeed();
+void stop_eth_dhcps();
 #endif
 
 


### PR DESCRIPTION
When connected to some 4G routers, the ESP32 with Ethernet seems to start and run a DHCP server.
This should never happen and for sure not unintended.