### PR TITLE
[WiFi] Fix scan issue, causing failed connections

### DIFF
--- a/src/src/ESPEasyCore/ESPEasyWifi.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi.cpp
@@ -873,6 +873,7 @@ void WifiScan(bool async, uint8_t channel) {
     }
     --nrScans;
     #ifdef ESP8266
+    /*
     {
       static bool FIRST_SCAN = true;
 
@@ -894,6 +895,7 @@ void WifiScan(bool async, uint8_t channel) {
       wifi_station_scan(&config, &onWiFiScanDone);
  
     }
+    */
     WiFi.scanNetworks(async, show_hidden, channel);
     #endif
     #ifdef ESP32

--- a/src/src/ESPEasyCore/ESPEasyWifi.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi.cpp
@@ -460,6 +460,7 @@ bool prepareWiFi() {
   #endif // if defined(ESP32)
   setConnectionSpeed();
   setupStaticIPconfig();
+  WiFiEventData.wifiConnectAttemptNeeded = true;
 
   return true;
 }

--- a/src/src/ESPEasyCore/ESPEasyWifi.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi.cpp
@@ -400,17 +400,11 @@ void AttemptWiFiConnect() {
       SetWiFiTXpower(tx_pwr, candidate.rssi);
       // Start connect attempt now, so no longer needed to attempt new connection.
       WiFiEventData.wifiConnectAttemptNeeded = false;
-      #ifdef ESP8266
-      ETS_UART_INTR_DISABLE();
-      #endif
       if (candidate.allowQuickConnect()) {
         WiFi.begin(candidate.ssid.c_str(), candidate.key.c_str(), candidate.channel, candidate.bssid.mac);
       } else {
         WiFi.begin(candidate.ssid.c_str(), candidate.key.c_str());
       }
-      #ifdef ESP8266
-      ETS_UART_INTR_ENABLE();
-      #endif
     }
   } else {
     if (!wifiAPmodeActivelyUsed() || WiFiEventData.wifiSetupConnect) {
@@ -750,11 +744,11 @@ WiFiConnectionProtocol getConnectionProtocol() {
 // ********************************************************************************
 void WifiDisconnect()
 {
-  #if defined(ESP32)
+  #ifdef ESP32
   WiFi.disconnect();
   WiFi.removeEvent(wm_event_id);
-  #else // if defined(ESP32)
-
+  #endif
+  #ifdef ESP8266
   // Only call disconnect when STA is active
   if (WifiIsSTA(WiFiMode())) {
     wifi_station_disconnect();

--- a/src/src/ESPEasyCore/ESPEasyWifi.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi.cpp
@@ -405,6 +405,8 @@ void AttemptWiFiConnect() {
       } else {
         WiFi.begin(candidate.ssid.c_str(), candidate.key.c_str());
       }
+    } else {
+      WiFiEventData.wifiConnectInProgress = false;
     }
   } else {
     if (!wifiAPmodeActivelyUsed() || WiFiEventData.wifiSetupConnect) {

--- a/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
@@ -533,9 +533,7 @@ void processScanDone() {
 
   WiFi_AP_Candidates.process_WiFiscan(scanCompleteStatus);
 
-  if (WiFi_AP_Candidates.addedKnownCandidate()) {
-    NetworkConnectRelaxed();
-  }
+  NetworkConnectRelaxed();
 }
 
 

--- a/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
@@ -206,7 +206,7 @@ void handle_unprocessedNetworkEvents()
 // ********************************************************************************
 void processDisconnect() {
   if (WiFiEventData.processingDisconnect.isSet()) {
-    if (WiFiEventData.processingDisconnect.millisPassedSince() > 5000) {
+    if (WiFiEventData.processingDisconnect.millisPassedSince() > 5000 || WiFiEventData.processedDisconnect) {
       WiFiEventData.processingDisconnect.clear();
     }
   }

--- a/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
@@ -96,6 +96,14 @@ void handle_unprocessedNetworkEvents()
   if (active_network_medium == NetworkMedium_t::WIFI) {
     if ((!WiFiEventData.WiFiServicesInitialized()) || WiFiEventData.unprocessedWifiEvents()) {
       if (WiFi.status() == WL_DISCONNECTED && WiFiEventData.wifiConnectInProgress) {
+        if (WiFiEventData.wifiConnectInProgress) {
+          if (WiFiEventData.last_wifi_connect_attempt_moment.isSet() && WiFiEventData.last_wifi_connect_attempt_moment.millisPassedSince() > 20000) {
+            WiFiEventData.last_wifi_connect_attempt_moment.clear();
+          }
+          if (!WiFiEventData.last_wifi_connect_attempt_moment.isSet()) {
+            WiFiEventData.wifiConnectInProgress = false;
+          }
+        }
         delay(10);
       }
 
@@ -524,6 +532,10 @@ void processScanDone() {
   }
 
   WiFi_AP_Candidates.process_WiFiscan(scanCompleteStatus);
+
+  if (WiFi_AP_Candidates.addedKnownCandidate()) {
+    NetworkConnectRelaxed();
+  }
 }
 
 

--- a/src/src/Helpers/ESPEasy_checks.cpp
+++ b/src/src/Helpers/ESPEasy_checks.cpp
@@ -113,8 +113,30 @@ void run_compiletime_checks() {
   #endif
 
   // Check for alignment issues at compile time
-  static_assert(256u == offsetof(SecurityStruct, ControllerUser), "");
-  static_assert((256 + (CONTROLLER_MAX * 26))  == offsetof(SecurityStruct, ControllerPassword), "");
+  {
+    const unsigned int ControllerUser_offset = 256u;
+    static_assert(ControllerUser_offset == offsetof(SecurityStruct, ControllerUser), "");
+
+    const unsigned int ControllerPassword_offset = 256u + (CONTROLLER_MAX * 26);
+    static_assert(ControllerPassword_offset == offsetof(SecurityStruct, ControllerPassword), "");
+
+    const unsigned int Password_offset = ControllerPassword_offset + (CONTROLLER_MAX * 64);
+    static_assert(Password_offset == offsetof(SecurityStruct, Password), "");
+
+    const unsigned int AllowedIPrangeLow_offset = Password_offset + 26;
+    static_assert(AllowedIPrangeLow_offset == offsetof(SecurityStruct, AllowedIPrangeLow), "");
+
+    const unsigned int IPblockLevel_offset = AllowedIPrangeLow_offset + 8;
+    static_assert(IPblockLevel_offset == offsetof(SecurityStruct, IPblockLevel), "");
+
+    const unsigned int ProgmemMd5_offset = IPblockLevel_offset + 1;
+    static_assert(ProgmemMd5_offset == offsetof(SecurityStruct, ProgmemMd5), "");
+
+    const unsigned int md5_offset = ProgmemMd5_offset + 16;
+    static_assert(md5_offset == offsetof(SecurityStruct, md5), "");
+  }
+
+
   static_assert(192u == offsetof(SettingsStruct, Protocol), "");
   static_assert(195u == offsetof(SettingsStruct, Notification), "CONTROLLER_MAX has changed?");
   static_assert(198u == offsetof(SettingsStruct, TaskDeviceNumber), "NOTIFICATION_MAX has changed?");


### PR DESCRIPTION
Running the SDK WiFi scan functions may result in a call to the callback function before the scan has finished.
This results in very strange (uninitialized) found APs.

Also the Arduino call was not commented out, but even with this removed the scan was unusable.