### PR TITLE
fix for building esp32 firmware from directory with space in name

### DIFF
--- a/tools/pio/post_esp32.py
+++ b/tools/pio/post_esp32.py
@@ -8,7 +8,7 @@ def esp32_create_factory_bin(source, target, env):
     sections = env.subst(env.get('FLASH_EXTRA_IMAGES'))
     new_file = open(new_file_name,"wb")
     for section in sections:
-      sect_adr,sect_file = section.split(" ")
+      sect_adr,sect_file = section.split(" ",1)
       source = open(sect_file,"rb")
       new_file.seek(int(sect_adr,0)-offset)
       new_file.write(source.read());


### PR DESCRIPTION
Fix for this issue: https://www.letscontrolit.com/forum/viewtopic.php?t=8146 

post_esp32.py does a split on a string containing an address and a filename, separated by a 'space'.  Unfortunately if there's a space in the filename it tries to split it there again.  

This just adds a limit of 1 to that split to prevent this happening.