### PR TITLE
[Sysvars] Add %dns1% and %dns2% sysvars and urlencode stringfunction

### DIFF
--- a/docs/source/Reference/SystemVariable.rst
+++ b/docs/source/Reference/SystemVariable.rst
@@ -214,7 +214,7 @@ More uses of these system variables can be seen in the rules section and formula
      -
    * - ``%dns1%``
      - 10.0.0.1
-     - The configured primairy Domain Name Server IP-address
+     - The configured primary Domain Name Server IP-address
      -
    * - ``%dns2%``
      - (IP unset)

--- a/docs/source/Reference/SystemVariable.rst
+++ b/docs/source/Reference/SystemVariable.rst
@@ -203,12 +203,23 @@ More uses of these system variables can be seen in the rules section and formula
    * - ``%isntp%``
      - 1
      - Indicates whether time was set
-     - yes
+     - Yes
    * - ``%ismqtt%``
      - 1
      - Indicates whether a configured MQTT broker is active
-     - yes
-
+     - Yes
+   * - ``%dns%``
+     - 10.0.0.1 / (IP unset)
+     - The configured Domain Name Server IP-addresses
+     -
+   * - ``%dns1%``
+     - 10.0.0.1
+     - The configured primairy Domain Name Server IP-address
+     -
+   * - ``%dns2%``
+     - (IP unset)
+     - The configured secondary Domain Name Server IP-address
+     -
 
 Standard Conversions
 ^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/Rules/Rules.rst
+++ b/docs/source/Rules/Rules.rst
@@ -905,6 +905,15 @@ For example:
    logentry,{bitwrite:0:122:1}   // Set least significant bit of the given nr '122' to '1' => '123'
  endon
 
+urlencode
+^^^^^^^^^^
+
+(Added: 2021-07-22)
+
+Replace any not-allowed characters in an url with their hex replacement (%-notation).
+
+Usage: ``{urlencode:"string to/encode"}`` will result in ``string%20to%2fencode``
+
 XOR / AND / OR
 ^^^^^^^^^^^^^^
 

--- a/src/src/ESPEasyCore/ESPEasyRules.cpp
+++ b/src/src/ESPEasyCore/ESPEasyRules.cpp
@@ -617,6 +617,12 @@ void parse_string_commands(String& line) {
         // Syntax like let 1,{ord:B}
         uint8_t uval = arg1.c_str()[0];
         replacement = String(uval);
+      } else if (cmd_s_lower.equals(F("urlencode"))) {
+        // Convert to url-encoded string
+        // Syntax like {urlencode:"string to/encode"}
+        if (!arg1.isEmpty()) {
+          replacement = URLEncode(arg1.c_str());
+        }
       }
 
       if (replacement.isEmpty()) {

--- a/src/src/Helpers/SystemVariables.cpp
+++ b/src/src/Helpers/SystemVariables.cpp
@@ -96,6 +96,8 @@ void SystemVariables::parseSystemVariables(String& s, boolean useURLencode)
       case IP4:               value = String( (int) NetworkLocalIP()[3] ); break; // 4th IP octet
       case SUBNET:            value = getValue(LabelType::IP_SUBNET); break;
       case DNS:               value = getValue(LabelType::DNS); break;
+      case DNS_1:             value = getValue(LabelType::DNS_1); break;
+      case DNS_2:             value = getValue(LabelType::DNS_2); break;
       case GATEWAY:           value = getValue(LabelType::GATEWAY); break;
       case CLIENTIP:          value = getValue(LabelType::CLIENT_IP); break;
       #ifdef USES_MQTT
@@ -276,6 +278,8 @@ const __FlashStringHelper * SystemVariables::toString(SystemVariables::Enum enum
     case Enum::IP:              return F("%ip%");
     case Enum::SUBNET:          return F("%subnet%");
     case Enum::DNS:             return F("%dns%");
+    case Enum::DNS_1:           return F("%dns1%");
+    case Enum::DNS_2:           return F("%dns2%");
     case Enum::GATEWAY:         return F("%gateway%");
     case Enum::CLIENTIP:        return F("%clientip%");
     case Enum::ISMQTT:          return F("%ismqtt%");

--- a/src/src/Helpers/SystemVariables.h
+++ b/src/src/Helpers/SystemVariables.h
@@ -19,6 +19,8 @@ public:
     SUBNET,
     GATEWAY,
     DNS,
+    DNS_1,
+    DNS_2,
     CLIENTIP,
     ISMQTT,
     ISMQTTIMP,

--- a/src/src/WebServer/SysVarPage.cpp
+++ b/src/src/WebServer/SysVarPage.cpp
@@ -59,6 +59,8 @@ void handle_sysvars() {
   addSysVar_enum_html(SystemVariables::SUBNET);
   addSysVar_enum_html(SystemVariables::GATEWAY);
   addSysVar_enum_html(SystemVariables::DNS);
+  addSysVar_enum_html(SystemVariables::DNS_1);
+  addSysVar_enum_html(SystemVariables::DNS_2);
   addSysVar_enum_html(SystemVariables::RSSI);
   addSysVar_enum_html(SystemVariables::SSID);
   addSysVar_enum_html(SystemVariables::BSSID);


### PR DESCRIPTION
- Add separate system variables for primary and secondary DNS IP addresses `%dns1%` and `%dns2`.
- Add string function to url encode a string: `{urlencode:"string to/encode"}`
- Update documentation

As requested in [the forum](https://www.letscontrolit.com/forum/viewtopic.php?f=6&t=8672)
