### PR TITLE
[ESP32] Fix maximum deepsleep time for ESP32

### DIFF
--- a/docs/source/Plugin/P000_commands.repl
+++ b/docs/source/Plugin/P000_commands.repl
@@ -101,8 +101,8 @@
     DeepSleep","
     :red:`Internal`","
     Switch the node to deep sleep.
-    Max sleep time depends on library version and differs from roughly 71 minutes to 3h46.
-    If you specify a Min sleep time of 0, you'll have to wake the device yourself by pulling RST to GND. 
+    Max sleep time depends on library version and differs from roughly 71 minutes (4294 sec.) to 3h46 for ESP8266, and up to 8 years (281474976 sec.) on ESP32 (theoretically).
+    If you specify a Min sleep time of 0, you'll have to wake the device yourself by pulling RST to GND. If you specify a negative sleep time value, the maximum will be applied.
 
     ``DeepSleep,<sleep time in seconds>``"
     "


### PR DESCRIPTION
For ESP32
- Correct a casting bug when setting the deepsleep time
- Limit deepsleep to the max. allowed duration (48 bits of microseconds == 281474976 seconds or almost 8 year)
- Updated documentation

In response to a report in [the forum](https://www.letscontrolit.com/forum/viewtopic.php?f=6&t=8680)

TODO:
- [x] Testing (confirmed by forum user)