### PR TITLE
[PLUGIN_INIT] Return true on PLUGIN_INIT so TaskEnable returns OK

### DIFF
--- a/src/_P005_DHT.ino
+++ b/src/_P005_DHT.ino
@@ -86,6 +86,12 @@ boolean Plugin_005(uint8_t function, struct EventStruct *event, String& string)
         break;
       }
 
+    case PLUGIN_INIT:
+      {
+        success = true;
+        break;
+      }
+
     case PLUGIN_READ:
       {
         success = P005_do_plugin_read(event);

--- a/src/_P007_PCF8591.ino
+++ b/src/_P007_PCF8591.ino
@@ -48,6 +48,12 @@ boolean Plugin_007(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_INIT:
+    {
+      success = true;
+      break;
+    }
+
     case PLUGIN_READ:
     {
       uint8_t unit       = (CONFIG_PORT - 1) / 4;

--- a/src/_P010_BH1750.ino
+++ b/src/_P010_BH1750.ino
@@ -97,6 +97,12 @@ boolean Plugin_010(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_INIT:
+    {
+      success = true;
+      break;
+    }
+
     case PLUGIN_READ:
     {
       uint8_t address = PCONFIG(0);

--- a/src/_P011_PME.ino
+++ b/src/_P011_PME.ino
@@ -66,6 +66,12 @@ boolean Plugin_011(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_INIT:
+    {
+      success = true;
+      break;
+    }
+
     case PLUGIN_READ:
     {
       UserVar[event->BaseVarIndex] = Plugin_011_Read(PCONFIG(0), CONFIG_PORT);

--- a/src/_P030_BMP280.ino
+++ b/src/_P030_BMP280.ino
@@ -130,6 +130,12 @@ boolean Plugin_030(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_INIT:
+    {
+      success = true;
+      break;
+    }
+
     case PLUGIN_READ:
     {
       uint8_t idx = PCONFIG(0) & 0x1;                                                                              // Addresses are 0x76 and

--- a/src/_P033_Dummy.ino
+++ b/src/_P033_Dummy.ino
@@ -61,6 +61,12 @@ boolean Plugin_033(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_INIT:
+    {
+      success = true;
+      break;
+    }
+
     case PLUGIN_READ:
     {
       event->sensorType = static_cast<Sensor_VType>(PCONFIG(0));

--- a/src/_P034_DHT12.ino
+++ b/src/_P034_DHT12.ino
@@ -50,6 +50,12 @@ boolean Plugin_034(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_INIT:
+    {
+      success = true;
+      break;
+    }
+
     case PLUGIN_READ:
     {
       uint8_t dht_dat[5];

--- a/src/_P047_i2c-soil-moisture-sensor.ino
+++ b/src/_P047_i2c-soil-moisture-sensor.ino
@@ -121,6 +121,12 @@ boolean Plugin_047(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_INIT:
+    {
+      success = true;
+      break;
+    }
+
     case PLUGIN_READ:
     {
       if (P047_SENSOR_SLEEP) {

--- a/src/_P051_AM2320.ino
+++ b/src/_P051_AM2320.ino
@@ -69,6 +69,12 @@ boolean Plugin_051(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_INIT:
+    {
+      success = true;
+      break;
+    }
+
     case PLUGIN_READ:
     {
       AM2320 th;

--- a/src/_P072_HDC1080.ino
+++ b/src/_P072_HDC1080.ino
@@ -50,6 +50,12 @@ boolean Plugin_072(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_INIT:
+    {
+      success = true;
+      break;
+    }
+
     case PLUGIN_READ:
     {
       uint8_t hdc1080_msb, hdc1080_lsb;

--- a/src/_P086_Homie.ino
+++ b/src/_P086_Homie.ino
@@ -155,6 +155,12 @@ boolean Plugin_086(uint8_t function, struct EventStruct *event, String& string)
         break;
       }
 
+    case PLUGIN_INIT:
+      {
+        success = true;
+        break;
+      }
+
     case PLUGIN_READ:
       {
         for (uint8_t x=0; x<PLUGIN_086_VALUE_MAX;x++)


### PR DESCRIPTION
Bugfix on Dummy Device plugin and the plugins listed by TD-er.

`TaskEnable` command will return `Failed` if PLUGIN_INIT doesn't return true. (Regression bug fixed some time ago.)