### PR TITLE
[I2C Scanner] Show available device(s) for detected addresses

### DIFF
--- a/src/Custom-sample.h
+++ b/src/Custom-sample.h
@@ -102,6 +102,7 @@
 #define DEFAULT_PIN_I2C_SDA                     4
 #define DEFAULT_PIN_I2C_SCL                     5
 #define DEFAULT_I2C_CLOCK_SPEED                 400000            // Use 100 kHz if working with old I2C chips
+#define USE_I2C_DEVICE_SCAN                     true
 
 #define DEFAULT_SPI                             0                 //0=disabled 1=enabled and for ESP32 there is option 2 =HSPI
 

--- a/src/_P006_BMP085.ino
+++ b/src/_P006_BMP085.ino
@@ -50,14 +50,11 @@ boolean Plugin_006(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    case PLUGIN_I2C_HAS_ADDRESS:
     {
-      string = F("77"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
+      success = (event->Par1 == 0x77);
       break;
     }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P006_BMP085.ino
+++ b/src/_P006_BMP085.ino
@@ -50,6 +50,15 @@ boolean Plugin_006(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("77"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
       addFormNumericBox(F("Altitude [m]"), F("_p006_bmp085_elev"), PCONFIG(1));

--- a/src/_P007_PCF8591.ino
+++ b/src/_P007_PCF8591.ino
@@ -16,8 +16,6 @@ boolean Plugin_007(uint8_t function, struct EventStruct *event, String& string)
 {
   boolean success = false;
 
-  // static uint8_t portValue = 0;
-
   switch (function)
   {
     case PLUGIN_DEVICE_ADD:
@@ -54,14 +52,12 @@ boolean Plugin_007(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    case PLUGIN_I2C_HAS_ADDRESS:
     {
-      string = F("48,49,4a,4b,4c,4d"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
+      const int i2cAddressValues[] = { 0x48, 0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e, 0x4f };
+      success = intArrayContains(8, i2cAddressValues, event->Par1);
       break;
     }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_READ:
     {

--- a/src/_P007_PCF8591.ino
+++ b/src/_P007_PCF8591.ino
@@ -54,6 +54,15 @@ boolean Plugin_007(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("48,49,4a,4b,4c,4d"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_READ:
     {
       uint8_t unit       = (CONFIG_PORT - 1) / 4;

--- a/src/_P009_MCP.ino
+++ b/src/_P009_MCP.ino
@@ -89,6 +89,15 @@ boolean Plugin_009(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("20,21,22,23,24,25,26,27"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
       // @giig1967g: set current task value for taking actions after changes

--- a/src/_P009_MCP.ino
+++ b/src/_P009_MCP.ino
@@ -89,14 +89,12 @@ boolean Plugin_009(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    case PLUGIN_I2C_HAS_ADDRESS:
     {
-      string = F("20,21,22,23,24,25,26,27"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
+      const int i2cAddressValues[] = { 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27 };
+      success = intArrayContains(8, i2cAddressValues, event->Par1);
       break;
     }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P010_BH1750.ino
+++ b/src/_P010_BH1750.ino
@@ -49,31 +49,18 @@ boolean Plugin_010(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      uint8_t choice = PCONFIG(0);
-
-      /*
-         String options[2];
-         options[0] = F("0x23 - default settings (ADDR Low)");
-         options[1] = F("0x5c - alternate settings (ADDR High)");
-       */
-      int optionValues[2];
-      optionValues[0] = BH1750_DEFAULT_I2CADDR;
-      optionValues[1] = BH1750_SECOND_I2CADDR;
-      addFormSelectorI2C(F("i2c_addr"), 2, optionValues, choice);
-      addFormNote(F("ADDR Low=0x23, High=0x5c"));
+      const int i2cAddressValues[] = { BH1750_DEFAULT_I2CADDR, BH1750_SECOND_I2CADDR };
+      if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
+        addFormSelectorI2C(F("i2c_addr"), 2, i2cAddressValues, PCONFIG(0));
+        addFormNote(F("ADDR Low=0x23, High=0x5c"));
+      } else {
+        success = intArrayContains(2, i2cAddressValues, event->Par1);
+      }
       break;
     }
-
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
-    {
-      string = F("23,5c"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
-      break;
-    }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P010_BH1750.ino
+++ b/src/_P010_BH1750.ino
@@ -66,6 +66,14 @@ boolean Plugin_010(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("23,5c"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P011_PME.ino
+++ b/src/_P011_PME.ino
@@ -49,14 +49,11 @@ boolean Plugin_011(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    case PLUGIN_I2C_HAS_ADDRESS:
     {
-      string = F("7f"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
+      success = (event->Par1 == 0x7f);
       break;
     }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P011_PME.ino
+++ b/src/_P011_PME.ino
@@ -49,6 +49,15 @@ boolean Plugin_011(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("7f"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
       uint8_t   choice     = PCONFIG(0);

--- a/src/_P012_LCD.ino
+++ b/src/_P012_LCD.ino
@@ -65,37 +65,17 @@ boolean Plugin_012(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      uint8_t choice = P012_I2C_ADDR;
-
-      // String options[16];
-      int optionValues[16];
-
-      for (uint8_t x = 0; x < 16; x++)
-      {
-        if (x < 8) {
-          optionValues[x] = 0x20 + x;
-        }
-        else {
-          optionValues[x] = 0x30 + x;
-        }
-
-        // options[x] = F("0x");
-        // options[x] += String(optionValues[x], HEX);
+      const int i2cAddressValues[] = { 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f };
+      if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
+        addFormSelectorI2C(F("i2c_addr"), 16, i2cAddressValues, P012_I2C_ADDR);
+      } else {
+        success = intArrayContains(16, i2cAddressValues, event->Par1);
       }
-      addFormSelectorI2C(F("i2c_addr"), 16, optionValues, choice);
       break;
     }
-
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
-    {
-      string = F("20,21,22,23,24,25,26,27,38,39,3a,3b,3c,3d,3e,3f"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
-      break;
-    }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P012_LCD.ino
+++ b/src/_P012_LCD.ino
@@ -88,6 +88,15 @@ boolean Plugin_012(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("20,21,22,23,24,25,26,27,38,39,3a,3b,3c,3d,3e,3f"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
       {

--- a/src/_P014_SI7021.ino
+++ b/src/_P014_SI7021.ino
@@ -407,6 +407,15 @@ boolean Plugin_014(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("40"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
         #define SI7021_RESOLUTION_OPTION 4

--- a/src/_P014_SI7021.ino
+++ b/src/_P014_SI7021.ino
@@ -407,14 +407,11 @@ boolean Plugin_014(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    case PLUGIN_I2C_HAS_ADDRESS:
     {
-      string = F("40"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
+      success = (event->Par1 == 0x40);
       break;
     }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P015_TSL2561.ino
+++ b/src/_P015_TSL2561.ino
@@ -81,6 +81,14 @@ boolean Plugin_015(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("29,39,49"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P015_TSL2561.ino
+++ b/src/_P015_TSL2561.ino
@@ -65,30 +65,17 @@ boolean Plugin_015(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      /*
-          String options1[3];
-          options1[0] = F("0x39 - (default)");
-          options1[1] = F("0x49");
-          options1[2] = F("0x29");
-       */
-      int optionValues[3];
-      optionValues[0] = TSL2561_ADDR;
-      optionValues[1] = TSL2561_ADDR_1;
-      optionValues[2] = TSL2561_ADDR_0;
-      addFormSelectorI2C(F("i2c_addr"), 3, optionValues, P015_I2C_ADDR);
+      const int i2cAddressValues[] = { TSL2561_ADDR, TSL2561_ADDR_1, TSL2561_ADDR_0 };
+      if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
+        addFormSelectorI2C(F("i2c_addr"), 3, i2cAddressValues, P015_I2C_ADDR);
+      } else {
+        success = intArrayContains(3, i2cAddressValues, event->Par1);
+      }
       break;
     }
-
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
-    {
-      string = F("29,39,49"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
-      break;
-    }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P017_PN532.ino
+++ b/src/_P017_PN532.ino
@@ -68,6 +68,15 @@ boolean Plugin_017(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("24"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
       // FIXME TD-er: Why is this using pin3 and not pin1? And why isn't this using the normal pin selection functions?

--- a/src/_P017_PN532.ino
+++ b/src/_P017_PN532.ino
@@ -68,14 +68,11 @@ boolean Plugin_017(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    case PLUGIN_I2C_HAS_ADDRESS:
     {
-      string = F("24"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
+      success = (event->Par1 == 0x24);
       break;
     }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P017_PN532.ino
+++ b/src/_P017_PN532.ino
@@ -148,7 +148,7 @@ boolean Plugin_017(uint8_t function, struct EventStruct *event, String& string)
       if (counter == 3)
       {
         // TODO: Clock stretching issue https://github.com/esp8266/Arduino/issues/1541
-        if (isI2CEnabled()
+        if (Settings.isI2CEnabled()
             && ((digitalRead(Settings.Pin_i2c_sda) == 0) || (digitalRead(Settings.Pin_i2c_scl) == 0)))
         {
           addLog(LOG_LEVEL_ERROR, F("PN532: BUS error"));

--- a/src/_P017_PN532.ino
+++ b/src/_P017_PN532.ino
@@ -148,7 +148,7 @@ boolean Plugin_017(uint8_t function, struct EventStruct *event, String& string)
       if (counter == 3)
       {
         // TODO: Clock stretching issue https://github.com/esp8266/Arduino/issues/1541
-        if ((Settings.Pin_i2c_sda >= 0) && (Settings.Pin_i2c_scl >= 0)
+        if (isI2CEnabled()
             && ((digitalRead(Settings.Pin_i2c_sda) == 0) || (digitalRead(Settings.Pin_i2c_scl) == 0)))
         {
           addLog(LOG_LEVEL_ERROR, F("PN532: BUS error"));

--- a/src/_P019_PCF8574.ino
+++ b/src/_P019_PCF8574.ino
@@ -88,6 +88,15 @@ boolean Plugin_019(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("20,21,22,23,24,25,26,27"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
       // @giig1967g: set current task value for taking actions after changes

--- a/src/_P019_PCF8574.ino
+++ b/src/_P019_PCF8574.ino
@@ -55,8 +55,6 @@ boolean Plugin_019(uint8_t function, struct EventStruct *event, String& string)
 {
   boolean success = false;
 
-  // static int8_t switchstate[TASKS_MAX];
-
   switch (function)
   {
     case PLUGIN_DEVICE_ADD:
@@ -88,14 +86,12 @@ boolean Plugin_019(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    case PLUGIN_I2C_HAS_ADDRESS:
     {
-      string = F("20,21,22,23,24,25,26,27"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
+      const int i2cAddressValues[] = { 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27 };
+      success = intArrayContains(8, i2cAddressValues, event->Par1);
       break;
     }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P022_PCA9685.ino
+++ b/src/_P022_PCA9685.ino
@@ -90,6 +90,21 @@ boolean Plugin_022(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = EMPTY_STRING;
+      string.reserve(PCA9685_NUMS_ADDRESS * 3); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      for (uint8_t i = 0; i < PCA9685_NUMS_ADDRESS; i++)
+      {
+        string += String(PCA9685_ADDRESS + i, HEX);
+        string += ',';
+      }
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
       // The options lists are quite long.

--- a/src/_P022_PCA9685.ino
+++ b/src/_P022_PCA9685.ino
@@ -90,21 +90,6 @@ boolean Plugin_022(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
-    {
-      string = EMPTY_STRING;
-      string.reserve(PCA9685_NUMS_ADDRESS * 3); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      for (uint8_t i = 0; i < PCA9685_NUMS_ADDRESS; i++)
-      {
-        string += String(PCA9685_ADDRESS + i, HEX);
-        string += ',';
-      }
-      success = true;
-      break;
-    }
-    #endif // if USE_I2C_DEVICE_SCAN
-
     case PLUGIN_WEBFORM_LOAD:
     {
       // The options lists are quite long.

--- a/src/_P023_OLED.ino
+++ b/src/_P023_OLED.ino
@@ -53,24 +53,17 @@ boolean Plugin_023(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      uint8_t choice = PCONFIG(0);
-
-      /*String options[2] = { F("3C"), F("3D") };*/
-      int optionValues[2] = { 0x3C, 0x3D };
-      addFormSelectorI2C(F("i2c_addr"), 2, optionValues, choice);
+      const int i2cAddressValues[] = { 0x3C, 0x3D };
+      if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
+        addFormSelectorI2C(F("i2c_addr"), 2, i2cAddressValues, PCONFIG(0));
+      } else {
+        success = intArrayContains(2, i2cAddressValues, event->Par1);
+      }
       break;
     }
-
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
-    {
-      string = F("3c,3d"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
-      break;
-    }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P023_OLED.ino
+++ b/src/_P023_OLED.ino
@@ -63,6 +63,15 @@ boolean Plugin_023(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("3c,3d"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
       addFormCheckBox(F("Use SH1106 controller"), F("p023_use_sh1106"), PCONFIG(5));

--- a/src/_P024_MLX90614.ino
+++ b/src/_P024_MLX90614.ino
@@ -50,14 +50,11 @@ boolean Plugin_024(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    case PLUGIN_I2C_HAS_ADDRESS:
     {
-      string = F("5a"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
+      success = (event->Par1 == 0x5a);
       break;
     }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P024_MLX90614.ino
+++ b/src/_P024_MLX90614.ino
@@ -50,6 +50,15 @@ boolean Plugin_024(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("5a"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
         #define MLX90614_OPTION 2

--- a/src/_P025_ADS1115.ino
+++ b/src/_P025_ADS1115.ino
@@ -58,6 +58,15 @@ boolean Plugin_025(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("48,49,4a,4b"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
       uint8_t port = CONFIG_PORT;

--- a/src/_P025_ADS1115.ino
+++ b/src/_P025_ADS1115.ino
@@ -49,23 +49,18 @@ boolean Plugin_025(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-        #define ADS1115_I2C_OPTION 4
-      uint8_t addr                            = PCONFIG(0);
-      int optionValues[ADS1115_I2C_OPTION] = { 0x48, 0x49, 0x4A, 0x4B };
-      addFormSelectorI2C(F("i2c_addr"), ADS1115_I2C_OPTION, optionValues, addr);
+      #define ADS1115_I2C_OPTION 4
+      const int i2cAddressValues[] = { 0x48, 0x49, 0x4A, 0x4B };
+      if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
+        addFormSelectorI2C(F("i2c_addr"), ADS1115_I2C_OPTION, i2cAddressValues, PCONFIG(0));
+      } else {
+        success = intArrayContains(ADS1115_I2C_OPTION, i2cAddressValues, event->Par1);
+      }
       break;
     }
-
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
-    {
-      string = F("48,49,4a,4b"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
-      break;
-    }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P027_INA219.ino
+++ b/src/_P027_INA219.ino
@@ -60,6 +60,15 @@ boolean Plugin_027(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("40,41,44,45"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
       {

--- a/src/_P027_INA219.ino
+++ b/src/_P027_INA219.ino
@@ -53,21 +53,17 @@ boolean Plugin_027(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      int Plugin_27_i2c_addresses[4] = { INA219_ADDRESS, INA219_ADDRESS2, INA219_ADDRESS3, INA219_ADDRESS4 };
-      addFormSelectorI2C(F("i2c_addr"), 4, Plugin_27_i2c_addresses, P027_I2C_ADDR);
+      const int i2cAddressValues[] = { INA219_ADDRESS, INA219_ADDRESS2, INA219_ADDRESS3, INA219_ADDRESS4 };
+      if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
+        addFormSelectorI2C(F("i2c_addr"), 4, i2cAddressValues, P027_I2C_ADDR);
+      } else {
+        success = intArrayContains(4, i2cAddressValues, event->Par1);
+      }
       break;
     }
-
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
-    {
-      string = F("40,41,44,45"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
-      break;
-    }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P028_BME280.ino
+++ b/src/_P028_BME280.ino
@@ -67,21 +67,17 @@ boolean Plugin_028(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      int Plugin_28_i2c_addresses[2] = { 0x76, 0x77 };
-      addFormSelectorI2C(F("i2c_addr"), 2, Plugin_28_i2c_addresses, PCONFIG(0));
+      const int i2cAddressValues[] = { 0x76, 0x77 };
+      if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
+        addFormSelectorI2C(F("i2c_addr"), 2, i2cAddressValues, PCONFIG(0));
+      } else {
+        success = intArrayContains(2, i2cAddressValues, event->Par1);
+      }
       break;
     }
-
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
-    {
-      string = F("76,77"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
-      break;
-    }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P028_BME280.ino
+++ b/src/_P028_BME280.ino
@@ -74,6 +74,15 @@ boolean Plugin_028(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("76,77"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
       P028_data_struct *P028_data =

--- a/src/_P030_BMP280.ino
+++ b/src/_P030_BMP280.ino
@@ -102,25 +102,18 @@ boolean Plugin_030(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      uint8_t choice = PCONFIG(0);
-
-      /*String options[2] = { F("0x76 - default settings (SDO Low)"), F("0x77 - alternate settings (SDO HIGH)") };*/
-      int optionValues[2] = { 0x76, 0x77 };
-      addFormSelectorI2C(F("i2c_addr"), 2, optionValues, choice);
-      addFormNote(F("SDO Low=0x76, High=0x77"));
+      const int i2cAddressValues[] = { 0x76, 0x77 };
+      if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
+        addFormSelectorI2C(F("i2c_addr"), 2, i2cAddressValues, PCONFIG(0));
+        addFormNote(F("SDO Low=0x76, High=0x77"));
+      } else {
+        success = intArrayContains(2, i2cAddressValues, event->Par1);
+      }
       break;
     }
-
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
-    {
-      string = F("76,77"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
-      break;
-    }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P030_BMP280.ino
+++ b/src/_P030_BMP280.ino
@@ -113,6 +113,15 @@ boolean Plugin_030(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("76,77"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
       addFormNumericBox(F("Altitude"), F("p030_bmp280_elev"), PCONFIG(1));

--- a/src/_P032_MS5611.ino
+++ b/src/_P032_MS5611.ino
@@ -50,24 +50,17 @@ boolean Plugin_032(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      uint8_t choice = PCONFIG(0);
-
-      /*String options[2] = { F("0x77 - default I2C address"), F("0x76 - alternate I2C address") };*/
-      int optionValues[2] = { 0x77, 0x76 };
-      addFormSelectorI2C(F("i2c_addr"), 2, optionValues, choice);
+      const int i2cAddressValues[] = { 0x77, 0x76 };
+      if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
+        addFormSelectorI2C(F("i2c_addr"), 2, i2cAddressValues, PCONFIG(0));
+      } else {
+        success = intArrayContains(2, i2cAddressValues, event->Par1);
+      }
       break;
     }
-
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
-    {
-      string = F("76,77"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
-      break;
-    }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P032_MS5611.ino
+++ b/src/_P032_MS5611.ino
@@ -60,6 +60,15 @@ boolean Plugin_032(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("76,77"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
       addFormNumericBox(F("Altitude [m]"), F("p032_ms5611_elev"), PCONFIG(1));

--- a/src/_P034_DHT12.ino
+++ b/src/_P034_DHT12.ino
@@ -50,6 +50,15 @@ boolean Plugin_034(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("5c"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_INIT:
     {
       success = true;

--- a/src/_P034_DHT12.ino
+++ b/src/_P034_DHT12.ino
@@ -50,14 +50,11 @@ boolean Plugin_034(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    case PLUGIN_I2C_HAS_ADDRESS:
     {
-      string = F("5c"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
+      success = (event->Par1 == DHT12_I2C_ADDRESS);
       break;
     }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_INIT:
     {

--- a/src/_P036_FrameOLED.ino
+++ b/src/_P036_FrameOLED.ino
@@ -179,6 +179,15 @@ boolean Plugin_036(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("3c,3d"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
 #ifdef PLUGIN_036_DEBUG

--- a/src/_P036_FrameOLED.ino
+++ b/src/_P036_FrameOLED.ino
@@ -170,23 +170,17 @@ boolean Plugin_036(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      int     optionValues[2];
-      optionValues[0] = 0x3C;
-      optionValues[1] = 0x3D;
-      addFormSelectorI2C(F("i2c_addr"), 2, optionValues, P036_ADR);
+      const int i2cAddressValues[] = { 0x3c, 0x3d };
+      if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
+        addFormSelectorI2C(F("i2c_addr"), 2, i2cAddressValues, P036_ADR);
+      } else {
+        success = intArrayContains(2, i2cAddressValues, event->Par1);
+      }
       break;
     }
-
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
-    {
-      string = F("3c,3d"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
-      break;
-    }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P045_MPU6050.ino
+++ b/src/_P045_MPU6050.ino
@@ -121,6 +121,15 @@ boolean Plugin_045(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("68,69"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
       uint8_t choice = PCONFIG(1);

--- a/src/_P045_MPU6050.ino
+++ b/src/_P045_MPU6050.ino
@@ -102,33 +102,18 @@ boolean Plugin_045(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      uint8_t choice = PCONFIG(0);
-
-      // Setup webform for address selection
-
-      /*
-         String options[10];
-         options[0] = F("0x68 - default settings (ADDR Low)");
-         options[1] = F("0x69 - alternate settings (ADDR High)");
-       */
-      int optionValues[2];
-      optionValues[0] = 0x68;
-      optionValues[1] = 0x69;
-      addFormSelectorI2C(F("i2c_addr"), 2, optionValues, choice);
-      addFormNote(F("ADDR Low=0x68, High=0x69"));
+      const int i2cAddressValues[] = { 0x68, 0x69 };
+      if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
+        addFormSelectorI2C(F("i2c_addr"), 2, i2cAddressValues, PCONFIG(0));
+        addFormNote(F("ADDR Low=0x68, High=0x69"));
+      } else {
+        success = intArrayContains(2, i2cAddressValues, event->Par1);
+      }
       break;
     }
-
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
-    {
-      string = F("68,69"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
-      break;
-    }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P050_TCS34725.ino
+++ b/src/_P050_TCS34725.ino
@@ -85,6 +85,16 @@ boolean Plugin_050(uint8_t function, struct EventStruct *event, String& string)
       }
       break;
     }
+
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("29"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
       uint8_t   choiceMode = PCONFIG(0);

--- a/src/_P050_TCS34725.ino
+++ b/src/_P050_TCS34725.ino
@@ -86,14 +86,11 @@ boolean Plugin_050(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    case PLUGIN_I2C_HAS_ADDRESS:
     {
-      string = F("29"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
+      success = (event->Par1 == 0x29);
       break;
     }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P051_AM2320.ino
+++ b/src/_P051_AM2320.ino
@@ -57,14 +57,11 @@ boolean Plugin_051(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    case PLUGIN_I2C_HAS_ADDRESS:
     {
-      string = F("5c"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
+      success = (event->Par1 == 0x5c);
       break;
     }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P051_AM2320.ino
+++ b/src/_P051_AM2320.ino
@@ -57,6 +57,15 @@ boolean Plugin_051(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("5c"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
       success = true;

--- a/src/_P057_HT16K33_LED.ino
+++ b/src/_P057_HT16K33_LED.ino
@@ -101,23 +101,17 @@ boolean Plugin_057(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      uint8_t addr = PCONFIG(0);
-
-      int optionValues[8] = { 0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77 };
-      addFormSelectorI2C(F("i2c_addr"), 8, optionValues, addr);
+      const int i2cAddressValues[] = { 0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77 };
+      if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
+        addFormSelectorI2C(F("i2c_addr"), 8, i2cAddressValues, PCONFIG(0));
+      } else {
+        success = intArrayContains(8, i2cAddressValues, event->Par1);
+      }
       break;
     }
-
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
-    {
-      string = F("70,71,72,73,74,75,76,77"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
-      break;
-    }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P057_HT16K33_LED.ino
+++ b/src/_P057_HT16K33_LED.ino
@@ -110,6 +110,14 @@ boolean Plugin_057(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("70,71,72,73,74,75,76,77"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P058_HT16K33_KeyPad.ino
+++ b/src/_P058_HT16K33_KeyPad.ino
@@ -73,23 +73,17 @@ boolean Plugin_058(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      uint8_t addr = PCONFIG(0);
-
-      int optionValues[8] = { 0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77 };
-      addFormSelectorI2C(F("i2c_addr"), 8, optionValues, addr);
+      const int i2cAddressValues[] = { 0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77 };
+      if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
+        addFormSelectorI2C(F("i2c_addr"), 8, i2cAddressValues, PCONFIG(0));
+      } else {
+        success = intArrayContains(8, i2cAddressValues, event->Par1);
+      }
       break;
     }
-
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
-    {
-      string = F("70,71,72,73,74,75,76,77"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
-      break;
-    }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P058_HT16K33_KeyPad.ino
+++ b/src/_P058_HT16K33_KeyPad.ino
@@ -82,6 +82,15 @@ boolean Plugin_058(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("70,71,72,73,74,75,76,77"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
       success = true;

--- a/src/_P060_MCP3221.ino
+++ b/src/_P060_MCP3221.ino
@@ -60,6 +60,15 @@ boolean Plugin_060(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("48,49,4a,4b,4c,4d,4e,4f"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
       addFormCheckBox(F("Oversampling"), F("p060_oversampling"), PCONFIG(1));

--- a/src/_P060_MCP3221.ino
+++ b/src/_P060_MCP3221.ino
@@ -51,23 +51,17 @@ boolean Plugin_060(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      uint8_t addr = PCONFIG(0);
-
-      int optionValues[8] = { 0x4D, 0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4E, 0x4F };
-      addFormSelectorI2C(F("i2c_addr"), 8, optionValues, addr);
+      const int i2cAddressValues[] = { 0x4D, 0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4E, 0x4F };
+      if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
+        addFormSelectorI2C(F("i2c_addr"), 8, i2cAddressValues, PCONFIG(0));
+      } else {
+        success = intArrayContains(8, i2cAddressValues, event->Par1);
+      }
       break;
     }
-
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
-    {
-      string = F("48,49,4a,4b,4c,4d,4e,4f"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
-      break;
-    }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P061_KeyPad.ino
+++ b/src/_P061_KeyPad.ino
@@ -110,6 +110,14 @@ boolean Plugin_061(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("20,21,22,23,24,25,26,27,38,39,3A,3B,3C,3D,3E,3F"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P061_KeyPad.ino
+++ b/src/_P061_KeyPad.ino
@@ -97,27 +97,21 @@ boolean Plugin_061(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      uint8_t addr = PCONFIG(0);
+      const int i2cAddressValues[] = { 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x38, 0x39, 0x3A, 0x3B, 0x3C, 0x3D, 0x3E, 0x3F };
+      if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
+        addFormSelectorI2C(F("i2c_addr"), (PCONFIG(1) == 0) ? 8 : 16, i2cAddressValues, PCONFIG(0));
 
-      int optionValues[16] = { 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x38, 0x39, 0x3A, 0x3B, 0x3C, 0x3D, 0x3E, 0x3F };
-      addFormSelectorI2C(F("i2c_addr"), (PCONFIG(1) == 0) ? 8 : 16, optionValues, addr);
-
-      if (PCONFIG(1) != 0) {
-        addFormNote(F("PCF8574 uses address 0x20+; PCF8574<b>A</b> uses address 0x38+"));
+        if (PCONFIG(1) != 0) {
+          addFormNote(F("PCF8574 uses address 0x20+; PCF8574<b>A</b> uses address 0x38+"));
+        }
+      } else {
+        success = intArrayContains(16, i2cAddressValues, event->Par1);
       }
       break;
     }
-
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
-    {
-      string = F("20,21,22,23,24,25,26,27,38,39,3A,3B,3C,3D,3E,3F"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
-      break;
-    }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P062_MPR121_KeyPad.ino
+++ b/src/_P062_MPR121_KeyPad.ino
@@ -79,6 +79,15 @@ boolean Plugin_062(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("5a,5b,5c,5d"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
       addFormCheckBox(F("ScanCode"), F("scancode"), PCONFIG(1));

--- a/src/_P062_MPR121_KeyPad.ino
+++ b/src/_P062_MPR121_KeyPad.ino
@@ -70,23 +70,17 @@ boolean Plugin_062(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      uint8_t addr = PCONFIG(0);
-
-      int optionValues[4] = { 0x5A, 0x5B, 0x5C, 0x5D };
-      addFormSelectorI2C(F("i2c_addr"), 4, optionValues, addr);
+      const int i2cAddressValues[] = { 0x5A, 0x5B, 0x5C, 0x5D };
+      if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
+        addFormSelectorI2C(F("i2c_addr"), 4, i2cAddressValues, PCONFIG(0));
+      } else {
+        success = intArrayContains(4, i2cAddressValues, event->Par1);
+      }
       break;
     }
-
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
-    {
-      string = F("5a,5b,5c,5d"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
-      break;
-    }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P064_APDS9960.ino
+++ b/src/_P064_APDS9960.ino
@@ -97,23 +97,17 @@ boolean Plugin_064(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      uint8_t addr = 0x39;                                         // P064_ADDR; chip has only 1 address
-
-      int optionValues[1] = { 0x39 };
-      addFormSelectorI2C(F("i2c_addr"), 1, optionValues, addr); // Only for display I2C address
+      const int i2cAddressValues[] = { 0x39 };
+      if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
+        addFormSelectorI2C(F("i2c_addr"), 1, i2cAddressValues, 0x39); // Only for display I2C address
+      } else {
+        success = (event->Par1 == 0x39);
+      }
       break;
     }
-
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
-    {
-      string = F("39"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
-      break;
-    }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P064_APDS9960.ino
+++ b/src/_P064_APDS9960.ino
@@ -106,6 +106,15 @@ boolean Plugin_064(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("39"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
       {

--- a/src/_P066_VEML6040.ino
+++ b/src/_P066_VEML6040.ino
@@ -62,21 +62,17 @@ boolean Plugin_066(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      int optionValues[1] = { VEML6040_ADDR };
-      addFormSelectorI2C(F("i2c_addr"), 1, optionValues, VEML6040_ADDR); // Only for display I2C address
+      const int i2cAddressValues[] = { VEML6040_ADDR };
+      if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
+        addFormSelectorI2C(F("i2c_addr"), 1, i2cAddressValues, VEML6040_ADDR); // Only for display I2C address
+      } else {
+        success = (event->Par1 == VEML6040_ADDR);
+      }
       break;
     }
-
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
-    {
-      string = F("10"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
-      break;
-    }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P066_VEML6040.ino
+++ b/src/_P066_VEML6040.ino
@@ -69,6 +69,15 @@ boolean Plugin_066(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("10"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
       {

--- a/src/_P068_SHT3x.ino
+++ b/src/_P068_SHT3x.ino
@@ -183,21 +183,17 @@ boolean Plugin_068(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      int optionValues[2] = { 0x44, 0x45 };
-      addFormSelectorI2C(F("i2c_addr"), 2, optionValues, PCONFIG(0));
+      const int i2cAddressValues[] = { 0x44, 0x45 };
+      if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
+        addFormSelectorI2C(F("i2c_addr"), 2, i2cAddressValues, PCONFIG(0));
+      } else {
+        success = intArrayContains(2, i2cAddressValues, event->Par1);
+      }
       break;
     }
-
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
-    {
-      string = F("44,45"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
-      break;
-    }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P068_SHT3x.ino
+++ b/src/_P068_SHT3x.ino
@@ -190,6 +190,15 @@ boolean Plugin_068(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("44,45"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
       addFormNumericBox(F("Temperature offset"), F("p068_tempoffset"), PCONFIG(1));

--- a/src/_P069_LM75A.ino
+++ b/src/_P069_LM75A.ino
@@ -63,6 +63,15 @@ boolean Plugin_069(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("48,49,4a,4b,4c,4d,4e,4f"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
       success = true;

--- a/src/_P069_LM75A.ino
+++ b/src/_P069_LM75A.ino
@@ -56,21 +56,17 @@ boolean Plugin_069(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      int optionValues[8] = { 0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4E, 0x4F };
-      addFormSelectorI2C(F("i2c_addr"), 8, optionValues, PCONFIG(0));
+      const int i2cAddressValues[] = { 0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4E, 0x4F };
+      if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
+        addFormSelectorI2C(F("i2c_addr"), 8, i2cAddressValues, PCONFIG(0));
+      } else {
+        success = intArrayContains(8, i2cAddressValues, event->Par1);
+      }
       break;
     }
-
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
-    {
-      string = F("48,49,4a,4b,4c,4d,4e,4f"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
-      break;
-    }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P072_HDC1080.ino
+++ b/src/_P072_HDC1080.ino
@@ -50,6 +50,15 @@ boolean Plugin_072(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("40"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_INIT:
     {
       success = true;

--- a/src/_P072_HDC1080.ino
+++ b/src/_P072_HDC1080.ino
@@ -50,14 +50,11 @@ boolean Plugin_072(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    case PLUGIN_I2C_HAS_ADDRESS:
     {
-      string = F("40"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
+      success = (event->Par1 == 0x40);
       break;
     }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_INIT:
     {

--- a/src/_P074_TSL2591.ino
+++ b/src/_P074_TSL2591.ino
@@ -153,6 +153,15 @@ boolean Plugin_074(uint8_t function, struct EventStruct *event, String& string) 
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("29"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD: {
       //        P074_data_struct* P074_data =
       //        static_cast<P074_data_struct*>(getPluginTaskData(event->TaskIndex));

--- a/src/_P074_TSL2591.ino
+++ b/src/_P074_TSL2591.ino
@@ -145,22 +145,18 @@ boolean Plugin_074(uint8_t function, struct EventStruct *event, String& string) 
       break;
     }
 
+    case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      int optionValues[1] = { TSL2591_ADDR };
-      addFormSelectorI2C(F("i2c_addr"), 1, optionValues,
-                         TSL2591_ADDR); // Only for display I2C address
+      const int i2cAddressValues[] = { TSL2591_ADDR };
+      if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
+        addFormSelectorI2C(F("i2c_addr"), 1, i2cAddressValues,
+                           TSL2591_ADDR); // Only for display I2C address
+      } else {
+        success = (event->Par1 == TSL2591_ADDR);
+      }
       break;
     }
-
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
-    {
-      string = F("29"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
-      break;
-    }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD: {
       //        P074_data_struct* P074_data =

--- a/src/_P083_SGP30.ino
+++ b/src/_P083_SGP30.ino
@@ -59,14 +59,11 @@ boolean Plugin_083(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    case PLUGIN_I2C_HAS_ADDRESS:
     {
-      string = F("58"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
+      success = (event->Par1 == 0x58);
       break;
     }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P083_SGP30.ino
+++ b/src/_P083_SGP30.ino
@@ -59,6 +59,15 @@ boolean Plugin_083(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("58"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
       addFormSubHeader(F("Sensor"));

--- a/src/_P084_VEML6070.ino
+++ b/src/_P084_VEML6070.ino
@@ -69,6 +69,15 @@ boolean Plugin_084(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("38,39"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
       const __FlashStringHelper * optionsMode[4] = { F("1/2T"), F("1T"), F("2T"), F("4T (Default)") };

--- a/src/_P084_VEML6070.ino
+++ b/src/_P084_VEML6070.ino
@@ -69,14 +69,11 @@ boolean Plugin_084(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    case PLUGIN_I2C_HAS_ADDRESS:
     {
-      string = F("38,39"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
+      success = (event->Par1 == 0x38);
       break;
     }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P090_CCS811.ino
+++ b/src/_P090_CCS811.ino
@@ -104,23 +104,19 @@ boolean Plugin_090(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
+      const int i2cAddressValues[] = { 0x5A, 0x5B };
       // I2C address choice
-      const __FlashStringHelper * options[2]      = { F("0x5A (ADDR pin is LOW)"), F("0x5B (ADDR pin is HIGH)") };
-      int    optionValues[2] = { 0x5A, 0x5B };
-      addFormSelector(F("I2C Address"), F("i2c_addr"), 2, options, optionValues, P090_I2C_ADDR);
+      if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
+        const __FlashStringHelper * options[2] = { F("0x5A (ADDR pin is LOW)"), F("0x5B (ADDR pin is HIGH)") };
+        addFormSelector(F("I2C Address"), F("i2c_addr"), 2, options, i2cAddressValues, P090_I2C_ADDR);
+      } else {
+        success = intArrayContains(2, i2cAddressValues, event->Par1);
+      }
       break;
     }
-
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
-    {
-      string = F("5a,5b"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
-      break;
-    }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P090_CCS811.ino
+++ b/src/_P090_CCS811.ino
@@ -113,6 +113,15 @@ boolean Plugin_090(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("5a,5b"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
       {

--- a/src/_P103_Atlas_EZO_pH_ORP_EC.ino
+++ b/src/_P103_Atlas_EZO_pH_ORP_EC.ino
@@ -70,7 +70,7 @@ boolean Plugin_103(uint8_t function, struct EventStruct *event, String &string)
     case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      const int i2cAddressValues[] = {0x62, 0x63, 0x64} // , 0x65, 0x66, 0x67}; // Disabled unsupported devices as discussed here: https://github.com/letscontrolit/ESPEasy/pull/3733 (review comment by TD-er)
+      const int i2cAddressValues[] = {0x62, 0x63, 0x64}; // , 0x65, 0x66, 0x67}; // Disabled unsupported devices as discussed here: https://github.com/letscontrolit/ESPEasy/pull/3733 (review comment by TD-er)
       if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
         addFormSelectorI2C(F("plugin_103_i2c"), _P103_ATLASEZO_I2C_NB_OPTIONS, i2cAddressValues, PCONFIG(1));
         addFormNote(F("pH: 0x63, ORP: 0x62, EC: 0x64. The plugin is able to detect the type of device automatically."));

--- a/src/_P103_Atlas_EZO_pH_ORP_EC.ino
+++ b/src/_P103_Atlas_EZO_pH_ORP_EC.ino
@@ -25,6 +25,8 @@
 
 #define ATLAS_EZO_RETURN_ARRAY_SIZE 33
 
+#define _P103_ATLASEZO_I2C_NB_OPTIONS 6
+
 #define FIXED_TEMP_VALUE 20 // Temperature correction for pH and EC sensor if no temperature is given from calculation
 
 boolean Plugin_103(uint8_t function, struct EventStruct *event, String &string)
@@ -65,22 +67,22 @@ boolean Plugin_103(uint8_t function, struct EventStruct *event, String &string)
     break;
   }
 
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    case PLUGIN_I2C_HAS_ADDRESS:
+    case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      string = F("62,63,64"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
+      const int i2cAddressValues[] = {0x62, 0x63, 0x64, 0x65, 0x66, 0x67};
+      if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
+        addFormSelectorI2C(F("plugin_103_i2c"), _P103_ATLASEZO_I2C_NB_OPTIONS, i2cAddressValues, PCONFIG(1));
+        addFormNote(F("pH: 0x63, ORP: 0x62, EC: 0x64. The plugin is able to detect the type of device automatically."));
+      } else {
+        success = intArrayContains(_P103_ATLASEZO_I2C_NB_OPTIONS, i2cAddressValues, event->Par1);
+      }
       break;
     }
-    #endif // if USE_I2C_DEVICE_SCAN
 
   case PLUGIN_WEBFORM_LOAD:
   {
     I2Cchoice = PCONFIG(1);
-#define _P103_ATLASEZO_I2C_NB_OPTIONS 6
-    int optionValues[_P103_ATLASEZO_I2C_NB_OPTIONS] = {0x62, 0x63, 0x64, 0x65, 0x66, 0x67};
-    addFormSelectorI2C(F("plugin_103_i2c"), _P103_ATLASEZO_I2C_NB_OPTIONS, optionValues, I2Cchoice);
-    addFormNote(F("pH: 0x63, ORP: 0x62, EC: 0x64. The plugin is able to detect the type of device automatically."));
 
     addFormSubHeader(F("Board"));
 

--- a/src/_P103_Atlas_EZO_pH_ORP_EC.ino
+++ b/src/_P103_Atlas_EZO_pH_ORP_EC.ino
@@ -65,6 +65,15 @@ boolean Plugin_103(uint8_t function, struct EventStruct *event, String &string)
     break;
   }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("62,63,64"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
   case PLUGIN_WEBFORM_LOAD:
   {
     I2Cchoice = PCONFIG(1);

--- a/src/_P103_Atlas_EZO_pH_ORP_EC.ino
+++ b/src/_P103_Atlas_EZO_pH_ORP_EC.ino
@@ -25,7 +25,7 @@
 
 #define ATLAS_EZO_RETURN_ARRAY_SIZE 33
 
-#define _P103_ATLASEZO_I2C_NB_OPTIONS 6
+#define _P103_ATLASEZO_I2C_NB_OPTIONS 3  // was: 6 see comment below at 'const int i2cAddressValues' 
 
 #define FIXED_TEMP_VALUE 20 // Temperature correction for pH and EC sensor if no temperature is given from calculation
 
@@ -70,7 +70,7 @@ boolean Plugin_103(uint8_t function, struct EventStruct *event, String &string)
     case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      const int i2cAddressValues[] = {0x62, 0x63, 0x64, 0x65, 0x66, 0x67};
+      const int i2cAddressValues[] = {0x62, 0x63, 0x64} // , 0x65, 0x66, 0x67}; // Disabled unsupported devices as discussed here: https://github.com/letscontrolit/ESPEasy/pull/3733 (review comment by TD-er)
       if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
         addFormSelectorI2C(F("plugin_103_i2c"), _P103_ATLASEZO_I2C_NB_OPTIONS, i2cAddressValues, PCONFIG(1));
         addFormNote(F("pH: 0x63, ORP: 0x62, EC: 0x64. The plugin is able to detect the type of device automatically."));

--- a/src/_P106_BME680.ino
+++ b/src/_P106_BME680.ino
@@ -64,29 +64,18 @@ boolean Plugin_106(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      uint8_t choice = PCONFIG(0);
-
-      /*
-         String options[2];
-         options[0] = F("0x76 - default settings (SDO Low)");
-         options[1] = F("0x77 - alternate settings (SDO HIGH)");
-       */
-      int optionValues[2] = { 0x77, 0x76 };
-      addFormSelectorI2C(F("i2c_addr"), 2, optionValues, choice);
-      addFormNote(F("SDO Low=0x76, High=0x77"));
+      const int i2cAddressValues[] = { 0x77, 0x76 };
+      if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
+        addFormSelectorI2C(F("i2c_addr"), 2, i2cAddressValues, PCONFIG(0));
+        addFormNote(F("SDO Low=0x76, High=0x77"));
+      } else {
+        success = intArrayContains(2, i2cAddressValues, event->Par1);
+      }
       break;
     }
-
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
-    {
-      string = F("67,77"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
-      break;
-    }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P106_BME680.ino
+++ b/src/_P106_BME680.ino
@@ -79,6 +79,15 @@ boolean Plugin_106(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("67,77"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
       addFormNumericBox(F("Altitude"), F("plugin_106_BME680_elev"), PCONFIG(1));

--- a/src/_P107_SI1145.ino
+++ b/src/_P107_SI1145.ino
@@ -50,6 +50,15 @@ boolean Plugin_107(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("60"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_INIT:
     {
       initPluginTaskData(event->TaskIndex, new (std::nothrow) P107_data_struct());

--- a/src/_P107_SI1145.ino
+++ b/src/_P107_SI1145.ino
@@ -50,14 +50,11 @@ boolean Plugin_107(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    case PLUGIN_I2C_HAS_ADDRESS:
     {
-      string = F("60"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
+      success = (event->Par1 == 0x60);
       break;
     }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_INIT:
     {

--- a/src/_P109_ThermOLED.ino
+++ b/src/_P109_ThermOLED.ino
@@ -157,6 +157,15 @@ boolean Plugin_109(byte function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("3c,3d"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
       byte   choice5 = Settings.TaskDevicePluginConfig[event->TaskIndex][2];

--- a/src/_P109_ThermOLED.ino
+++ b/src/_P109_ThermOLED.ino
@@ -157,36 +157,27 @@ boolean Plugin_109(byte function, struct EventStruct *event, String& string)
       break;
     }
 
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    case PLUGIN_I2C_HAS_ADDRESS:
+    case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      string = F("3c,3d"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
+      const int i2cAddressValues[] = { 0x3c, 0x3d };
+      if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
+        addFormSelectorI2C(F("plugin_109_adr"), 2, i2cAddressValues, PCONFIG(0));
+      } else {
+        success = intArrayContains(2, i2cAddressValues, event->Par1);
+      }
       break;
     }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {
-      byte   choice5 = Settings.TaskDevicePluginConfig[event->TaskIndex][2];
-      String options5[2];
-      options5[0] = F("SSD1306");
-      options5[1] = F("SH1106");
-      int optionValues5[2] = { 1, 2 };
-      addFormSelector(F("Controller"), F("plugin_109_controler"), 2, options5, optionValues5, choice5);
+      const __FlashStringHelper* options5[]      = { F("SSD1306"), F("SH1106") };
+      const int                  optionValues5[] = { 1, 2 };
+      addFormSelector(F("Controller"), F("plugin_109_controler"), 2, options5, optionValues5, PCONFIG(2));
 
-      byte choice0 = Settings.TaskDevicePluginConfig[event->TaskIndex][0];
-      int  optionValues0[2];
-      optionValues0[0] = 0x3C;
-      optionValues0[1] = 0x3D;
-      addFormSelectorI2C(F("plugin_109_adr"), 2, optionValues0, choice0);
-
-      byte   choice1 = Settings.TaskDevicePluginConfig[event->TaskIndex][1];
-      String options1[2];
-      options1[0] = F("Normal");
-      options1[1] = F("Rotated");
-      int optionValues1[2] = { 1, 2 };
-      addFormSelector(F("Rotation"), F("plugin_109_rotate"), 2, options1, optionValues1, choice1);
+      const __FlashStringHelper* options1[]      = { F("Normal"), F("Rotated") };
+      const int                  optionValues1[] = { 1, 2 };
+      addFormSelector(F("Rotation"), F("plugin_109_rotate"), 2, options1, optionValues1, PCONFIG(1));
 
       LoadCustomTaskSettings(event->TaskIndex, (byte *)&P109_deviceTemplate, sizeof(P109_deviceTemplate));
 
@@ -205,34 +196,22 @@ boolean Plugin_109(byte function, struct EventStruct *event, String& string)
         }
       }
 
-      addFormPinSelect(F("Button left"),  F("taskdevicepin1"), Settings.TaskDevicePin1[event->TaskIndex]);
-      addFormPinSelect(F("Button right"), F("taskdevicepin2"), Settings.TaskDevicePin2[event->TaskIndex]);
-      addFormPinSelect(F("Button mode"),  F("taskdevicepin3"), Settings.TaskDevicePin3[event->TaskIndex]);
+      addFormPinSelect(F("Button left"),  F("taskdevicepin1"), CONFIG_PIN1);
+      addFormPinSelect(F("Button right"), F("taskdevicepin2"), CONFIG_PIN2);
+      addFormPinSelect(F("Button mode"),  F("taskdevicepin3"), CONFIG_PIN3);
 
-      addFormPinSelect(F("Relay"),        F("heatrelay"),      Settings.TaskDevicePluginConfig[event->TaskIndex][4]);
+      addFormPinSelect(F("Relay"),        F("heatrelay"),      PCONFIG(4));
 
-      byte choice6 = Settings.TaskDevicePluginConfig[event->TaskIndex][3];
+      byte choice6 = PCONFIG(3);
 
       if (choice6 == 0) { choice6 = P109_CONTRAST_HIGH; }
-      String options6[3];
-      options6[0] = F("Low");
-      options6[1] = F("Medium");
-      options6[2] = F("High");
-      int optionValues6[3];
-      optionValues6[0] = P109_CONTRAST_LOW;
-      optionValues6[1] = P109_CONTRAST_MED;
-      optionValues6[2] = P109_CONTRAST_HIGH;
+      const __FlashStringHelper* options6[]      = { F("Low"), F("Medium"), F("High") };
+      const int                  optionValues6[] = { P109_CONTRAST_LOW, P109_CONTRAST_MED, P109_CONTRAST_HIGH };
       addFormSelector(F("Contrast"), F("plugin_109_contrast"), 3, options6, optionValues6, choice6);
 
-      byte   choice4 = (Settings.TaskDevicePluginConfigFloat[event->TaskIndex][0] * 10);
-      String options4[3];
-      options4[0] = F("0.2");
-      options4[1] = F("0.5");
-      options4[2] = F("1");
-      int optionValues4[3];
-      optionValues4[0] = 2;
-      optionValues4[1] = 5;
-      optionValues4[2] = 10;
+      byte   choice4 = (PCONFIG_FLOAT(0) * 10);
+      const __FlashStringHelper* options4[] = { F("0.2"), F("0.5"), F("1") };
+      const int                  optionValues4[] = { 2, 5, 10 };
       addFormSelector(F("Hysteresis"), F("plugin_109_hyst"), 3, options4, optionValues4, choice4);
 
       success = true;
@@ -241,12 +220,12 @@ boolean Plugin_109(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_WEBFORM_SAVE:
     {
-      Settings.TaskDevicePluginConfig[event->TaskIndex][0]      = getFormItemInt(F("plugin_109_adr"));
-      Settings.TaskDevicePluginConfig[event->TaskIndex][1]      = getFormItemInt(F("plugin_109_rotate"));
-      Settings.TaskDevicePluginConfig[event->TaskIndex][2]      = getFormItemInt(F("plugin_109_controler"));
-      Settings.TaskDevicePluginConfig[event->TaskIndex][3]      = getFormItemInt(F("plugin_109_contrast"));
-      Settings.TaskDevicePluginConfig[event->TaskIndex][4]      = getFormItemInt(F("heatrelay"));
-      Settings.TaskDevicePluginConfigFloat[event->TaskIndex][0] = (getFormItemInt(F("plugin_109_hyst")) / 10.0);
+      PCONFIG(0)       = getFormItemInt(F("plugin_109_adr"));
+      PCONFIG(1)       = getFormItemInt(F("plugin_109_rotate"));
+      PCONFIG(2)       = getFormItemInt(F("plugin_109_controler"));
+      PCONFIG(3)       = getFormItemInt(F("plugin_109_contrast"));
+      PCONFIG(4)       = getFormItemInt(F("heatrelay"));
+      PCONFIG_FLOAT(0) = (getFormItemInt(F("plugin_109_hyst")) / 10.0f);
 
       String argName;
 

--- a/src/_P110_VL53L0X.ino
+++ b/src/_P110_VL53L0X.ino
@@ -59,22 +59,19 @@ boolean Plugin_110(uint8_t function, struct EventStruct *event, String& string)
         strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[0], PSTR(PLUGIN_VALUENAME1_110));
         break;
       }
+
+    case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
       {
-        uint8_t choice = PCONFIG(0);
-        int optionValues[2] = { 0x29, 0x30 };
-        addFormSelectorI2C(F("plugin_110_vl53l0x_i2c"), 2, optionValues, choice);
-        addFormNote(F("SDO Low=0x29, High=0x30"));
+        const int i2cAddressValues[] = { 0x29, 0x30 };
+        if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
+          addFormSelectorI2C(F("plugin_110_vl53l0x_i2c"), 2, i2cAddressValues, PCONFIG(0));
+          addFormNote(F("SDO Low=0x29, High=0x30"));
+        } else {
+          success = intArrayContains(2, i2cAddressValues, event->Par1);
+        }
         break;
       }
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
-      {
-        string = F("29,30"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-        success = true;
-        break;
-      }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
       {

--- a/src/_P110_VL53L0X.ino
+++ b/src/_P110_VL53L0X.ino
@@ -67,6 +67,15 @@ boolean Plugin_110(uint8_t function, struct EventStruct *event, String& string)
         addFormNote(F("SDO Low=0x29, High=0x30"));
         break;
       }
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+      {
+        string = F("29,30"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+        success = true;
+        break;
+      }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
       {
         unsigned int choiceMode2 = PCONFIG(1);

--- a/src/_P112_AS7265x.ino
+++ b/src/_P112_AS7265x.ino
@@ -61,21 +61,17 @@ boolean Plugin_112(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      int optionValues[1] = { AS7265X_ADDR };
-      addFormSelectorI2C(F("i2c_addr"), 1, optionValues, AS7265X_ADDR);
+      const int i2cAddressValues[1] = { AS7265X_ADDR };
+      if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
+        addFormSelectorI2C(F("i2c_addr"), 1, i2cAddressValues, AS7265X_ADDR);
+      } else {
+        success = (event->Par1 == AS7265X_ADDR);
+      }
       break;
     }
-
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
-    {
-      string = F("49"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
-      break;
-    }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_SET_DEFAULTS:
     {

--- a/src/_P112_AS7265x.ino
+++ b/src/_P112_AS7265x.ino
@@ -68,6 +68,15 @@ boolean Plugin_112(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("49"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_SET_DEFAULTS:
     {
       PCONFIG_LONG(0) = AS7265X_GAIN_37X;               // Set Gain (AS7265X_GAIN_37X) => This is 3.7x

--- a/src/_P113_VL53L1X.ino
+++ b/src/_P113_VL53L1X.ino
@@ -55,24 +55,17 @@ boolean Plugin_113(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      uint8_t choice          = PCONFIG(0);
-      int  optionValues[2] = { 0x29, 0x30 };
-      addFormSelectorI2C(F("plugin_113_vl53l1x_i2c"), 2, optionValues, choice);
-
-      // addFormNote(F("SDO Low=0x29, High=0x30"));
+      const int i2cAddressValues[] = { 0x29, 0x30 };
+      if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
+        addFormSelectorI2C(F("plugin_113_vl53l1x_i2c"), 2, i2cAddressValues, PCONFIG(0));
+      } else {
+        success = intArrayContains(2, i2cAddressValues, event->Par1);
+      }
       break;
     }
-
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
-    {
-      string = F("29,30"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
-      break;
-    }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P113_VL53L1X.ino
+++ b/src/_P113_VL53L1X.ino
@@ -65,6 +65,15 @@ boolean Plugin_113(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("29,30"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
       unsigned int choiceMode2 = PCONFIG(1);

--- a/src/_P114_VEML6075.ino
+++ b/src/_P114_VEML6075.ino
@@ -63,6 +63,15 @@ boolean Plugin_114(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("10,11"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_WEBFORM_LOAD:
     {
       {

--- a/src/_P114_VEML6075.ino
+++ b/src/_P114_VEML6075.ino
@@ -55,22 +55,18 @@ boolean Plugin_114(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      int optionValues[2] = { 0x10, 0x11 };
-      addFormSelectorI2C(F("plugin_114_veml6075_i2c"), 2, optionValues, PCONFIG(0));
-      addFormNote(F("SDO Low=0x10, High=0x11"));
+      const int i2cAddressValues[2] = { 0x10, 0x11 };
+      if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
+        addFormSelectorI2C(F("plugin_114_veml6075_i2c"), 2, i2cAddressValues, PCONFIG(0));
+        addFormNote(F("SDO Low=0x10, High=0x11"));
+      } else {
+        success = intArrayContains(2, i2cAddressValues, event->Par1);
+      }
       break;
     }
-
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
-    {
-      string = F("10,11"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
-      break;
-    }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_WEBFORM_LOAD:
     {

--- a/src/_P115_MAX1704x_v2.ino
+++ b/src/_P115_MAX1704x_v2.ino
@@ -69,6 +69,15 @@ boolean Plugin_115(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
+    #if USE_I2C_DEVICE_SCAN
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    {
+      string = F("36"); // List of device addresses, hex, comma separated, _no_ 0x prefix
+      success = true;
+      break;
+    }
+    #endif // if USE_I2C_DEVICE_SCAN
+
     case PLUGIN_INIT:
     {
       const sfe_max1704x_devices_e device = static_cast<sfe_max1704x_devices_e>(P115_DEVICESELECTOR);

--- a/src/_P115_MAX1704x_v2.ino
+++ b/src/_P115_MAX1704x_v2.ino
@@ -69,14 +69,11 @@ boolean Plugin_115(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
-    #if USE_I2C_DEVICE_SCAN
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    case PLUGIN_I2C_HAS_ADDRESS:
     {
-      string = F("36"); // List of device addresses, hex, comma separated, _no_ 0x prefix
-      success = true;
+      success = (event->Par1 == 0x36);
       break;
     }
-    #endif // if USE_I2C_DEVICE_SCAN
 
     case PLUGIN_INIT:
     {

--- a/src/src/CustomBuild/ESPEasyDefaults.h
+++ b/src/src/CustomBuild/ESPEasyDefaults.h
@@ -184,6 +184,9 @@
 #ifndef DEFAULT_I2C_CLOCK_SPEED_SLOW
 #define DEFAULT_I2C_CLOCK_SPEED_SLOW      100000            // Use 100 kHz for old/slow I2C chips
 #endif
+#ifndef USE_I2C_DEVICE_SCAN
+#define USE_I2C_DEVICE_SCAN              true               // Show device name in I2C scan
+#endif
 
 #ifndef DEFAULT_PIN_STATUS_LED
 #define DEFAULT_PIN_STATUS_LED           (-1)

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -412,6 +412,10 @@ To create/register a plugin, you have to :
     #ifndef LIMIT_BUILD_SIZE
         #define LIMIT_BUILD_SIZE
     #endif
+    #if USE_I2C_DEVICE_SCAN
+        #undef USE_I2C_DEVICE_SCAN
+        #define USE_I2C_DEVICE_SCAN     false   // turn feature off in OTA builds
+    #endif // if USE_I2C_DEVICE_SCAN
     #ifdef KEEP_TRIGONOMETRIC_FUNCTIONS_RULES
         #undef KEEP_TRIGONOMETRIC_FUNCTIONS_RULES
     #endif

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -412,6 +412,9 @@ To create/register a plugin, you have to :
     #ifndef LIMIT_BUILD_SIZE
         #define LIMIT_BUILD_SIZE
     #endif
+    #if USE_I2C_DEVICE_SCAN
+        #define USE_I2C_DEVICE_SCAN     false   // turn feature off in OTA builds
+    #endif // if USE_I2C_DEVICE_SCAN
     #ifdef KEEP_TRIGONOMETRIC_FUNCTIONS_RULES
         #undef KEEP_TRIGONOMETRIC_FUNCTIONS_RULES
     #endif

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -412,9 +412,6 @@ To create/register a plugin, you have to :
     #ifndef LIMIT_BUILD_SIZE
         #define LIMIT_BUILD_SIZE
     #endif
-    #if USE_I2C_DEVICE_SCAN
-        #define USE_I2C_DEVICE_SCAN     false   // turn feature off in OTA builds
-    #endif // if USE_I2C_DEVICE_SCAN
     #ifdef KEEP_TRIGONOMETRIC_FUNCTIONS_RULES
         #undef KEEP_TRIGONOMETRIC_FUNCTIONS_RULES
     #endif

--- a/src/src/DataStructs/SettingsStruct.cpp
+++ b/src/src/DataStructs/SettingsStruct.cpp
@@ -581,7 +581,8 @@ template<unsigned int N_TASKS>
 bool SettingsStruct_tmpl<N_TASKS>::isI2CEnabled() const {
   return (Pin_i2c_sda != -1) &&
          (Pin_i2c_scl != -1) &&
-         (I2C_clockSpeed > 0);
+         (I2C_clockSpeed > 0) &&
+         (I2C_clockSpeed_Slow > 0);
 }
 
 template<unsigned int N_TASKS>

--- a/src/src/DataStructs/SettingsStruct.cpp
+++ b/src/src/DataStructs/SettingsStruct.cpp
@@ -578,6 +578,13 @@ bool SettingsStruct_tmpl<N_TASKS>::isI2C_pin(int8_t pin) const {
 }
 
 template<unsigned int N_TASKS>
+bool SettingsStruct_tmpl<N_TASKS>::isI2CEnabled() const {
+  return (Pin_i2c_sda != -1) &&
+         (Pin_i2c_scl != -1) &&
+         (I2C_clockSpeed > 0);
+}
+
+template<unsigned int N_TASKS>
 bool SettingsStruct_tmpl<N_TASKS>::isEthernetPin(int8_t pin) const {
   #ifdef HAS_ETHERNET
   if (pin < 0) return false;

--- a/src/src/DataStructs/SettingsStruct.h
+++ b/src/src/DataStructs/SettingsStruct.h
@@ -179,6 +179,9 @@ class SettingsStruct_tmpl
   // Return true when pin is one of the configured I2C pins.
   bool isI2C_pin(int8_t pin) const;
 
+  // Return true if I2C settings are correct
+  bool isI2CEnabled() const;
+
   // Return true when pin is one of the fixed Ethernet pins and Ethernet is enabled
   bool isEthernetPin(int8_t pin) const;
 

--- a/src/src/DataTypes/ESPEasy_plugin_functions.h
+++ b/src/src/DataTypes/ESPEasy_plugin_functions.h
@@ -45,6 +45,7 @@
 #define PLUGIN_MQTT_IMPORT                 37 // For P037 MQTT import
 #define PLUGIN_FORMAT_USERVAR              38 // Allow plugin specific formatting of a task variable (event->idx = variable)
 #define PLUGIN_WEBFORM_SHOW_GPIO_DESCR     39 // Show GPIO description on devices overview tab
+#define PLUGIN_I2C_GET_ADDRESSES_HEX       40 // Fetch the I2C addresses from the plugin, hex formatted, no 0x prefix, comma separated, output in 'string'
 
 
 

--- a/src/src/DataTypes/ESPEasy_plugin_functions.h
+++ b/src/src/DataTypes/ESPEasy_plugin_functions.h
@@ -45,7 +45,7 @@
 #define PLUGIN_MQTT_IMPORT                 37 // For P037 MQTT import
 #define PLUGIN_FORMAT_USERVAR              38 // Allow plugin specific formatting of a task variable (event->idx = variable)
 #define PLUGIN_WEBFORM_SHOW_GPIO_DESCR     39 // Show GPIO description on devices overview tab
-#define PLUGIN_I2C_GET_ADDRESSES_HEX       40 // Fetch the I2C addresses from the plugin, hex formatted, no 0x prefix, comma separated, output in 'string'
+#define PLUGIN_I2C_HAS_ADDRESS             40 // Check the I2C addresses from the plugin, output in 'success'
 
 
 

--- a/src/src/Globals/Plugins.cpp
+++ b/src/src/Globals/Plugins.cpp
@@ -141,16 +141,17 @@ String getPluginNameFromPluginID(pluginID_t pluginID) {
   return getPluginNameFromDeviceIndex(deviceIndex);
 }
 
-#if USE_I2C_DEVICE_SCAN
-String getPluginI2CAddressesFromDeviceIndex(deviceIndex_t deviceIndex) {
-  String i2cAdresses;
+bool checkPluginI2CAddressFromDeviceIndex(deviceIndex_t deviceIndex, uint8_t i2cAddress) {
+  bool hasI2CAddress = false;
 
   if (validDeviceIndex(deviceIndex)) {
-    Plugin_ptr[deviceIndex](PLUGIN_I2C_GET_ADDRESSES_HEX, nullptr, i2cAdresses);
+    String dummy;
+    struct EventStruct TempEvent;
+    TempEvent.Par1 = i2cAddress;
+    hasI2CAddress = Plugin_ptr[deviceIndex](PLUGIN_I2C_HAS_ADDRESS, &TempEvent, dummy);
   }
-  return i2cAdresses;
+  return hasI2CAddress;
 }
-#endif // if USE_I2C_DEVICE_SCAN
 
 // ********************************************************************************
 // Device Sort routine, compare two array entries
@@ -640,7 +641,7 @@ bool PluginCall(uint8_t Function, struct EventStruct *event, String& str)
     case PLUGIN_FORMAT_USERVAR:
     case PLUGIN_SET_CONFIG:
     case PLUGIN_SET_DEFAULTS:
-    case PLUGIN_I2C_GET_ADDRESSES_HEX:
+    case PLUGIN_I2C_HAS_ADDRESS:
 
     // PLUGIN_MQTT_xxx functions are directly called from the scheduler.
     //case PLUGIN_MQTT_CONNECTION_STATE:

--- a/src/src/Globals/Plugins.cpp
+++ b/src/src/Globals/Plugins.cpp
@@ -141,6 +141,17 @@ String getPluginNameFromPluginID(pluginID_t pluginID) {
   return getPluginNameFromDeviceIndex(deviceIndex);
 }
 
+#if USE_I2C_DEVICE_SCAN
+String getPluginI2CAddressesFromDeviceIndex(deviceIndex_t deviceIndex) {
+  String i2cAdresses;
+
+  if (validDeviceIndex(deviceIndex)) {
+    Plugin_ptr[deviceIndex](PLUGIN_I2C_GET_ADDRESSES_HEX, nullptr, i2cAdresses);
+  }
+  return i2cAdresses;
+}
+#endif // if USE_I2C_DEVICE_SCAN
+
 // ********************************************************************************
 // Device Sort routine, compare two array entries
 // ********************************************************************************
@@ -629,6 +640,7 @@ bool PluginCall(uint8_t Function, struct EventStruct *event, String& str)
     case PLUGIN_FORMAT_USERVAR:
     case PLUGIN_SET_CONFIG:
     case PLUGIN_SET_DEFAULTS:
+    case PLUGIN_I2C_GET_ADDRESSES_HEX:
 
     // PLUGIN_MQTT_xxx functions are directly called from the scheduler.
     //case PLUGIN_MQTT_CONNECTION_STATE:

--- a/src/src/Globals/Plugins.cpp
+++ b/src/src/Globals/Plugins.cpp
@@ -141,6 +141,7 @@ String getPluginNameFromPluginID(pluginID_t pluginID) {
   return getPluginNameFromDeviceIndex(deviceIndex);
 }
 
+#if USE_I2C_DEVICE_SCAN
 bool checkPluginI2CAddressFromDeviceIndex(deviceIndex_t deviceIndex, uint8_t i2cAddress) {
   bool hasI2CAddress = false;
 
@@ -152,6 +153,7 @@ bool checkPluginI2CAddressFromDeviceIndex(deviceIndex_t deviceIndex, uint8_t i2c
   }
   return hasI2CAddress;
 }
+#endif // if USE_I2C_DEVICE_SCAN
 
 // ********************************************************************************
 // Device Sort routine, compare two array entries

--- a/src/src/Globals/Plugins.h
+++ b/src/src/Globals/Plugins.h
@@ -87,6 +87,9 @@ pluginID_t getPluginID_from_TaskIndex(taskIndex_t taskIndex);
 deviceIndex_t getDeviceIndex(pluginID_t Number);
 
 String        getPluginNameFromDeviceIndex(deviceIndex_t deviceIndex);
+#endif // if USE_I2C_DEVICE_SCAN
+String        getPluginI2CAddressesFromDeviceIndex(deviceIndex_t deviceIndex);
+#if USE_I2C_DEVICE_SCAN
 String        getPluginNameFromPluginID(pluginID_t pluginID);
 
 void          sortDeviceIndexArray();

--- a/src/src/Globals/Plugins.h
+++ b/src/src/Globals/Plugins.h
@@ -87,9 +87,8 @@ pluginID_t getPluginID_from_TaskIndex(taskIndex_t taskIndex);
 deviceIndex_t getDeviceIndex(pluginID_t Number);
 
 String        getPluginNameFromDeviceIndex(deviceIndex_t deviceIndex);
-#if USE_I2C_DEVICE_SCAN
-String        getPluginI2CAddressesFromDeviceIndex(deviceIndex_t deviceIndex);
-#endif // if USE_I2C_DEVICE_SCAN
+bool          checkPluginI2CAddressFromDeviceIndex(deviceIndex_t deviceIndex, uint8_t i2cAddress);
+
 String        getPluginNameFromPluginID(pluginID_t pluginID);
 
 void          sortDeviceIndexArray();

--- a/src/src/Globals/Plugins.h
+++ b/src/src/Globals/Plugins.h
@@ -87,9 +87,9 @@ pluginID_t getPluginID_from_TaskIndex(taskIndex_t taskIndex);
 deviceIndex_t getDeviceIndex(pluginID_t Number);
 
 String        getPluginNameFromDeviceIndex(deviceIndex_t deviceIndex);
-#endif // if USE_I2C_DEVICE_SCAN
-String        getPluginI2CAddressesFromDeviceIndex(deviceIndex_t deviceIndex);
 #if USE_I2C_DEVICE_SCAN
+String        getPluginI2CAddressesFromDeviceIndex(deviceIndex_t deviceIndex);
+#endif // if USE_I2C_DEVICE_SCAN
 String        getPluginNameFromPluginID(pluginID_t pluginID);
 
 void          sortDeviceIndexArray();

--- a/src/src/Globals/Plugins.h
+++ b/src/src/Globals/Plugins.h
@@ -87,8 +87,9 @@ pluginID_t getPluginID_from_TaskIndex(taskIndex_t taskIndex);
 deviceIndex_t getDeviceIndex(pluginID_t Number);
 
 String        getPluginNameFromDeviceIndex(deviceIndex_t deviceIndex);
+#if USE_I2C_DEVICE_SCAN
 bool          checkPluginI2CAddressFromDeviceIndex(deviceIndex_t deviceIndex, uint8_t i2cAddress);
-
+#endif // if USE_I2C_DEVICE_SCAN
 String        getPluginNameFromPluginID(pluginID_t pluginID);
 
 void          sortDeviceIndexArray();

--- a/src/src/Helpers/Hardware.cpp
+++ b/src/src/Helpers/Hardware.cpp
@@ -163,9 +163,15 @@ void hardwareInit()
 #endif // ifdef FEATURE_SD
 }
 
+bool isI2CEnabled() {
+  return ((Settings.Pin_i2c_sda != -1) &&
+          (Settings.Pin_i2c_scl != -1) &&
+          (Settings.I2C_clockSpeed > 0));
+}
+
 void initI2C() {
   // configure hardware pins according to eeprom settings.
-  if (Settings.Pin_i2c_sda != -1 && Settings.Pin_i2c_scl != -1)
+  if (isI2CEnabled())
   {
     addLog(LOG_LEVEL_INFO, F("INIT : I2C"));
     I2CSelectClockSpeed(false); // Set normal clock speed

--- a/src/src/Helpers/Hardware.cpp
+++ b/src/src/Helpers/Hardware.cpp
@@ -163,15 +163,9 @@ void hardwareInit()
 #endif // ifdef FEATURE_SD
 }
 
-bool isI2CEnabled() {
-  return ((Settings.Pin_i2c_sda != -1) &&
-          (Settings.Pin_i2c_scl != -1) &&
-          (Settings.I2C_clockSpeed > 0));
-}
-
 void initI2C() {
   // configure hardware pins according to eeprom settings.
-  if (isI2CEnabled())
+  if (Settings.isI2CEnabled())
   {
     addLog(LOG_LEVEL_INFO, F("INIT : I2C"));
     I2CSelectClockSpeed(false); // Set normal clock speed

--- a/src/src/Helpers/Hardware.h
+++ b/src/src/Helpers/Hardware.h
@@ -22,8 +22,6 @@
  \*********************************************************************************************/
 void hardwareInit();
 
-bool isI2CEnabled();
-
 void initI2C();
 
 void I2CSelectClockSpeed(bool setLowSpeed);

--- a/src/src/Helpers/Hardware.h
+++ b/src/src/Helpers/Hardware.h
@@ -22,6 +22,8 @@
  \*********************************************************************************************/
 void hardwareInit();
 
+bool isI2CEnabled();
+
 void initI2C();
 
 void I2CSelectClockSpeed(bool setLowSpeed);

--- a/src/src/Helpers/Misc.cpp
+++ b/src/src/Helpers/Misc.cpp
@@ -444,6 +444,16 @@ int getUptimeMinutes() {
   return wdcounter / 2;
 }
 
+/******************************************************************************
+ * scan an int array of specified size for a value
+ *****************************************************************************/
+bool intArrayContains(const int arraySize, const int array[], const int value){
+  for(int i = 0; i < arraySize; i++) {
+    if (array[i] == value) return true;
+  }
+  return false;
+}
+
 #ifndef BUILD_NO_RAM_TRACKER
 void logMemUsageAfter(const __FlashStringHelper * function, int value) {
   // Store free memory in an int, as subtracting may sometimes result in negative value.

--- a/src/src/Helpers/Misc.h
+++ b/src/src/Helpers/Misc.h
@@ -177,6 +177,8 @@ int getLoopCountPerSec();
 
 int getUptimeMinutes();
 
+bool intArrayContains(const int arraySize, const int array[], const int value);
+
 #ifndef BUILD_NO_RAM_TRACKER
 void logMemUsageAfter(const __FlashStringHelper * function, int value = -1);
 #endif

--- a/src/src/WebServer/DevicesPage.cpp
+++ b/src/src/WebServer/DevicesPage.cpp
@@ -1014,7 +1014,7 @@ void devicePage_show_pin_config(taskIndex_t taskIndex, deviceIndex_t DeviceIndex
   }
 
   if ((Device[DeviceIndex].Type == DEVICE_TYPE_I2C)
-      && !isI2CEnabled()) {
+      && !Settings.isI2CEnabled()) {
     addFormNote(F("I2C Interface is not configured yet (Hardware page)."));
   }
 

--- a/src/src/WebServer/DevicesPage.cpp
+++ b/src/src/WebServer/DevicesPage.cpp
@@ -1014,9 +1014,7 @@ void devicePage_show_pin_config(taskIndex_t taskIndex, deviceIndex_t DeviceIndex
   }
 
   if ((Device[DeviceIndex].Type == DEVICE_TYPE_I2C)
-      && ((Settings.Pin_i2c_sda == -1)
-          || (Settings.Pin_i2c_scl == -1)
-          || (Settings.I2C_clockSpeed == 0))) {
+      && !isI2CEnabled()) {
     addFormNote(F("I2C Interface is not configured yet (Hardware page)."));
   }
 

--- a/src/src/WebServer/DevicesPage.cpp
+++ b/src/src/WebServer/DevicesPage.cpp
@@ -212,8 +212,9 @@ void addDeviceSelect(const __FlashStringHelper * name,  int choice)
         deviceName = getPluginNameFromDeviceIndex(deviceIndex);
 
 
-  # if defined(PLUGIN_BUILD_DEV) || defined(PLUGIN_SET_MAX)
-        String plugin = "P";
+        # if defined(PLUGIN_BUILD_DEV) || defined(PLUGIN_SET_MAX)
+        String plugin;
+        plugin += 'P';
 
         if (pluginID < 10) { plugin += '0'; }
 
@@ -221,7 +222,7 @@ void addDeviceSelect(const __FlashStringHelper * name,  int choice)
         plugin    += pluginID;
         plugin    += F(" - ");
         deviceName = plugin + deviceName;
-  # endif // if defined(PLUGIN_BUILD_DEV) || defined(PLUGIN_SET_MAX)
+        # endif // if defined(PLUGIN_BUILD_DEV) || defined(PLUGIN_SET_MAX)
 
         addSelector_Item(deviceName,
                          Device[deviceIndex].Number,

--- a/src/src/WebServer/I2C_Scanner.cpp
+++ b/src/src/WebServer/I2C_Scanner.cpp
@@ -146,6 +146,7 @@ void handle_i2cscanner_json() {
 String getKnownI2Cdevice(uint8_t address) {
   String result;
 
+  #if USE_I2C_DEVICE_SCAN
   for (uint8_t x = 0; x <= deviceCount; x++) {
     const deviceIndex_t deviceIndex = DeviceIndex_sorted[x];
 
@@ -170,6 +171,7 @@ String getKnownI2Cdevice(uint8_t address) {
       }
     }
   }
+  #endif // if USE_I2C_DEVICE_SCAN
   #ifndef LIMIT_BUILD_SIZE
 
   switch (address)

--- a/src/src/WebServer/I2C_Scanner.cpp
+++ b/src/src/WebServer/I2C_Scanner.cpp
@@ -382,7 +382,7 @@ void handle_i2cscanner() {
   html_table_header(F("I2C Addresses in use"));
   html_table_header(F("Supported devices"));
 
-  if (isI2CEnabled()) {
+  if (Settings.isI2CEnabled()) {
     int  nDevices = 0;
     I2CSelectClockSpeed(true);  // Scan bus using low speed
     #ifdef FEATURE_I2CMULTIPLEXER

--- a/src/src/WebServer/I2C_Scanner.cpp
+++ b/src/src/WebServer/I2C_Scanner.cpp
@@ -146,50 +146,30 @@ void handle_i2cscanner_json() {
 String getKnownI2Cdevice(uint8_t address) {
   String result;
 
-  #if USE_I2C_DEVICE_SCAN
-  String i2cAddresses;
-
   for (uint8_t x = 0; x <= deviceCount; x++) {
     const deviceIndex_t deviceIndex = DeviceIndex_sorted[x];
 
     if (validDeviceIndex(deviceIndex)) {
       const pluginID_t pluginID = DeviceIndex_to_Plugin_id[deviceIndex];
 
-      if (validPluginID(pluginID)) {
-        i2cAddresses = getPluginI2CAddressesFromDeviceIndex(deviceIndex);
+      if (validPluginID(pluginID) &&
+          checkPluginI2CAddressFromDeviceIndex(deviceIndex, address)) {
+        result += F("(Device) ");
 
-        if (!i2cAddresses.isEmpty()) {
-          String addresses;
-          addresses.reserve(i2cAddresses.length() + 2);
-          addresses += ',';
-          addresses += i2cAddresses;
-          addresses += ',';
-          addresses.toLowerCase();
-          String findAddress;
-          findAddress += ',';
-          findAddress += String(address, HEX);
-          findAddress += ',';
-          findAddress.toLowerCase();
+        # if defined(PLUGIN_BUILD_DEV) || defined(PLUGIN_SET_MAX) // Use same name as in Add Device combobox
+        result += 'P';
 
-          if (addresses.indexOf(findAddress) > -1) {
-            result += F("(Device) ");
-            # if defined(PLUGIN_BUILD_DEV) || defined(PLUGIN_SET_MAX) // Use same name as in Add Device combobox
-            result += 'P';
+        if (pluginID < 10) { result += '0'; }
 
-            if (pluginID < 10) { result += '0'; }
-
-            if (pluginID < 100) { result += '0'; }
-            result += pluginID;
-            result += F(" - ");
-            # endif // if defined(PLUGIN_BUILD_DEV) || defined(PLUGIN_SET_MAX)
-            result += getPluginNameFromDeviceIndex(deviceIndex);
-            result += ',';
-          }
-        }
+        if (pluginID < 100) { result += '0'; }
+        result += pluginID;
+        result += F(" - ");
+        # endif // if defined(PLUGIN_BUILD_DEV) || defined(PLUGIN_SET_MAX)
+        result += getPluginNameFromDeviceIndex(deviceIndex);
+        result += ',';
       }
     }
   }
-  #endif // if USE_I2C_DEVICE_SCAN
   #ifndef LIMIT_BUILD_SIZE
 
   switch (address)

--- a/src/src/WebServer/I2C_Scanner.cpp
+++ b/src/src/WebServer/I2C_Scanner.cpp
@@ -382,7 +382,7 @@ void handle_i2cscanner() {
   html_table_header(F("I2C Addresses in use"));
   html_table_header(F("Supported devices"));
 
-  if ((Settings.Pin_i2c_scl != -1) && (Settings.Pin_i2c_sda != -1)) {
+  if (isI2CEnabled()) {
     int  nDevices = 0;
     I2CSelectClockSpeed(true);  // Scan bus using low speed
     #ifdef FEATURE_I2CMULTIPLEXER
@@ -412,7 +412,7 @@ void handle_i2cscanner() {
       addHtml(F("<TR>No I2C devices found"));
     }
   } else {
-    addHtml(F("<TR>No I2C pins configured"));
+    addHtml(F("<TR>I2C pins not configured"));
   }
 
   html_end_table();

--- a/src/src/WebServer/I2C_Scanner.cpp
+++ b/src/src/WebServer/I2C_Scanner.cpp
@@ -145,6 +145,51 @@ void handle_i2cscanner_json() {
 
 String getKnownI2Cdevice(uint8_t address) {
   String result;
+
+  #if USE_I2C_DEVICE_SCAN
+  String i2cAddresses;
+
+  for (uint8_t x = 0; x <= deviceCount; x++) {
+    const deviceIndex_t deviceIndex = DeviceIndex_sorted[x];
+
+    if (validDeviceIndex(deviceIndex)) {
+      const pluginID_t pluginID = DeviceIndex_to_Plugin_id[deviceIndex];
+
+      if (validPluginID(pluginID)) {
+        i2cAddresses = getPluginI2CAddressesFromDeviceIndex(deviceIndex);
+
+        if (!i2cAddresses.isEmpty()) {
+          String addresses;
+          addresses.reserve(i2cAddresses.length() + 2);
+          addresses += ',';
+          addresses += i2cAddresses;
+          addresses += ',';
+          addresses.toLowerCase();
+          String findAddress;
+          findAddress += ',';
+          findAddress += String(address, HEX);
+          findAddress += ',';
+          findAddress.toLowerCase();
+
+          if (addresses.indexOf(findAddress) > -1) {
+            result += F("(Device) ");
+            # if defined(PLUGIN_BUILD_DEV) || defined(PLUGIN_SET_MAX) // Use same name as in Add Device combobox
+            result += 'P';
+
+            if (pluginID < 10) { result += '0'; }
+
+            if (pluginID < 100) { result += '0'; }
+            result += pluginID;
+            result += F(" - ");
+            # endif // if defined(PLUGIN_BUILD_DEV) || defined(PLUGIN_SET_MAX)
+            result += getPluginNameFromDeviceIndex(deviceIndex);
+            result += ',';
+          }
+        }
+      }
+    }
+  }
+  #endif // if USE_I2C_DEVICE_SCAN
   #ifndef LIMIT_BUILD_SIZE
 
   switch (address)
@@ -155,118 +200,118 @@ String getKnownI2Cdevice(uint8_t address) {
     case 0x25:
     case 0x26:
     case 0x27:
-      result =  F("PCF8574,MCP23017,LCD");
+      result +=  F("PCF8574,MCP23017,LCD");
       break;
     case 0x23:
-      result =  F("PCF8574,MCP23017,LCD,BH1750");
+      result +=  F("PCF8574,MCP23017,LCD,BH1750");
       break;
     case 0x24:
-      result =  F("PCF8574,MCP23017,LCD,PN532");
+      result +=  F("PCF8574,MCP23017,LCD,PN532");
       break;
     case 0x29:
-      result =  F("TSL2561,TCS34725,VL53L0X,VL53L1X");
+      result +=  F("TSL2561,TSL2591,TCS34725,VL53L0X,VL53L1X");
       break;
     case 0x30:
-      result =  F("VL53L0X,VL53L1X");
+      result +=  F("VL53L0X,VL53L1X");
       break;
     case 0x36:
-      result =  F("MAX1704x");
+      result +=  F("MAX1704x");
       break;
     case 0x38:
     case 0x3A:
     case 0x3B:
     case 0x3E:
     case 0x3F:
-      result =  F("PCF8574A");
+      result +=  F("PCF8574A");
       break;
     case 0x39:
-      result =  F("PCF8574A,TSL2561,APDS9960");
+      result +=  F("PCF8574A,TSL2561,APDS9960");
       break;
     case 0x3C:
     case 0x3D:
-      result =  F("PCF8574A,OLED");
+      result +=  F("PCF8574A,OLED");
       break;
     case 0x40:
-      result =  F("SI7021,HTU21D,INA219,PCA9685,HDC1080");
+      result +=  F("SI7021,HTU21D,INA219,PCA9685,HDC1080");
       break;
     case 0x41:
     case 0x42:
     case 0x43:
-      result =  F("INA219");
+      result +=  F("INA219");
       break;
     case 0x44:
     case 0x45:
-      result =  F("SHT30/31/35");
+      result +=  F("SHT30/31/35");
       break;
     case 0x48:
     case 0x4A:
     case 0x4B:
-      result =  F("PCF8591,ADS1115,LM75A");
+      result +=  F("PCF8591,ADS1115,LM75A");
       break;
     case 0x49:
-      result =  F("PCF8591,ADS1115,TSL2561,LM75A");
+      result +=  F("PCF8591,ADS1115,TSL2561,LM75A");
       break;
     case 0x4C:
     case 0x4E:
     case 0x4F:
-      result =  F("PCF8591,LM75A");
+      result +=  F("PCF8591,LM75A");
       break;
     case 0x4D:
-      result =  F("PCF8591,MCP3221,LM75A");
+      result +=  F("PCF8591,MCP3221,LM75A");
       break;
     case 0x51:
-      result =  F("PCF8563");
+      result +=  F("PCF8563");
       break;
     case 0x58:
-      result =  F("SGP30");
+      result +=  F("SGP30");
       break;
     case 0x5A:
-      result =  F("MLX90614,MPR121,CCS811");
+      result +=  F("MLX90614,MPR121,CCS811");
       break;
     case 0x5B:
-      result =  F("MPR121,CCS811");
+      result +=  F("MPR121,CCS811");
       break;
     case 0x5C:
-      result =  F("DHT12,AM2320,BH1750,MPR121");
+      result +=  F("DHT12,AM2320,BH1750,MPR121");
       break;
     case 0x5D:
-      result =  F("MPR121");
+      result +=  F("MPR121");
       break;
     case 0x60:
-      result =  F("Adafruit Motorshield v2,SI1145");
+      result +=  F("Adafruit Motorshield v2,SI1145");
       break;
     case 0x62:
-      result = F("Atlas EZO ORP");
+      result += F("Atlas EZO ORP");
       break;
     case 0x63:
-      result = F("Atlas EZO pH");
+      result += F("Atlas EZO pH");
       break;
     case 0x64:
-      result = F("Atlas EZO EC");
+      result += F("Atlas EZO EC");
       break;
     case 0x68:
-      result =  F("DS1307,DS3231,PCF8523");
+      result +=  F("DS1307,DS3231,PCF8523");
       break;
     case 0x70:
-      result =  F("Adafruit Motorshield v2 (Catchall),HT16K33,TCA9543a/6a/8a I2C multiplexer,PCA9540 I2C multiplexer");
+      result +=  F("Adafruit Motorshield v2 (Catchall),HT16K33,TCA9543a/6a/8a I2C multiplexer,PCA9540 I2C multiplexer");
       break;
     case 0x71:
     case 0x72:
     case 0x73:
-      result =  F("HT16K33,TCA9543a/6a/8a I2C multiplexer");
+      result +=  F("HT16K33,TCA9543a/6a/8a I2C multiplexer");
       break;
     case 0x74:
     case 0x75:
-      result =  F("HT16K33,TCA9546a/8a I2C multiplexer");
+      result +=  F("HT16K33,TCA9546a/8a I2C multiplexer");
       break;
     case 0x76:
-      result =  F("BMP280,BME280,BME680,MS5607,MS5611,HT16K33,TCA9546a/8a I2C multiplexer");
+      result +=  F("BMP280,BME280,BME680,MS5607,MS5611,HT16K33,TCA9546a/8a I2C multiplexer");
       break;
     case 0x77:
-      result =  F("BMP085,BMP180,BMP280,BME280,BME680,MS5607,MS5611,HT16K33,TCA9546a/8a I2C multiplexer");
+      result +=  F("BMP085,BMP180,BMP280,BME280,BME680,MS5607,MS5611,HT16K33,TCA9546a/8a I2C multiplexer");
       break;
     case 0x7f:
-      result =  F("Arduino PME");
+      result +=  F("Arduino PME");
       break;
   }
   #endif // LIMIT_BUILD_SIZE


### PR DESCRIPTION
Shows the Device(s) (plugins) that are available in the current build that support a device with the detected I2C address.
Optionally, compile-time, enabled by default, disabled in MINIMAL OTA builds.
The extra data is also included in the JSON output.

NB: A few plugins (the motor shields) are ignored (i.e. don't return their I2C addresses on request) as they can be configured for any I2C address, so they would show up for each address found. That's not very useful, and so they are left out.

TODO:
- [x] ~~Update documentation~~ (No documentation to update)

Example screenshot (ESP32 MAX build, so includes the Pxxx prefix):
![I2CScanner_WithDevices](https://user-images.githubusercontent.com/1922393/127992162-10ef5fd2-5278-4136-ac39-eb3c2fb7df21.png)

Example screenshot (ESP8266 Custom with additional VL53LnX plugins enabled):
![I2CScanner_WithDevices_Custom](https://user-images.githubusercontent.com/1922393/127995991-2fd7961f-61d1-4478-9600-e460a14e139a.png)
