### PR TITLE
[P108] DDS238 Fix 2-complement values (#3662)

### DIFF
--- a/src/_P108_DDS238.ino
+++ b/src/_P108_DDS238.ino
@@ -395,12 +395,12 @@ float p108_readValue(uint8_t query, struct EventStruct *event) {
         value = P108_data->modbus.readHoldingRegister(0x0D, errorcode) / 100.0f; // 0.01 A => A
         break;
       case P108_QUERY_W:
-        value =  P108_data->modbus.readHoldingRegister(0x0E, errorcode) * 1.0f;
-        if (value > 32767) { value = 0 - (65535 - value); }
+        value =  P108_data->modbus.readHoldingRegister(0x0E, errorcode);
+        if (value > 32767) { value -= 65535; }
         break;
       case P108_QUERY_VA:
-        value = P108_data->modbus.readHoldingRegister(0x0F, errorcode) * 1.0f;
-        if (value > 32767) { value = 0 - (65535 - value); }
+        value = P108_data->modbus.readHoldingRegister(0x0F, errorcode);
+        if (value > 32767) { value -= 65535; }
         break;
       case P108_QUERY_PF:
         value = P108_data->modbus.readHoldingRegister(0x10, errorcode) / 1000.0f; // 0.001 Pf => Pf

--- a/src/_P108_DDS238.ino
+++ b/src/_P108_DDS238.ino
@@ -382,38 +382,40 @@ int p108_storageValueToBaudrate(uint8_t baudrate_setting) {
 
 float p108_readValue(uint8_t query, struct EventStruct *event) {
   uint8_t errorcode     = -1; // DF - not present in P085
-  float value = 0; // DF - not present in P085
+  float value = 0.0f; // DF - not present in P085
   P108_data_struct *P108_data =
     static_cast<P108_data_struct *>(getPluginTaskData(event->TaskIndex));
 
   if ((nullptr != P108_data) && P108_data->isInitialized()) {
     switch (query) {
       case P108_QUERY_V:
-        value = P108_data->modbus.readHoldingRegister(0x0C ,errorcode) / 10.0; // 0.1 V => V
+        value = P108_data->modbus.readHoldingRegister(0x0C ,errorcode) / 10.0f; // 0.1 V => V
         break;
       case P108_QUERY_A:
-        value = P108_data->modbus.readHoldingRegister(0x0D, errorcode) / 100.0; // 0.01 A => A
+        value = P108_data->modbus.readHoldingRegister(0x0D, errorcode) / 100.0f; // 0.01 A => A
         break;
       case P108_QUERY_W:
-        value =  P108_data->modbus.readHoldingRegister(0x0E, errorcode) * 1.0 ;
+        value =  P108_data->modbus.readHoldingRegister(0x0E, errorcode) * 1.0f;
+        if (value > 32767) { value = 0 - (65535 - value); }
         break;
       case P108_QUERY_VA:
-        value = P108_data->modbus.readHoldingRegister(0x0F, errorcode) * 1.0 ;
+        value = P108_data->modbus.readHoldingRegister(0x0F, errorcode) * 1.0f;
+        if (value > 32767) { value = 0 - (65535 - value); }
         break;
       case P108_QUERY_PF:
-        value = P108_data->modbus.readHoldingRegister(0x10, errorcode) / 1000.0; // 0.001 Pf => Pf
+        value = P108_data->modbus.readHoldingRegister(0x10, errorcode) / 1000.0f; // 0.001 Pf => Pf
         break;
       case P108_QUERY_F:
-        value = P108_data->modbus.readHoldingRegister(0x11, errorcode) / 100.0 ; // 0.01 Hz => Hz
+        value = P108_data->modbus.readHoldingRegister(0x11, errorcode) / 100.0f; // 0.01 Hz => Hz
         break;
       case P108_QUERY_Wh_imp:
-        return P108_data->modbus.read_32b_HoldingRegister(0x0A) * 10.0;     // 0.01 kWh => Wh
+        return P108_data->modbus.read_32b_HoldingRegister(0x0A) * 10.0f;     // 0.01 kWh => Wh
         break;
       case P108_QUERY_Wh_exp:
-        return P108_data->modbus.read_32b_HoldingRegister(0x08) * 10.0;     // 0.01 kWh => Wh
+        return P108_data->modbus.read_32b_HoldingRegister(0x08) * 10.0f;     // 0.01 kWh => Wh
         break;
       case P108_QUERY_Wh_tot:
-        return P108_data->modbus.read_32b_HoldingRegister(0x00) * 10.0;     // 0.01 kWh => Wh
+        return P108_data->modbus.read_32b_HoldingRegister(0x00) * 10.0f;     // 0.01 kWh => Wh
         break;
     }
   }


### PR DESCRIPTION
- Fix a reported bug that VA (and probably also W) measurements return wrong values when negative (2s complement)
- Minor code improvements, using `f` postfix for float constants

Resolved #3662 