### PR TITLE
Exclude not needed parts for USES_MQTT and WEBSERVER_METRICS

### DIFF
--- a/src/src/ControllerQueue/MQTT_queue_element.cpp
+++ b/src/src/ControllerQueue/MQTT_queue_element.cpp
@@ -1,5 +1,6 @@
 #include "../ControllerQueue/MQTT_queue_element.h"
 
+#ifdef USES_MQTT
 
 MQTT_queue_element::MQTT_queue_element(int ctrl_idx,
                                        taskIndex_t TaskIndex,
@@ -42,3 +43,4 @@ void MQTT_queue_element::removeEmptyTopics() {
     _topic.replace(F("//"), F("/"));
   }
 }
+#endif // USES_MQTT

--- a/src/src/ControllerQueue/MQTT_queue_element.h
+++ b/src/src/ControllerQueue/MQTT_queue_element.h
@@ -5,6 +5,7 @@
 #include "../DataStructs/UnitMessageCount.h"
 #include "../Globals/CPlugins.h"
 
+#ifdef USES_MQTT
 
 /*********************************************************************************************\
 * MQTT_queue_element for all MQTT base controllers
@@ -48,5 +49,6 @@ public:
   UnitMessageCount_t UnitMessageCount;
 };
 
+#endif // USES_MQTT
 
 #endif // CONTROLLERQUEUE_MQTT_QUEUE_ELEMENT_H

--- a/src/src/WebServer/Metrics.cpp
+++ b/src/src/WebServer/Metrics.cpp
@@ -7,11 +7,12 @@
 # include "../../_Plugin_Helper.h"
 # include "../Helpers/ESPEasyStatistics.h"
 # include "../Static/WebStaticData.h"
-HELPERS_ESPEASY_MATH_H
+//HELPERS_ESPEASY_MATH_H  //clumsy-stefan: what's this for?
+
+#ifdef WEBSERVER_METRICS
 #ifdef ESP32
 # include <esp_partition.h>
 #endif // ifdef ESP32
-
 
 void handle_metrics() {
     TXBuffer.startStream(F("text/plain"), F("*"));
@@ -71,12 +72,7 @@ void handle_metrics() {
       TXBuffer.endStream();
 }
 
-
-
-
 void handle_metrics_devices(){
-
-
     for (taskIndex_t x = 0; validTaskIndex(x); x++)
     {        
         const deviceIndex_t DeviceIndex = getDeviceIndex_from_TaskIndex(x);
@@ -118,4 +114,4 @@ void handle_metrics_devices(){
          }
     }
 }
-
+#endif // WEBSERVER_METRICS

--- a/src/src/WebServer/Metrics.cpp
+++ b/src/src/WebServer/Metrics.cpp
@@ -7,9 +7,9 @@
 # include "../../_Plugin_Helper.h"
 # include "../Helpers/ESPEasyStatistics.h"
 # include "../Static/WebStaticData.h"
-//HELPERS_ESPEASY_MATH_H  //clumsy-stefan: what's this for?
 
 #ifdef WEBSERVER_METRICS
+
 #ifdef ESP32
 # include <esp_partition.h>
 #endif // ifdef ESP32

--- a/src/src/WebServer/Metrics.h
+++ b/src/src/WebServer/Metrics.h
@@ -3,15 +3,10 @@
 
 #include "../WebServer/common.h"
 
-
 #ifdef WEBSERVER_METRICS
 
 void handle_metrics();
-
-
-
 void handle_metrics_devices();
-
 
 #endif    // ifdef WEBSERVER_METRICS
 


### PR DESCRIPTION
Exclude not needed code to save space (USES_MQTT) and make it compile again (WEBSERVER_METRICS).