### PR TITLE
[RTClib] (Bugfix) Write month correctly to DS3231 (#3749)

### DIFF
--- a/lib/Adafruit_RTClib/src/RTClib.cpp
+++ b/lib/Adafruit_RTClib/src/RTClib.cpp
@@ -1599,7 +1599,7 @@ void RTC_DS3231::adjust(const DateTime &dt) {
   // The RTC must know the day of the week for the weekly alarms to work.
   RTCWireBus->_I2C_WRITE(bin2bcd(dowToDS3231(dt.dayOfTheWeek())));
   RTCWireBus->_I2C_WRITE(bin2bcd(dt.day()));
-  RTCWireBus->_I2C_WRITE(bin2bcd(dt.month()) + 0x7F); // Need to write the century bit
+  RTCWireBus->_I2C_WRITE(bin2bcd(dt.month()) | 0x80); // Need to write the century bit
   RTCWireBus->_I2C_WRITE(bin2bcd(dt.year() - 2000U));
   RTCWireBus->endTransmission();
 


### PR DESCRIPTION
After [a report](https://www.letscontrolit.com/forum/viewtopic.php?f=6&t=8643#p54263) in the forum, then reported in the issue tracker.

Resolves #3749 