### PR TITLE
Add 'client' to http.begin call

### DIFF
--- a/src/src/Helpers/_CPlugin_Helper.cpp
+++ b/src/src/Helpers/_CPlugin_Helper.cpp
@@ -528,7 +528,7 @@ String send_via_http(const String& logIdentifier,
 #if defined(CORE_POST_2_6_0) || defined(ESP32)
   http.begin(client, host, port, uri, false); // HTTP
 #else
-  http.begin(host, port, uri);
+  http.begin(client, host, port, uri);
 #endif
   
   {


### PR DESCRIPTION
This is also present as function signature in core 2.5.0.
See: 
https://github.com/esp8266/Arduino/blob/951aeffa765605f30ae144a1075fac9c93fa199e/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.h#L151

Apparently it causes build issues in Arduino IDE, but fixing it will not break core 2.5.0 builds, so it probably does no harm.