### PR TITLE
patch for Safe Button and FHEM (#3739)

### DIFF
--- a/src/_P001_Switch.ino
+++ b/src/_P001_Switch.ino
@@ -652,8 +652,8 @@ boolean Plugin_001(uint8_t function, struct EventStruct *event, String& string)
                 addLog(LOG_LEVEL_INFO, log);
               }
               #endif
-              // send task event
-              sendData(event);
+              // send task event: DO NOT SEND TASK EVENT
+              //sendData(event);
               // send monitor event
               if (currentStatus.monitor) sendMonitorEvent(monitorEventString.c_str(), CONFIG_PIN1, SAFE_BUTTON_EVENT);
 

--- a/src/_P009_MCP.ino
+++ b/src/_P009_MCP.ino
@@ -453,8 +453,8 @@ boolean Plugin_009(uint8_t function, struct EventStruct *event, String& string)
               log += tempUserVar;
               addLog(LOG_LEVEL_INFO, log);
             }
-            // send task event
-            sendData(event);
+            // send task event: DO NOT SEND TASK EVENT
+            //sendData(event);
             // send monitor event
             if (currentStatus.monitor) sendMonitorEvent(monitorEventString.c_str(), CONFIG_PORT, 4);
 

--- a/src/_P019_PCF8574.ino
+++ b/src/_P019_PCF8574.ino
@@ -511,8 +511,8 @@ boolean Plugin_019(uint8_t function, struct EventStruct *event, String& string)
               log += tempUserVar;
               addLog(LOG_LEVEL_INFO, log);
             }
-            // send task event
-            sendData(event);
+            // send task event: DO NOT SEND TASK EVENT
+            //sendData(event);
             // send monitor event
             if (currentStatus.monitor) sendMonitorEvent(monitorEventString.c_str(), CONFIG_PORT, SAFE_BUTTON_EVENT);
 


### PR DESCRIPTION

[ESP_Easy_mega_20210808_normal_ESP8266_4M1M.bin.gz](https://github.com/letscontrolit/ESPEasy/files/6951090/ESP_Easy_mega_20210808_normal_ESP8266_4M1M.bin.gz)
Patch for #3739.

Removed EVENT=4 for P001, P009 and P019
If an EVENT is needed, the pin should have MONITOR active.

SHOULD BE TESTED BEFORE MERGING.

@TungstenE2:
please try this version and confirm if everything is working as expected.

[ESP_Easy_mega_20210808_normal_ESP8266_4M1M.bin.gz](https://github.com/letscontrolit/ESPEasy/files/6951090/ESP_Easy_mega_20210808_normal_ESP8266_4M1M.bin.gz)