### PR TITLE
[MQTT] Fix duplicate call task PLUGIN_READ at MQTT connect (#3754)

### DIFF
--- a/src/src/Helpers/PeriodicalActions.cpp
+++ b/src/src/Helpers/PeriodicalActions.cpp
@@ -264,7 +264,7 @@ void scheduleNextMQTTdelayQueue() {
   }
 }
 
-void schedule_all_tasks_using_MQTT_controller() {
+void schedule_all_MQTTimport_tasks() {
   controllerIndex_t ControllerIndex = firstEnabledMQTT_ControllerIndex();
 
   if (!validControllerIndex(ControllerIndex)) { return; }
@@ -278,15 +278,6 @@ void schedule_all_tasks_using_MQTT_controller() {
         event.Par1 = MQTTclient_connected ? 1 : 0;
         Scheduler.schedule_plugin_task_event_timer(DeviceIndex, PLUGIN_MQTT_CONNECTION_STATE, std::move(event));
       }
-    }
-  }
-
-  for (taskIndex_t task = 0; task < TASKS_MAX; task++) {
-    if (Settings.TaskDeviceSendData[ControllerIndex][task] &&
-        Settings.ControllerEnabled[ControllerIndex] &&
-        Settings.Protocol[ControllerIndex])
-    {
-      Scheduler.schedule_task_device_timer_at_init(task);
     }
   }
 }
@@ -340,7 +331,7 @@ void updateMQTTclient_connected() {
       MQTTclient_must_send_LWT_connected = false;
     } else {
       // Now schedule all tasks using the MQTT controller.
-      schedule_all_tasks_using_MQTT_controller();
+      schedule_all_MQTTimport_tasks();
     }
     if (Settings.UseRules) {
       if (MQTTclient_connected) {

--- a/src/src/Helpers/PeriodicalActions.h
+++ b/src/src/Helpers/PeriodicalActions.h
@@ -32,7 +32,7 @@ void runEach30Seconds();
 #ifdef USES_MQTT
 
 void scheduleNextMQTTdelayQueue();
-void schedule_all_tasks_using_MQTT_controller();
+void schedule_all_MQTTimport_tasks();
 
 void processMQTTdelayQueue();
 

--- a/src/src/Helpers/Scheduler.h
+++ b/src/src/Helpers/Scheduler.h
@@ -50,25 +50,25 @@ public:
     TIMER_C023_DELAY_QUEUE,
     TIMER_C024_DELAY_QUEUE,
     TIMER_C025_DELAY_QUEUE,
-    // When extending this, search for EXTEND_CONTROLLER_IDS 
-    // in the code to find all places that need to be updated too.
 
+    // When extending this, search for EXTEND_CONTROLLER_IDS
+    // in the code to find all places that need to be updated too.
   };
 
   static String toString(IntervalTimer_e timer);
 
   enum class SchedulerTimerType_e {
-    SYSTEM_EVENT_QUEUE  = 0, // Not really a timer.
-    CONST_INTERVAL_TIMER= 1,
-    PLUGIN_TASK_TIMER   = 2,
-    TASK_DEVICE_TIMER   = 3,
-    GPIO_TIMER          = 4,
-    PLUGIN_TIMER        = 5,
-    RULES_TIMER         = 6,
-    REBOOT_TIMER        = 15 // Used to show intended reboot
+    SYSTEM_EVENT_QUEUE   = 0, // Not really a timer.
+    CONST_INTERVAL_TIMER = 1,
+    PLUGIN_TASK_TIMER    = 2,
+    TASK_DEVICE_TIMER    = 3,
+    GPIO_TIMER           = 4,
+    PLUGIN_TIMER         = 5,
+    RULES_TIMER          = 6,
+    REBOOT_TIMER         = 15 // Used to show intended reboot
   };
 
-  static const __FlashStringHelper * toString(SchedulerTimerType_e timerType);
+  static const __FlashStringHelper* toString(SchedulerTimerType_e timerType);
 
 
   enum class PluginPtrType {
@@ -77,7 +77,7 @@ public:
     NotificationPlugin
   };
 
-  static const __FlashStringHelper * toString(PluginPtrType pluginType);
+  static const __FlashStringHelper* toString(PluginPtrType pluginType);
 
   enum class IntendedRebootReason_e {
     DeepSleep,
@@ -89,25 +89,24 @@ public:
     RestoreSettings,
     OTA_error,
     ConnectionFailuresThreshold,
-
   };
 
   static String toString(IntendedRebootReason_e reason);
 
 
-  void markIntendedReboot(IntendedRebootReason_e reason);
+  void          markIntendedReboot(IntendedRebootReason_e reason);
 
   /*********************************************************************************************\
   * Generic Timer functions.
   \*********************************************************************************************/
-  void setNewTimerAt(unsigned long id,
-                     unsigned long timer);
+  void          setNewTimerAt(unsigned long id,
+                              unsigned long timer);
 
   // Mix timer type int with an ID describing the scheduled job.
   static unsigned long getMixedId(SchedulerTimerType_e timerType,
-                                  unsigned long id);
+                                  unsigned long        id);
 
-  static unsigned long decodeSchedulerId(unsigned long  mixed_id,
+  static unsigned long decodeSchedulerId(unsigned long         mixed_id,
                                          SchedulerTimerType_e& timerType);
 
   static String        decodeSchedulerId(unsigned long mixed_id);
@@ -204,7 +203,7 @@ public:
   \*********************************************************************************************/
   static unsigned long createGPIOTimerId(uint8_t GPIOType,
                                          uint8_t pinNumber,
-                                         int  Par1);
+                                         int     Par1);
 
 
   void setGPIOTimer(unsigned long msecFromNow,
@@ -248,44 +247,44 @@ public:
   \*********************************************************************************************/
 
   // Note: event will be moved
-  void schedule_plugin_task_event_timer(deviceIndex_t       DeviceIndex,
-                                        uint8_t                Function,
-                                        struct EventStruct &&event);
+  void schedule_plugin_task_event_timer(deviceIndex_t        DeviceIndex,
+                                        uint8_t              Function,
+                                        struct EventStruct&& event);
 
-  void schedule_mqtt_plugin_import_event_timer(deviceIndex_t   DeviceIndex,
-                                               taskIndex_t     TaskIndex,
-                                               uint8_t            Function,
-                                               char           *c_topic,
-                                               uint8_t           *b_payload,
-                                               unsigned int    length);
+  void schedule_mqtt_plugin_import_event_timer(deviceIndex_t DeviceIndex,
+                                               taskIndex_t   TaskIndex,
+                                               uint8_t       Function,
+                                               char         *c_topic,
+                                               uint8_t      *b_payload,
+                                               unsigned int  length);
 
 
   // Note: the event will be moved
-  void schedule_controller_event_timer(protocolIndex_t     ProtocolIndex,
-                                       uint8_t                Function,
-                                       struct EventStruct &&event);
+  void schedule_controller_event_timer(protocolIndex_t      ProtocolIndex,
+                                       uint8_t              Function,
+                                       struct EventStruct&& event);
 
-  void schedule_mqtt_controller_event_timer(protocolIndex_t ProtocolIndex,
+  void schedule_mqtt_controller_event_timer(protocolIndex_t   ProtocolIndex,
                                             CPlugin::Function Function,
-                                            char           *c_topic,
-                                            uint8_t           *b_payload,
-                                            unsigned int    length);
+                                            char             *c_topic,
+                                            uint8_t          *b_payload,
+                                            unsigned int      length);
 
   // Note: The event will be moved
-  void schedule_notification_event_timer(uint8_t                NotificationProtocolIndex,
-                                         NPlugin::Function   Function,
-                                         struct EventStruct &&event);
+  void schedule_notification_event_timer(uint8_t              NotificationProtocolIndex,
+                                         NPlugin::Function    Function,
+                                         struct EventStruct&& event);
 
 
   static unsigned long createSystemEventMixedId(PluginPtrType ptr_type,
-                                                uint8_t          Index,
-                                                uint8_t          Function);
+                                                uint8_t       Index,
+                                                uint8_t       Function);
 
   // Note, the event will be moved
-  void schedule_event_timer(PluginPtrType       ptr_type,
-                            uint8_t                Index,
-                            uint8_t                Function,
-                            struct EventStruct &&event);
+  void schedule_event_timer(PluginPtrType        ptr_type,
+                            uint8_t              Index,
+                            uint8_t              Function,
+                            struct EventStruct&& event);
 
   void process_system_event_queue();
 

--- a/src/src/Helpers/Scheduler.h
+++ b/src/src/Helpers/Scheduler.h
@@ -57,11 +57,27 @@ public:
 
   static String toString(IntervalTimer_e timer);
 
+  enum class SchedulerTimerType_e {
+    SYSTEM_EVENT_QUEUE  = 0, // Not really a timer.
+    CONST_INTERVAL_TIMER= 1,
+    PLUGIN_TASK_TIMER   = 2,
+    TASK_DEVICE_TIMER   = 3,
+    GPIO_TIMER          = 4,
+    PLUGIN_TIMER        = 5,
+    RULES_TIMER         = 6,
+    REBOOT_TIMER        = 15 // Used to show intended reboot
+  };
+
+  static const __FlashStringHelper * toString(SchedulerTimerType_e timerType);
+
+
   enum class PluginPtrType {
     TaskPlugin,
     ControllerPlugin,
     NotificationPlugin
   };
+
+  static const __FlashStringHelper * toString(PluginPtrType pluginType);
 
   enum class IntendedRebootReason_e {
     DeepSleep,
@@ -88,11 +104,11 @@ public:
                      unsigned long timer);
 
   // Mix timer type int with an ID describing the scheduled job.
-  static unsigned long getMixedId(unsigned long timerType,
+  static unsigned long getMixedId(SchedulerTimerType_e timerType,
                                   unsigned long id);
 
   static unsigned long decodeSchedulerId(unsigned long  mixed_id,
-                                         unsigned long& timerType);
+                                         SchedulerTimerType_e& timerType);
 
   static String        decodeSchedulerId(unsigned long mixed_id);
 
@@ -260,9 +276,6 @@ public:
                                          NPlugin::Function   Function,
                                          struct EventStruct &&event);
 
-
-  static unsigned long createSystemEventMixedId(PluginPtrType ptr_type,
-                                                uint16_t      crc16);
 
   static unsigned long createSystemEventMixedId(PluginPtrType ptr_type,
                                                 uint8_t          Index,

--- a/src/src/Helpers/Scheduler.h
+++ b/src/src/Helpers/Scheduler.h
@@ -58,14 +58,14 @@ public:
   static String toString(IntervalTimer_e timer);
 
   enum class SchedulerTimerType_e {
-    SYSTEM_EVENT_QUEUE   = 0, // Not really a timer.
-    CONST_INTERVAL_TIMER = 1,
-    PLUGIN_TASK_TIMER    = 2,
-    TASK_DEVICE_TIMER    = 3,
-    GPIO_TIMER           = 4,
-    PLUGIN_TIMER         = 5,
-    RULES_TIMER          = 6,
-    REBOOT_TIMER         = 15 // Used to show intended reboot
+    SystemEventQueue       = 0, // Not really a timer.
+    ConstIntervalTimer     = 1,
+    PLUGIN_TIMER_IN_e      = 2, // Called with a previously defined event at a specific time, set via setPluginTaskTimer
+    TaskDeviceTimer        = 3, // Essentially calling PLUGIN_READ
+    GPIO_timer             = 4,
+    PLUGIN_ONLY_TIMER_IN_e = 5, // Similar to PLUGIN_TIMER_IN, addressed to a plugin instead of a task.
+    RulesTimer             = 6,
+    IntendedReboot         = 15 // Used to show intended reboot
   };
 
   static const __FlashStringHelper* toString(SchedulerTimerType_e timerType);


### PR DESCRIPTION
Fixes: #3754 

Problem was that upon MQTT connect to the broker, the tasks were re-scheduled to run.
This is not useful now the read values are queued.
It only needs to call the MQTT import tasks if present.