### PR TITLE
[NTP] Use random interval for NTP sync interval

### DIFF
--- a/docs/source/Tools/Tools.rst
+++ b/docs/source/Tools/Tools.rst
@@ -91,17 +91,132 @@ Info
 
 The ``sysinfo`` page does show a lot of information about the system.
 
-* Unit Number: The assigned unit number of the node.
-* Local Time:	The local time as known by the node. This includes any set timezone and DST (Daylight Saving).
-* Time Source:	The origin of the current system time. (e.g. NTP / GPS / Manual set)
-* Time Wander:	Time drift of the crystal in msec/sec. Espressif states the crystal should have an accuracy of better than 10 ppm, which translates in a wander of 0.010 msec/sec.
-* Uptime:	Current uptime of the node
-* Load:	CPU load in percent. ``LC`` is the number of calls to the ``loop()`` function per second.
-* CPU Eco Mode:	Whether the ECO mode is enabled or not.
-* Boot:	e.g. ``Manual Reboot (22)`` Stating the latest reboot reason and number of reboots since power on.
-* Reset Reason:	More extensive last reboot reason.
-* Last Action before Reboot:	Some indicator of the last action performed before the last reboot.
-* SW WD count:	Counter of the number of reboots triggered by the Software Watchdog. (not reliable at this moment)
+* **Unit Number**: The assigned unit number of the node.
+* **Local Time**:	The local time as known by the node. This includes any set timezone and DST (Daylight Saving).
+* **Time Source**:	The origin of the current system time. (e.g. NTP / GPS / Manual set)
+* **Time Wander**:	Time drift of the crystal in msec/sec. Espressif states the crystal should have an accuracy of better than 10 ppm, which translates in a wander of 0.010 msec/sec.
+* **Uptime**:	Current uptime of the node
+* **Load**:	CPU load in percent. ``LC`` is the number of calls to the ``loop()`` function per second.
+* **CPU Eco Mode**:	Whether the ECO mode is enabled or not.
+* **Boot**:	e.g. ``Manual Reboot (22)`` Stating the latest reboot reason and number of reboots since power on.
+* **Reset Reason**:	More extensive last reboot reason.
+* **Last Action before Reboot**:	Some indicator of the last action performed before the last reboot.
+* **SW WD count**:	Counter of the number of reboots triggered by the Software Watchdog. (not reliable at this moment)
+
+Memory
+------
+
+* **Free RAM**:	Amount of free heap memory. With statistics enabled, also showing the lowest amount of free heap and the function where this occured. Example: ``12112 (9592 - sendContentBlocking)``
+* **Heap Max Free Block**:	Largest continuous free block in heap memory.
+* **Heap Fragmentation**:	Amount of fragmentation of the heap memory. High fragmentation may lead to crashes or slow response of the node.
+* **Free Stack**:	Amount of free memory on the stack. With statistics enabled, also showing the lowest amount of free stack and the function where this occured. Example: ``3664 (848 - sendContentBlocking)``
+
+Network
+-------
+
+* **IP Config**:	Static or DHCP
+* **IP / Subnet**:	Example: ``192.168.10.58 / 255.255.255.0``
+* **Gateway**:	Example: ``192.168.10.254``
+* **Client IP**:	IP-address of the computer used to access the ESP. Example: ``192.168.10.135``
+* **DNS**:	Example: ``192.168.88.1 / (IP unset)``
+* **Allowed IP Range**:	Configured filter to allow access to the web interface only from a specific subnet, or ``All Allowed``
+* **Connected**:	Duration of the current network connection. Example: ``4h55m``
+* **Number Reconnects**:	Number of reconnects to a network since boot.
+
+WiFi
+----
+
+* **WiFi Connection**:	Description of the current connection speed and signal strength of the access point connected to. Example: ``802.11n (RSSI -41 dBm)``
+* **SSID**:	SSID of the WiFi network the node is connected to, plus its BSSID. Example: ``Lurch_2G (74:4D:28:FA:35:7D)``
+* **Channel**:	Current used WiFi channel.
+* **Encryption Type**:	Used WiFi encryption. Example: ``WPA/WPA2/PSK``
+* **Last Disconnect Reason**:	The reason of the last disconnect from the access point. Showing the numeric ID and a description. Example: ``(1) Unspecified``
+* **Configured SSID1**:	The first SSID of a WiFi network stored in the settings.
+* **Configured SSID2**:	The second SSID of a WiFi network stored in the settings.
+* **STA MAC**:	MAC address of the station WiFi interface of the ESPEasy node. Example: ``2C:3A:E8:39:14:07``
+* **AP MAC**:	MAC address of the access point WiFi interface of the ESPEasy node. Example: ``2E:3A:E8:39:14:07``
+
+WiFi Settings
+-------------
+
+All these values are described in great detail in the Advanced section, where the WiFi settings can be configured.
+
+* **Force WiFi B/G**:	Shows whether the ESPEasy node is forced into 802.11b/g mode.
+* **Restart WiFi Lost Conn**:	Shows whether the ESPEasy node is configured to restart the WiFi radio when connection is lost. When reporting false (the default), the WiFi radio is not restarted, but it just retries to connect to WiFi.
+* **Force WiFi No Sleep**:	``true`` indicates the WiFi radio is not allowed to enter low power mode to conserve energy.
+* **Periodical send Gratuitous ARP**:	``true`` indicates the ESPEasy node will send Gratuitous ARP packets to improve reachability from the network to the node.
+* **Connection Failure Threshold**:	Counter indicating the number of failed connection attempts needed to perform a reboot.
+* **Max WiFi TX Power**:	The set maximum TX power in dBm.
+* **Current WiFi TX Power**:	The current active TX power in dBm
+* **WiFi Sensitivity Margin**:	The set WiFi Sensitivity Margin
+* **Send With Max TX Power**:	``true`` indicates the WiFi TX power will not be changed and thus is sending at maximum TX power for the active WiFi mode (802.11 b/g/n)
+* **Extra WiFi scan loops**:	The set number of extra scans of all channels when a WiFi scan is needed.
+* **Use Last Connected AP from RTC**:	``false`` means the ESPEasy node needs to scan at reboot and cannot reuse the last used connection before the reboot.
+
+Firmware
+--------
+
+* **Build**:  Showing the internal build number. Example: ``20114 - Mega``
+* **System Libraries**:  Showing the used core library version. Example: ``ESP82xx Core 2843a5ac, NONOS SDK 2.2.2-dev(38a443e), LWIP: 2.1.2 PUYA support``
+* **Git Build**: Showing the GIT branch or tag information with SHA of the last commit. 	Example: ``feature/randomize_NTP_interval_569442e``
+* **Plugin Count**: 	Number of plugins included in the build. 
+* **Build Origin**:	Indication whether it is "self built" or an official build.
+* **Build Time**:  Date and time when the running version of ESPEasy was built. Example: ``Aug 11 2021 14:00:44``
+* **Binary Filename**: The filename of the installed ESPEasy build.  Example: ``ESP_Easy_mega_20210811_custom_ESP8266_4M1M``
+* **Build Platform**:	The platform used to build the installed ESPEasy build. Example: ``Windows-10-10.0.19041-SP0``
+* **Git HEAD**: The Git branch + SHA of the last commit used to build the installed ESPEasy build.	Example: ``feature/randomize_NTP_interval_569442e``
+
+System Status
+-------------
+
+Showing the current active log level per log destination.
+N.B. The web log will switch to ``None`` when the log is not fetched from the web log page, regardless of the actual setting.
+
+* **Syslog Log Level**:	None
+* **Serial Log Level**:	Info
+* **Web Log Level**:	None
+
+Network Services
+----------------
+
+Showing checkboxes when a service is started with success.
+
+* **Network Connected**:	✔
+* **NTP Initialized**:	✔
+* **MQTT Client Connected**:	✔
+
+ESP Board
+---------
+
+Showing detected chip and used board definition.
+
+* **ESP Chip ID**:	Unique chip ID, showin in decimal and hexadecimal notation. Example: ``3740679 (0x391407)``
+* **ESP Chip Frequency**:	Set CPU clock frequency. Example: ``80 MHz``
+* **ESP Chip Model**:	Detected or configured CPU platform. Example: ``ESP8266``
+* **ESP Chip Cores**:	Detected or configured number of CPU cores. Example: ``1`
+* **ESP Board Name**:	Used board definition. Example: ``PLATFORMIO_ESP12E``
+
+Storage
+-------
+
+Showing detailed information about the flash chip and used file system.
+
+* **Flash Chip ID**:  Detected flash chip vendor ID and flash model. Example: ``Vendor: 0x20 Device: 0x4016``
+* **Flash Chip Real Size**:	The detected real size of the flash chip. Example: ``4096 kB``
+* **Flash IDE Size**:	Defined size in the build project. (may be less than the detected real size) Example: ``4096 kB``
+* **Flash IDE Speed**:	Configured frequency of the flash chip. Example: ``40 MHz``
+* **Flash IDE Mode**:	Configured access mode to the flash chip. Example: ``DOUT``
+* **Flash Writes**:	Number of writes to the flash of the current day and since the last power cycle boot. Example: ``16 daily / 37 boot``
+* **Sketch Size**:	Size of the current ESPEasy build + the amount of free space for an OTA update.  Example: ``844 kB (2224 kB free)``
+* **Max. OTA Sketch Size**:	Example: Maximum size of an ESPEasy build that can be flashed using OTA. ``1019 kB (1044464 bytes)``
+* **OTA possible**:	``true`` indicates it is possible to update the firmware via OTA.
+* **OTA 2-step Needed**:	``false`` indicates a user does not need to perform an OTA update via the 2-step OTA process. ``true`` means it is only possible to perform an OTA update via the 2-step OTA update process.
+* **SPIFFS Size**:	Example: Total size + free space of the current file system. Example: ``934 kB (792 kB free)``
+* **Page size**:	The size of a page on the flash chip. Example: ``256``
+* **Block size**:	Smallest size of consequitive pages that can be erased. Example: ``8192``
+* **Number of blocks**:	Total number of blocks occupied by the file system. Example: ``116``
+* **Maximum open files**:	Configured maximum number of simultaneous open files. Example: ``5``
+* **Maximum path length**:	Maximum length of file name + path. Example: ``32``
 
 Advanced
 ========

--- a/docs/source/Tools/Tools.rst
+++ b/docs/source/Tools/Tools.rst
@@ -89,6 +89,20 @@ For the best performance the log level on all output directions should be set as
 Info
 ====
 
+The ``sysinfo`` page does show a lot of information about the system.
+
+* Unit Number: The assigned unit number of the node.
+* Local Time:	The local time as known by the node. This includes any set timezone and DST (Daylight Saving).
+* Time Source:	The origin of the current system time. (e.g. NTP / GPS / Manual set)
+* Time Wander:	Time drift of the crystal in msec/sec. Espressif states the crystal should have an accuracy of better than 10 ppm, which translates in a wander of 0.010 msec/sec.
+* Uptime:	Current uptime of the node
+* Load:	CPU load in percent. ``LC`` is the number of calls to the ``loop()`` function per second.
+* CPU Eco Mode:	Whether the ECO mode is enabled or not.
+* Boot:	e.g. ``Manual Reboot (22)`` Stating the latest reboot reason and number of reboots since power on.
+* Reset Reason:	More extensive last reboot reason.
+* Last Action before Reboot:	Some indicator of the last action performed before the last reboot.
+* SW WD count:	Counter of the number of reboots triggered by the Software Watchdog. (not reliable at this moment)
+
 Advanced
 ========
 

--- a/src/src/Helpers/ESPEasy_time.cpp
+++ b/src/src/Helpers/ESPEasy_time.cpp
@@ -154,12 +154,43 @@ unsigned long ESPEasy_time::now() {
       }
     }
     if (updatedTime) {
+      const double time_offset = unixTime_d - sysTime - (timePassedSince(prevMillis) / 1000.0);
+
+      if (statusNTPInitialized && time_offset < 1.0) {
+        // Clock instability in msec/second
+        timeWander = ((time_offset * 1000000.0f) / timePassedSince(lastTimeWanderCalculation));
+      }
+      lastTimeWanderCalculation = millis();
+
       prevMillis = millis(); // restart counting from now (thanks to Korman for this fix)
       timeSynced = true;
 
-      const double time_offset = unixTime_d - sysTime;
       sysTime = unixTime_d;
       ExtRTC_set(sysTime);
+      {
+        const unsigned long abs_time_offset_ms = std::abs(time_offset) * 1000;
+
+        if (timeSource == timeSource_t::NTP_time_source) {
+          // May need to lessen the load on the NTP servers, randomize the sync interval
+          if (abs_time_offset_ms < 1000) {
+            // offset is less than 1 second, so we consider it a regular time sync.
+            if (abs_time_offset_ms < 100) {
+              // Good clock stability, use 5 - 6 hour interval
+              syncInterval = random(18000, 21600);
+            } else {
+              // Dynamic interval between 30 minutes ... 5 hours.
+              syncInterval = 1800000 / abs_time_offset_ms;
+            }
+          } else {
+            syncInterval = 3600;
+          }
+          if (syncInterval <= 3600) {
+            syncInterval = random(3600, 4000);
+          }
+        } else {
+          syncInterval = 3600;
+        }
+      }
 
       if (loglevelActiveFor(LOG_LEVEL_INFO)) {
         String log         = F("Time set to ");
@@ -170,7 +201,7 @@ unsigned long ESPEasy_time::now() {
           log += F(" Time adjusted by ");
           log += String(time_offset * 1000.0f);
           log += F(" msec. Wander: ");
-          log += String((time_offset * 1000.0f) / syncInterval);
+          log += String(timeWander, 3);
           log += F(" msec/second");
           log += F(" Source: ");
           log += toString(timeSource);
@@ -271,7 +302,7 @@ bool ESPEasy_time::getNtpTime(double& unixTime_d)
     log += Settings.NTPHost;
 
     // When single set host fails, retry again in 20 seconds
-    nextSyncTime = sysTime + 20;
+    nextSyncTime = sysTime + random(20, 60);
   } else  {
     // Have to do a lookup each time, since the NTP pool always returns another IP
     String ntpServerName = String(random(0, 3));
@@ -280,7 +311,7 @@ bool ESPEasy_time::getNtpTime(double& unixTime_d)
     log += ntpServerName;
 
     // When pool host fails, retry can be much sooner
-    nextSyncTime = sysTime + 5;
+    nextSyncTime = sysTime + random(5, 20);
     useNTPpool = true;
   }
 

--- a/src/src/Helpers/ESPEasy_time.h
+++ b/src/src/Helpers/ESPEasy_time.h
@@ -185,6 +185,8 @@ public:
   struct tm sunRise;
   struct tm sunSet;
   timeSource_t timeSource = timeSource_t::No_time_source;
+  float timeWander = 0.0f;  // Clock instability in msec/second
+  uint32_t lastTimeWanderCalculation = 0;
 
   uint8_t PrevMinutes = 0;
 };

--- a/src/src/Helpers/StringProvider.cpp
+++ b/src/src/Helpers/StringProvider.cpp
@@ -44,6 +44,7 @@ const __FlashStringHelper * getLabel(LabelType::Enum label) {
 
     case LabelType::LOCAL_TIME:             return F("Local Time");
     case LabelType::TIME_SOURCE:            return F("Time Source");
+    case LabelType::TIME_WANDER:            return F("Time Wander");
     case LabelType::UPTIME:                 return F("Uptime");
     case LabelType::LOAD_PCT:               return F("Load");
     case LabelType::LOOP_COUNT:             return F("Load LC");
@@ -212,6 +213,7 @@ String getValue(LabelType::Enum label) {
 
     case LabelType::LOCAL_TIME:             return node_time.getDateTimeString('-', ':', ' ');
     case LabelType::TIME_SOURCE:            return toString(node_time.timeSource);
+    case LabelType::TIME_WANDER:            return String(node_time.timeWander, 3);
     case LabelType::UPTIME:                 return String(getUptimeMinutes());
     case LabelType::LOAD_PCT:               return String(getCPUload());
     case LabelType::LOOP_COUNT:             return String(getLoopCountPerSec());

--- a/src/src/Helpers/StringProvider.h
+++ b/src/src/Helpers/StringProvider.h
@@ -18,6 +18,7 @@ struct LabelType {
 
     LOCAL_TIME,
     TIME_SOURCE,
+    TIME_WANDER,
     UPTIME,
     LOAD_PCT,            // 15.10
     LOOP_COUNT,          // 400

--- a/src/src/WebServer/JSON.cpp
+++ b/src/src/WebServer/JSON.cpp
@@ -157,6 +157,7 @@ void handle_json()
         LabelType::PLUGIN_DESCRIPTION,
         LabelType::LOCAL_TIME,
         LabelType::TIME_SOURCE,
+        LabelType::TIME_WANDER,
         LabelType::ISNTP,
         LabelType::UNIT_NR,
         LabelType::UNIT_NAME,

--- a/src/src/WebServer/SysInfoPage.cpp
+++ b/src/src/WebServer/SysInfoPage.cpp
@@ -288,6 +288,8 @@ void handle_sysinfo_basicInfo() {
   {
     addRowLabelValue(LabelType::LOCAL_TIME);
     addRowLabelValue(LabelType::TIME_SOURCE);
+    addRowLabelValue(LabelType::TIME_WANDER);
+    addUnit(F("msec/sec"));
   }
 
   addRowLabel(LabelType::UPTIME);


### PR DESCRIPTION
This will be easier on pool.ntp.org.
For example after a power outage, lots of nodes may use the same sync interval and thus perform a small DDoS like attack to the NTP pool servers as they may request several requests at the same time from the same public IP address.

By randomising this interval this will unlikely cause a peak.

Also added a time wander indicator, to get some idea of the stability of the used crystal in the ESP.
Typically this wander should be less than 0.010 msec/sec (< 10 ppm)

Idea for this change was inspired by [this Tweakers article](https://tweakers.net/reviews/9242/7/het-network-time-protocol-de-wankele-basis-van-kloksynchronisatie-tot-slot-over-vrijwilligers-en-big-tech.html?showReaction=16442436#r_16442436) (+comments)