### PR TITLE
[Build] Use up-to-date platformio/toolchain-xtensa for the esp8266

### DIFF
--- a/platformio_core_defs.ini
+++ b/platformio_core_defs.ini
@@ -136,7 +136,7 @@ build_flags               = ${esp82xx_2_6_x.build_flags}
                             -Wno-deprecated-declarations
 platform_packages = 
     platformio/framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
-    mcspr/toolchain-xtensa @ 5.100200.201223
+    platformio/toolchain-xtensa @ ~2.100300.210717
 
 ; Updated ESP-IDF to the latest stable 4.0.1
 ; See: https://github.com/platformio/platform-espressif32/releases


### PR DESCRIPTION
10.3 with various patches from the recent Core 3.0.2 release