### PR TITLE
[P093] Added support for operating and compressor frequency

### DIFF
--- a/docs/source/Plugin/P093.rst
+++ b/docs/source/Plugin/P093.rst
@@ -26,13 +26,8 @@ Plugin is based on `Arduino library to control Mitsubishi Heat Pumps <https://gi
 Supported hardware
 ------------------
 
-Plugin should support all Mitsubishi heat pump units with a CN105 connector:
-
-* `P-Series <https://www.mitsubishicomfort.com/sites/default/themes/mitsubishicomfort/pdf/2018-01_P-Series_Controls-Compatibility-Chart.pdf>`_,
-* `M-Series <https://www.mitsubishicomfort.com/sites/default/themes/mitsubishicomfort/pdf/2018-01_M-Series_Controls-Compatibility-Chart.pdf>`_,
-* `CITY MULTI <https://www.mitsubishicomfort.com/sites/default/themes/mitsubishicomfort/pdf/Controller_Compatibility_Chart_2017-12_CITY_MULTI.pdf>`_.
-
-Open issue, where users can report models they are using - `list <https://github.com/SwiCago/HeatPump/issues/13>`_.
+Plugin should support all Mitsubishi heat pump units with a CN105 connector- git issue, where users can report models they are 
+using - `list <https://github.com/SwiCago/HeatPump/issues/13>`_.
 
 How to connect
 ~~~~~~~~~~~~~~
@@ -77,7 +72,7 @@ The Mitsubishi Heatpump plugin can be added as simple as selecting it from the l
 
 Once we hit submit, the plugin will start sending messages through controller, i.e. MQTT with payload:
 
-``{"roomTemperature":23.0,"wideVane":"|","power":"OFF","mode":"AUTO","fan":"QUIET","vane":"AUTO","iSee":false,"temperature":24.0}``
+``{"roomTemperature":25.5,"wideVane":"|","power":"OFF","mode":"COOL","fan":"AUTO","vane":"AUTO","iSee":true,"operating":true,"compressorFrequency":5,"temperature":24.0}``
 
 Message is send every time a change is detected (i.e. one changes settings using IR remote control) and every X seconds, as set in the settings (60 seconds in above screenshot).
 
@@ -101,11 +96,17 @@ Special thanks
 
 * to SwiCago and other maintainers and contributors of the *Arduino library to control Mitsubishi Heat Pumps* from https://github.com/SwiCago/HeatPump/,
 * to Chris Davis for his great `blog <https://chrdavis.github.io/hacking-a-mitsubishi-heat-pump-Part-1/>`_,
-* to Hadley from New Zealand for his *hacking* https://nicegear.co.nz/blog/hacking-a-mitsubishi-heat-pump-air-conditioner/,
+* to Hadley from New Zealand for his *hacking*.
 * and all others that contributed on this subject.
 
 Change log
 ----------
+
+.. versionchanged:: 2021/08/03
+  ...
+
+  |added|
+  Status of operating and compressor frequency.
 
 .. versionadded:: 2020/03/07
   ...

--- a/docs/source/Plugin/_plugin_substitutions_p09x.repl
+++ b/docs/source/Plugin/_plugin_substitutions_p09x.repl
@@ -39,8 +39,8 @@
 .. |P093_type| replace:: :cyan:`Energy (Heat)`
 .. |P093_typename| replace:: :cyan:`Energy (Heat) - Mitsubishi Heat Pump`
 .. |P093_status| replace:: :yellow:`ENERGY, TESTING D`
-.. |P093_github| replace:: P093_MitsubishiAC.ino
-.. _P093_github: https://github.com/letscontrolit/ESPEasy/blob/mega/src/_P093_MitsubishiAC.ino
+.. |P093_github| replace:: P093_MitsubishiHP.ino
+.. _P093_github: https://github.com/letscontrolit/ESPEasy/blob/mega/src/_P093_MitsubishiHP.ino
 .. |P093_usedby| replace:: `.`
 .. |P093_shortinfo| replace:: `Should support all Mitsubishi heatpump units with a CN105 connector`
 .. |P093_maintainer| replace:: `crnjan`

--- a/src/_P093_MitsubishiHP.ino
+++ b/src/_P093_MitsubishiHP.ino
@@ -38,7 +38,7 @@ static const uint8_t INFOMODE[] = {
 
 struct P093_data_struct : public PluginTaskData_base {
   P093_data_struct(const ESPEasySerialPort port, const int16_t serialRx, const int16_t serialTx, bool includeStatus) :
-    _serial(new (std::nothrow) ESPeasySerial(port, serialRx, serialTx)),
+    _serial(port, serialRx, serialTx),
     _state(NotConnected),
     _fastBaudRate(false),
     _readPos(0),
@@ -51,10 +51,6 @@ struct P093_data_struct : public PluginTaskData_base {
     _includeStatus(includeStatus) {
 
     setState(Connecting);
-  }
-
-  virtual ~P093_data_struct() {
-    delete _serial;
   }
 
   boolean sync() {
@@ -469,7 +465,7 @@ private:
   void connect() {
     addLog(LOG_LEVEL_DEBUG, String(F("M-AC: Connect ")) + getBaudRate());
 
-    _serial->begin(getBaudRate(), SERIAL_8E1);
+    _serial.begin(getBaudRate(), SERIAL_8E1);
     const uint8_t buffer[] = { 0xfc, 0x5a, 0x01, 0x30, 0x02, 0xca, 0x01, 0xa8 };
     sendPacket(buffer, sizeof(buffer));
   }
@@ -483,7 +479,7 @@ private:
     addLog(LOG_LEVEL_DEBUG_MORE, dumpOutgoingPacket(packet, size));
 #endif
 
-    _serial->write(packet, size);
+    _serial.write(packet, size);
     _writeTimeout = millis() + 2000;
   }
 
@@ -507,8 +503,8 @@ private:
 
     static const uint8_t DATA_LEN_INDEX = 4;
 
-    while(_serial->available() > 0) {
-      uint8_t value = _serial->read();
+    while(_serial.available() > 0) {
+      uint8_t value = _serial.read();
 
       if (_readPos == 0) {
         // Wait for start uint8_t.
@@ -701,7 +697,7 @@ private:
   #endif
 
 private:
-  ESPeasySerial* _serial;
+  ESPeasySerial _serial;
   State _state;
   boolean _fastBaudRate;
   uint8_t _readBuffer[READ_BUFFER_LEN];

--- a/src/_P093_MitsubishiHP.ino
+++ b/src/_P093_MitsubishiHP.ino
@@ -29,7 +29,8 @@ static const uint8_t READ_BUFFER_LEN = 32;
 
 static const uint8_t INFOMODE[] = {
   0x02, // request a settings packet
-  0x03  // request the current room temp
+  0x03, // request the current room temp
+  0x06  // request status
 };
 
 struct P093_data_struct : public PluginTaskData_base {
@@ -91,6 +92,10 @@ struct P093_data_struct : public PluginTaskData_base {
     result += map(_currentValues.vane, _mappings.vane);
     result += F("\",\"iSee\":");
     result += boolToString(_currentValues.iSee);
+    result += F("\",\"operating\":");
+    result += boolToString(_currentValues.operating);
+    result += F("\",\"compressorFrequency\":");
+    result += _currentValues.compressorFrequency;
     result += F(",\"temperature\":");
     result += toString(_currentValues.temperature, 1) + '}';
 
@@ -220,6 +225,8 @@ private:
     uint8_t vane;
     uint8_t wideVane;
     float roomTemperature;
+    boolean operating;
+    uint8_t compressorFrequency;
 
     Values() :
       power(0),
@@ -229,7 +236,9 @@ private:
       fan(0),
       vane(0),
       wideVane(0),
-      roomTemperature(0) {
+      roomTemperature(0),
+      operating(false),
+      compressorFrequency(0) {
     }
 
     boolean operator!=(const Values& rhs) const {
@@ -240,7 +249,9 @@ private:
         vane != rhs.vane ||
         wideVane != rhs.wideVane ||
         iSee != rhs.iSee ||
-        roomTemperature != rhs.roomTemperature;
+        roomTemperature != rhs.roomTemperature ||
+        operating != rhs.operating ||
+        compressorFrequency != rhs.compressorFrequency;
     }
   };
 
@@ -569,6 +580,14 @@ private:
           } else {
             _currentValues.roomTemperature = data[3] + 10;
           }
+          return true;
+        }
+        break;
+
+      case 0x06:
+        if (length > 4) {
+          _currentValues.operating = data[4];
+          _currentValues.compressorFrequency = data[3];
           return true;
         }
         break;

--- a/src/_P093_MitsubishiHP.ino
+++ b/src/_P093_MitsubishiHP.ino
@@ -92,9 +92,9 @@ struct P093_data_struct : public PluginTaskData_base {
     result += map(_currentValues.vane, _mappings.vane);
     result += F("\",\"iSee\":");
     result += boolToString(_currentValues.iSee);
-    result += F("\",\"operating\":");
+    result += F(",\"operating\":");
     result += boolToString(_currentValues.operating);
-    result += F("\",\"compressorFrequency\":");
+    result += F(",\"compressorFrequency\":");
     result += _currentValues.compressorFrequency;
     result += F(",\"temperature\":");
     result += toString(_currentValues.temperature, 1) + '}';


### PR DESCRIPTION
As [discussed](https://community.openhab.org/t/mitsubishi-heat-pump/91765/66) added support for additional AC parameters - operating and compressor frequency + removed some links that don't exist anymore from docs.