### PR TITLE
[I2C] Fix switching low/high clock + fix PCF8563 ext. RTC

### DIFF
--- a/lib/Adafruit_RTClib/src/RTClib.cpp
+++ b/lib/Adafruit_RTClib/src/RTClib.cpp
@@ -809,7 +809,7 @@ static uint8_t bin2bcd(uint8_t val) { return val + 6 * (val / 10); }
 
 boolean RTC_DS1307::begin(TwoWire *wireInstance) {
   RTCWireBus = wireInstance;
-  RTCWireBus->begin();
+  //RTCWireBus->begin();
   RTCWireBus->beginTransmission(DS1307_ADDRESS);
   if (RTCWireBus->endTransmission() == 0)
     return true;
@@ -1054,7 +1054,7 @@ DateTime RTC_Micros::now() {
 
 boolean RTC_PCF8523::begin(TwoWire *wireInstance) {
   RTCWireBus = wireInstance;
-  RTCWireBus->begin();
+  //RTCWireBus->begin();
   RTCWireBus->beginTransmission(PCF8523_ADDRESS);
   if (RTCWireBus->endTransmission() == 0)
     return true;
@@ -1403,7 +1403,7 @@ void RTC_PCF8523::calibrate(Pcf8523OffsetMode mode, int8_t offset) {
 
 boolean RTC_PCF8563::begin(TwoWire *wireInstance) {
   RTCWireBus = wireInstance;
-  RTCWireBus->begin();
+  //RTCWireBus->begin();
   RTCWireBus->beginTransmission(PCF8563_ADDRESS);
   if (RTCWireBus->endTransmission() == 0)
     return true;
@@ -1565,7 +1565,7 @@ static uint8_t dowToDS3231(uint8_t d) { return d == 0 ? 7 : d; }
 
 boolean RTC_DS3231::begin(TwoWire *wireInstance) {
   RTCWireBus = wireInstance;
-  RTCWireBus->begin();
+  //RTCWireBus->begin();
   RTCWireBus->beginTransmission(DS3231_ADDRESS);
   if (RTCWireBus->endTransmission() == 0)
     return true;

--- a/platformio_core_defs.ini
+++ b/platformio_core_defs.ini
@@ -148,8 +148,8 @@ platform                  = espressif32@2.1.0
 build_flags               =
 
 [core_esp32_3_3_2]
-platform                  = https://github.com/platformio/platform-espressif32.git#feature/arduino-idf-master
-platform_packages         = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/424/framework-arduinoespressif32-master-cdcf92440.tar.gz
+platform                  = espressif32 @ 3.3.2
+platform_packages         = framework-arduinoespressif32
 build_flags               = -DESP32_STAGE
 
 [core_esp32_3_3_2_esp32s2]

--- a/platformio_esp32_envs.ini
+++ b/platformio_esp32_envs.ini
@@ -50,6 +50,7 @@ build_flags               = ${esp32_common.build_flags}
 board                     = esp32-s2-saola-1
 extra_scripts             = ${esp32_common.extra_scripts}
                             pre:tools/pio/pre_custom_esp32.py
+platform                  = ${core_esp32_3_3_2_esp32s2.platform}
 platform_packages         = ${core_esp32_3_3_2_esp32s2.platform_packages}
 
 

--- a/src/src/ESPEasyCore/ESPEasy_setup.cpp
+++ b/src/src/ESPEasyCore/ESPEasy_setup.cpp
@@ -224,6 +224,14 @@ void ESPEasy_setup()
   logMemUsageAfter(F("LoadSettings()"));
   #endif
 
+  #ifndef BUILD_NO_RAM_TRACKER
+  checkRAM(F("hardwareInit"));
+  #endif // ifndef BUILD_NO_RAM_TRACKER
+  hardwareInit();
+  #ifndef BUILD_NO_RAM_TRACKER
+  logMemUsageAfter(F("hardwareInit()"));
+  #endif
+
   node_time.restoreFromRTC();
 
   Settings.UseRTOSMultitasking = false; // For now, disable it, we experience heap corruption.
@@ -308,14 +316,6 @@ void ESPEasy_setup()
   if (Settings.UseSerial && (Settings.SerialLogLevel >= LOG_LEVEL_DEBUG_MORE)) {
     Serial.setDebugOutput(true);
   }
-
-  #ifndef BUILD_NO_RAM_TRACKER
-  checkRAM(F("hardwareInit"));
-  #endif // ifndef BUILD_NO_RAM_TRACKER
-  hardwareInit();
-  #ifndef BUILD_NO_RAM_TRACKER
-  logMemUsageAfter(F("hardwareInit()"));
-  #endif
 
 
   timermqtt_interval      = 250; // Interval for checking MQTT

--- a/src/src/Globals/Plugins.cpp
+++ b/src/src/Globals/Plugins.cpp
@@ -239,7 +239,7 @@ void prepare_I2C_by_taskIndex(taskIndex_t taskIndex, deviceIndex_t DeviceIndex) 
 #endif
 
   if (bitRead(Settings.I2C_Flags[taskIndex], I2C_FLAGS_SLOW_SPEED)) {
-    I2CSelectClockSpeed(true); // Set to slow
+    I2CSelectLowClockSpeed(); // Set to slow
   }
 }
 
@@ -256,7 +256,7 @@ void post_I2C_by_taskIndex(taskIndex_t taskIndex, deviceIndex_t DeviceIndex) {
 #endif
 
   if (bitRead(Settings.I2C_Flags[taskIndex], I2C_FLAGS_SLOW_SPEED)) {
-    I2CSelectClockSpeed(false);  // Reset
+    I2CSelectHighClockSpeed();  // Reset
   }
 }
 

--- a/src/src/Helpers/ESPEasy_time.cpp
+++ b/src/src/Helpers/ESPEasy_time.cpp
@@ -11,6 +11,7 @@
 #include "../Globals/Settings.h"
 #include "../Globals/TimeZone.h"
 
+#include "../Helpers/Hardware.h"
 #include "../Helpers/Misc.h"
 #include "../Helpers/Networking.h"
 #include "../Helpers/Numerical.h"
@@ -723,6 +724,7 @@ bool ESPEasy_time::ExtRTC_get(uint32_t &unixtime)
     case ExtTimeSource_e::DS1307:
       {
         #ifdef USE_EXT_RTC
+        I2CSelect_Max100kHz_ClockSpeed(); // Only supports upto 100 kHz
         RTC_DS1307 rtc;
         if (!rtc.begin()) {
           // Not found
@@ -815,6 +817,7 @@ bool ESPEasy_time::ExtRTC_set(uint32_t unixtime)
     case ExtTimeSource_e::DS1307:
       {
         #ifdef USE_EXT_RTC
+        I2CSelect_Max100kHz_ClockSpeed(); // Only supports upto 100 kHz
         RTC_DS1307 rtc;
         if (rtc.begin()) {
           rtc.adjust(DateTime(unixtime));

--- a/src/src/Helpers/Hardware.h
+++ b/src/src/Helpers/Hardware.h
@@ -24,7 +24,10 @@ void hardwareInit();
 
 void initI2C();
 
-void I2CSelectClockSpeed(bool setLowSpeed);
+void I2CSelectHighClockSpeed();
+void I2CSelectLowClockSpeed();
+void I2CSelect_Max100kHz_ClockSpeed();
+void I2CSelectClockSpeed(uint32_t clockFreq);
 
 #ifdef FEATURE_I2CMULTIPLEXER
 bool isI2CMultiplexerEnabled();

--- a/src/src/WebServer/I2C_Scanner.cpp
+++ b/src/src/WebServer/I2C_Scanner.cpp
@@ -113,7 +113,7 @@ void handle_i2cscanner_json() {
 
   int  nDevices = 0;
 
-  I2CSelectClockSpeed(true);    // Always scan in low speed to also find old/slow devices
+  I2CSelect_Max100kHz_ClockSpeed();    // Always scan in low speed to also find old/slow devices
 #ifdef FEATURE_I2CMULTIPLEXER
   i2c_addresses_t mainBusDevices;
   mainBusDevices.resize(128);
@@ -135,7 +135,7 @@ void handle_i2cscanner_json() {
     I2CMultiplexerOff();
   }
 #endif
-  I2CSelectClockSpeed(false); // Reset bus to standard speed
+  I2CSelectHighClockSpeed(); // Reset bus to standard speed
   
   json_close(true);
   TXBuffer.endStream();
@@ -386,7 +386,7 @@ void handle_i2cscanner() {
 
   if (Settings.isI2CEnabled()) {
     int  nDevices = 0;
-    I2CSelectClockSpeed(true);  // Scan bus using low speed
+    I2CSelect_Max100kHz_ClockSpeed();  // Scan bus using low speed
     #ifdef FEATURE_I2CMULTIPLEXER
     i2c_addresses_t mainBusDevices;
     mainBusDevices.resize(128);
@@ -408,7 +408,7 @@ void handle_i2cscanner() {
       I2CMultiplexerOff();
     }
     #endif
-    I2CSelectClockSpeed(false);   // By default the bus is in standard speed
+    I2CSelectHighClockSpeed();   // By default the bus is in standard speed
 
     if (nDevices == 0) {
       addHtml(F("<TR>No I2C devices found"));


### PR DESCRIPTION
`initI2C()` did not setup I2C due to inverted check if enabled.

Also made code for switching I2C frequency a bit more readable.

PCF8563 was not running reliable on ESP32, since I2C was initialized after the ext. RTC was tried to read.