### PR TITLE
[Build] Enable IR plugins in custom_IR and MAX ESP32 builds

### DIFF
--- a/docs/source/Plugin/_Plugin.rst
+++ b/docs/source/Plugin/_Plugin.rst
@@ -19,7 +19,7 @@ There are different released versions of ESP Easy:
 
 .. comment :red:`DEVELOPMENT` is used for plugins that are still being developed and are not considered stable at all.
 
-:yellow:`ENERGY` :yellow:`DISPLAY` are specialized builds holding all Energy- and Display- related plugins.
+:yellow:`ENERGY` :yellow:`DISPLAY` :yellow:`IR` are specialized builds holding all Energy-, Display- and Infra Red- related plugins.
 
 :yellow:`MAX` is the build that has all plugins that are available in the ESPEasy repository. Only available for ESP32 16MB Flash units.
 

--- a/docs/source/Plugin/_Plugin.rst
+++ b/docs/source/Plugin/_Plugin.rst
@@ -19,7 +19,7 @@ There are different released versions of ESP Easy:
 
 .. comment :red:`DEVELOPMENT` is used for plugins that are still being developed and are not considered stable at all.
 
-:yellow:`ENERGY` :yellow:`DISPLAY` :yellow:`IR` are specialized builds holding all Energy-, Display- and Infra Red- related plugins.
+:yellow:`ENERGY` :yellow:`DISPLAY` :yellow:`IR` :yellow:`IRext` are specialized builds holding all Energy-, Display- and Infra Red- (extended) related plugins.
 
 :yellow:`MAX` is the build that has all plugins that are available in the ESPEasy repository. Only available for ESP32 16MB Flash units.
 

--- a/docs/source/Plugin/_plugin_substitutions_p01x.repl
+++ b/docs/source/Plugin/_plugin_substitutions_p01x.repl
@@ -80,7 +80,7 @@
 .. |P016_type| replace:: :cyan:`Communication`
 .. |P016_typename| replace:: :cyan:`Communication - TSOP4838`
 .. |P016_porttype| replace:: `.`
-.. |P016_status| replace:: :green:`NORMAL`
+.. |P016_status| replace:: :yellow:`IR`
 .. |P016_github| replace:: P016_IR.ino
 .. _P016_github: https://github.com/letscontrolit/ESPEasy/blob/mega/src/_P016_IR.ino
 .. |P016_usedby| replace:: `.`

--- a/docs/source/Plugin/_plugin_substitutions_p03x.repl
+++ b/docs/source/Plugin/_plugin_substitutions_p03x.repl
@@ -67,7 +67,7 @@
 .. |P035_type| replace:: :cyan:`Communication`
 .. |P035_typename| replace:: :cyan:`Communication - IR Transmit`
 .. |P035_porttype| replace:: `.`
-.. |P035_status| replace:: :green:`NORMAL`
+.. |P035_status| replace:: :yellow:`IR`
 .. |P035_github| replace:: P035_IRTX.ino
 .. _P035_github: https://github.com/letscontrolit/ESPEasy/blob/mega/src/_P035_IRTX.ino
 .. |P035_usedby| replace:: `.`

--- a/docs/source/Plugin/_plugin_substitutions_p08x.repl
+++ b/docs/source/Plugin/_plugin_substitutions_p08x.repl
@@ -106,7 +106,7 @@
 .. |P088_type| replace:: :cyan:`Energy (Heat)`
 .. |P088_typename| replace:: :cyan:`Energy (Heat) - HeatpumpIR`
 .. |P088_porttype| replace:: `.`
-.. |P088_status| replace:: :yellow:`TESTING, IRext`
+.. |P088_status| replace:: :yellow:`IRext`
 .. |P088_github| replace:: P088_HeatpumpIR.ino
 .. _P088_github: https://github.com/letscontrolit/ESPEasy/blob/mega/src/_P088_HeatpumpIR.ino
 .. |P088_usedby| replace:: `.`

--- a/docs/source/Plugin/_plugin_substitutions_p08x.repl
+++ b/docs/source/Plugin/_plugin_substitutions_p08x.repl
@@ -106,7 +106,7 @@
 .. |P088_type| replace:: :cyan:`Energy (Heat)`
 .. |P088_typename| replace:: :cyan:`Energy (Heat) - HeatpumpIR`
 .. |P088_porttype| replace:: `.`
-.. |P088_status| replace:: :yellow:`TESTING`
+.. |P088_status| replace:: :yellow:`TESTING, IRext`
 .. |P088_github| replace:: P088_HeatpumpIR.ino
 .. _P088_github: https://github.com/letscontrolit/ESPEasy/blob/mega/src/_P088_HeatpumpIR.ino
 .. |P088_usedby| replace:: `.`

--- a/platformio_esp32_envs.ini
+++ b/platformio_esp32_envs.ini
@@ -328,6 +328,7 @@ board_upload.maximum_size = 4194304
 build_flags               = ${esp32_common.build_flags}  
                             -DFEATURE_ARDUINO_OTA
                             -DPLUGIN_BUILD_MAX_ESP32
+                            -DPLUGIN_BUILD_IR_EXTENDED
 ; TODO: To enable PS-RAM Support needs more build flags than these 2, for now define ESP32_ENABLE_PSRAM is used to en/disable detecting PS-Ram size on Info page
 ;                            -DBOARD_HAS_PSRAM // both flags already enabled for Lolin D32 Pro board by PlatformIO
 ;                            -mfix-esp32-psram-cache-issue

--- a/platformio_esp32_envs.ini
+++ b/platformio_esp32_envs.ini
@@ -57,7 +57,7 @@ platform_packages         = ${core_esp32_3_3_2_esp32s2.platform_packages}
 [env:custom_IR_ESP32_4M316k]
 extends                   = esp32_common
 platform                  = ${esp32_common.platform}
-build_flags               = ${esp32_common.build_flags}   -DPLUGIN_BUILD_CUSTOM
+build_flags               = ${esp32_common.build_flags}   -DPLUGIN_BUILD_CUSTOM -DPLUGIN_BUILD_IR
 board                     = esp32dev
 lib_ignore                = ${esp32_always.lib_ignore}, ESP32_ping, HeatpumpIR
 extra_scripts             = ${esp32_common.extra_scripts}

--- a/platformio_esp82xx_envs.ini
+++ b/platformio_esp82xx_envs.ini
@@ -44,6 +44,7 @@ platform_packages         = ${regular_platform.platform_packages}
 build_flags               = ${regular_platform.build_flags} 
                             ${esp8266_4M1M.build_flags} 
                             -DPLUGIN_BUILD_CUSTOM
+                            -DPLUGIN_BUILD_IR
 lib_ignore                = ESP32_ping, ESP32WebServer, ServoESP32, ESP32HTTPUpdateServer, Adafruit GFX Library, LOLIN_EPD, Adafruit ILI9341, Adafruit BusIO, Adafruit NeoPixel, Adafruit Motor Shield V2 Library
 extra_scripts             = ${esp8266_custom_common.extra_scripts}
 

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -444,7 +444,9 @@ To create/register a plugin, you have to :
 // #define DECODE_TOSHIBA_AC      true
 // #define SEND_TOSHIBA_AC        true
 #ifdef PLUGIN_BUILD_IR
-    #define PLUGIN_DESCR  "IR"
+    #if !defined(PLUGIN_DESCR) && !defined(PLUGIN_BUILD_MAX_ESP32)
+      #define PLUGIN_DESCR  "IR"
+    #endif
     #define USES_P016      // IR
     #define P016_SEND_IR_TO_CONTROLLER false //IF true then the JSON replay solution is transmited back to the condroller.
     #define USES_P035      // IRTX
@@ -452,7 +454,7 @@ To create/register a plugin, you have to :
 #endif
 
 #ifdef PLUGIN_BUILD_IR_EXTENDED
-    #ifndef PLUGIN_DESCR
+    #if !defined(PLUGIN_DESCR) && !defined(PLUGIN_BUILD_MAX_ESP32)
         #define PLUGIN_DESCR  "IR Extended"
     #endif // PLUGIN_DESCR
     #define USES_P016      // IR
@@ -469,7 +471,7 @@ To create/register a plugin, you have to :
 #endif
 
 #ifdef PLUGIN_BUILD_IR_EXTENDED_NO_RX
-    #ifndef PLUGIN_DESCR
+    #if !defined(PLUGIN_DESCR) && !defined(PLUGIN_BUILD_MAX_ESP32)
         #define PLUGIN_DESCR  "IR Extended, no IR RX"
     #endif // PLUGIN_DESCR
     #define USES_P035      // IRTX
@@ -703,7 +705,9 @@ To create/register a plugin, you have to :
 #endif
 
 #ifdef PLUGIN_BUILD_MAX_ESP32
-    #define PLUGIN_DESCR  "MAX ESP32"
+    #ifndef PLUGIN_DESCR
+      #define PLUGIN_DESCR  "MAX ESP32"
+    #endif
     #ifndef ESP32
         #define ESP32
     #endif

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -1437,9 +1437,7 @@ To create/register a plugin, you have to :
 
   // Controllers
   #ifndef USES_C015
-    #ifndef ESP32
-      #define USES_C015   // Blynk (?doesn't compile on ESP32?)
-    #endif
+    #define USES_C015   // Blynk
   #endif
   #ifndef USES_C016
     #define USES_C016   // Cache controller


### PR DESCRIPTION
To my surprise the IR plugins where missing from the custom_IR builds, and for unknown reasons not included in the MAX ESP32 builds. That is corrected by these adjustments.
After merging PR 3783 the Blynk controller [C015] wasn't made available in the MAX ESP32 builds, that is now also corrected.
 
- [x] Re-enable IR plugins in custom_IR builds (standard IR options)
- [x] Enable IR plugins in MAX ESP32 builds (extended IR options, including A/C)
- [x] Enable Blynk controller in MAX ESP32 builds
- [x] Fix some documentation mishaps