### PR TITLE
[ESP32] Revert to PlatformIO platform 3.3.0 to fix web login

### DIFF
--- a/platformio_core_defs.ini
+++ b/platformio_core_defs.ini
@@ -145,8 +145,12 @@ platform                  = espressif32@1.12.4
 
 [core_esp32_2_1_0]
 platform                  = espressif32@2.1.0
-build_flags               =
+build_flags               = -DESP32_STAGE
 
+[core_esp32_3_3_0]
+platform                  = espressif32 @ 3.3.0
+platform_packages         = framework-arduinoespressif32
+build_flags               = -DESP32_STAGE
 
 [core_esp32_3_3_2]
 platform                  = espressif32 @ 3.3.2

--- a/platformio_esp32_envs.ini
+++ b/platformio_esp32_envs.ini
@@ -9,7 +9,7 @@ lib_ignore                = ESP8266WiFi, ESP8266Ping, ESP8266WebServer, ESP8266H
 
 
 [esp32_common]
-extends                   = common, core_esp32_3_3_2
+extends                   = common, core_esp32_3_3_0
 lib_deps                  = td-er/ESPeasySerial @ 2.0.6, adafruit/Adafruit ILI9341 @ ^1.5.6, Adafruit GFX Library, LOLIN_EPD, Adafruit BusIO, VL53L0X @ 1.3.0, SparkFun VL53L1X 4m Laser Distance Sensor @ 1.2.9, td-er/SparkFun MAX1704x Fuel Gauge Arduino Library @ ^1.0.1
 lib_ignore                = ${esp32_always.lib_ignore}, ESP32_ping, IRremoteESP8266, HeatpumpIR
 board_build.f_flash       = 80000000L
@@ -19,7 +19,7 @@ board_build.partitions    = esp32_partition_app1810k_spiffs316k.csv
 extra_scripts             = post:tools/pio/post_esp32.py
                             ${extra_scripts_default.extra_scripts}
 build_unflags             = -Wall
-build_flags               = ${core_esp32_3_3_2.build_flags} 
+build_flags               = ${core_esp32_3_3_0.build_flags} 
                             ${mqtt_flags.build_flags} 
                             -DCONFIG_FREERTOS_ASSERT_DISABLE
                             -DCONFIG_LWIP_ESP_GRATUITOUS_ARP


### PR DESCRIPTION
As reported on [the forum](https://www.letscontrolit.com/forum/viewtopic.php?f=4&t=8786)

Apparently the latest ESP32 code does have something broken regarding web UI login.