### PR TITLE
[ESPEasySerial] Fix issues on ESP32 with serial (restart serial)

### DIFF
--- a/lib/ESPEasySerial/ESPEasySerial_ESP32.cpp
+++ b/lib/ESPEasySerial/ESPEasySerial_ESP32.cpp
@@ -1,11 +1,71 @@
 #include <ESPeasySerial.h>
 
+
 // ****************************************
 // ESP32 implementation wrapper
 // Only support HW serial on Serial 0 .. 2
 // ****************************************
 
 #ifdef ESP32
+
+// Temporary work-around for bug in ESP32 code, where the pin matrix is not cleaned up between calling end() and begin()
+// Work-around is to keep track of the last used pins for a serial port,
+// as it is likely that a node will always use the same pins most of the time.
+// If not, a reboot may be OK to fix it.
+// Another idea is to swap pins among UART ports.
+// e.g. use the same pins on Serial1 if it was used on Serial2 before.
+
+// PR to fix it: https://github.com/espressif/arduino-esp32/pull/5385
+// See: https://github.com/espressif/arduino-esp32/issues/3878
+
+
+static int receivePin0 = -1;
+static int transmitPin0 = -1;
+static int receivePin1 = -1;
+static int transmitPin1 = -1;
+static int receivePin2 = -1;
+static int transmitPin2 = -1;
+
+bool pinsChanged(ESPEasySerialPort port, 
+                 int receivePin, 
+                 int transmitPin) 
+{
+  switch (port) {
+    case  ESPEasySerialPort::serial0: return receivePin != receivePin0 || transmitPin != transmitPin0;
+    case  ESPEasySerialPort::serial1: return receivePin != receivePin1 || transmitPin != transmitPin1;
+    #ifndef ESP32S2
+    case  ESPEasySerialPort::serial2: return receivePin != receivePin2 || transmitPin != transmitPin2;
+    #endif
+  }
+  return false;
+}
+
+void setPinsCache(ESPEasySerialPort port, 
+                 int receivePin, 
+                 int transmitPin) 
+{
+  switch (port) {
+    case  ESPEasySerialPort::serial0: 
+      receivePin0  = receivePin;
+      transmitPin0 = transmitPin;
+      break;
+    case  ESPEasySerialPort::serial1:
+      receivePin1  = receivePin;
+      transmitPin1 = transmitPin;
+      break;
+
+    #ifndef ESP32S2
+    case  ESPEasySerialPort::serial2:
+      receivePin2  = receivePin;
+      transmitPin2 = transmitPin;
+      break;
+
+    #endif
+  }
+}
+
+// End of messy work-around.
+
 ESPeasySerial::ESPeasySerial(
   ESPEasySerialPort port, 
   int receivePin, 
@@ -17,7 +77,9 @@ ESPeasySerial::ESPeasySerial(
   switch (port) {
     case  ESPEasySerialPort::serial0:
     case  ESPEasySerialPort::serial1:
+    #ifndef ESP32S2
     case  ESPEasySerialPort::serial2:
+    #endif
       _serialtype = port;
       break;
     default:
@@ -56,7 +118,7 @@ void ESPeasySerial::begin(unsigned long baud, uint32_t config
 
   if (txPin != -1) { _transmitPin = txPin; }
 
-  if (invert) { _inverse_logic = true; }
+  _inverse_logic = invert;
 
   if (!isValid()) {
     _baud = 0;
@@ -78,7 +140,10 @@ void ESPeasySerial::begin(unsigned long baud, uint32_t config
       // Timeout added for 1.0.1
       // See: https://github.com/espressif/arduino-esp32/commit/233d31bed22211e8c85f82bcf2492977604bbc78
       // getHW()->begin(baud, config, _receivePin, _transmitPin, invert, timeout_ms);
-      getHW()->begin(baud, config, _receivePin, _transmitPin, _inverse_logic);
+      if (pinsChanged(_serialtype, _receivePin, _transmitPin)) {
+        setPinsCache(_serialtype, _receivePin, _transmitPin);  
+        getHW()->begin(baud, config, _receivePin, _transmitPin, _inverse_logic);
+      }
     }
   }
 }
@@ -87,12 +152,15 @@ void ESPeasySerial::end() {
   if (!isValid()) {
     return;
   }
+  flush();
   if (isI2Cserial()) {
 #ifndef DISABLE_SC16IS752_Serial
     _i2cserial->end();
 #endif
   } else {
-    getHW()->end();
+    // Work-around to fix proper detach RX pin for older ESP32 core versions
+    // For now do not call end()
+    //getHW()->end();
   }
 }
 
@@ -126,10 +194,14 @@ const HardwareSerial * ESPeasySerial::getHW() const {
 bool ESPeasySerial::isValid() const {
   switch (_serialtype) {
     case ESPEasySerialPort::serial0:
-    case ESPEasySerialPort::serial2:
-      return true;
     case ESPEasySerialPort::serial1:
-      return _transmitPin != -1 && _receivePin != -1;
+      return true;
+    case ESPEasySerialPort::serial2:
+      #ifdef ESP32S2
+      return false;
+      #else
+      return true;
+      #endif
     case ESPEasySerialPort::sc16is752:
     #ifndef DISABLE_SC16IS752_Serial
       return _i2cserial != nullptr;
@@ -188,7 +260,7 @@ size_t ESPeasySerial::write(const uint8_t *buffer, size_t size) {
 
 size_t ESPeasySerial::write(const char *buffer) {
   if (!buffer) { return 0; }
-  return write(buffer, strlen(buffer));
+  return write(buffer, strlen_P(buffer));
 }
 
 int ESPeasySerial::read(void) {
@@ -227,8 +299,9 @@ void ESPeasySerial::flush(void) {
 #ifndef DISABLE_SC16IS752_Serial
     _i2cserial->flush();
 #endif
+  } else {
+    getHW()->flush();
   }
-  getHW()->flush();
 }
 
 int ESPeasySerial::baudRate(void) {

--- a/lib/ESPEasySerial/library.json
+++ b/lib/ESPEasySerial/library.json
@@ -1,6 +1,6 @@
 {
     "name": "ESPeasySerial",
-    "version": "2.0.6",
+    "version": "2.0.7",
     "keywords": [
       "serial", "io", "softwareserial", "hardwareserial"
     ],
@@ -27,6 +27,6 @@
     ],
     "frameworks": "arduino",
     "platforms": [
-      "espressif8266","espressif32"
+      "espressif8266","espressif32","espressif32s2"
     ]
 }

--- a/lib/ESPEasySerial/library.properties
+++ b/lib/ESPEasySerial/library.properties
@@ -1,5 +1,5 @@
 name=ESPeasySerial
-version=2.0.6
+version=2.0.7
 author=Gijs Noorlander
 maintainer=Gijs Noorlander <gijs.noorlander@gmail.com>
 sentence=Wrapper for SoftwareSerial, SC16IS752 I2C to UART bridge and HardwareSerial for ESP8266 and ESP32/ESP32S2.
@@ -7,4 +7,4 @@ paragraph=
 depends=SC16IS752
 category=Signal Input/Output
 url=
-architectures=esp8266,esp32
+architectures=esp8266,esp32,esp32s2

--- a/platformio_core_defs.ini
+++ b/platformio_core_defs.ini
@@ -170,6 +170,6 @@ platform_packages         = framework-arduinoespressif32 @ https://github.com/Ja
 
 
 [core_esp32_stage]
-platform                  = espressif32
+platform                  = https://github.com/platformio/platform-espressif32.git#feature/arduino-upstream
 platform_packages         = framework-arduinoespressif32 @ https://github.com/Jason2866/arduino-esp32/releases/download/v.2.0-post/framework-arduinoespressif32_i2c.zip
 build_flags               = -DESP32_STAGE

--- a/platformio_esp32_envs.ini
+++ b/platformio_esp32_envs.ini
@@ -10,7 +10,7 @@ lib_ignore                = ESP8266WiFi, ESP8266Ping, ESP8266WebServer, ESP8266H
 
 [esp32_common]
 extends                   = common, core_esp32_3_3_0
-lib_deps                  = td-er/ESPeasySerial @ 2.0.6, adafruit/Adafruit ILI9341 @ ^1.5.6, Adafruit GFX Library, LOLIN_EPD, Adafruit BusIO, VL53L0X @ 1.3.0, SparkFun VL53L1X 4m Laser Distance Sensor @ 1.2.9, td-er/SparkFun MAX1704x Fuel Gauge Arduino Library @ ^1.0.1
+lib_deps                  = td-er/ESPeasySerial @ 2.0.7, adafruit/Adafruit ILI9341 @ ^1.5.6, Adafruit GFX Library, LOLIN_EPD, Adafruit BusIO, VL53L0X @ 1.3.0, SparkFun VL53L1X 4m Laser Distance Sensor @ 1.2.9, td-er/SparkFun MAX1704x Fuel Gauge Arduino Library @ ^1.0.1
 lib_ignore                = ${esp32_always.lib_ignore}, ESP32_ping, IRremoteESP8266, HeatpumpIR
 board_build.f_flash       = 80000000L
 board_build.flash_mode    = dout

--- a/platformio_esp82xx_base.ini
+++ b/platformio_esp82xx_base.ini
@@ -52,7 +52,7 @@ extends                   = common
 board_build.f_cpu         = 80000000L
 build_flags               = ${debug_flags.build_flags} ${mqtt_flags.build_flags} -DHTTPCLIENT_1_1_COMPATIBLE=0
 build_unflags             = -DDEBUG_ESP_PORT
-lib_deps                  = td-er/ESPeasySerial @ 2.0.6, adafruit/Adafruit ILI9341 @ ^1.5.6, Adafruit GFX Library, LOLIN_EPD, Adafruit BusIO, bblanchon/ArduinoJson @ ^6.17.2, VL53L0X @ 1.3.0, SparkFun VL53L1X 4m Laser Distance Sensor @ 1.2.9, td-er/RABurton ESP8266 Mutex @ ^1.0.2, td-er/SparkFun MAX1704x Fuel Gauge Arduino Library @ ^1.0.1
+lib_deps                  = td-er/ESPeasySerial @ 2.0.7, adafruit/Adafruit ILI9341 @ ^1.5.6, Adafruit GFX Library, LOLIN_EPD, Adafruit BusIO, bblanchon/ArduinoJson @ ^6.17.2, VL53L0X @ 1.3.0, SparkFun VL53L1X 4m Laser Distance Sensor @ 1.2.9, td-er/RABurton ESP8266 Mutex @ ^1.0.2, td-er/SparkFun MAX1704x Fuel Gauge Arduino Library @ ^1.0.1
 lib_ignore                = ${esp82xx_defaults.lib_ignore}, IRremoteESP8266, HeatpumpIR, LittleFS(esp8266), ServoESP32, TinyWireM
 board                     = esp12e
 monitor_filters           = esp8266_exception_decoder


### PR DESCRIPTION
ESP32 does have an issue with restarting serial communication.
Calling `end()` followed by `begin()` on the serial port, may render the port unusable.

This work-around is to keep track of the last used pins and do not call `end()` and `begin()` if the pins have not changed.

It is a really dirty hack, but it does work.

The serial port may be stopped/started when updating a setting on a task, so this was for sure a big issue on ESP32.

See: https://github.com/TD-er/ESPEasySerial/commit/c71148f6bd997bc07b4c90c635d607cb7e8a052d