### PR TITLE
[ESP32] Update GPIO description docs & add event to get boot strap pins

### DIFF
--- a/docs/source/Plugin/P000_events.repl
+++ b/docs/source/Plugin/P000_events.repl
@@ -55,6 +55,38 @@
 
    "
    "
+   ``System#BootMode``
+   Added: 2021-10-18
+  
+   On ESP32 only.
+
+   Event is sent right before network connection is attempted.
+
+   On normal boots (GPIO-0 is high), the ESP32 can record the state of a number of pins and make these available after boot in the ``GPIO_STRAP_REG``.
+
+   ","
+
+   .. code-block:: none
+
+        on System#BootMode do
+          LogEntry,'Boot pins: GPIO-5: %eventvalue1%, GPIO-15: %eventvalue2%, GPIO-4: %eventvalue3%, GPIO-2: %eventvalue4%'
+        endon
+
+   The event values represent the state of these pins in the following order:
+
+   * GPIO-5: ``%eventvalue1%`` (internal pull-up, default: ``1``)
+   * GPIO-15: ``%eventvalue2%`` (internal pull-up, default: ``1``)
+   * GPIO-4: ``%eventvalue3%`` (internal pull-down, default: ``0``)
+   * GPIO-2: ``%eventvalue4%`` (internal pull-down, default: ``0``)
+
+   The standard BootMode event will be: ``System#BootMode=1,1,0,0``
+   
+   N.B. When pulling down GPIO-15 during boot, the ROM bootloader messages will be silenced.
+
+   N.B.2 Do not pull GPIO-2 high when GPIO-0 is low for programming mode.
+
+   "
+   "
    ``System#Boot``
    Triggered at boot time.
    ","

--- a/docs/source/Reference/GPIO.rst
+++ b/docs/source/Reference/GPIO.rst
@@ -115,7 +115,7 @@ Best pins to use on ESP32
 There is also a NodeMCU version using the ESP32.
 Fortunately the designers used the GPIO numbers as labels on the board.
 
-.. list-table:: Best pins to use (best to worst)
+.. list-table:: Sorted in reverse GPIO pinnr order
    :widths: 10 25 25 40
    :header-rows: 1
 
@@ -131,27 +131,19 @@ Fortunately the designers used the GPIO numbers as labels on the board.
      - :green:`OK`
      -
      - :yellow:`input only`
-   * - 34
-     - :green:`OK`
-     -
-     - :yellow:`input only`
    * - 35
      - :green:`OK`
      -
      - :yellow:`input only`
-   * - 32
-     - :green:`OK`
+   * - 34
      - :green:`OK`
      -
+     - :yellow:`input only`
    * - 33
      - :green:`OK`
      - :green:`OK`
      -
-   * - 25
-     - :green:`OK`
-     - :green:`OK`
-     -
-   * - 26
+   * - 32
      - :green:`OK`
      - :green:`OK`
      -
@@ -159,10 +151,14 @@ Fortunately the designers used the GPIO numbers as labels on the board.
      - :green:`OK`
      - :green:`OK`
      -
-   * - 14
+   * - 26
      - :green:`OK`
      - :green:`OK`
-     - :yellow:`output PWM signal at boot`
+     -
+   * - 25
+     - :green:`OK`
+     - :green:`OK`
+     -
    * - 23
      - :green:`OK`
      - :green:`OK`
@@ -183,10 +179,6 @@ Fortunately the designers used the GPIO numbers as labels on the board.
      - :green:`OK`
      - :green:`OK`
      -
-   * - 5
-     - :green:`OK`
-     - :green:`OK`
-     - :yellow:`output PWM signal at boot`
    * - 17
      - :green:`OK`
      - :green:`OK`
@@ -195,44 +187,59 @@ Fortunately the designers used the GPIO numbers as labels on the board.
      - :green:`OK`
      - :green:`OK`
      -
-   * - 4
-     - :green:`OK`
-     - :green:`OK`
-     -
-   * - 2
-     - :green:`OK`
-     - :green:`OK`
-     - Often connected to LED
    * - 15
      - :green:`OK`
      - :green:`OK`
+     - :yellow:`output PWM signal at boot, internal pull-up` Silences boot messages when pulled low at boot.
+   * - 14
+     - :green:`OK`
+     - :green:`OK`
      - :yellow:`output PWM signal at boot`
+   * - 13
+     - :green:`OK`
+     - :green:`OK`
+     -
    * - 12
      -
      - :green:`OK`
-     - :yellow:`Boot fail if pulled high`
-   * - 0
-     - :yellow:`pulled up`
-     - :yellow:`OK`
-     - :yellow:`Boot fail if pulled low & output PWM signal at boot`
-   * - 3 (RX)
-     - :yellow:`High at boot`
-     - :red:`is RX`
-     - RX channel of serial0
-   * - 1 (TX)
-     - :red:`is TX`
-     - :yellow:`debug output at boot`
-     - TX channel of serial0
-   * - 6, 7, 8
-     -
-     -
-     - :red:`See notes`
+     - :yellow:`Boot fail if pulled high` :red:`May damage flash if low at boot on 1.8V flash chips`
    * - 9, 10, 11
      - :red:`High at boot`
      -
      - :red:`See notes`
+   * - 6, 7, 8
+     -
+     -
+     - :red:`See notes`
+   * - 5
+     - :green:`OK`
+     - :green:`OK`
+     - :yellow:`output PWM signal at boot, internal pull-up`
+   * - 4
+     - :green:`OK`
+     - :green:`OK`
+     - :yellow:`Internal pull-down`
+   * - 3 (RX)
+     - :yellow:`High at boot`
+     - :red:`is RX`
+     - RX channel of serial0
+   * - 2
+     - :green:`OK`
+     - :green:`OK`
+     - Often connected to LED, :yellow:`Internal pull-down`
+   * - 1 (TX)
+     - :red:`is TX`
+     - :yellow:`debug output at boot`
+     - TX channel of serial0
+   * - 0
+     - :yellow:`pulled up`
+     - :yellow:`OK`
+     - :yellow:`Boot fail if pulled low & output PWM signal at boot`
 
-Source used: `The Hook Up - How To: Pick the right pins on the NodeMCU ESP8266 and ESP32 <https://www.youtube.com/watch?v=7h2bE2vNoaY>`_
+Source used: 
+
+* `The Hook Up - How To: Pick the right pins on the NodeMCU ESP8266 and ESP32 <https://www.youtube.com/watch?v=7h2bE2vNoaY>`_
+* `Random Nerd Tutorials - ESP32 Pinout Reference: Which GPIO pins should you use? <https://randomnerdtutorials.com/esp32-pinout-reference-gpios/>`_
 
 Special notes on GPIO 6 - 11
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -243,6 +250,37 @@ It is best not to use any of the GPIO pins 6 - 11.
 
 GPIO 6, 7 & 8 may output some PWM signals at boot.
 GPIO 9, 10 & 11 output high at boot and may fail to boot of pulled either high or low.
+
+Boot Strapping Pins
+~~~~~~~~~~~~~~~~~~~
+
+The logic state of some pins during boot determines how the ESP32 will boot and into what mode.
+
+* GPIO-0: Low: flash mode. High: Normal execution mode
+* GPIO-2: Must also be either left unconnected/floating, or driven Low, in order to enter the serial bootloader.  In normal boot mode (GPIO0 high), GPIO2 is ignored.
+* GPIO-12: If driven High, flash voltage (VDD_SDIO) is 1.8V not default 3.3V. Has internal pull-down, so unconnected = Low = 3.3V. May prevent flashing and/or booting if 3.3V flash is used and this pin is pulled high, causing the flash to brownout. See the ESP32 datasheet for more details.
+* GPIO-15: If driven Low, silences boot messages printed by the ROM bootloader. Has an internal pull-up, so unconnected = High = normal output.
+
+There is a number of pins that will be read at boot and their value is displayed in the "boot" value:
+
+.. code-block:: none
+
+  ets Jun  8 2016 00:22:57
+  rst:0x1 (POWERON_RESET),boot:0x3 (DOWNLOAD_BOOT(UART0/UART1/SDIO_REI_REO_V2))
+
+``boot:0xNN (DESCRIPTION)`` is the hex value of the strapping pins, as represented in the GPIO_STRAP register. The individual bit values are as follows:
+
+* ``0x01`` - GPIO5
+* ``0x02`` - MTDO (GPIO15)
+* ``0x04`` - GPIO4
+* ``0x08`` - GPIO2
+* ``0x10`` - GPIO0
+* ``0x20`` - MTDI (GPIO12)
+
+See `boot_mode.h <https://github.com/espressif/esp-idf/blob/1cb31e50943bb757966ca91ed7f4852692a5b0ed/components/soc/esp32/include/soc/boot_mode.h>`_ for more information.
+
+See ``System#BootMode`` event to access the boot strap pin values.
+
 
 
 Pins used for RMII Ethernet PHY

--- a/src/src/ESPEasyCore/ESPEasy_setup.cpp
+++ b/src/src/ESPEasyCore/ESPEasy_setup.cpp
@@ -36,6 +36,11 @@
 # include "../Helpers/OTA.h"
 #endif // ifdef FEATURE_ARDUINO_OTA
 
+#ifdef ESP32
+#include <soc/boot_mode.h>
+#include <soc/gpio_reg.h>
+#endif
+
 
 #ifdef USE_RTOS_MULTITASKING
 void RTOS_TaskServers(void *parameter)
@@ -368,6 +373,24 @@ void ESPEasy_setup()
     String event = F("System#Wake");
     rulesProcessing(event); // TD-er: Process events in the setup() now.
   }
+  #ifdef ESP32
+  if (Settings.UseRules)
+  {
+    const uint32_t gpio_strap =   GPIO_REG_READ(GPIO_STRAP_REG);
+//    BOOT_MODE_GET();
+
+    // Event values: GPIO-5, GPIO-15, GPIO-4, GPIO-2
+    String event = F("System#BootMode=");
+    event += bitRead(gpio_strap, 0); // GPIO-5
+    event += ',';
+    event += bitRead(gpio_strap, 1); // GPIO-15
+    event += ',';
+    event += bitRead(gpio_strap, 2); // GPIO-4
+    event += ',';
+    event += bitRead(gpio_strap, 3); // GPIO-2
+    rulesProcessing(event);
+  }
+  #endif
 
   NetworkConnectRelaxed();
   #ifndef BUILD_NO_RAM_TRACKER


### PR DESCRIPTION
ESP32 can keep track of the pin state of a number of pins at boot.
With this update these pin states will be send at boot as an event, so one may act on it during boot.

Possible use case:
Detect voltage and immediately go to sleep again.
Later features may use these too to enter for example a service mode.