### PR TITLE
[P046 Ventus] Fix UV only "binary" (#3073)

### DIFF
--- a/src/_P046_VentusW266.ino
+++ b/src/_P046_VentusW266.ino
@@ -421,7 +421,7 @@ boolean Plugin_046(uint8_t function, struct EventStruct *event, String& string)
             }
             case (3):
             {
-              float uvindex = float((P046_data->Plugin_046_databuffer[17]) / 10);
+              float uvindex = static_cast<float>(P046_data->Plugin_046_databuffer[17]) / 10.0f;
               UserVar[event->BaseVarIndex] = uvindex;
               break;
             }

--- a/src/_P046_VentusW266.ino
+++ b/src/_P046_VentusW266.ino
@@ -380,19 +380,18 @@ boolean Plugin_046(uint8_t function, struct EventStruct *event, String& string)
             {
               int myTemp = int((P046_data->Plugin_046_databuffer[5] * 256) + P046_data->Plugin_046_databuffer[4]);
               if (myTemp > 0x8000) { myTemp |= 0xffff0000; }                    // int @ esp8266 = 32 bits!
-              float temperature = float(myTemp) / 10.0f; // Temperature
+              float temperature = static_cast<float>(myTemp) / 10.0f; // Temperature
               uint8_t myHum = (P046_data->Plugin_046_databuffer[2] >> 4) * 10 + (P046_data->Plugin_046_databuffer[2] & 0x0f);
-              float humidity = float(myHum);
               UserVar[event->BaseVarIndex] = temperature;
-              UserVar[event->BaseVarIndex + 1] = humidity;
+              UserVar[event->BaseVarIndex + 1] = static_cast<float>(myHum);
               event->sensorType = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
               break;
             }
             case (1):
             {
-              float average = float((P046_data->Plugin_046_databuffer[11] << 8) + P046_data->Plugin_046_databuffer[10]) / 10;   // Wind speed average in m/s
-              float gust = float((P046_data->Plugin_046_databuffer[13] << 8) + P046_data->Plugin_046_databuffer[12]) / 10;      // Wind speed gust in m/s
-              float bearing = float(P046_data->Plugin_046_databuffer[9] & 0x0f) * 22.5f;                              // Wind bearing (0-359)
+              const float average = static_cast<float>((P046_data->Plugin_046_databuffer[11] << 8) + P046_data->Plugin_046_databuffer[10]) / 10.0f;   // Wind speed average in m/s
+              const float gust = static_cast<float>((P046_data->Plugin_046_databuffer[13] << 8) + P046_data->Plugin_046_databuffer[12]) / 10.0f;      // Wind speed gust in m/s
+              const float bearing = static_cast<float>(P046_data->Plugin_046_databuffer[9] & 0x0f) * 22.5f;                              // Wind bearing (0-359)
               UserVar[event->BaseVarIndex] = bearing;                                                     // degrees
               UserVar[event->BaseVarIndex + 1] = average;
               UserVar[event->BaseVarIndex + 2] = gust;
@@ -401,7 +400,7 @@ boolean Plugin_046(uint8_t function, struct EventStruct *event, String& string)
             }
             case (2):
             {
-              float raincnt = float(((P046_data->Plugin_046_databuffer[15]) * 256 + P046_data->Plugin_046_databuffer[14]) / 4);
+              float raincnt = static_cast<float>(((P046_data->Plugin_046_databuffer[15]) * 256 + P046_data->Plugin_046_databuffer[14])) / 4.0f;
               int rainnow = int(raincnt);
               if (wdcounter < Plugin_046_lastrainctr) { Plugin_046_lastrainctr = wdcounter; }
               if (Plugin_046_lastrainctr > (wdcounter + 10))                      // 5 min interval
@@ -409,7 +408,7 @@ boolean Plugin_046(uint8_t function, struct EventStruct *event, String& string)
                 Plugin_046_lastrainctr = wdcounter;
                 if (rainnow > Plugin_046_lastraincount)
                 {                                                                 // per 5 min * 12 = per hour
-                  Plugin_046_rainmmph = float(rainnow - Plugin_046_lastraincount) * 12;
+                  Plugin_046_rainmmph = static_cast<float>(rainnow - Plugin_046_lastraincount) * 12.0f;
                   Plugin_046_lastraincount = rainnow;
                 } else {
                   Plugin_046_rainmmph = 0;
@@ -441,7 +440,7 @@ boolean Plugin_046(uint8_t function, struct EventStruct *event, String& string)
                   Plugin_046_strikesph = 0;
                 }
               }
-              UserVar[event->BaseVarIndex] = float(Plugin_046_strikesph);
+              UserVar[event->BaseVarIndex] = Plugin_046_strikesph;
               break;
             }
             case (5):
@@ -449,24 +448,24 @@ boolean Plugin_046(uint8_t function, struct EventStruct *event, String& string)
               float distance = -1.0f;
               if (P046_data->Plugin_046_databuffer[18] != 0x3F )
               {
-                distance = float(P046_data->Plugin_046_databuffer[18]);
+                distance = P046_data->Plugin_046_databuffer[18];
               }
               UserVar[event->BaseVarIndex] = distance;
               break;
             }
             case (6):
             {
-              UserVar[event->BaseVarIndex] = float(P046_data->Plugin_046_databuffer[6]);
+              UserVar[event->BaseVarIndex] = P046_data->Plugin_046_databuffer[6];
               break;
             }
             case (7):
             {
-              UserVar[event->BaseVarIndex] = float(P046_data->Plugin_046_databuffer[16]);
+              UserVar[event->BaseVarIndex] = P046_data->Plugin_046_databuffer[16];
               break;
             }
             case (8):
             {
-              UserVar[event->BaseVarIndex] = float(P046_data->Plugin_046_databuffer[19]);
+              UserVar[event->BaseVarIndex] = P046_data->Plugin_046_databuffer[19];
               break;
             }
           }   // switch


### PR DESCRIPTION
Fixes: #3073
The read UV value was only converted to float after it was divided by an integer, thus only showing 0 or 1.