### PR TITLE
[P053] Fix support for PMS5003T

### DIFF
--- a/src/_P053_PMSx003.ino
+++ b/src/_P053_PMSx003.ino
@@ -42,13 +42,13 @@ boolean Plugin_053(uint8_t function, struct EventStruct *event, String& string)
       Device[deviceCount].Ports              = 0;
       Device[deviceCount].PullUpOption       = false;
       Device[deviceCount].InverseLogicOption = false;
-        # ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
+      # ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
       Device[deviceCount].FormulaOption = true;
       Device[deviceCount].ValueCount    = 4;
-        # else // ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
+      # else // ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
       Device[deviceCount].FormulaOption = false;
       Device[deviceCount].ValueCount    = 3;
-        # endif // ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
+      # endif // ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
       Device[deviceCount].SendDataOption   = true;
       Device[deviceCount].TimerOption      = true;
       Device[deviceCount].GlobalSyncOption = true;
@@ -166,27 +166,19 @@ boolean Plugin_053(uint8_t function, struct EventStruct *event, String& string)
       # ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
       {
         addFormSubHeader(F("Device"));
-        #  ifdef PLUGIN_053_ENABLE_S_AND_T
-        int unitModelCount = 5;
-        #  else // ifdef PLUGIN_053_ENABLE_S_AND_T
-        int unitModelCount = 3;
-        #  endif // ifdef PLUGIN_053_ENABLE_S_AND_T
+        int unitModelCount                      = 5;
         const __FlashStringHelper *unitModels[] = {
           toString(PMSx003_type::PMS1003_5003_7003),
           toString(PMSx003_type::PMS2003_3003),
-          #  ifdef PLUGIN_053_ENABLE_S_AND_T
           toString(PMSx003_type::PMS5003_S),
           toString(PMSx003_type::PMS5003_T),
-          #  endif // ifdef PLUGIN_053_ENABLE_S_AND_T
           toString(PMSx003_type::PMS5003_ST)
         };
         const int unitModelOptions[] = {
           static_cast<int>(PMSx003_type::PMS1003_5003_7003),
           static_cast<int>(PMSx003_type::PMS2003_3003),
-          #  ifdef PLUGIN_053_ENABLE_S_AND_T
           static_cast<int>(PMSx003_type::PMS5003_S),
           static_cast<int>(PMSx003_type::PMS5003_T),
-          #  endif // ifdef PLUGIN_053_ENABLE_S_AND_T
           static_cast<int>(PMSx003_type::PMS5003_ST)
         };
         addFormSelector(F("Sensor model"), F("p053_model"), unitModelCount, unitModels, unitModelOptions, PLUGIN_053_SENSOR_MODEL_SELECTOR);
@@ -314,9 +306,9 @@ boolean Plugin_053(uint8_t function, struct EventStruct *event, String& string)
 
       PMSx003_type Plugin_053_sensortype = PMSx003_type::PMS1003_5003_7003;
 
-        # ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
+      # ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
       Plugin_053_sensortype = GET_PLUGIN_053_SENSOR_MODEL_SELECTOR;
-        # endif // ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
+      # endif // ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
 
       initPluginTaskData(
         event->TaskIndex,

--- a/src/src/PluginStructs/P053_data_struct.cpp
+++ b/src/src/PluginStructs/P053_data_struct.cpp
@@ -616,11 +616,14 @@ bool P053_data_struct::getValue(uint8_t index, float& value) {
       if (!hasFormaldehyde()) { return false; }
       value = _data[index] / 1000.0f;
       break;
+    case PMS_cnt5_0_100ml:
+    case PMS_cnt10_0_100ml: // this option was missing :-|
+
+      if (_sensortype == PMSx003_type::PMS5003_T) { return false; } // else: fall through
     case PMS_cnt0_3_100ml:
     case PMS_cnt0_5_100ml:
     case PMS_cnt1_0_100ml:
     case PMS_cnt2_5_100ml:
-    case PMS_cnt5_0_100ml:
       value = _data[index];
 
       if (_splitCntBins) {

--- a/src/src/PluginStructs/P053_data_struct.cpp
+++ b/src/src/PluginStructs/P053_data_struct.cpp
@@ -46,17 +46,17 @@ P053_data_struct::P053_data_struct(
   int8_t                  pwrPin,
   PMSx003_type            sensortype,
   uint32_t                delay_read_after_wakeup_ms
-# ifdef                   PLUGIN_053_ENABLE_EXTRA_SENSORS
+  # ifdef                 PLUGIN_053_ENABLE_EXTRA_SENSORS
   , bool                  oversample
   , bool                  splitCntBins
-# endif // ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
+  # endif // ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
   )
   : _taskIndex(TaskIndex),
   _sensortype(sensortype),
-# ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
+  # ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
   _oversample(oversample),
   _splitCntBins(splitCntBins),
-# endif // ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
+  # endif // ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
   _delay_read_after_wakeup_ms(delay_read_after_wakeup_ms),
   _resetPin(resetPin), _pwrPin(pwrPin)
 {
@@ -129,7 +129,7 @@ void P053_data_struct::SerialRead16(uint16_t& value, uint16_t *checksum)
     *checksum += data_low;
   }
 
-# ifdef P053_LOW_LEVEL_DEBUG
+  # ifdef P053_LOW_LEVEL_DEBUG
 
   // Low-level logging to see data from sensor
   String log = F("PMSx003 : uint8_t high=0x");
@@ -139,7 +139,7 @@ void P053_data_struct::SerialRead16(uint16_t& value, uint16_t *checksum)
   log += F(" result=0x");
   log += String(value, HEX);
   addLog(LOG_LEVEL_INFO, log);
-# endif // ifdef P053_LOW_LEVEL_DEBUG
+  # endif // ifdef P053_LOW_LEVEL_DEBUG
 }
 
 void P053_data_struct::SerialFlush() {
@@ -260,16 +260,16 @@ bool P053_data_struct::processData(struct EventStruct *event) {
     SerialRead16(data[i], &checksum);
   }
 
-# ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
+  # ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
 
   if (GET_PLUGIN_053_SENSOR_MODEL_SELECTOR == PMSx003_type::PMS5003_T) {
     data[PMS_Temp_C]  = data[PMS_T_Temp_C]; // Move data to the 'usual' location for Temp/Hum
     data[PMS_Hum_pct] = data[PMS_T_Hum_pct];
   }
-# endif // ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
+  # endif // ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
 
-# ifndef BUILD_NO_DEBUG
-#  ifdef P053_LOW_LEVEL_DEBUG
+  # ifndef BUILD_NO_DEBUG
+  #  ifdef P053_LOW_LEVEL_DEBUG
 
   if (loglevelActiveFor(LOG_LEVEL_DEBUG)) { // Available on all supported sensor models
     String log;
@@ -289,7 +289,7 @@ bool P053_data_struct::processData(struct EventStruct *event) {
     addLog(LOG_LEVEL_DEBUG, log);
   }
 
-#   ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
+  #   ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
 
   if (loglevelActiveFor(LOG_LEVEL_DEBUG)
       && (GET_PLUGIN_053_SENSOR_MODEL_SELECTOR != PMSx003_type::PMS2003_3003)) { // 'Count' values not available on
@@ -312,7 +312,6 @@ bool P053_data_struct::processData(struct EventStruct *event) {
     addLog(LOG_LEVEL_DEBUG, log);
   }
 
-  #    ifdef PLUGIN_053_ENABLE_S_AND_T
 
   if (loglevelActiveFor(LOG_LEVEL_DEBUG)
       && ((GET_PLUGIN_053_SENSOR_MODEL_SELECTOR == PMSx003_type::PMS5003_ST)
@@ -330,10 +329,9 @@ bool P053_data_struct::processData(struct EventStruct *event) {
     }
     addLog(LOG_LEVEL_DEBUG, log);
   }
-  #    endif // ifdef PLUGIN_053_ENABLE_S_AND_T
-  #   endif  // ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
-#  endif     // ifdef P053_LOW_LEVEL_DEBUG
-# endif      // ifndef BUILD_NO_DEBUG
+  #   endif // ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
+  #  endif     // ifdef P053_LOW_LEVEL_DEBUG
+  # endif      // ifndef BUILD_NO_DEBUG
 
   // Compare checksums
   SerialRead16(checksum2, nullptr);
@@ -362,14 +360,14 @@ bool P053_data_struct::processData(struct EventStruct *event) {
       # endif // ifndef BUILD_NO_DEBUG
     return false;
   }
-# ifndef PLUGIN_053_ENABLE_EXTRA_SENSORS
+  # ifndef PLUGIN_053_ENABLE_EXTRA_SENSORS
 
   // Data is checked and good, fill in output
   UserVar[event->BaseVarIndex]     = data[PMS_PM1_0_ug_m3_normal];
   UserVar[event->BaseVarIndex + 1] = data[PMS_PM2_5_ug_m3_normal];
   UserVar[event->BaseVarIndex + 2] = data[PMS_PM10_0_ug_m3_normal];
   _values_received                 = 1;
-# else // ifndef PLUGIN_053_ENABLE_EXTRA_SENSORS
+  # else // ifndef PLUGIN_053_ENABLE_EXTRA_SENSORS
 
   // Store in the averaging buffer to process later
   if (!_oversample) {
@@ -380,7 +378,7 @@ bool P053_data_struct::processData(struct EventStruct *event) {
     _data[i] += data[i];
   }
   ++_values_received;
-# endif // ifndef PLUGIN_053_ENABLE_EXTRA_SENSORS
+  # endif // ifndef PLUGIN_053_ENABLE_EXTRA_SENSORS
 
 
   // Store new checksum, to help detect duplicates.

--- a/src/src/PluginStructs/P053_data_struct.cpp
+++ b/src/src/PluginStructs/P053_data_struct.cpp
@@ -260,6 +260,14 @@ bool P053_data_struct::processData(struct EventStruct *event) {
     SerialRead16(data[i], &checksum);
   }
 
+# ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
+
+  if (GET_PLUGIN_053_SENSOR_MODEL_SELECTOR == PMSx003_type::PMS5003_T) {
+    data[PMS_Temp_C]  = data[PMS_T_Temp_C]; // Move data to the 'usual' location for Temp/Hum
+    data[PMS_Hum_pct] = data[PMS_T_Hum_pct];
+  }
+# endif // ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
+
 # ifndef BUILD_NO_DEBUG
 #  ifdef P053_LOW_LEVEL_DEBUG
 
@@ -307,15 +315,19 @@ bool P053_data_struct::processData(struct EventStruct *event) {
   #    ifdef PLUGIN_053_ENABLE_S_AND_T
 
   if (loglevelActiveFor(LOG_LEVEL_DEBUG)
-      && (GET_PLUGIN_053_SENSOR_MODEL_SELECTOR == PMSx003_type::PMS5003_ST)) { // Values only available on PMS5003ST
+      && ((GET_PLUGIN_053_SENSOR_MODEL_SELECTOR == PMSx003_type::PMS5003_ST)
+          || (GET_PLUGIN_053_SENSOR_MODEL_SELECTOR == PMSx003_type::PMS5003_T))) { // Values only available on PMS5003ST & PMS5003T
     String log;
     log.reserve(45);
     log  = F("PMSx003 : temp=");
     log += static_cast<float>(data[PMS_Temp_C]) / 10.0f;
     log += F(", humi=");
     log += static_cast<float>(data[PMS_Hum_pct]) / 10.0f;
-    log += F(", hcho=");
-    log += static_cast<float>(data[PMS_Formaldehyde_mg_m3]) / 1000.0f;
+
+    if (GET_PLUGIN_053_SENSOR_MODEL_SELECTOR == PMSx003_type::PMS5003_ST) {
+      log += F(", hcho=");
+      log += static_cast<float>(data[PMS_Formaldehyde_mg_m3]) / 1000.0f;
+    }
     addLog(LOG_LEVEL_DEBUG, log);
   }
   #    endif // ifdef PLUGIN_053_ENABLE_S_AND_T

--- a/src/src/PluginStructs/P053_data_struct.h
+++ b/src/src/PluginStructs/P053_data_struct.h
@@ -15,7 +15,8 @@
 // Difference in build size is roughly 4k
 # define PLUGIN_053_ENABLE_EXTRA_SENSORS
 
-// #define PLUGIN_053_ENABLE_S_AND_T // Enable setting to support S and T types, in addition to bas PMSx003 and PMSx003ST
+// Enable setting to support S and T types, in addition to bas PMSx003 and PMSx003ST
+# define PLUGIN_053_ENABLE_S_AND_T
 
 # if !defined(PLUGIN_BUILD_CUSTOM) && defined(SIZE_1M) && defined(PLUGIN_053_ENABLE_EXTRA_SENSORS) // Turn off for 1M OTA builds
 #  undef PLUGIN_053_ENABLE_EXTRA_SENSORS
@@ -108,7 +109,9 @@ const __FlashStringHelper* toString(PMSx003_event_datatype selection);
 
 # define PMS_Formaldehyde_mg_m3    12
 # define PMS_Temp_C                13
+# define PMS_T_Temp_C              10
 # define PMS_Hum_pct               14
+# define PMS_T_Hum_pct             11
 # define PMS_Reserved              15
 # define PMS_FW_rev_error          16
 # define PMS_RECEIVE_BUFFER_SIZE   ((PMS5003_ST_SIZE / 2) - 3)

--- a/src/src/PluginStructs/P053_data_struct.h
+++ b/src/src/PluginStructs/P053_data_struct.h
@@ -15,9 +15,6 @@
 // Difference in build size is roughly 4k
 # define PLUGIN_053_ENABLE_EXTRA_SENSORS
 
-// Enable setting to support S and T types, in addition to bas PMSx003 and PMSx003ST
-# define PLUGIN_053_ENABLE_S_AND_T
-
 # if !defined(PLUGIN_BUILD_CUSTOM) && defined(SIZE_1M) && defined(PLUGIN_053_ENABLE_EXTRA_SENSORS) // Turn off for 1M OTA builds
 #  undef PLUGIN_053_ENABLE_EXTRA_SENSORS
 # endif // if defined(SIZE_1M) && defined(PLUGIN_BUILD_MINIMAL_OTA) && defined(PLUGIN_053_ENABLE_EXTRA_SENSORS)
@@ -128,13 +125,13 @@ public:
     int8_t                  resetPin,
     int8_t                  pwrPin,
     PMSx003_type            sensortype,
-    uint32_t               delay_read_after_wakeup_ms
-# ifdef                     PLUGIN_053_ENABLE_EXTRA_SENSORS
+    uint32_t                delay_read_after_wakeup_ms
+    # ifdef                 PLUGIN_053_ENABLE_EXTRA_SENSORS
     ,
     bool                    oversample
     ,
     bool                    splitCntBins
-# endif // ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
+    # endif // ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
     );
 
   P053_data_struct() = delete;
@@ -158,13 +155,13 @@ public:
 
 private:
 
-# ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
+  # ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
   void sendEvent(const String& baseEvent,
                  uint8_t       index);
 
   bool hasFormaldehyde() const;
   bool hasTempHum() const;
-# endif // ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
+  # endif // ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
 
 public:
 
@@ -186,14 +183,14 @@ private:
 
   void requestData();
 
-# ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
+  # ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
 
   float getValue(uint8_t index);
 
   bool  getValue(uint8_t index,
                  float & value);
 
-# endif // ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
+  # endif // ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
   void clearReceivedData();
 
 public:


### PR DESCRIPTION
Fix reading the Temperature and Humidity from the PMS3005T sensor model.

Resolves: #3840 

To use this sensor requires having a Custom build, and enable compile-time define `PLUGIN_053_ENABLE_S_AND_T` in `Custom.h` or a `pre_custom*.py` script.

May need adjusting of event names for this sensor model.