### PR TITLE
[Build] Enable Dummy device and Neopixel on ESP32 Custom (script)

### DIFF
--- a/tools/pio/pre_custom_esp32.py
+++ b/tools/pio/pre_custom_esp32.py
@@ -31,7 +31,9 @@ else:
     "-DUSES_P026",  # System info
     "-DUSES_P027",  # INA219
     "-DUSES_P028",  # BME280
+    "-DUSES_P033",  # Dummy
     "-DUSES_P036",  # FrameOLED
+    "-DUSES_P038",  # Neopixel
     "-DUSES_P045",  # MPU6050
     "-DUSES_P049",  # MHZ19
     "-DUSES_P052",  # SenseAir


### PR DESCRIPTION
As requested in the [forum](https://www.letscontrolit.com/forum/viewtopic.php?f=4&t=8843)

Adds Generic - Dummy device (for generic use) and Output - NeoPixel (Basic) plugins for use on ESP32-S2 (Saola) units.