### PR TITLE
[Build, MAX] Increase max. plugin count from 125 to 135

### DIFF
--- a/src/src/CustomBuild/ESPEasyLimits.h
+++ b/src/src/CustomBuild/ESPEasyLimits.h
@@ -77,7 +77,7 @@
   #else    // if defined(PLUGIN_BUILD_TESTING) || defined(PLUGIN_BUILD_DEV)
     # ifdef ESP32
       # ifdef PLUGIN_BUILD_MAX_ESP32
-        #  define DEVICES_MAX                      125
+        #  define DEVICES_MAX                    135
       # else // ifdef PLUGIN_BUILD_MAX_ESP32
       #  define DEVICES_MAX                      100
       # endif // ifdef PLUGIN_BUILD_MAX_ESP32

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -1448,6 +1448,36 @@ To create/register a plugin, you have to :
   #ifndef USES_P125
     #define USES_P125   //
   #endif
+  #ifndef USES_P126
+    #define USES_P126   //
+  #endif
+  #ifndef USES_P127
+    #define USES_P127   //
+  #endif
+  #ifndef USES_P128
+    #define USES_P128   //
+  #endif
+  #ifndef USES_P129
+    #define USES_P129   //
+  #endif
+  #ifndef USES_P130
+    #define USES_P130   //
+  #endif
+  #ifndef USES_P131
+    #define USES_P131   //
+  #endif
+  #ifndef USES_P132
+    #define USES_P132   //
+  #endif
+  #ifndef USES_P133
+    #define USES_P133   //
+  #endif
+  #ifndef USES_P134
+    #define USES_P134   //
+  #endif
+  #ifndef USES_P135
+    #define USES_P135   //
+  #endif
 
   // Controllers
   #ifndef USES_C015


### PR DESCRIPTION
To accommodate for Plugin IDs > 125
Only applies to the MAX builds, as they include all available plugins.