### PR TITLE
[Build] Set LIMIT_BUILD_SIZE also for ESP32 on DISPLAY builds (and pre-IDF4.x)

### DIFF
--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -1221,7 +1221,7 @@ To create/register a plugin, you have to :
 
 // Collection of all display plugins. (also NeoPixel)
 #ifdef PLUGIN_DISPLAY_COLLECTION
-   #if !defined(LIMIT_BUILD_SIZE) && (defined(ESP8266) || ESP_IDF_VERSION_MAJOR < 4)
+   #if !defined(LIMIT_BUILD_SIZE) && (defined(ESP8266) || !(ESP_IDF_VERSION_MAJOR > 3))
      #define LIMIT_BUILD_SIZE // Reduce buildsize (on ESP8266 / pre-IDF4.x) to fit in all Display plugins
    #endif
    #ifndef USES_P012

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -1221,8 +1221,8 @@ To create/register a plugin, you have to :
 
 // Collection of all display plugins. (also NeoPixel)
 #ifdef PLUGIN_DISPLAY_COLLECTION
-   #if !defined(LIMIT_BUILD_SIZE) && defined(ESP8266)
-    #define LIMIT_BUILD_SIZE // Redice buildsize on ESP8266 to fit in all Display plugins
+   #if !defined(LIMIT_BUILD_SIZE) && (defined(ESP8266) || ESP_IDF_VERSION_MAJOR < 4)
+     #define LIMIT_BUILD_SIZE // Reduce buildsize (on ESP8266 / pre-IDF4.x) to fit in all Display plugins
    #endif
    #ifndef USES_P012
      #define USES_P012   // LCD


### PR DESCRIPTION
To fix build-size issue for ESP32 `DISPLAY` build.