### PR TITLE
[Formatting] Fix issue with unexpected leading space

### DIFF
--- a/src/src/Helpers/Convert.cpp
+++ b/src/src/Helpers/Convert.cpp
@@ -244,6 +244,7 @@ String toString(const float& value, uint8_t decimals)
 
 String doubleToString(const double& value, int decimals, bool trimTrailingZeros) {
   String res(value, decimals);
+  res.trim();
   if (trimTrailingZeros) {
     int dot_pos = res.lastIndexOf('.');
     if (dot_pos != -1) {


### PR DESCRIPTION
Resolves #3921
 
An unexpected leading space seems to be inserted by the Arduino `String(value, decimals)` constructor if the result is length 1 and decimals is 0. Trimming the result solves that.