### PR TITLE
[Log] Prevent String copy when adding log

### DIFF
--- a/src/_C002.cpp
+++ b/src/_C002.cpp
@@ -190,7 +190,7 @@ bool CPlugin_002(CPlugin::Function function, struct EventStruct *event, String& 
         if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
           String log = F("MQTT : ");
           log += json;
-          addLog(LOG_LEVEL_DEBUG, log);
+          addLogMove(LOG_LEVEL_DEBUG, log);
         }
 # endif // ifndef BUILD_NO_DEBUG
 

--- a/src/_C005.cpp
+++ b/src/_C005.cpp
@@ -161,7 +161,7 @@ bool CPlugin_005(CPlugin::Function function, struct EventStruct *event, String& 
           log += tmppubname;
           log += ' ';
           log += value;
-          addLog(LOG_LEVEL_DEBUG, log);
+          addLogMove(LOG_LEVEL_DEBUG, log);
         }
 # endif // ifndef BUILD_NO_DEBUG
 

--- a/src/_C008.cpp
+++ b/src/_C008.cpp
@@ -49,7 +49,7 @@ bool CPlugin_008(CPlugin::Function function, struct EventStruct *event, String& 
 
     case CPlugin::Function::CPLUGIN_PROTOCOL_TEMPLATE:
     {
-      event->String1.clear();
+      event->String1 = String();
       event->String2 = F("demo.php?name=%sysname%&task=%tskname%&valuename=%valname%&value=%value%");
       break;
     }

--- a/src/_C008.cpp
+++ b/src/_C008.cpp
@@ -89,13 +89,12 @@ bool CPlugin_008(CPlugin::Function function, struct EventStruct *event, String& 
 
         for (uint8_t x = 0; x < valueCount; x++)
         {
-          String tmppubname = pubname;
           bool   isvalid;
-          String formattedValue = formatUserVar(event, x, isvalid);
+          const String formattedValue = formatUserVar(event, x, isvalid);
 
           if (isvalid) {
-            element.txt[x]  = "/";
-            element.txt[x] += tmppubname;
+            element.txt[x]  = '/';
+            element.txt[x] += pubname;
             parseSingleControllerVariable(element.txt[x], event, x, true);
             element.txt[x].replace(F("%value%"), formattedValue);
 # ifndef BUILD_NO_DEBUG

--- a/src/_C009.cpp
+++ b/src/_C009.cpp
@@ -126,7 +126,7 @@ bool do_process_c009_delay_queue(int controller_number, const C009_queue_element
       }
     }
     {
-      jsonString = '{';
+      jsonString += '{';
       {
         jsonString += to_json_object_value(F("module"),  F("ESPEasy"));
         jsonString += ',';

--- a/src/_C010.cpp
+++ b/src/_C010.cpp
@@ -83,11 +83,10 @@ bool CPlugin_010(CPlugin::Function function, struct EventStruct *event, String& 
         for (uint8_t x = 0; x < valueCount; x++)
         {
           bool   isvalid;
-          String formattedValue = formatUserVar(event, x, isvalid);
+          const String formattedValue = formatUserVar(event, x, isvalid);
 
           if (isvalid) {
-            String tmppubname = pubname;
-            element.txt[x] = tmppubname;
+            element.txt[x] = pubname;
             parseSingleControllerVariable(element.txt[x], event, x, false);
             element.txt[x].replace(F("%value%"), formattedValue);
             if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE))

--- a/src/_C010.cpp
+++ b/src/_C010.cpp
@@ -35,7 +35,7 @@ bool CPlugin_010(CPlugin::Function function, struct EventStruct *event, String& 
 
     case CPlugin::Function::CPLUGIN_PROTOCOL_TEMPLATE:
     {
-      event->String1.clear();
+      event->String1 = String();
       event->String2 = F("%sysname%_%tskname%_%valname%=%value%");
       break;
     }

--- a/src/_C011.cpp
+++ b/src/_C011.cpp
@@ -276,7 +276,7 @@ boolean Create_schedule_HTTP_C011(struct EventStruct *event)
         log += element.uri;
         log += element.header;
         log += element.postStr;
-        addLog(LOG_LEVEL_ERROR, log);
+        addLogMove(LOG_LEVEL_ERROR, log);
       }
       C011_DelayHandler->sendQueue.pop_back();
       return false;
@@ -357,25 +357,31 @@ void ReplaceTokenByValue(String& s, struct EventStruct *event, bool sendBinary)
   // write?db=testdb&type=%1%%vname1%%/1%%2%;%vname2%%/2%%3%;%vname3%%/3%%4%;%vname4%%/4%&value=%1%%val1%%/1%%2%;%val2%%/2%%3%;%val3%%/3%%4%;%val4%%/4%
   //	%1%%vname1%,Standort=%tskname% Wert=%val1%%/1%%2%%LF%%vname2%,Standort=%tskname% Wert=%val2%%/2%%3%%LF%%vname3%,Standort=%tskname%
   //  Wert=%val3%%/3%%4%%LF%%vname4%,Standort=%tskname% Wert=%val4%%/4%
+  #ifndef BUILD_NO_DEBUG
   if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE)) {
     addLog(LOG_LEVEL_DEBUG_MORE, F("HTTP before parsing: "));
     addLog(LOG_LEVEL_DEBUG_MORE, s);
   }
+  #endif
   const uint8_t valueCount = getValueCountForTask(event->TaskIndex);
 
   DeleteNotNeededValues(s, valueCount);
 
+  #ifndef BUILD_NO_DEBUG
   if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE)) {
     addLog(LOG_LEVEL_DEBUG_MORE, F("HTTP after parsing: "));
     addLog(LOG_LEVEL_DEBUG_MORE, s);
   }
+  #endif
 
   parseControllerVariables(s, event, !sendBinary);
 
+  #ifndef BUILD_NO_DEBUG
   if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE)) {
     addLog(LOG_LEVEL_DEBUG_MORE, F("HTTP after replacements: "));
     addLog(LOG_LEVEL_DEBUG_MORE, s);
   }
+  #endif
 }
 
 #endif // ifdef USES_C011

--- a/src/_C012.cpp
+++ b/src/_C012.cpp
@@ -63,7 +63,7 @@ bool CPlugin_012(CPlugin::Function function, struct EventStruct *event, String& 
       for (uint8_t x = 0; x < valueCount; x++)
       {
         bool   isvalid;
-        String formattedValue = formatUserVar(event, x, isvalid);
+        const String formattedValue = formatUserVar(event, x, isvalid);
 
         if (isvalid) {
           element.txt[x]  = F("update/V");

--- a/src/_C013.cpp
+++ b/src/_C013.cpp
@@ -192,7 +192,7 @@ void C013_sendUDP(uint8_t unit, const uint8_t *data, uint8_t size)
   if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE)) {
     String log = F("C013 : Send UDP message to ");
     log += unit;
-    addLog(LOG_LEVEL_DEBUG_MORE, log);
+    addLogMove(LOG_LEVEL_DEBUG_MORE, log);
   }
 # endif // ifndef BUILD_NO_DEBUG
 
@@ -233,7 +233,7 @@ void C013_Receive(struct EventStruct *event) {
         log += ' ';
         log += static_cast<int>(event->Data[x]);
       }
-      addLog(LOG_LEVEL_DEBUG_MORE, log);
+      addLogMove(LOG_LEVEL_DEBUG_MORE, log);
     }
   }
 # endif // ifndef BUILD_NO_DEBUG

--- a/src/_C014.cpp
+++ b/src/_C014.cpp
@@ -829,7 +829,6 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
           {
             if (Settings.UseRules) {
               String newEvent = parseStringToEnd(cmd, 2);
-              eventQueue.add(newEvent);
 
               if (loglevelActiveFor(LOG_LEVEL_INFO)) {
                 String log = F("C014 : taskIndex:");
@@ -847,6 +846,7 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
                 log += newEvent;
                 addLogMove(LOG_LEVEL_INFO, log);
               }
+              eventQueue.addMove(std::move(newEvent));
             }
           } else { // not an event
             String log;

--- a/src/_C014.cpp
+++ b/src/_C014.cpp
@@ -89,7 +89,7 @@ bool CPlugin_014_sendMQTTdevice(String tmppubname,
     log += F(" P: ");
     log += payload;
     log += F(" success!");
-    addLog(LOG_LEVEL_DEBUG_MORE, log);
+    addLogMove(LOG_LEVEL_DEBUG_MORE, log);
   }
 #endif
 
@@ -99,7 +99,7 @@ bool CPlugin_014_sendMQTTdevice(String tmppubname,
     log += F(" P: ");
     log += payload;
     log += F(" ERROR!");
-    addLog(LOG_LEVEL_ERROR, log);
+    addLogMove(LOG_LEVEL_ERROR, log);
   }
   processMQTTdelayQueue();
   return mqttReturn;
@@ -130,6 +130,7 @@ bool CPlugin_014_sendMQTTnode(String      tmppubname,
   if (mqttReturn) { msgCounter++; }
   else { errorCounter++; }
 
+  #ifndef BUILD_NO_DEBUG
   if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE) && mqttReturn) {
     String log = F("C014 : V:");
     log += value;
@@ -138,8 +139,9 @@ bool CPlugin_014_sendMQTTnode(String      tmppubname,
     log += F(" P: ");
     log += payload;
     log += F(" success!");
-    addLog(LOG_LEVEL_DEBUG_MORE, log);
+    addLogMove(LOG_LEVEL_DEBUG_MORE, log);
   }
+  #endif
 
   if (loglevelActiveFor(LOG_LEVEL_ERROR) && !mqttReturn) {
     String log = F("C014 : V:");
@@ -149,7 +151,7 @@ bool CPlugin_014_sendMQTTnode(String      tmppubname,
     log += F(" P: ");
     log += payload;
     log += F(" ERROR!");
-    addLog(LOG_LEVEL_ERROR, log);
+    addLogMove(LOG_LEVEL_ERROR, log);
   }
   processMQTTdelayQueue();
   return mqttReturn;
@@ -237,6 +239,7 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
           success = true;
         }
 
+        #ifndef BUILD_NO_DEBUG
         if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
           String log = F("C014 : $stats information sent with ");
 
@@ -246,8 +249,9 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
           log       += msgCounter;
           log       += F(" messages)");
           msgCounter = 0;
-          addLog(LOG_LEVEL_DEBUG, log);
+          addLogMove(LOG_LEVEL_DEBUG, log);
         }
+        #endif
       }
       break;
     }
@@ -552,12 +556,14 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
                     }
                   }      // end loop throug values
                 } else { // Device has custom Values
+                  #ifndef BUILD_NO_DEBUG
                   if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
                     String log = F("C014 : Device has custom values: ");
                     log += getPluginNameFromDeviceIndex(getDeviceIndex_from_TaskIndex(x));
                     log += F(" not implemented!");
-                    addLog(LOG_LEVEL_DEBUG, log);
+                    addLogMove(LOG_LEVEL_DEBUG, log);
                   }
+                  #endif
                 }
               }
 
@@ -595,12 +601,14 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
                 valuesList = F("");
               }
             } else { // device not enabeled
+              #ifndef BUILD_NO_DEBUG
               if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
                 String log = F("C014 : Device Disabled: ");
                 log += getPluginNameFromDeviceIndex(getDeviceIndex_from_TaskIndex(x));
                 log += F(" not propagated!");
-                addLog(LOG_LEVEL_DEBUG, log);
+                addLogMove(LOG_LEVEL_DEBUG, log);
               }
+              #endif
             }
           } // device configured
         }   // loop through devices
@@ -636,7 +644,7 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
         log         += F(" errors! (");
         log         += msgCounter;
         log         += F(" messages)");
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
       msgCounter   = 0;
       errorCounter = 0;
@@ -665,7 +673,7 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
 
         if (success) { log += F(" got invalid (disconnected)."); }
         else { log += F(" got invaild (disconnect) failed!"); }
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
       break;
     }
@@ -837,7 +845,7 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
                 }
                 log += F(" Event: ");
                 log += newEvent;
-                addLog(LOG_LEVEL_INFO, log);
+                addLogMove(LOG_LEVEL_INFO, log);
               }
             }
           } else { // not an event
@@ -864,7 +872,7 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
             }
 
             if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-              addLog(LOG_LEVEL_INFO, log);
+              addLogMove(LOG_LEVEL_INFO, log);
             }
           }
         }
@@ -900,13 +908,15 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
           MQTTpublish(event->ControllerIndex, event->TaskIndex, tmppubname.c_str(), value.c_str(), mqtt_retainFlag);
         }
 
+#ifndef BUILD_NO_DEBUG
         if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
           String log = F("C014 : Sent to ");
           log += tmppubname;
           log += ' ';
           log += value;
-          addLog(LOG_LEVEL_DEBUG, log);
+          addLogMove(LOG_LEVEL_DEBUG, log);
         }
+#endif
       }
       break;
     }
@@ -979,7 +989,7 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
             log += valueInt;
             log += ')';
             log += F(" success!");
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
           }
 
           if (loglevelActiveFor(LOG_LEVEL_ERROR) && !success) {
@@ -991,7 +1001,7 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
             log += valueInt;
             log += ')';
             log += F(" ERROR!");
-            addLog(LOG_LEVEL_ERROR, log);
+            addLogMove(LOG_LEVEL_ERROR, log);
           }
         } else // not gpio
         {
@@ -1025,7 +1035,7 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
                 log += F(" value: ");
                 log += valueStr;
                 log += F(" success!");
-                addLog(LOG_LEVEL_INFO, log);
+                addLogMove(LOG_LEVEL_INFO, log);
               }
 
               if (loglevelActiveFor(LOG_LEVEL_ERROR) && !success) {
@@ -1038,7 +1048,7 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
                 log += F(" value: ");
                 log += valueStr;
                 log += F(" ERROR!");
-                addLog(LOG_LEVEL_ERROR, log);
+                addLogMove(LOG_LEVEL_ERROR, log);
               }
             } else if (parseString(commandName, 1) == F("homievalueset")) { // acknolages value form P086 Homie Receiver
               switch (Settings.TaskDevicePluginConfig[deviceIndex - 1][taskVarIndex]) {
@@ -1091,7 +1101,7 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
                 log += F(" valueStr:");
                 log += valueStr;
                 log += F(" success!");
-                addLog(LOG_LEVEL_INFO, log);
+                addLogMove(LOG_LEVEL_INFO, log);
               }
 
               if (loglevelActiveFor(LOG_LEVEL_ERROR) && !success) {
@@ -1104,7 +1114,7 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
                 log += F(" value: ");
                 log += valueStr;
                 log += F(" failed!");
-                addLog(LOG_LEVEL_ERROR, log);
+                addLogMove(LOG_LEVEL_ERROR, log);
               }
             } else // Acknowledge not implemented yet
             {

--- a/src/_C015.cpp
+++ b/src/_C015.cpp
@@ -224,7 +224,7 @@ bool CPlugin_015(CPlugin::Function function, struct EventStruct *event, String& 
               log += F(", got not valid value: ");
               log += vPinNumberStr;
             }
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
           }
           element.vPin[x] = vPinNumber;
           element.txt[x]  = formattedValue;
@@ -316,8 +316,10 @@ boolean Blynk_keep_connection_c015(int controllerIndex, ControllerSettingsStruct
       String hostName = ControllerSettings.getHost();
 
       if (!hostName.isEmpty()) {
-        log += F("Connecting to custom blynk server ");
-        log += ControllerSettings.getHostPortString();
+        if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+          log += F("Connecting to custom blynk server ");
+          log += ControllerSettings.getHostPortString();
+        }
         Blynk.config(auth.c_str(),
                      CPlugin_015_handleInterrupt,
                      hostName.c_str(),
@@ -328,7 +330,9 @@ boolean Blynk_keep_connection_c015(int controllerIndex, ControllerSettingsStruct
                      );
       }
       else {
-        log           += F("Custom blynk server name not specified. ");
+        if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+          log += F("Custom blynk server name not specified. ");
+        }
         connectDefault = true;
       }
     }
@@ -336,8 +340,10 @@ boolean Blynk_keep_connection_c015(int controllerIndex, ControllerSettingsStruct
       IPAddress ip = ControllerSettings.getIP();
 
       if ((ip[0] + ip[1] + ip[2] + ip[3]) > 0) {
-        log += F("Connecting to custom blynk server ");
-        log += ControllerSettings.getHostPortString();
+        if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+          log += F("Connecting to custom blynk server ");
+          log += ControllerSettings.getHostPortString();
+        }
         Blynk.config(auth.c_str(),
                      CPlugin_015_handleInterrupt,
                      ip,
@@ -348,11 +354,13 @@ boolean Blynk_keep_connection_c015(int controllerIndex, ControllerSettingsStruct
                      );
       }
       else {
-        log           += F("Custom blynk server ip not specified. ");
+        if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+          log += F("Custom blynk server ip not specified. ");
+        }
         connectDefault = true;
       }
     }
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
 
     if (connectDefault) {
       addLog(LOG_LEVEL_INFO, F(C015_LOG_PREFIX "Connecting to default server"));
@@ -412,7 +420,7 @@ String Command_Blynk_Set_c015(struct EventStruct *event, const char *Line) {
     log += vPin;
     log += F(" = ");
     log += data;
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
 
   Blynk.virtualWrite(vPin, data);
@@ -441,7 +449,7 @@ BLYNK_WRITE_DEFAULT() {
     log += vPin;
     log += F(" to ");
     log += pinValue;
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
 
   if (Settings.UseRules) {

--- a/src/_C015.cpp
+++ b/src/_C015.cpp
@@ -194,7 +194,7 @@ bool CPlugin_015(CPlugin::Function function, struct EventStruct *event, String& 
 
           if (!isvalid) {
             // send empty string to Blynk in case of error
-            formattedValue = EMPTY_STRING;
+            formattedValue = String();
           }
 
           String valueName     = ExtraTaskSettings.TaskDeviceValueNames[x];

--- a/src/_C016.cpp
+++ b/src/_C016.cpp
@@ -104,8 +104,8 @@ bool CPlugin_016(CPlugin::Function function, struct EventStruct *event, String& 
 
     case CPlugin::Function::CPLUGIN_PROTOCOL_TEMPLATE:
     {
-      event->String1.clear();
-      event->String2.clear();
+      event->String1 = String();
+      event->String2 = String();
       break;
     }
 

--- a/src/_C018.cpp
+++ b/src/_C018.cpp
@@ -204,7 +204,7 @@ struct C018_data_struct {
     if (loglevelActiveFor(LOG_LEVEL_INFO)) {
       String log = F("sendRawCommand: ");
       log += command;
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
     String res = myLora->sendRawCommand(command);
 
@@ -347,7 +347,7 @@ private:
         log += command;
         log += F(": ");
         log += error;
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
     }
   }
@@ -410,7 +410,7 @@ private:
         log += response;
         log += F(" status: ");
         log += myLora->sendRawCommand(F("mac get status"));
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
         C018_logError(F("autobaud check"));
       }
       --retries;
@@ -924,7 +924,7 @@ bool C018_init(struct EventStruct *event) {
       log += F(" DevEUI: ");
       log += customConfig->DeviceEUI;
 
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
 
     if (!C018_data->initOTAA(AppEUI, AppKey, customConfig->DeviceEUI)) {
@@ -971,7 +971,7 @@ bool do_process_c018_delay_queue(int controller_number, const C018_queue_element
           log += F(" Air Time: ");
           log += toString(airtime_ms, 3);
           log += F(" ms");
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
       }
     }
@@ -992,7 +992,7 @@ bool do_process_c018_delay_queue(int controller_number, const C018_queue_element
       log += F(" (success) ");
     }
     log += error;
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
 
   if (mustSetDelay) {
@@ -1005,7 +1005,7 @@ bool do_process_c018_delay_queue(int controller_number, const C018_queue_element
       String log = F("LoRaWAN : Unable to send. Delay for ");
       log += 10 * airtime_ms;
       log += F(" ms");
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
   }
 

--- a/src/_C018.cpp
+++ b/src/_C018.cpp
@@ -48,9 +48,9 @@ struct C018_data_struct {
       delete C018_easySerial;
       C018_easySerial = nullptr;
     }
-    cacheDevAddr.clear();
-    cacheHWEUI.clear();
-    cacheSysVer.clear();
+    cacheDevAddr = String();
+    cacheHWEUI = String();
+    cacheSysVer = String();
     autobaud_success = false;
   }
 
@@ -353,7 +353,7 @@ private:
   }
 
   void updateCacheOnInit() {
-    cacheDevAddr.clear();
+    cacheDevAddr = String();
 
     if (isInitialized()) {
       if (myLora->getStatus().Joined)
@@ -361,7 +361,7 @@ private:
         cacheDevAddr = myLora->sendRawCommand(F("mac get devaddr"));
 
         if (cacheDevAddr == F("00000000")) {
-          cacheDevAddr.clear();
+          cacheDevAddr = String();
         }
       }
     }

--- a/src/_N001_Email.cpp
+++ b/src/_N001_Email.cpp
@@ -159,10 +159,11 @@ bool NPlugin_001_send(const NotificationSettingsStruct& notificationsettings, co
 				break;
 			}
 			while (nextAddressAvailable) {
-				String mailFound = F("Email: To ");
-				mailFound += emailTo;
-				if (loglevelActiveFor(LOG_LEVEL_INFO))
-					addLog(LOG_LEVEL_INFO, mailFound);
+				if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+					String log = F("Email: To ");
+					log += emailTo;
+					addLogMove(LOG_LEVEL_INFO, log);
+				}
 				if (!NPlugin_001_MTA(client, String(F("RCPT TO:<")) + emailTo + ">", F("250 "))) break;
 				++i;
 				nextAddressAvailable = getNextMailAddress(notificationsettings.Receiver, emailTo, i);
@@ -184,7 +185,7 @@ bool NPlugin_001_send(const NotificationSettingsStruct& notificationsettings, co
 			if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
 				String log = F("EMAIL: Connection Closed With Error. Used header: ");
 				log += mailheader;
-				addLog(LOG_LEVEL_ERROR, log);
+				addLogMove(LOG_LEVEL_ERROR, log);
 			}
 		}
 	}
@@ -224,7 +225,7 @@ bool NPlugin_001_MTA(WiFiClient& client, const String& aStr, const String &aWait
 			if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
 				String log = F("NPlugin_001_MTA: timeout. ");
 				log += aStr;
-				addLog(LOG_LEVEL_ERROR, log);
+				addLogMove(LOG_LEVEL_ERROR, log);
 			}
 			return false;
 		}
@@ -235,10 +236,14 @@ bool NPlugin_001_MTA(WiFiClient& client, const String& aStr, const String &aWait
 		String line;
 		safeReadStringUntil(client, line, '\n');
 
-        if (loglevelActiveFor(LOG_LEVEL_DEBUG))
-			addLog(LOG_LEVEL_DEBUG, line);
+		const bool patternFound = line.indexOf(aWaitForPattern) >= 0;
 
-		if (line.indexOf(aWaitForPattern) >= 0) {
+		#ifndef BUILD_NO_DEBUG
+        if (loglevelActiveFor(LOG_LEVEL_DEBUG))
+			addLogMove(LOG_LEVEL_DEBUG, line);
+		#endif
+
+		if (patternFound) {
 			return true;
 		}
 	}

--- a/src/_P001_Switch.ino
+++ b/src/_P001_Switch.ino
@@ -526,7 +526,7 @@ boolean Plugin_001(uint8_t function, struct EventStruct *event, String& string)
                   log += state ? '1' : '0';
                   log += output_value == 3 ? F(" Doubleclick=") : F(" Output value=");
                   log += output_value;
-                  addLog(LOG_LEVEL_INFO, log);
+                  addLogMove(LOG_LEVEL_INFO, log);
                 }
                 #endif
                 // send task event
@@ -620,7 +620,7 @@ boolean Plugin_001(uint8_t function, struct EventStruct *event, String& string)
                   log += state ? '1' : '0';
                   log += F(" Output value=");
                   log += output_value;
-                  addLog(LOG_LEVEL_INFO, log);
+                  addLogMove(LOG_LEVEL_INFO, log);
                 }
                 #endif
                 // send task event
@@ -649,7 +649,7 @@ boolean Plugin_001(uint8_t function, struct EventStruct *event, String& string)
                 log += CONFIG_PIN1;
                 log += F(" State=");
                 log += tempUserVar;
-                addLog(LOG_LEVEL_INFO, log);
+                addLogMove(LOG_LEVEL_INFO, log);
               }
               #endif
               // send task event: DO NOT SEND TASK EVENT
@@ -703,7 +703,7 @@ boolean Plugin_001(uint8_t function, struct EventStruct *event, String& string)
       if (loglevelActiveFor(LOG_LEVEL_INFO)) {
         String log = F("SW   : State ");
         log += UserVar[event->BaseVarIndex];
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
       #endif
       success = true;
@@ -723,7 +723,7 @@ boolean Plugin_001(uint8_t function, struct EventStruct *event, String& string)
         if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
           String log = F("inputswitchstate is deprecated");
           log += string;
-          addLog(LOG_LEVEL_ERROR, log);
+          addLogMove(LOG_LEVEL_ERROR, log);
         }
 
 /*        portStatusStruct tempStatus;

--- a/src/_P002_ADC.ino
+++ b/src/_P002_ADC.ino
@@ -236,7 +236,7 @@ boolean Plugin_002(uint8_t function, struct EventStruct *event, String& string)
               log += P002_data->OversamplingCount;
               log += F(" samples)");
             }
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
           }
           P002_data->reset();
           success = true;

--- a/src/_P003_Pulse.ino
+++ b/src/_P003_Pulse.ino
@@ -179,7 +179,7 @@ boolean Plugin_003(uint8_t function, struct EventStruct *event, String& string)
         if (loglevelActiveFor(LOG_LEVEL_INFO)) {
           String log; 
           if (log.reserve(20)) {
-            log = F("INIT : PulsePin: "); 
+            log += F("INIT : PulsePin: "); 
             log += Settings.TaskDevicePin1[event->TaskIndex];
             addLogMove(LOG_LEVEL_INFO, log);
           }

--- a/src/_P003_Pulse.ino
+++ b/src/_P003_Pulse.ino
@@ -181,7 +181,7 @@ boolean Plugin_003(uint8_t function, struct EventStruct *event, String& string)
           if (log.reserve(20)) {
             log = F("INIT : PulsePin: "); 
             log += Settings.TaskDevicePin1[event->TaskIndex];
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
           }
         }
 

--- a/src/_P004_Dallas.ino
+++ b/src/_P004_Dallas.ino
@@ -308,7 +308,7 @@ boolean Plugin_004(uint8_t function, struct EventStruct *event, String& string)
                 log += F(" (");
                 log += P004_data->get_formatted_address(i);
                 log += ')';
-                addLog(LOG_LEVEL_INFO, log);
+                addLogMove(LOG_LEVEL_INFO, log);
               }
             }
             P004_data->set_measurement_inactive();

--- a/src/_P005_DHT.ino
+++ b/src/_P005_DHT.ino
@@ -115,17 +115,21 @@ void P005_log(struct EventStruct *event, int logNr)
     case P005_error_checksum_error:      text += F("Checksum Error"); break;
     case P005_error_invalid_NAN_reading: text += F("Invalid NAN reading"); break;
     case P005_info_temperature:
-      text += F("Temperature: ");
-      text += formatUserVarNoCheck(event->TaskIndex, 0);
+      if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+        text += F("Temperature: ");
+        text += formatUserVarNoCheck(event->TaskIndex, 0);
+      }
       isError = false;
       break;
     case P005_info_humidity:
-      text += F("Humidity: ");
-      text += formatUserVarNoCheck(event->TaskIndex, 1);
+      if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+        text += F("Humidity: ");
+        text += formatUserVarNoCheck(event->TaskIndex, 1);
+      }
       isError = false;
       break;
   }
-  addLog(LOG_LEVEL_INFO, text);
+  addLogMove(LOG_LEVEL_INFO, text);
   if (isError) {
     UserVar[event->BaseVarIndex] = NAN;
     UserVar[event->BaseVarIndex + 1] = NAN;

--- a/src/_P006_BMP085.ino
+++ b/src/_P006_BMP085.ino
@@ -103,10 +103,10 @@ boolean Plugin_006(uint8_t function, struct EventStruct *event, String& string)
           if (loglevelActiveFor(LOG_LEVEL_INFO)) {
             String log = F("BMP  : Temperature: ");
             log += formatUserVarNoCheck(event->TaskIndex, 0);
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
             log  = F("BMP  : Barometric Pressure: ");
             log += formatUserVarNoCheck(event->TaskIndex, 1);
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
           }
           success = true;
         }

--- a/src/_P007_PCF8591.ino
+++ b/src/_P007_PCF8591.ino
@@ -181,7 +181,7 @@ boolean Plugin_007(uint8_t function, struct EventStruct *event, String& string)
                 log += ':';
                 log += ' ';
                 log += formatUserVarNoCheck(event->TaskIndex, var);
-                addLog(LOG_LEVEL_INFO, log);
+                addLogMove(LOG_LEVEL_INFO, log);
               }
             }
             success = true;

--- a/src/_P007_PCF8591.ino
+++ b/src/_P007_PCF8591.ino
@@ -174,7 +174,7 @@ boolean Plugin_007(uint8_t function, struct EventStruct *event, String& string)
             if (loglevelActiveFor(LOG_LEVEL_INFO)) {
               String log;
               if (log.reserve(40)) {
-                log  = F("PCF  : Analog port: A");
+                log += F("PCF  : Analog port: A");
                 log += port - 1;
                 log += F(" value ");
                 log += var + 1;

--- a/src/_P008_RFID.ino
+++ b/src/_P008_RFID.ino
@@ -182,7 +182,7 @@ boolean Plugin_008(uint8_t function, struct EventStruct *event, String& string)
               if (loglevelActiveFor(LOG_LEVEL_INFO)) {
                 String log = F("RFID : reset bits: ");
                 log += Plugin_008_bitCount;
-                addLog(LOG_LEVEL_INFO, log);
+                addLogMove(LOG_LEVEL_INFO, log);
               }
 
               // reset after ~5 sec
@@ -221,7 +221,7 @@ boolean Plugin_008(uint8_t function, struct EventStruct *event, String& string)
             log += ull2String(keyMask, 16);
             log += F(" Bits: ");
             log += Plugin_008_bitCount;
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
           }
 
           // reset everything

--- a/src/_P009_MCP.ino
+++ b/src/_P009_MCP.ino
@@ -236,7 +236,7 @@ boolean Plugin_009(uint8_t function, struct EventStruct *event, String& string)
         if (loglevelActiveFor(LOG_LEVEL_INFO)) {
           String log = F("MCP INIT=");
           log += newStatus.state;
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
         newStatus.output                         = newStatus.state;
         (newStatus.state == -1) ? newStatus.mode = PIN_MODE_OFFLINE : newStatus.mode = PIN_MODE_INPUT_PULLUP; // @giig1967g: if it is in the
@@ -386,7 +386,7 @@ boolean Plugin_009(uint8_t function, struct EventStruct *event, String& string)
               log += state;
               log += output_value == 3 ? F(" Doubleclick=") : F(" Output value=");
               log += output_value;
-              addLog(LOG_LEVEL_INFO, log);
+              addLogMove(LOG_LEVEL_INFO, log);
             }
 
             // send task event
@@ -453,7 +453,7 @@ boolean Plugin_009(uint8_t function, struct EventStruct *event, String& string)
               log += state ? '1' : '0';
               log += F(" Output value=");
               log += output_value;
-              addLog(LOG_LEVEL_INFO, log);
+              addLogMove(LOG_LEVEL_INFO, log);
             }
 
             // send task event
@@ -479,7 +479,7 @@ boolean Plugin_009(uint8_t function, struct EventStruct *event, String& string)
               log += CONFIG_PORT;
               log += F(" State=");
               log += tempUserVar;
-              addLog(LOG_LEVEL_INFO, log);
+              addLogMove(LOG_LEVEL_INFO, log);
             }
             // send task event: DO NOT SEND TASK EVENT
             //sendData(event);
@@ -500,7 +500,7 @@ boolean Plugin_009(uint8_t function, struct EventStruct *event, String& string)
           String log = F("MCP  : Port=");
           log += CONFIG_PORT;
           log += F(" is offline (EVENT= -1)");
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
 
         // send task event
@@ -531,7 +531,7 @@ boolean Plugin_009(uint8_t function, struct EventStruct *event, String& string)
         log += CONFIG_PORT;
         log += F(" State=");
         log += UserVar[event->BaseVarIndex];
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
       success = true;
       break;

--- a/src/_P010_BH1750.ino
+++ b/src/_P010_BH1750.ino
@@ -131,7 +131,7 @@ boolean Plugin_010(uint8_t function, struct EventStruct *event, String& string)
           log += String(mode);
           log += F(" : Light intensity: ");
           log += formatUserVarNoCheck(event->TaskIndex, 0);
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
         success = true;
       }

--- a/src/_P011_PME.ino
+++ b/src/_P011_PME.ino
@@ -82,7 +82,7 @@ boolean Plugin_011(uint8_t function, struct EventStruct *event, String& string)
       if (loglevelActiveFor(LOG_LEVEL_INFO)) {
         String log = F("PME  : PortValue: ");
         log += formatUserVarNoCheck(event->TaskIndex, 0);
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
       success = true;
       break;

--- a/src/_P013_HCSR04.ino
+++ b/src/_P013_HCSR04.ino
@@ -203,7 +203,7 @@ boolean                    Plugin_013(uint8_t function, struct EventStruct *even
         }
         log += F(" nr_tasks: ");
         log += P_013_sensordefs.size();
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
 
       success = true;
@@ -239,7 +239,7 @@ boolean                    Plugin_013(uint8_t function, struct EventStruct *even
             log += Plugin_013_getErrorStatusString(event->TaskIndex);
           }
 
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
       }
       success = true;
@@ -271,7 +271,7 @@ boolean                    Plugin_013(uint8_t function, struct EventStruct *even
               log += F(" Error: ");
               log += Plugin_013_getErrorStatusString(event->TaskIndex);
             }
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
           }
           switchstate[event->TaskIndex] = state;
           UserVar[event->BaseVarIndex]  = state;

--- a/src/_P014_SI7021.ino
+++ b/src/_P014_SI7021.ino
@@ -74,7 +74,7 @@ struct P014_data_struct : public PluginTaskData_base {
       log += String(res, HEX);
       log += F(" => Error 0x");
       log += String(ret, HEX);
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
     return false;
   }
@@ -166,10 +166,10 @@ struct P014_data_struct : public PluginTaskData_base {
         if (loglevelActiveFor(LOG_LEVEL_INFO)) {
           String log = F("SI7021 : Temperature: ");
           log += temperature;
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
           log  = F("SI7021 : Humidity: ");
           log += humidity;
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
         break;
       }

--- a/src/_P016_IR.ino
+++ b/src/_P016_IR.ino
@@ -325,7 +325,7 @@ boolean Plugin_016(uint8_t function, struct EventStruct *event, String& string)
           if (loglevelActiveFor(LOG_LEVEL_INFO)) {
             String log; // Log this always
             if (log.reserve(30)) {
-              log  = F("IR: available decodetypes: ");
+              log += F("IR: available decodetypes: ");
               log += size;
               addLogMove(LOG_LEVEL_INFO, log);
             }
@@ -378,7 +378,7 @@ boolean Plugin_016(uint8_t function, struct EventStruct *event, String& string)
             html_TD();
             addCheckBox(getPluginCustomArgName(rowCnt + 1), bitRead(line.CodeFlags, P16_FLAGS_REPEAT));
             html_TD();
-            strCode = String();
+            strCode.clear();
 
             if (line.Code > 0) {
               strCode = uint64ToString(line.Code, 16); // convert code to hex for display
@@ -393,7 +393,7 @@ boolean Plugin_016(uint8_t function, struct EventStruct *event, String& string)
             html_TD();
             addCheckBox(getPluginCustomArgName(rowCnt + 4), bitRead(line.AlternativeCodeFlags, P16_FLAGS_REPEAT));
             html_TD();
-            strCode = String();
+            strCode.clear();
 
             if (line.AlternativeCode > 0) {
               strCode = uint64ToString(line.AlternativeCode, 16); // convert code to hex for display
@@ -462,7 +462,7 @@ boolean Plugin_016(uint8_t function, struct EventStruct *event, String& string)
           for (uint8_t varNr = 0; varNr < P16_Nlines; varNr++) {
             tCommandLinesV2 line;
 
-            strError = String();
+            strError.clear();
 
             // Normal Code & flags
             line.CodeDecodeType = static_cast<decode_type_t>(getFormItemInt(getPluginCustomArgName(rowCnt + 0)));
@@ -567,7 +567,7 @@ boolean Plugin_016(uint8_t function, struct EventStruct *event, String& string)
             // + ',' + uint64ToString(results.bits);
             // addLog(LOG_LEVEL_INFO, output); //Show the appropriate command to the user, so he can replay the message via P035 // Old style
             // command
-            output  = F("{\"protocol\":\"");
+            output += F("{\"protocol\":\"");
             output += typeToString(results.decode_type, results.repeat);
             output += F("\",\"data\":\"");
             output += resultToHexidecimal(&results);
@@ -578,7 +578,7 @@ boolean Plugin_016(uint8_t function, struct EventStruct *event, String& string)
             if (loglevelActiveFor(LOG_LEVEL_INFO)) {
               String Log;
               if (Log.reserve(output.length() + 22)) {
-                Log  = F("IRSEND,\'");
+                Log += F("IRSEND,\'");
                 Log += output;
                 Log += F("\' type: 0x");
                 Log += uint64ToString(results.decode_type);

--- a/src/_P016_IR.ino
+++ b/src/_P016_IR.ino
@@ -378,7 +378,7 @@ boolean Plugin_016(uint8_t function, struct EventStruct *event, String& string)
             html_TD();
             addCheckBox(getPluginCustomArgName(rowCnt + 1), bitRead(line.CodeFlags, P16_FLAGS_REPEAT));
             html_TD();
-            strCode.clear();
+            strCode = String();
 
             if (line.Code > 0) {
               strCode = uint64ToString(line.Code, 16); // convert code to hex for display
@@ -393,7 +393,7 @@ boolean Plugin_016(uint8_t function, struct EventStruct *event, String& string)
             html_TD();
             addCheckBox(getPluginCustomArgName(rowCnt + 4), bitRead(line.AlternativeCodeFlags, P16_FLAGS_REPEAT));
             html_TD();
-            strCode.clear();
+            strCode = String();
 
             if (line.AlternativeCode > 0) {
               strCode = uint64ToString(line.AlternativeCode, 16); // convert code to hex for display
@@ -462,7 +462,7 @@ boolean Plugin_016(uint8_t function, struct EventStruct *event, String& string)
           for (uint8_t varNr = 0; varNr < P16_Nlines; varNr++) {
             tCommandLinesV2 line;
 
-            strError.clear();
+            strError = String();
 
             // Normal Code & flags
             line.CodeDecodeType = static_cast<decode_type_t>(getFormItemInt(getPluginCustomArgName(rowCnt + 0)));

--- a/src/_P016_IR.ino
+++ b/src/_P016_IR.ino
@@ -153,7 +153,7 @@ void P016_infoLogMemory(const __FlashStringHelper * text) {
       log += FreeMem();
       log += F(" stack: ");
       log += getCurrentFreeStack();
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
   }
 }
@@ -327,7 +327,7 @@ boolean Plugin_016(uint8_t function, struct EventStruct *event, String& string)
             if (log.reserve(30)) {
               log  = F("IR: available decodetypes: ");
               log += size;
-              addLog(LOG_LEVEL_INFO, log);
+              addLogMove(LOG_LEVEL_INFO, log);
             }
           }
 
@@ -582,7 +582,7 @@ boolean Plugin_016(uint8_t function, struct EventStruct *event, String& string)
                 Log += output;
                 Log += F("\' type: 0x");
                 Log += uint64ToString(results.decode_type);
-                addLog(LOG_LEVEL_INFO, Log); // JSON representation of the command
+                addLogMove(LOG_LEVEL_INFO, Log); // JSON representation of the command
               }
             }
             event->String2 = std::move(output);
@@ -674,9 +674,9 @@ boolean Plugin_016(uint8_t function, struct EventStruct *event, String& string)
             // If we got a human-readable description of the message, display it.
             String log;
             if (log.reserve(10 + description.length())) {
-              log  = F("AC State: ");
+              log += F("AC State: ");
               log += description;
-              addLog(LOG_LEVEL_INFO, log);
+              addLogMove(LOG_LEVEL_INFO, log);
             }
           }
         }
@@ -755,10 +755,10 @@ boolean Plugin_016(uint8_t function, struct EventStruct *event, String& string)
             // Show the command that the user can put to replay the AC state with P035
             String log;
             if (log.reserve(12 + event->String2.length())) {
-              log  = F("IRSENDAC,'");
+              log += F("IRSENDAC,'");
               log += event->String2;
               log += '\'';
-              addLog(LOG_LEVEL_INFO, log);
+              addLogMove(LOG_LEVEL_INFO, log);
             }
           }
         }
@@ -800,6 +800,7 @@ boolean displayRawToReadableB32Hex(String& outputStr, decode_results results)
 {
   uint16_t div[2];
 
+  #ifndef BUILD_NO_DEBUG
   // print the values: either pulses or blanks
   if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
     String line;
@@ -807,8 +808,9 @@ boolean displayRawToReadableB32Hex(String& outputStr, decode_results results)
     for (uint16_t i = 1; i < results.rawlen; i++) {
       line += uint64ToString(results.rawbuf[i] * RAWTICK, 10) + ",";
     }
-    addLog(LOG_LEVEL_DEBUG, line); // Display the RAW timings
+    addLogMove(LOG_LEVEL_DEBUG, line); // Display the RAW timings
   }
+  #endif
 
   // Find a common denominator divisor for odd indexes (pulses) and then even indexes (blanks).
   for (uint16_t p = 0; p < 2; p++)
@@ -875,6 +877,7 @@ boolean displayRawToReadableB32Hex(String& outputStr, decode_results results)
     }
     div[p] = bstDiv;
 
+    #ifndef BUILD_NO_DEBUG
     if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
       String line;
       line  = p ? F("Blank: ") : F("Pulse: ");
@@ -886,8 +889,9 @@ boolean displayRawToReadableB32Hex(String& outputStr, decode_results results)
       line += uint64ToString((uint16_t)bstMul, 10);
       line += '.';
       line += ((char)((bstMul - (uint16_t)bstMul) * 10) + '0');
-      addLog(LOG_LEVEL_DEBUG, line);
+      addLogMove(LOG_LEVEL_DEBUG, line);
     }
+    #endif
   }
 
   // Generate the B32 Hex string, per the divisors found.
@@ -945,7 +949,7 @@ boolean displayRawToReadableB32Hex(String& outputStr, decode_results results)
   out[iOut] = 0;
 
   outputStr.reserve(32 + iOut);
-  outputStr  = F("IRSEND,RAW2,");
+  outputStr += F("IRSEND,RAW2,");
   outputStr += out;
   outputStr += F(",38,");
   outputStr += uint64ToString(div[0], 10);

--- a/src/_P017_PN532.ino
+++ b/src/_P017_PN532.ino
@@ -176,7 +176,7 @@ boolean Plugin_017(uint8_t function, struct EventStruct *event, String& string)
           if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
             String log = F("PN532: Read error: ");
             log += errorCount;
-            addLog(LOG_LEVEL_ERROR, log);
+            addLogMove(LOG_LEVEL_ERROR, log);
           }
         }
         else {
@@ -204,6 +204,7 @@ boolean Plugin_017(uint8_t function, struct EventStruct *event, String& string)
             new_key                          = true;
           }
 
+          tempcounter++;
           if (loglevelActiveFor(LOG_LEVEL_INFO)) {
             String log = F("PN532: ");
 
@@ -213,10 +214,9 @@ boolean Plugin_017(uint8_t function, struct EventStruct *event, String& string)
               log += F("Old Tag: ");
             }
             log += key;
-            tempcounter++;
             log += ' ';
             log += tempcounter;
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
           }
 
           if (new_key) { sendData(event); }
@@ -241,7 +241,7 @@ boolean Plugin_017_Init(int8_t resetPin)
     if (loglevelActiveFor(LOG_LEVEL_INFO)) {
       String log = F("PN532: Reset on pin: ");
       log += resetPin;
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
     pinMode(resetPin, OUTPUT);
     digitalWrite(resetPin, LOW);
@@ -265,7 +265,7 @@ boolean Plugin_017_Init(int8_t resetPin)
       log += String((versiondata >> 16) & 0xFF, HEX);
       log += '.';
       log += String((versiondata >> 8) & 0xFF, HEX);
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
   }
   else {

--- a/src/_P018_Dust.ino
+++ b/src/_P018_Dust.ino
@@ -87,7 +87,7 @@ boolean Plugin_018(uint8_t function, struct EventStruct *event, String& string)
         if (loglevelActiveFor(LOG_LEVEL_INFO)) {
           String log = F("GPY  : Dust value: ");
           log += value;
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
         success = true;
         break;

--- a/src/_P019_PCF8574.ino
+++ b/src/_P019_PCF8574.ino
@@ -445,7 +445,7 @@ boolean Plugin_019(uint8_t function, struct EventStruct *event, String& string)
               log += state;
               log += output_value == 3 ? F(" Doubleclick=") : F(" Output value=");
               log += output_value;
-              addLog(LOG_LEVEL_INFO, log);
+              addLogMove(LOG_LEVEL_INFO, log);
             }
             // send task event
             sendData(event);
@@ -510,7 +510,7 @@ boolean Plugin_019(uint8_t function, struct EventStruct *event, String& string)
               log += state ? '1' : '0';
               log += F(" Output value=");
               log += output_value;
-              addLog(LOG_LEVEL_INFO, log);
+              addLogMove(LOG_LEVEL_INFO, log);
             }
             // send task event
             sendData(event);
@@ -536,7 +536,7 @@ boolean Plugin_019(uint8_t function, struct EventStruct *event, String& string)
               log += CONFIG_PORT;
               log += F(" State=");
               log += tempUserVar;
-              addLog(LOG_LEVEL_INFO, log);
+              addLogMove(LOG_LEVEL_INFO, log);
             }
             // send task event: DO NOT SEND TASK EVENT
             //sendData(event);
@@ -559,7 +559,7 @@ boolean Plugin_019(uint8_t function, struct EventStruct *event, String& string)
           String log = F("PCF  : Port=");
           log += CONFIG_PORT;
           log += F(" is offline (EVENT= -1)");
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
         // send task event
         sendData(event);
@@ -588,7 +588,7 @@ boolean Plugin_019(uint8_t function, struct EventStruct *event, String& string)
         log += CONFIG_PORT;
         log += F(" State=");
         log += UserVar[event->BaseVarIndex];
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
       success = true;
       break;

--- a/src/_P020_Ser2Net.ino
+++ b/src/_P020_Ser2Net.ino
@@ -187,7 +187,7 @@ boolean Plugin_020(uint8_t function, struct EventStruct *event, String& string)
         log += P020_SERVER_PORT;
         log += F(" SERIAL_PROCESSING=");
         log += P020_SERIAL_PROCESSING;
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
 
       // serial0 on esp32 is Ser2net: port=2 rxPin=3 txPin=1; serial1 on esp32 is Ser2net: port=4 rxPin=13 txPin=15; Serial2 on esp32 is
@@ -202,13 +202,15 @@ boolean Plugin_020(uint8_t function, struct EventStruct *event, String& string)
       }
 
       if (validGpio(P020_RESET_TARGET_PIN)) {
+        #ifndef BUILD_NO_DEBUG
         if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
           String log;
           log.reserve(38);
-          log  = F("Ser2net  : P020_RESET_TARGET_PIN : ");
+          log += F("Ser2net  : P020_RESET_TARGET_PIN : ");
           log += P020_RESET_TARGET_PIN;
-          addLog(LOG_LEVEL_DEBUG, log);
+          addLogMove(LOG_LEVEL_DEBUG, log);
         }
+        #endif
         pinMode(P020_RESET_TARGET_PIN, OUTPUT);
         digitalWrite(P020_RESET_TARGET_PIN, LOW);
         delay(500);

--- a/src/_P021_Level.ino
+++ b/src/_P021_Level.ino
@@ -168,7 +168,7 @@ boolean Plugin_021(uint8_t function, struct EventStruct *event, String& string)
         if (loglevelActiveFor(LOG_LEVEL_INFO)) {
           String log = F("LEVEL: State ");
           log += state;
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
         switchstate[event->TaskIndex] = state;
         digitalWrite(CONFIG_PIN1, state);

--- a/src/_P024_MLX90614.ino
+++ b/src/_P024_MLX90614.ino
@@ -112,7 +112,7 @@ boolean Plugin_024(uint8_t function, struct EventStruct *event, String& string)
         if (loglevelActiveFor(LOG_LEVEL_INFO)) {
           String log = F("MLX90614  : Temperature: ");
           log += formatUserVarNoCheck(event->TaskIndex, 0);
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
         //        send(msgObjTemp024->set(UserVar[event->BaseVarIndex], 1)); // Mysensors
         success = true;

--- a/src/_P025_ADS1115.ino
+++ b/src/_P025_ADS1115.ino
@@ -171,11 +171,13 @@ boolean Plugin_025(uint8_t function, struct EventStruct *event, String& string)
         const int16_t value = P025_data->read();
         UserVar[event->BaseVarIndex] = value;
 
+        #ifndef BUILD_NO_DEBUG
         String log;
         if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
           log  = F("ADS1115 : Analog value: ");
           log += value;
         }
+        #endif
 
         if (PCONFIG(3)) // Calibration?
         {
@@ -188,18 +190,22 @@ boolean Plugin_025(uint8_t function, struct EventStruct *event, String& string)
           {
             const float normalized = static_cast<float>(value - adc1) / static_cast<float>(adc2 - adc1);
             UserVar[event->BaseVarIndex] = normalized * (out2 - out1) + out1;
+            #ifndef BUILD_NO_DEBUG
             if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
               log += ' ';
               log += formatUserVarNoCheck(event->TaskIndex, 0);
             }
+            #endif
           }
         }
 
         // TEST log += F(" @0x");
         // TEST log += String(config, 16);
+        #ifndef BUILD_NO_DEBUG
         if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
-          addLog(LOG_LEVEL_DEBUG, log);
+          addLogMove(LOG_LEVEL_DEBUG, log);
         }
+        #endif
         success = true;
       }
       break;

--- a/src/_P026_Sysinfo.ino
+++ b/src/_P026_Sysinfo.ino
@@ -166,7 +166,7 @@ boolean Plugin_026(uint8_t function, struct EventStruct *event, String& string)
         String log;
         if (log.reserve(7 * (P026_NR_OUTPUT_VALUES + 1)))
         {
-          log = F("SYS  : ");
+          log += F("SYS  : ");
 
           for (int i = 0; i < P026_NR_OUTPUT_VALUES; ++i) {
             if (i != 0) {
@@ -174,7 +174,7 @@ boolean Plugin_026(uint8_t function, struct EventStruct *event, String& string)
             }
             log += formatUserVarNoCheck(event->TaskIndex, i);
           }
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
       }
       success = true;

--- a/src/_P027_INA219.ino
+++ b/src/_P027_INA219.ino
@@ -140,7 +140,7 @@ boolean Plugin_027(uint8_t function, struct EventStruct *event, String& string)
           }
         }
         if (mustLog)
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         success = true;
       }
       break;
@@ -223,7 +223,7 @@ boolean Plugin_027(uint8_t function, struct EventStruct *event, String& string)
           }
         }
         if (mustLog)
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         success = true;
       }
       break;

--- a/src/_P028_BME280.ino
+++ b/src/_P028_BME280.ino
@@ -167,22 +167,22 @@ boolean Plugin_028(uint8_t function, struct EventStruct *event, String& string)
             log  = P028_data->getDeviceName();
             log += F(" : Address: 0x");
             log += String(PCONFIG(0), HEX);
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
             log  = P028_data->getDeviceName();
             log += F(" : Temperature: ");
             log += formatUserVarNoCheck(event->TaskIndex, 0);
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
 
             if (P028_data->hasHumidity()) {
               log  = P028_data->getDeviceName();
               log += F(" : Humidity: ");
               log += formatUserVarNoCheck(event->TaskIndex, 1);
-              addLog(LOG_LEVEL_INFO, log);
+              addLogMove(LOG_LEVEL_INFO, log);
             }
             log  = P028_data->getDeviceName();
             log += F(" : Barometric Pressure: ");
             log += formatUserVarNoCheck(event->TaskIndex, 2);
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
           }
         }
         success = true;

--- a/src/_P028_BME280.ino
+++ b/src/_P028_BME280.ino
@@ -168,6 +168,7 @@ boolean Plugin_028(uint8_t function, struct EventStruct *event, String& string)
             log += F(" : Address: 0x");
             log += String(PCONFIG(0), HEX);
             addLogMove(LOG_LEVEL_INFO, log);
+            // addLogMove does also clear the string.
             log  = P028_data->getDeviceName();
             log += F(" : Temperature: ");
             log += formatUserVarNoCheck(event->TaskIndex, 0);

--- a/src/_P030_BMP280.ino
+++ b/src/_P030_BMP280.ino
@@ -170,13 +170,13 @@ boolean Plugin_030(uint8_t function, struct EventStruct *event, String& string)
         if (loglevelActiveFor(LOG_LEVEL_INFO)) {
           String log = F("BMP280  : Address: 0x");
           log += String(bmp280_i2caddr, HEX);
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
           log  = F("BMP280  : Temperature: ");
           log += formatUserVarNoCheck(event->TaskIndex, 0);
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
           log  = F("BMP280  : Barometric Pressure: ");
           log += formatUserVarNoCheck(event->TaskIndex, 1);
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
 
         /*
                   log = F("BMP280  : Coefficients [T]: ");

--- a/src/_P031_SHT1X.ino
+++ b/src/_P031_SHT1X.ino
@@ -321,10 +321,14 @@ boolean Plugin_031(uint8_t function, struct EventStruct *event, String& string)
         if (nullptr == P031_data) {
           return success;
         }
-        uint8_t status = P031_data->init(
+        #ifndef BUILD_NO_DEBUG
+        uint8_t status = 
+        #endif
+        P031_data->init(
           CONFIG_PIN1, CONFIG_PIN2,
           Settings.TaskDevicePin1PullUp[event->TaskIndex],
           PCONFIG(0));
+        #ifndef BUILD_NO_DEBUG
         if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
           String log = F("SHT1X : Status uint8_t: ");
           log += String(status, HEX);
@@ -334,8 +338,9 @@ boolean Plugin_031(uint8_t function, struct EventStruct *event, String& string)
           log += (((status >> 1) & 1) ? F("yes") : F("no"));
           log += F(", heater: ");
           log += (((status >> 2) & 1) ? F("on") : F("off"));
-          addLog(LOG_LEVEL_DEBUG, log);
+          addLogMove(LOG_LEVEL_DEBUG, log);
         }
+        #endif
         success = true;
         break;
       }

--- a/src/_P032_MS5611.ino
+++ b/src/_P032_MS5611.ino
@@ -115,10 +115,10 @@ boolean Plugin_032(uint8_t function, struct EventStruct *event, String& string)
           if (loglevelActiveFor(LOG_LEVEL_INFO)) {
             String log = F("MS5611  : Temperature: ");
             log += formatUserVarNoCheck(event->TaskIndex, 0);
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
             log  = F("MS5611  : Barometric Pressure: ");
             log += formatUserVarNoCheck(event->TaskIndex, 1);
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
           }
           success = true;
         }

--- a/src/_P033_Dummy.ino
+++ b/src/_P033_Dummy.ino
@@ -79,7 +79,7 @@ boolean Plugin_033(uint8_t function, struct EventStruct *event, String& string)
           log += x + 1;
           log += F(": ");
           log += formatUserVarNoCheck(event->TaskIndex, x);
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
       }
       success = true;
@@ -106,7 +106,7 @@ boolean Plugin_033(uint8_t function, struct EventStruct *event, String& string)
               log += event->Par2;
               log += F(" set to ");
               log += floatValue;
-              addLog(LOG_LEVEL_INFO, log);
+              addLogMove(LOG_LEVEL_INFO, log);
             }
             UserVar[event->BaseVarIndex + event->Par2 - 1] = floatValue;
             success                                        = true;
@@ -120,7 +120,7 @@ boolean Plugin_033(uint8_t function, struct EventStruct *event, String& string)
               log += F(" parameter3: ");
               log += parseStringKeepCase(string, 4);
               log += F(" not a float value!");
-              addLog(LOG_LEVEL_ERROR, log);
+              addLogMove(LOG_LEVEL_ERROR, log);
             }
           }
         }

--- a/src/_P034_DHT12.ino
+++ b/src/_P034_DHT12.ino
@@ -102,10 +102,10 @@ boolean Plugin_034(uint8_t function, struct EventStruct *event, String& string)
           if (loglevelActiveFor(LOG_LEVEL_INFO)) {
             String log = F("DHT12: Temperature: ");
             log += formatUserVarNoCheck(event->TaskIndex, 0);
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
             log  = F("DHT12: Humidity: ");
             log += formatUserVarNoCheck(event->TaskIndex, 1);
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
 
             /*
                         log = F("DHT12: Data: ");

--- a/src/_P036_FrameOLED.ino
+++ b/src/_P036_FrameOLED.ino
@@ -997,7 +997,7 @@ boolean Plugin_036(uint8_t function, struct EventStruct *event, String& string)
             log += P036_data->display->getStringWidth(P036_data->DisplayLinesV1[LineNo - 1].Content);
             log += F(" Reserved:");
             log += P036_data->DisplayLinesV1[LineNo - 1].reserved;
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
           }
 #endif // PLUGIN_036_DEBUG
         }
@@ -1011,7 +1011,7 @@ boolean Plugin_036(uint8_t function, struct EventStruct *event, String& string)
         log += subcommand;
         log += F(" Success:");
         log += success ? F("true") : F("false");
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
 #endif // PLUGIN_036_DEBUG
       break;

--- a/src/_P037_MQTTImport.ino
+++ b/src/_P037_MQTTImport.ino
@@ -166,14 +166,14 @@ boolean Plugin_037(uint8_t function, struct EventStruct *event, String& string)
               if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
                 String log = F("IMPT : Bad Import MQTT Command ");
                 log += event->String1;
-                addLog(LOG_LEVEL_ERROR, log);
+                addLogMove(LOG_LEVEL_ERROR, log);
               }
               if (loglevelActiveFor(LOG_LEVEL_INFO)) {
                 String log = F("ERR  : Illegal Payload ");
                 log += event->String2;
                 log += ' ';
                 log += getTaskDeviceName(event->TaskIndex);
-                addLog(LOG_LEVEL_INFO, log);
+                addLogMove(LOG_LEVEL_INFO, log);
               }
               success = false;
               break;
@@ -189,7 +189,7 @@ boolean Plugin_037(uint8_t function, struct EventStruct *event, String& string)
               log += ExtraTaskSettings.TaskDeviceValueNames[x];
               log += F("] : ");
               log += floatPayload;
-              addLog(LOG_LEVEL_INFO, log);
+              addLogMove(LOG_LEVEL_INFO, log);
             }
 
             // Generate event for rules processing - proposed by TridentTD
@@ -240,7 +240,7 @@ bool MQTTSubscribe_037(struct EventStruct *event)
           log += ExtraTaskSettings.TaskDeviceValueNames[x];
           log += F("] subscribed to ");
           log += subscribeTo;
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
       }
       else
@@ -248,7 +248,7 @@ bool MQTTSubscribe_037(struct EventStruct *event)
         if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
           String log = F("IMPT : Error subscribing to ");
           log += subscribeTo;
-          addLog(LOG_LEVEL_ERROR, log);
+          addLogMove(LOG_LEVEL_ERROR, log);
         }
         return false;
       }

--- a/src/_P038_NeoPixel.ino
+++ b/src/_P038_NeoPixel.ino
@@ -167,7 +167,7 @@ boolean Plugin_038(uint8_t function, struct EventStruct *event, String& string)
               log += rgbw[2];
               log += ',';
               log += rgbw[3];
-              addLog(LOG_LEVEL_INFO,log);
+              addLogMove(LOG_LEVEL_INFO, log);
             }
             Plugin_038_pixels->setPixelColor(event->Par1 - 1, Plugin_038_pixels->Color(rgbw[0], rgbw[1], rgbw[2], rgbw[3]));
             Plugin_038_pixels->show(); // This sends the updated pixel color to the hardware.
@@ -206,7 +206,7 @@ boolean Plugin_038(uint8_t function, struct EventStruct *event, String& string)
               log += rgbw[2];
               log += ',';
               log += rgbw[3];
-              addLog(LOG_LEVEL_INFO,log);
+              addLogMove(LOG_LEVEL_INFO, log);
             }
 
            for (int i = 0; i < MaxPixels; i++)
@@ -253,7 +253,7 @@ boolean Plugin_038(uint8_t function, struct EventStruct *event, String& string)
               log += rgbw[2];
               log += ',';
               log += rgbw[3];
-              addLog(LOG_LEVEL_INFO,log);
+              addLogMove(LOG_LEVEL_INFO, log);
             }
 
   					for (int i = event->Par1 - 1; i < event->Par2; i++)

--- a/src/_P039_Thermosensors.ino
+++ b/src/_P039_Thermosensors.ino
@@ -390,7 +390,7 @@ boolean Plugin_039(uint8_t function, struct EventStruct *event, String& string)
           log = F("P039 : ");                            // 7 char
           log += getTaskDeviceName(event->TaskIndex);    // 41 char
           log += F(" : SPI Init - DONE" );               // 18 char
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
       }
 
@@ -618,7 +618,7 @@ boolean Plugin_039(uint8_t function, struct EventStruct *event, String& string)
               log += formatUserVarNoCheck(event->TaskIndex, i);                         //  char 
               log += ' ';                                                               // 1 char
             }
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
           }
         }
         success = true;
@@ -635,7 +635,7 @@ boolean Plugin_039(uint8_t function, struct EventStruct *event, String& string)
             log += getTaskDeviceName(event->TaskIndex);                               // 41 char
             log += F(" : ");                                                          // 3 char
             log += F("No Sensor attached !");                                         // 20 char
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
           }
         }
         success = false;
@@ -682,7 +682,7 @@ boolean Plugin_039(uint8_t function, struct EventStruct *event, String& string)
                         log += F("; delta: ");                                // 9 char
                         log += String(delta, DEC);                            // 4 char
                         log += F(" ms");                                      // 3 char
-                        addLog(LOG_LEVEL_DEBUG, log);
+                        addLogMove(LOG_LEVEL_DEBUG, log);
                       }
                     }
                   # endif // ifndef BUILD_NO_DEBUG
@@ -705,7 +705,7 @@ boolean Plugin_039(uint8_t function, struct EventStruct *event, String& string)
                         log += F(" : ");                                      // 3 char
                         log += F("Next State: ");                             // 12 char
                         log += String(event->Par1, DEC);                      // 4 char
-                        addLog(LOG_LEVEL_DEBUG, log);
+                        addLogMove(LOG_LEVEL_DEBUG, log);
                       }
                     }
                   # endif // ifndef BUILD_NO_DEBUG
@@ -732,7 +732,7 @@ boolean Plugin_039(uint8_t function, struct EventStruct *event, String& string)
                         log += F("; delta: ");                          // 9 char
                         log += String(delta, DEC);                      // 4 char - more than 1000ms delta will not occur
                         log += F(" ms");                                // 2 char   
-                        addLog(LOG_LEVEL_DEBUG, log);
+                        addLogMove(LOG_LEVEL_DEBUG, log);
                       }
                     }
                   # endif // ifndef BUILD_NO_DEBUG
@@ -763,7 +763,7 @@ boolean Plugin_039(uint8_t function, struct EventStruct *event, String& string)
                           log += formatToHex_decimal(P039_data->deviceFaults);       // 9 char
                           log += F("; Next State: ");                        // 13 char
                           log += String(event->Par1, DEC);                   // 4 char
-                          addLog(LOG_LEVEL_DEBUG, log);
+                          addLogMove(LOG_LEVEL_DEBUG, log);
                       }
 
                     }
@@ -791,7 +791,7 @@ boolean Plugin_039(uint8_t function, struct EventStruct *event, String& string)
                         log += F(" : ");                                            // 3 char
                         log += F("current state: MAX31865_INIT_STATE, default;");   // many char - 44
                         log += F(" next state: MAX31865_BIAS_ON_STATE");            // a little less char - 35
-                        addLog(LOG_LEVEL_DEBUG, log);
+                        addLogMove(LOG_LEVEL_DEBUG, log);
                       }
                       
                       // save current timer for next calculation
@@ -857,7 +857,7 @@ float readMax6675(struct EventStruct *event)
         log += formatToHex_decimal(messageBuffer[0]);          // 9 char 
         log += F(" LSB: ");                          // 5 char
         log += formatToHex_decimal(messageBuffer[1]);          // 9 char
-        addLog(LOG_LEVEL_DEBUG, log);
+        addLogMove(LOG_LEVEL_DEBUG, log);
       }
     }
 
@@ -918,7 +918,7 @@ float readMax31855(struct EventStruct *event)
                 log += ' ';                                 // 1 char
                 log += formatToHex_decimal(messageBuffer[i]);  // 9 char
         }
-        addLog(LOG_LEVEL_DEBUG, log);
+        addLogMove(LOG_LEVEL_DEBUG, log);
       }
     }
 
@@ -932,6 +932,8 @@ float readMax31855(struct EventStruct *event)
       if (P039_data->sensorFault != ((rawvalue & (MAX31855_TC_SCVCC | MAX31855_TC_SC | MAX31855_TC_OC)) == 0)) {
         // Fault code changed, log them
         P039_data->sensorFault = ((rawvalue & (MAX31855_TC_SCVCC | MAX31855_TC_SC | MAX31855_TC_OC)) == 0);
+
+#ifndef BUILD_NO_DEBUG
 
          if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE)) 
           {
@@ -956,10 +958,10 @@ float readMax31855(struct EventStruct *event)
                   log += F(" Short-circuit to Vcc");
                 }
               }
-              addLog(LOG_LEVEL_DEBUG_MORE, log);
+              addLogMove(LOG_LEVEL_DEBUG_MORE, log);
             }
           } 
-
+#endif
 
       }
 
@@ -974,7 +976,7 @@ float readMax31855(struct EventStruct *event)
             log += formatToHex_decimal(rawvalue);
             log += F(" P039_data->sensorFault: ");
             log += formatToHex_decimal(P039_data->sensorFault);
-            addLog(LOG_LEVEL_DEBUG, log);
+            addLogMove(LOG_LEVEL_DEBUG, log);
           }
         } 
        
@@ -1063,7 +1065,7 @@ float readMax31856(struct EventStruct *event)
         }
         log+= F(" rawvalue: ");
         log+= formatToHex_decimal(rawvalue);
-        addLog(LOG_LEVEL_DEBUG, log);
+        addLogMove(LOG_LEVEL_DEBUG, log);
       }
     }
 
@@ -1090,10 +1092,10 @@ float readMax31856(struct EventStruct *event)
 
     P039_data->sensorFault = (sr != 0); // Set new state
 
-    const bool faultResolved = (P039_data->sensorFault) && (sr == 0);
-
+#ifndef BUILD_NO_DEBUG
     if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE)) 
     {
+      const bool faultResolved = (P039_data->sensorFault) && (sr == 0);
       if ((P039_data->sensorFault) || faultResolved) {
         String log;
         if((log.reserve(140u))) { // reserve value derived from example log file
@@ -1135,11 +1137,12 @@ float readMax31856(struct EventStruct *event)
             if (sr & MAX31856_TC_CJRANGE) {
               log += F(" CJ Range");
             }
-          addLog(LOG_LEVEL_DEBUG_MORE, log);
+            addLogMove(LOG_LEVEL_DEBUG_MORE, log);
           }
         }
       }
     }
+#endif
   }
 
 
@@ -1209,7 +1212,7 @@ float readMax31865(struct EventStruct *event)
           log += F(" P039_data->convReady: ");
           log += boolToString(P039_data->convReady);
 
-          addLog(LOG_LEVEL_DEBUG, log);
+          addLogMove(LOG_LEVEL_DEBUG, log);
         }
       }
 
@@ -1245,7 +1248,7 @@ float readMax31865(struct EventStruct *event)
           log += formatToHex_decimal(registers[i]);
         }
 
-        addLog(LOG_LEVEL_DEBUG_MORE, log);
+        addLogMove(LOG_LEVEL_DEBUG_MORE, log);
       }
     }
 
@@ -1276,6 +1279,7 @@ float readMax31865(struct EventStruct *event)
     Scheduler.setPluginTaskTimer(MAX31865_BIAS_WAIT_TIME, event->TaskIndex, MAX31865_BIAS_ON_STATE);
   }
  
+ #ifndef BUILD_NO_DEBUG
     if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE))
     {
       if (registers[MAX31865_FAULT])
@@ -1317,10 +1321,11 @@ float readMax31865(struct EventStruct *event)
           {
             log += F(" RTD High Threshold");
           }
-          addLog(LOG_LEVEL_DEBUG_MORE, log);
+          addLogMove(LOG_LEVEL_DEBUG_MORE, log);
         }
       }
     }
+    #endif
 
 
   bool ValueValid = false;
@@ -1339,7 +1344,7 @@ float readMax31865(struct EventStruct *event)
         log += formatToHex_decimal(registers[MAX31865_FAULT]);      // 7 char
         log += F(" ValueValid: ");                                  // 13 char       
         log += boolToString(ValueValid);                            // 5 char
-        addLog(LOG_LEVEL_DEBUG, log);
+        addLogMove(LOG_LEVEL_DEBUG, log);
       }
     }
 
@@ -1366,7 +1371,7 @@ float readMax31865(struct EventStruct *event)
           log += String(P039_RTD_TYPE, DEC);          // 1 char
           log += F(" P039_RTD_RES: ");                // 15 char
           log += String(P039_RTD_RES, DEC);           // 4 char
-          addLog(LOG_LEVEL_DEBUG, log);
+          addLogMove(LOG_LEVEL_DEBUG, log);
         }
       }
 
@@ -1542,7 +1547,7 @@ float readLM7x(struct EventStruct *event)
         log += formatToHex(device_id);
         log += F(" temperature: ");
         log += String(temperature, DEC);
-        addLog(LOG_LEVEL_DEBUG, log);
+        addLogMove(LOG_LEVEL_DEBUG, log);
       }
     }
 
@@ -1616,7 +1621,7 @@ float convertLM7xTemp(uint16_t l_rawValue, uint16_t l_LM7xsubtype)
         log += String(l_noBits, DEC);
         log += F(" l_lsbvalue: ");
         log += String(l_lsbvalue, DEC);
-        addLog(LOG_LEVEL_DEBUG_MORE, log);
+        addLogMove(LOG_LEVEL_DEBUG_MORE, log);
       }
     }
 
@@ -1748,7 +1753,7 @@ uint16_t readLM7xRegisters(uint8_t l_CS_pin_no, uint8_t l_LM7xsubType, uint8_t l
         log += formatToHex_decimal(l_returnValue);
         log += F(" l_device_id: ");
         log += formatToHex(*(l_device_id));
-        addLog(LOG_LEVEL_DEBUG_MORE, log);
+        addLogMove(LOG_LEVEL_DEBUG_MORE, log);
       }
     }
 
@@ -1857,7 +1862,7 @@ void write8BitRegister(uint8_t l_CS_pin_no, uint8_t l_address, uint8_t value)
         log += formatToHex(l_address);
         log += F(" value: ");
         log += formatToHex_decimal(value);
-        addLog(LOG_LEVEL_DEBUG_MORE, log);
+        addLogMove(LOG_LEVEL_DEBUG_MORE, log);
       }
     }
 
@@ -1894,7 +1899,7 @@ void write16BitRegister(uint8_t l_CS_pin_no, uint8_t l_address, uint16_t value)
         log += formatToHex(l_address);
         log += F(" value: ");
         log += formatToHex_decimal(value);
-        addLog(LOG_LEVEL_DEBUG_MORE, log);
+        addLogMove(LOG_LEVEL_DEBUG_MORE, log);
       }
     }
 
@@ -1930,7 +1935,7 @@ uint8_t read8BitRegister(uint8_t l_CS_pin_no, uint8_t l_address)
         log += formatToHex(l_address);
         log += F(" returnvalue: ");
         log += formatToHex_decimal(l_messageBuffer[1]);
-        addLog(LOG_LEVEL_DEBUG_MORE, log);
+        addLogMove(LOG_LEVEL_DEBUG_MORE, log);
       }
     }
 
@@ -1970,7 +1975,7 @@ uint16_t read16BitRegister(uint8_t l_CS_pin_no, uint8_t l_address)
         log += formatToHex(l_address);
         log += F(" l_returnValue: ");
         log += formatToHex_decimal(l_returnValue);
-        addLog(LOG_LEVEL_DEBUG_MORE, log);
+        addLogMove(LOG_LEVEL_DEBUG_MORE, log);
       }
     }
 
@@ -2020,7 +2025,7 @@ void transfer_n_ByteSPI(uint8_t l_CS_pin_no, uint8_t l_noBytesToSend, uint8_t* l
           log += ' ';                                               // 1 char
           log += formatToHex_decimal(l_inoutMessageBuffer[i]);      // 9 char
         }
-        addLog(LOG_LEVEL_DEBUG_MORE, log);
+        addLogMove(LOG_LEVEL_DEBUG_MORE, log);
       }
     }
 

--- a/src/_P040_ID12.ino
+++ b/src/_P040_ID12.ino
@@ -151,7 +151,7 @@ boolean Plugin_040(uint8_t function, struct EventStruct *event, String& string)
                   log += F("Old Tag: "); 
                 }
                 log += key;
-                addLog(LOG_LEVEL_INFO, log);
+                addLogMove(LOG_LEVEL_INFO, log);
               }
               
               if (new_key) sendData(event);

--- a/src/_P042_Candle.ino
+++ b/src/_P042_Candle.ino
@@ -284,7 +284,7 @@ boolean Plugin_042(uint8_t function, struct EventStruct *event, String& string)
           if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
             String log = F("CAND : Init WS2812 Pin : ");
             log += CONFIG_PIN1;
-            addLog(LOG_LEVEL_DEBUG, log);
+            addLogMove(LOG_LEVEL_DEBUG, log);
           }
           #endif
         }
@@ -428,7 +428,7 @@ boolean Plugin_042(uint8_t function, struct EventStruct *event, String& string)
                 if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
                   String log = F("CAND : CMD - Type : ");
                   log += val_Type;
-                  addLog(LOG_LEVEL_DEBUG, log);
+                  addLogMove(LOG_LEVEL_DEBUG, log);
                 }
                 #endif
              }
@@ -442,7 +442,7 @@ boolean Plugin_042(uint8_t function, struct EventStruct *event, String& string)
                 if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
                   String log = F("CAND : CMD - Bright : ");
                   log += val_Bright;
-                  addLog(LOG_LEVEL_DEBUG, log);
+                  addLogMove(LOG_LEVEL_DEBUG, log);
                 }
                 #endif
              }
@@ -472,7 +472,7 @@ boolean Plugin_042(uint8_t function, struct EventStruct *event, String& string)
               log += g;
               log += F(" B ");
               log += b;
-              addLog(LOG_LEVEL_DEBUG, log);
+              addLogMove(LOG_LEVEL_DEBUG, log);
             }
             #endif
           } else {

--- a/src/_P043_ClkOutput.ino
+++ b/src/_P043_ClkOutput.ino
@@ -164,7 +164,7 @@ boolean Plugin_043(uint8_t function, struct EventStruct *event, String& string)
               if (loglevelActiveFor(LOG_LEVEL_INFO)) {
                 String log = F("TCLK : State ");
                 log += state;
-                addLog(LOG_LEVEL_INFO, log);
+                addLogMove(LOG_LEVEL_INFO, log);
               }
               sendData(event);
             }

--- a/src/_P046_VentusW266.ino
+++ b/src/_P046_VentusW266.ino
@@ -334,6 +334,7 @@ boolean Plugin_046(uint8_t function, struct EventStruct *event, String& string)
             }
             P046_data->Plugin_046_MasterSlave = false;
             P046_data->Plugin_046_newData = false;
+            #ifndef BUILD_NO_DEBUG
             if (PLUGIN_046_DEBUG) {
               String log = F("Ventus W266 Rcvd(");
               log += node_time.getTimeString(':');
@@ -356,8 +357,9 @@ boolean Plugin_046(uint8_t function, struct EventStruct *event, String& string)
               myHex = (crc & 0x0f) + 0x30;
               if (myHex > 0x39) { myHex += 7; }
               log += myHex;
-              addLog(LOG_LEVEL_INFO, log);
+              addLogMove(LOG_LEVEL_INFO, log);
             }
+            #endif
             if (crc != 00)
             {
               P046_data->Plugin_046_databuffer[0] = 0;                   // Not MagicByte, so not valid.

--- a/src/_P047_i2c-soil-moisture-sensor.ino
+++ b/src/_P047_i2c-soil-moisture-sensor.ino
@@ -197,16 +197,16 @@ boolean Plugin_047(uint8_t function, struct EventStruct *event, String& string)
             log += F(" Version: 0x");
             log += String(sensorVersion, HEX);
           }
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
           log  = F("SoilMoisture: Temperature: ");
           log += temperature;
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
           log  = F("SoilMoisture: Moisture: ");
           log += moisture;
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
           log  = F("SoilMoisture: Light: ");
           log += light;
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
 
         if (P047_SENSOR_SLEEP) {

--- a/src/_P048_Motorshield_v2.ino
+++ b/src/_P048_Motorshield_v2.ino
@@ -132,7 +132,7 @@ boolean Plugin_048(uint8_t function, struct EventStruct *event, String& string) 
         if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
           String log = F("MotorShield: Address: 0x");
           log += String(Plugin_048_MotorShield_address, HEX);
-          addLog(LOG_LEVEL_DEBUG, log);
+          addLogMove(LOG_LEVEL_DEBUG, log);
         }
         #endif
 
@@ -155,7 +155,7 @@ boolean Plugin_048(uint8_t function, struct EventStruct *event, String& string) 
                 log += param2;
                 log += F("->Forward Speed: ");
                 log += speed;
-                addLog(LOG_LEVEL_INFO, log);
+                addLogMove(LOG_LEVEL_INFO, log);
               }
               myMotor->setSpeed(speed);
               myMotor->run(FORWARD);
@@ -175,7 +175,7 @@ boolean Plugin_048(uint8_t function, struct EventStruct *event, String& string) 
                 log += param2;
                 log += F("->Backward Speed: ");
                 log += speed;
-                addLog(LOG_LEVEL_INFO, log);
+                addLogMove(LOG_LEVEL_INFO, log);
               }
 
               myMotor->setSpeed(speed);
@@ -191,7 +191,7 @@ boolean Plugin_048(uint8_t function, struct EventStruct *event, String& string) 
                 String log = F("DCMotor");
                 log += param2;
                 log += F("->Release");
-                addLog(LOG_LEVEL_INFO, log);
+                addLogMove(LOG_LEVEL_INFO, log);
               }
               myMotor->run(RELEASE);
               success = true;
@@ -216,7 +216,7 @@ boolean Plugin_048(uint8_t function, struct EventStruct *event, String& string) 
               log += String(Plugin_048_MotorStepsPerRevolution);
               log += F(" Stepperspeed: ");
               log += String(Plugin_048_StepperSpeed);
-              addLog(LOG_LEVEL_DEBUG_MORE, log);
+              addLogMove(LOG_LEVEL_DEBUG_MORE, log);
             }
             #endif
 
@@ -260,7 +260,7 @@ boolean Plugin_048(uint8_t function, struct EventStruct *event, String& string) 
                   log += steps;
                   log += ' ';
                   log += param5;
-                  addLog(LOG_LEVEL_INFO, log);
+                  addLogMove(LOG_LEVEL_INFO, log);
                 }
               }
             }
@@ -306,7 +306,7 @@ boolean Plugin_048(uint8_t function, struct EventStruct *event, String& string) 
                   log += steps;
                   log += ' ';
                   log += param5;
-                  addLog(LOG_LEVEL_INFO, log);
+                  addLogMove(LOG_LEVEL_INFO, log);
                 }
               }
             }
@@ -318,7 +318,7 @@ boolean Plugin_048(uint8_t function, struct EventStruct *event, String& string) 
                 String log = F("Stepper");
                 log += param2;
                 log += F("->Release.");
-                addLog(LOG_LEVEL_INFO, log);
+                addLogMove(LOG_LEVEL_INFO, log);
               }
               myStepper->release();
               success = true;

--- a/src/_P049_MHZ19.ino
+++ b/src/_P049_MHZ19.ino
@@ -630,7 +630,7 @@ boolean Plugin_049(uint8_t function, struct EventStruct *event, String& string)
           log += s;
           log += '/';
           log += u;
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
         break;
 
@@ -652,7 +652,7 @@ boolean Plugin_049(uint8_t function, struct EventStruct *event, String& string)
         if (loglevelActiveFor(LOG_LEVEL_INFO)) {
           String log = F("MHZ19: Unknown response:");
           log += P049_data->getBufferHexDump();
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
 
         // Check for stable reads and allow unstable reads the first 3 minutes after reset.

--- a/src/_P050_TCS34725.ino
+++ b/src/_P050_TCS34725.ino
@@ -366,7 +366,7 @@ boolean Plugin_050(uint8_t function, struct EventStruct *event, String& string)
           log += formatUserVarNoCheck(event->TaskIndex, 1);
           log += F(" B: ");
           log += formatUserVarNoCheck(event->TaskIndex, 2);
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
 
 #ifdef P050_OPTION_RGB_EVENTS

--- a/src/_P050_TCS34725.ino
+++ b/src/_P050_TCS34725.ino
@@ -378,7 +378,8 @@ boolean Plugin_050(uint8_t function, struct EventStruct *event, String& string)
           for (int i = 0; i < 6; i++) {
             if (i != PCONFIG(2)) { // Skip currently selected RGB output to keep nr. of events a bit limited
               sRGBFactor = 1.0f;
-              RuleEvent  = getTaskDeviceName(event->TaskIndex);
+              RuleEvent.clear();
+              RuleEvent += getTaskDeviceName(event->TaskIndex);
               RuleEvent += '#';
               switch (i) {
               case 0:
@@ -434,7 +435,7 @@ boolean Plugin_050(uint8_t function, struct EventStruct *event, String& string)
                 break;
               }
               if (!RuleEvent.isEmpty()) {
-                eventQueue.add(RuleEvent);
+                eventQueue.addMove(std::move(RuleEvent));
               }
             }
           }
@@ -446,7 +447,8 @@ boolean Plugin_050(uint8_t function, struct EventStruct *event, String& string)
           String RuleEvent;
           RuleEvent.reserve(48);
           for (int i = 0; i < 4; i++) {
-            RuleEvent  = getTaskDeviceName(event->TaskIndex);
+            RuleEvent.clear();
+            RuleEvent += getTaskDeviceName(event->TaskIndex);
             RuleEvent += '#';
             switch (i) {
             case 0:
@@ -470,7 +472,7 @@ boolean Plugin_050(uint8_t function, struct EventStruct *event, String& string)
               break;
             }
             if (!RuleEvent.isEmpty()) {
-              eventQueue.add(RuleEvent);
+              eventQueue.addMove(std::move(RuleEvent));
             }
           }
         }

--- a/src/_P051_AM2320.ino
+++ b/src/_P051_AM2320.ino
@@ -100,10 +100,10 @@ boolean Plugin_051(uint8_t function, struct EventStruct *event, String& string)
           if (loglevelActiveFor(LOG_LEVEL_INFO)) {
             String log = F("AM2320: Temperature: ");
             log += formatUserVarNoCheck(event->TaskIndex, 0);
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
             log  = F("AM2320: Humidity: ");
             log += formatUserVarNoCheck(event->TaskIndex, 1);
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
           }
           success = true;
           break;

--- a/src/_P052_SenseAir.ino
+++ b/src/_P052_SenseAir.ino
@@ -585,7 +585,7 @@ boolean Plugin_052(uint8_t function, struct EventStruct *event, String& string) 
             log                                 += value;
           }
         }
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
 
         success = true;
         break;

--- a/src/_P054_DMX512.ino
+++ b/src/_P054_DMX512.ino
@@ -168,7 +168,9 @@ boolean Plugin_054(uint8_t function, struct EventStruct *event, String& string)
           {
             while (param.length())
             {
+              #ifndef BUILD_NO_DEBUG
               addLog(LOG_LEVEL_DEBUG_MORE, param);
+              #endif
 
               if (param == F("log"))
               {
@@ -179,7 +181,7 @@ boolean Plugin_054(uint8_t function, struct EventStruct *event, String& string)
                     log += Plugin_054_DMXBuffer[i];
                     log += F(", ");
                   }
-                  addLog(LOG_LEVEL_INFO, log);
+                  addLogMove(LOG_LEVEL_INFO, log);
                 }
                 success = true;
               }

--- a/src/_P055_Chiming.ino
+++ b/src/_P055_Chiming.ino
@@ -490,7 +490,7 @@ uint8_t Plugin_055_ReadChime(const String& name, String& tokens)
   log += fileName;
   log += ' ';
 
-  tokens.clear();
+  tokens = String();
   fs::File f = tryOpenFile(fileName, "r");
   if (f)
   {

--- a/src/_P055_Chiming.ino
+++ b/src/_P055_Chiming.ino
@@ -196,7 +196,7 @@ boolean Plugin_055(uint8_t function, struct EventStruct *event, String& string)
           }
           if (Plugin_055_Data->lowActive)
             log += F("!");
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
           success = true;
         }
 
@@ -320,7 +320,7 @@ boolean Plugin_055(uint8_t function, struct EventStruct *event, String& string)
             String log = F("Chime: Process '");
             log += c;
             log += '\'';
-            addLog(LOG_LEVEL_DEBUG, log);
+            addLogMove(LOG_LEVEL_DEBUG, log);
 
             switch (c)
             {
@@ -477,7 +477,7 @@ void Plugin_055_WriteChime(const String& name, const String& tokens)
     log += tokens;
   }
 
-  addLog(LOG_LEVEL_INFO, log);
+  addLogMove(LOG_LEVEL_INFO, log);
 }
 
 uint8_t Plugin_055_ReadChime(const String& name, String& tokens)
@@ -506,7 +506,7 @@ uint8_t Plugin_055_ReadChime(const String& name, String& tokens)
     log += tokens;
   }
 
-  addLog(LOG_LEVEL_INFO, log);
+  addLogMove(LOG_LEVEL_INFO, log);
 
   return tokens.length();
 }

--- a/src/_P056_SDS011-Dust.ino
+++ b/src/_P056_SDS011-Dust.ino
@@ -116,7 +116,7 @@ boolean Plugin_056(uint8_t function, struct EventStruct *event, String& string)
         log += serial_rx;
         log += F(" TX:");
         log += serial_tx;
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
 
         success = true;
         break;
@@ -145,11 +145,15 @@ boolean Plugin_056(uint8_t function, struct EventStruct *event, String& string)
         {
           const float pm2_5 = Plugin_056_SDS->GetPM2_5();
           const float pm10 = Plugin_056_SDS->GetPM10_();
-          String log = F("SDS  : act ");
-          log += pm2_5;
-          log += ' ';
-          log += pm10;
-          addLog(LOG_LEVEL_DEBUG, log);
+          #ifndef BUILD_NO_DEBUG
+          if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+            String log = F("SDS  : act ");
+            log += pm2_5;
+            log += ' ';
+            log += pm10;
+            addLogMove(LOG_LEVEL_DEBUG, log);
+          }
+          #endif
 
           if (Settings.TaskDeviceTimer[event->TaskIndex] == 0)
           {
@@ -214,9 +218,11 @@ void Plugin_056_setWorkingPeriod(int minutes) {
   if (!Plugin_056_SDS)
     return;
   Plugin_056_SDS->SetWorkingPeriod(minutes);
-  String log = F("SDS  : Working Period set to: ");
-  log += Plugin_056_WorkingPeriodToString(minutes);
-  addLog(LOG_LEVEL_INFO, log);
+  if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+    String log = F("SDS  : Working Period set to: ");
+    log += Plugin_056_WorkingPeriodToString(minutes);
+    addLogMove(LOG_LEVEL_INFO, log);
+  }
 }
 
 //#endif

--- a/src/_P057_HT16K33_LED.ino
+++ b/src/_P057_HT16K33_LED.ino
@@ -234,7 +234,9 @@ boolean Plugin_057(uint8_t function, struct EventStruct *event, String& string)
         {
           while (param.length())
           {
+            #ifndef BUILD_NO_DEBUG
             addLog(LOG_LEVEL_DEBUG_MORE, param);
+            #endif
 
             if (param == F("log"))
             {
@@ -246,7 +248,7 @@ boolean Plugin_057(uint8_t function, struct EventStruct *event, String& string)
                   log += String(P057_data->ledMatrix.GetRow(i), 16);
                   log += F("h, ");
                 }
-                addLog(LOG_LEVEL_INFO, log);
+                addLogMove(LOG_LEVEL_INFO, log);
               }
               success = true;
             }

--- a/src/_P058_HT16K33_KeyPad.ino
+++ b/src/_P058_HT16K33_KeyPad.ino
@@ -129,7 +129,7 @@ boolean Plugin_058(uint8_t function, struct EventStruct *event, String& string)
           if (loglevelActiveFor(LOG_LEVEL_INFO)) {
             String log = F("Mkey : key=0x");
             log += String(key, 16);
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
           }
 
           sendData(event);

--- a/src/_P059_Encoder.ino
+++ b/src/_P059_Encoder.ino
@@ -132,7 +132,7 @@ boolean Plugin_059(uint8_t function, struct EventStruct *event, String& string)
           log += pin;
           log += ' ';
         }
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
 
         success = true;
         break;
@@ -154,9 +154,11 @@ boolean Plugin_059(uint8_t function, struct EventStruct *event, String& string)
             UserVar[event->BaseVarIndex] = c;
             event->sensorType = Sensor_VType::SENSOR_TYPE_SWITCH;
 
-            String log = F("QEI  : ");
-            log += c;
-            addLog(LOG_LEVEL_INFO, log);
+            if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+              String log = F("QEI  : ");
+              log += c;
+              addLogMove(LOG_LEVEL_INFO, log);
+            }
 
             sendData(event);
           }
@@ -188,7 +190,7 @@ boolean Plugin_059(uint8_t function, struct EventStruct *event, String& string)
                 if (loglevelActiveFor(LOG_LEVEL_INFO)) {
                   String log = F("QEI  : ");
                   log += string;
-                  addLog(LOG_LEVEL_INFO, log);
+                  addLogMove(LOG_LEVEL_INFO, log);
                 }
                 P_059_sensordefs[event->TaskIndex]->write(event->Par1);
                 Scheduler.schedule_task_device_timer(event->TaskIndex, millis());

--- a/src/_P060_MCP3221.ino
+++ b/src/_P060_MCP3221.ino
@@ -159,7 +159,7 @@ boolean Plugin_060(uint8_t function, struct EventStruct *event, String& string)
           }
         }
 
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
         success = true;
       }
       break;

--- a/src/_P061_KeyPad.ino
+++ b/src/_P061_KeyPad.ino
@@ -165,9 +165,11 @@ boolean Plugin_061(uint8_t function, struct EventStruct *event, String& string)
           UserVar[event->BaseVarIndex] = actScanCode;
           event->sensorType            = Sensor_VType::SENSOR_TYPE_SWITCH;
 
-          String log = F("KPad : ScanCode=0x");
-          log += String(actScanCode, 16);
-          addLog(LOG_LEVEL_INFO, log);
+          if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+            String log = F("KPad : ScanCode=0x");
+            log += String(actScanCode, 16);
+            addLogMove(LOG_LEVEL_INFO, log);
+          }
 
           sendData(event);
 

--- a/src/_P062_MPR121_KeyPad.ino
+++ b/src/_P062_MPR121_KeyPad.ino
@@ -226,9 +226,11 @@ boolean Plugin_062(uint8_t function, struct EventStruct *event, String& string)
           P062_data->StoredSettings.TouchObjects[objectNr].release = getFormItemInt(getPluginCustomArgName(objectNr + 200));
         }
         # ifdef PLUGIN_062_DEBUG
-        String log = F("p062_data save size: ");
-        log += sizeof(P062_data->StoredSettings);
-        addLog(LOG_LEVEL_INFO, log);
+        if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+          String log = F("p062_data save size: ");
+          log += sizeof(P062_data->StoredSettings);
+          addLogMove(LOG_LEVEL_INFO, log);
+        }
         # endif // PLUGIN_062_DEBUG
         SaveCustomTaskSettings(event->TaskIndex, reinterpret_cast<const uint8_t *>(&(P062_data->StoredSettings)),
                                sizeof(P062_data->StoredSettings));
@@ -319,7 +321,7 @@ boolean Plugin_062(uint8_t function, struct EventStruct *event, String& string)
               log = F("KeyMap=0x");
             }
             log += String(key, 16);
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
 
             bool tbUseCalibration = bitRead(P062_CONFIG_FLAGS, P062_FLAGS_USE_CALIBRATION);
 
@@ -343,7 +345,7 @@ boolean Plugin_062(uint8_t function, struct EventStruct *event, String& string)
                   log += min;
                   log += F(" max: ");
                   log += max;
-                  addLog(LOG_LEVEL_INFO, log);
+                  addLogMove(LOG_LEVEL_INFO, log);
 
                   if (!PCONFIG(1)) {
                     break;

--- a/src/_P063_TTP229_KeyPad.ino
+++ b/src/_P063_TTP229_KeyPad.ino
@@ -124,11 +124,13 @@ boolean Plugin_063(uint8_t function, struct EventStruct *event, String& string)
         int16_t pinSCL = CONFIG_PIN1;
         int16_t pinSDO = CONFIG_PIN2;
 
-        String log = F("Tkey : GPIO: ");
-        log += pinSCL;
-        log += ' ';
-        log += pinSDO;
-        addLog(LOG_LEVEL_INFO, log);
+        if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+          String log = F("Tkey : GPIO: ");
+          log += pinSCL;
+          log += ' ';
+          log += pinSDO;
+          addLogMove(LOG_LEVEL_INFO, log);
+        }
 
         if (pinSCL >= 0 && pinSDO >= 0)
         {
@@ -189,13 +191,15 @@ boolean Plugin_063(uint8_t function, struct EventStruct *event, String& string)
             UserVar[event->BaseVarIndex] = key;
             event->sensorType = Sensor_VType::SENSOR_TYPE_SWITCH;
 
-            String log = F("Tkey : ");
-            if (PCONFIG(1))
-              log = F("ScanCode=0x");
-            else
-              log = F("KeyMap=0x");
-            log += String(key, 16);
-            addLog(LOG_LEVEL_INFO, log);
+            if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+              String log = F("Tkey : ");
+              if (PCONFIG(1))
+                log = F("ScanCode=0x");
+              else
+                log = F("KeyMap=0x");
+              log += String(key, 16);
+              addLogMove(LOG_LEVEL_INFO, log);
+            }
 
             sendData(event);
           }

--- a/src/_P064_APDS9960.ino
+++ b/src/_P064_APDS9960.ino
@@ -266,7 +266,7 @@ boolean Plugin_064(uint8_t function, struct EventStruct *event, String& string)
           log += F("Error during APDS-9960 init!");
         }
 
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
         success = true;
       }
       break;
@@ -296,28 +296,29 @@ boolean Plugin_064(uint8_t function, struct EventStruct *event, String& string)
       // if ( 0 && P064_data->sensor.isGestureAvailable() )
       if (gesture >= 0)
       {
-        String log = F("APDS : Gesture=");
+        if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+          String log = F("APDS : Gesture=");
 
-        switch (gesture)
-        {
-          case DIR_UP:      log += F("UP");      break;
-          case DIR_DOWN:    log += F("DOWN");    break;
-          case DIR_LEFT:    log += F("LEFT");    break;
-          case DIR_RIGHT:   log += F("RIGHT");   break;
-          case DIR_NEAR:    log += F("NEAR");    break;
-          case DIR_FAR:     log += F("FAR");     break;
-          default:          log += F("NONE");    break;
+          switch (gesture)
+          {
+            case DIR_UP:      log += F("UP");      break;
+            case DIR_DOWN:    log += F("DOWN");    break;
+            case DIR_LEFT:    log += F("LEFT");    break;
+            case DIR_RIGHT:   log += F("RIGHT");   break;
+            case DIR_NEAR:    log += F("NEAR");    break;
+            case DIR_FAR:     log += F("FAR");     break;
+            default:          log += F("NONE");    break;
+          }
+          log += F(" (");
+          log += gesture;
+          log += ')';
+          addLogMove(LOG_LEVEL_INFO, log);
         }
-        log += F(" (");
-        log += gesture;
-        log += ')';
 
         UserVar[event->BaseVarIndex] = static_cast<float>(gesture);
         event->sensorType            = Sensor_VType::SENSOR_TYPE_SWITCH;
 
         sendData(event);
-
-        addLog(LOG_LEVEL_INFO, log);
       }
 
       success = true;

--- a/src/_P065_DRF0299_MP3.ino
+++ b/src/_P065_DRF0299_MP3.ino
@@ -189,7 +189,7 @@ boolean Plugin_065(uint8_t function, struct EventStruct *event, String& string)
           log += '=';
           log += value;
         }
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
       break;
     }
@@ -257,6 +257,7 @@ void Plugin_065_SendCmd(uint8_t cmd, int16_t data)
 
   P065_easySerial->write(buffer, 10); // Send the byte array
 
+#ifndef BUILD_NO_DEBUG
   if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
     String log = F("MP3  : Send Cmd ");
 
@@ -264,8 +265,9 @@ void Plugin_065_SendCmd(uint8_t cmd, int16_t data)
       log += String(buffer[i], 16);
       log += ' ';
     }
-    addLog(LOG_LEVEL_DEBUG, log);
+    addLogMove(LOG_LEVEL_DEBUG, log);
   }
+#endif
 }
 
 #endif // USES_P065

--- a/src/_P067_HX711_Load_Cell.ino
+++ b/src/_P067_HX711_Load_Cell.ino
@@ -311,11 +311,13 @@ boolean Plugin_067(uint8_t function, struct EventStruct *event, String& string)
         int16_t pinSCL = CONFIG_PIN1;
         int16_t pinDOUT = CONFIG_PIN2;
 
-        String log = F("HX711: GPIO: SCL=");
-        log += pinSCL;
-        log += F(" DOUT=");
-        log += pinDOUT;
-        addLog(LOG_LEVEL_INFO, log);
+        if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+          String log = F("HX711: GPIO: SCL=");
+          log += pinSCL;
+          log += F(" DOUT=");
+          log += pinDOUT;
+          addLogMove(LOG_LEVEL_INFO, log);
+        }
 
         if (pinSCL >= 0 && pinDOUT >= 0)
         {
@@ -377,7 +379,6 @@ boolean Plugin_067(uint8_t function, struct EventStruct *event, String& string)
 
     case PLUGIN_READ:
       {
-        String log;
         int8_t modeChanA = (PCONFIG(0) >> 2) & 0x03;
         int8_t modeChanB = (PCONFIG(0) >> 4) & 0x01;
         float valFloat;
@@ -390,7 +391,7 @@ boolean Plugin_067(uint8_t function, struct EventStruct *event, String& string)
         // Channel A activated?
         if (modeChanA != modeAoff)
         {
-          log = F("HX711: ChanA: ");
+          String log = F("HX711: ChanA: ");
 
           if (Plugin_067_OversamplingCountChanA[event->TaskIndex] > 0)
           {
@@ -424,13 +425,13 @@ boolean Plugin_067(uint8_t function, struct EventStruct *event, String& string)
           {
             log += F("NO NEW VALUE");
           }
-          addLog(LOG_LEVEL_INFO,log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
 
         // Channel B activated?
         if (modeChanB != modeBoff)
         {
-          log = F("HX711: ChanB: ");
+          String log = F("HX711: ChanB: ");
 
           if (Plugin_067_OversamplingCountChanB[event->TaskIndex] > 0)
           {
@@ -464,7 +465,7 @@ boolean Plugin_067(uint8_t function, struct EventStruct *event, String& string)
           {
             log += F("NO NEW VALUE");
           }
-          addLog(LOG_LEVEL_INFO,log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
 
         success = true;

--- a/src/_P068_SHT3x.ino
+++ b/src/_P068_SHT3x.ino
@@ -238,10 +238,10 @@ boolean Plugin_068(uint8_t function, struct EventStruct *event, String& string)
         if (log.reserve(25)) {
           log = F("SHT3x: Temperature: ");
           log += formatUserVarNoCheck(event->TaskIndex, 0);
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
           log  = F("SHT3x: Humidity: ");
           log += formatUserVarNoCheck(event->TaskIndex, 1);
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
       }
       success = true;

--- a/src/_P069_LM75A.ino
+++ b/src/_P069_LM75A.ino
@@ -119,7 +119,7 @@ boolean Plugin_069(uint8_t function, struct EventStruct *event, String& string)
         {
           String log = F("LM75A: Temperature: ");
           log += tempC;
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
       }
       break;

--- a/src/_P071_Kamstrup401.ino
+++ b/src/_P071_Kamstrup401.ino
@@ -232,22 +232,26 @@ boolean Plugin_071(uint8_t function, struct EventStruct *event, String& string)
               UserVar[event->BaseVarIndex] = m_energy; //gives energy in Wh
               UserVar[event->BaseVarIndex+1] = m_volume;  //gives volume in liters
 
-              String log = F("Kamstrup  : Heat value: ");
-              log += m_energy/1000;
-              log += F(" kWh");
-              addLog(LOG_LEVEL_INFO, log);
-              log = F("Kamstrup  : Volume value: ");
-              log += m_volume;
-              log += F(" Liter");
-              addLog(LOG_LEVEL_INFO, log);
+              if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+                String log = F("Kamstrup  : Heat value: ");
+                log += m_energy/1000;
+                log += F(" kWh");
+                addLogMove(LOG_LEVEL_INFO, log);
+                log = F("Kamstrup  : Volume value: ");
+                log += m_volume;
+                log += F(" Liter");
+                addLogMove(LOG_LEVEL_INFO, log);
+              }
             }
             else
             {
               message[i] = 0;
-              String log = F("ERR(PARITY):" );
-              serialPrint("par");
-              log += message;
-              addLog(LOG_LEVEL_INFO, log);
+              if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+                String log = F("ERR(PARITY):" );
+                serialPrint("par");
+                log += message;
+                addLogMove(LOG_LEVEL_INFO, log);
+              }
               //UserVar[event->BaseVarIndex] = NAN;
               //UserVar[event->BaseVarIndex + 1] = NAN;
             }
@@ -256,9 +260,11 @@ boolean Plugin_071(uint8_t function, struct EventStruct *event, String& string)
           if (to>100)
           {
             message[i] = 0;
-            String log = F("ERR(TIMEOUT):" );
-            log += message;
-            addLog(LOG_LEVEL_INFO, log);
+            if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+              String log = F("ERR(TIMEOUT):" );
+              log += message;
+              addLogMove(LOG_LEVEL_INFO, log);
+            }
 
             //UserVar[event->BaseVarIndex] = NAN;
             //UserVar[event->BaseVarIndex + 1] = NAN;

--- a/src/_P072_HDC1080.ino
+++ b/src/_P072_HDC1080.ino
@@ -101,10 +101,10 @@ boolean Plugin_072(uint8_t function, struct EventStruct *event, String& string)
       if (loglevelActiveFor(LOG_LEVEL_INFO)) {
         String log = F("HDC1080: Temperature: ");
         log += formatUserVarNoCheck(event->TaskIndex, 0);
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
         log  = F("HDC1080: Humidity: ");
         log += formatUserVarNoCheck(event->TaskIndex, 1);
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
       success = true;
       break;

--- a/src/_P073_7DGT.ino
+++ b/src/_P073_7DGT.ino
@@ -398,7 +398,7 @@ bool p073_plugin_write(struct EventStruct *event,
         if (loglevelActiveFor(LOG_LEVEL_INFO)) {
           String log = F("7DGT : Brightness=");
           log += event->Par1;
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
         P073_data->brightness = event->Par1;
         PCONFIG(2)            = event->Par1;
@@ -411,7 +411,7 @@ bool p073_plugin_write(struct EventStruct *event,
         if (loglevelActiveFor(LOG_LEVEL_INFO)) {
           String log = F("7DGT : Display output=");
           log += event->Par1;
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
         P073_data->output = event->Par1;
         PCONFIG(1)        = event->Par1;
@@ -456,7 +456,7 @@ bool p073_plugin_write_7dn(struct EventStruct *event,
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
     String log = F("7DGT : Show Number=");
     log += event->Par1;
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
 
   switch (P073_data->displayModel) {
@@ -518,7 +518,7 @@ bool p073_plugin_write_7dt(struct EventStruct *event,
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
     String log = F("7DGT : Show Temperature=");
     log += p073_temptemp;
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
 
   switch (P073_data->displayModel) {
@@ -557,7 +557,7 @@ bool p073_plugin_write_7dt(struct EventStruct *event,
       if (loglevelActiveFor(LOG_LEVEL_INFO)) {
         String log = F("7DGT : 7dt preprocessed =");
         log += p073_temptemp;
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
       # endif // ifdef P073_DEBUG
 
@@ -598,7 +598,7 @@ bool p073_plugin_write_7ddt(struct EventStruct *event,
     log += p073_lefttemp;
     log += F(" 2nd=");
     log += p073_righttemp;
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
 
   switch (P073_data->displayModel) {
@@ -650,7 +650,7 @@ bool p073_plugin_write_7ddt(struct EventStruct *event,
         log += p073_lefttemp;
         log += F(" 2nd=");
         log += p073_righttemp;
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
       #  endif // ifdef P073_DEBUG
 
@@ -689,7 +689,7 @@ bool p073_plugin_write_7dst(struct EventStruct *event) {
     log += event->Par2;
     log += ':';
     log += event->Par3;
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
   P073_data->timesep = true;
   P073_data->FillBufferWithTime(false, event->Par1, event->Par2, event->Par3, false);
@@ -730,7 +730,7 @@ bool p073_plugin_write_7dsd(struct EventStruct *event) {
     log += event->Par2;
     log += '-';
     log += event->Par3;
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
   P073_data->FillBufferWithDate(false, event->Par1, event->Par2, event->Par3);
 
@@ -767,7 +767,7 @@ bool p073_plugin_write_7dtext(struct EventStruct *event,
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
     String log = F("7DGT : Show Text=");
     log += text;
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
   # ifdef P073_SCROLL_TEXT
   P073_data->setTextToScroll("");
@@ -837,7 +837,7 @@ bool p073_plugin_write_7dfont(struct EventStruct *event,
       info += fontArg;
       info += F(" -> ");
       info += fontNr;
-      addLog(LOG_LEVEL_INFO, info);
+      addLogMove(LOG_LEVEL_INFO, info);
     }
     #  endif // P073_DEBUG
 
@@ -983,7 +983,7 @@ void tm1637_i2cAck(uint8_t clk_pin,
     } else {
       log += F("FALSE");
     }
-    addLog(LOG_LEVEL_DEBUG, log);
+    addLogMove(LOG_LEVEL_DEBUG, log);
   }
   # endif // ifdef P073_DEBUG
   CLK_HIGH();

--- a/src/_P074_TSL2591.ino
+++ b/src/_P074_TSL2591.ino
@@ -233,7 +233,7 @@ boolean Plugin_074(uint8_t function, struct EventStruct *event, String& string) 
             case TSL2591_GAIN_HIGH: log += F("428x (High)");  break;
             case TSL2591_GAIN_MAX:  log += F("9876x (Max)");  break;
           }
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
       } else {
         clearPluginTaskData(event->TaskIndex);
@@ -279,7 +279,7 @@ boolean Plugin_074(uint8_t function, struct EventStruct *event, String& string) 
             log += String(ir);
             log += F(" duration: ");
             log += P074_data->duration;
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
           }
 
           // Update was succesfull, schedule a read.

--- a/src/_P075_Nextion.ino
+++ b/src/_P075_Nextion.ino
@@ -271,7 +271,8 @@ boolean Plugin_075(uint8_t function, struct EventStruct *event, String& string)
             if(RssiIndex >= 0) {
               int barVal=0;
               newString.reserve(P75_Nchars+10);               // Prevent re-allocation
-              newString = P075_data->displayLines[x].substring(0, RssiIndex);
+              newString.clear();
+              newString += P075_data->displayLines[x].substring(0, RssiIndex);
               int nbars = WiFi.RSSI();
               if (nbars < -100 || nbars >= 0)
                  barVal=0;

--- a/src/_P075_Nextion.ino
+++ b/src/_P075_Nextion.ino
@@ -11,7 +11,7 @@
 //#######################################################################################################
 //
 // Updated: Oct-03-2018, ThomasB.
-// Added DEBUG_LOG define to reduce info log messages and prevent serial log flooding.
+// Added P075_DEBUG_LOG define to reduce info log messages and prevent serial log flooding.
 // Added SendStatus() to post log message on browser to acknowledge HTTP write.
 // Added reserve() to minimize string memory allocations.
 //
@@ -23,7 +23,7 @@
 // Defines start here
 // *****************************************************************************************************
 
-//#define DEBUG_LOG             // Enable this to include additional info messages in log output.
+//#define P075_DEBUG_LOG             // Enable this to include additional info messages in log output.
 
 
 // Plug-In defines
@@ -303,34 +303,34 @@ boolean Plugin_075(uint8_t function, struct EventStruct *event, String& string)
             }
 
             P075_sendCommand(event->TaskIndex, newString.c_str());
-            #ifdef DEBUG_LOG
+            #ifdef P075_DEBUG_LOG
               String log;
               log.reserve(P75_Nchars+50);                 // Prevent re-allocation
               log = F("NEXTION075 : Cmd Statement Line-");
               log += String(x+1);
               log += F(" Sent: ");
               log += newString;
-              addLog(LOG_LEVEL_INFO, log);
+              addLogMove(LOG_LEVEL_INFO, log);
             #endif
           }
         }
 
         // At Interval timer, send idx & value data only if user enabled "values" interval mode.
         if(P075_IncludeValues) {
-            #ifdef DEBUG_LOG
+            #ifdef P075_DEBUG_LOG
              String log;
              log.reserve(120);                          // Prevent re-allocation
              log = F("NEXTION075: Interval values data enabled, resending idx=");
              log += formatUserVarNoCheck(event->TaskIndex, 0);
              log += F(", value=");
              log += formatUserVarNoCheck(event->TaskIndex, 1);
-             addLog(LOG_LEVEL_INFO, log);
+             addLogMove(LOG_LEVEL_INFO, log);
             #endif
 
             success = true;
         }
         else {
-            #ifdef DEBUG_LOG
+            #ifdef P075_DEBUG_LOG
              addLog(LOG_LEVEL_INFO, F("NEXTION075: Interval values data disabled, idx & value not resent"));
             #endif
 
@@ -406,10 +406,10 @@ boolean Plugin_075(uint8_t function, struct EventStruct *event, String& string)
         if(charCount >= RXBUFFWARN) {
             String log;
             log.reserve(70);                           // Prevent re-allocation
-            log = F("NEXTION075 : RxD P075_data->easySerial Buffer capacity warning, ");
+            log += F("NEXTION075 : RxD P075_data->easySerial Buffer capacity warning, ");
             log += String(charCount);
             log += F(" bytes");
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
         }
         uint32_t baudrate_delay_unit = P075_data->baudrate / 9600;
         if (baudrate_delay_unit == 0) {
@@ -436,16 +436,16 @@ boolean Plugin_075(uint8_t function, struct EventStruct *event, String& string)
                 UserVar[event->BaseVarIndex + 1] = __buffer[3];
                 sendData(event);
 
-                #ifdef DEBUG_LOG
+                #ifdef P075_DEBUG_LOG
                   String log;
                   log.reserve(70);                        // Prevent re-allocation
-                  log = F("NEXTION075 : code: ");
+                  log += F("NEXTION075 : code: ");
                   log += __buffer[1];
                   log += ',';
                   log += __buffer[2];
                   log += ',';
                   log += __buffer[3];
-                  addLog(LOG_LEVEL_INFO, log);
+                  addLogMove(LOG_LEVEL_INFO, log);
                 #endif
               }
             }
@@ -469,12 +469,12 @@ boolean Plugin_075(uint8_t function, struct EventStruct *event, String& string)
 
               String tmpString = __buffer;
 
-              #ifdef DEBUG_LOG
+              #ifdef P075_DEBUG_LOG
                 String log;
                 log.reserve(50);                          // Prevent re-allocation
                 log = F("NEXTION075 : Code = ");
                 log += tmpString;
-                addLog(LOG_LEVEL_INFO, log);
+                addLogMove(LOG_LEVEL_INFO, log);
               #endif
 
               int argIndex = tmpString.indexOf(F(",i"));
@@ -509,17 +509,17 @@ boolean Plugin_075(uint8_t function, struct EventStruct *event, String& string)
                   validFloatFromString(Svalue, UserVar[event->BaseVarIndex+1]);
                   sendData(event);
 
-                  #ifdef DEBUG_LOG
+                  #ifdef P075_DEBUG_LOG
                   String log;
                   log.reserve(80);                       // Prevent re-allocation
                   log = F("NEXTION075 : Pipe Command Sent: ");
                   log += __buffer;
                   log += formatUserVarNoCheck(event->TaskIndex, 0);
-                  addLog(LOG_LEVEL_INFO, log);
+                  addLogMove(LOG_LEVEL_INFO, log);
                   #endif
               }
               else {
-                  #ifdef DEBUG_LOG
+                  #ifdef P075_DEBUG_LOG
                   addLog(LOG_LEVEL_INFO, F("NEXTION075 : Unknown Pipe Command, skipped"));
                   #endif
               }

--- a/src/_P076_HLW8012.ino
+++ b/src/_P076_HLW8012.ino
@@ -259,9 +259,11 @@ boolean Plugin_076(uint8_t function, struct EventStruct *event, String &string) 
     if (hlwMultipliers[0] > 1.0 && hlwMultipliers[1] > 1.0 && hlwMultipliers[2] > 1.0) {
       SaveCustomTaskSettings(event->TaskIndex, reinterpret_cast<const uint8_t *>(&hlwMultipliers),
                              sizeof(hlwMultipliers));
+      #ifndef BUILD_NO_DEBUG
       if (PLUGIN_076_DEBUG) {
         addLog(LOG_LEVEL_INFO, F("P076: Saved Calibration from Config Page"));
       }
+      #endif
 
       if (Plugin_076_hlw) {
         Plugin_076_hlw->setCurrentMultiplier(hlwMultipliers[0]);
@@ -269,11 +271,14 @@ boolean Plugin_076(uint8_t function, struct EventStruct *event, String &string) 
         Plugin_076_hlw->setPowerMultiplier(hlwMultipliers[2]);
       }
 
+#ifndef BUILD_NO_DEBUG
       if (PLUGIN_076_DEBUG) {
         addLog(LOG_LEVEL_INFO, F("P076: Multipliers Reassigned"));
       }
+#endif
     }
 
+#ifndef BUILD_NO_DEBUG
     if (PLUGIN_076_DEBUG) {
       String log = F("P076: PIN Settings ");
 
@@ -283,8 +288,9 @@ boolean Plugin_076(uint8_t function, struct EventStruct *event, String &string) 
       log +=  PCONFIG(5);
       log +=  F(" cf1_edge: ");
       log +=  PCONFIG(6);
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
+#endif
 
     success = true;
     break;
@@ -340,6 +346,7 @@ boolean Plugin_076(uint8_t function, struct EventStruct *event, String &string) 
         
         // Measurement is complete.
         p076_read_stage = 0;
+#ifndef BUILD_NO_DEBUG
         if (PLUGIN_076_DEBUG) {
           String log = F("P076: Read values");
           log += F(" - V=");
@@ -350,8 +357,9 @@ boolean Plugin_076(uint8_t function, struct EventStruct *event, String &string) 
           log += p076_hpower;
           log += F(" - Pf%=");
           log += p076_hpowfact;
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
+#endif
         UserVar[event->BaseVarIndex] = p076_hvoltage;
         UserVar[event->BaseVarIndex + 1] = p076_hcurrent;
         UserVar[event->BaseVarIndex + 2] = p076_hpower;
@@ -385,21 +393,27 @@ boolean Plugin_076(uint8_t function, struct EventStruct *event, String &string) 
         Plugin_076_hlw->begin(CF_PIN, CF1_PIN, SEL_PIN, currentRead,
                               true); // set use_interrupts to true to use
                                      // interrupts to monitor pulse widths
+#ifndef BUILD_NO_DEBUG
         if (PLUGIN_076_DEBUG){
           addLog(LOG_LEVEL_INFO, F("P076: Init object done"));
         }
+#endif
         Plugin_076_hlw->setResistors(HLW_CURRENT_RESISTOR,
                                      HLW_VOLTAGE_RESISTOR_UP,
                                      HLW_VOLTAGE_RESISTOR_DOWN);
+#ifndef BUILD_NO_DEBUG
         if (PLUGIN_076_DEBUG){
           addLog(LOG_LEVEL_INFO, F("P076: Init Basic Resistor Values done"));
         }
+#endif
 
         double current, voltage, power;
         if (Plugin076_LoadMultipliers(event->TaskIndex, current, voltage, power)) {
+#ifndef BUILD_NO_DEBUG
           if (PLUGIN_076_DEBUG){
             addLog(LOG_LEVEL_INFO, F("P076: Saved Calibration after INIT"));
           }
+#endif
 
           Plugin_076_hlw->setCurrentMultiplier(current);
           Plugin_076_hlw->setVoltageMultiplier(voltage);
@@ -408,9 +422,11 @@ boolean Plugin_076(uint8_t function, struct EventStruct *event, String &string) 
           Plugin076_ResetMultipliers();
         }
 
+#ifndef BUILD_NO_DEBUG
         if (PLUGIN_076_DEBUG){
           addLog(LOG_LEVEL_INFO, F("P076: Applied Calibration after INIT"));
         }
+#endif
         StoredTaskIndex = event->TaskIndex; // store task index value in order to
                                             // use it in the PLUGIN_WRITE routine
 
@@ -440,6 +456,7 @@ boolean Plugin_076(uint8_t function, struct EventStruct *event, String &string) 
             validUIntFromString(parseString(string, 4), CalibAcPwr);
           }
         }
+#ifndef BUILD_NO_DEBUG
         if (PLUGIN_076_DEBUG) {
           String log = F("P076: Calibration to values");
           log += F(" - Expected-V=");
@@ -448,8 +465,9 @@ boolean Plugin_076(uint8_t function, struct EventStruct *event, String &string) 
           log += CalibCurr;
           log += F(" - Expected-W=");
           log += CalibAcPwr;
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
+#endif
         bool changed = false;
         if (CalibVolt != 0) {
           Plugin_076_hlw->expectedVoltage(CalibVolt);
@@ -481,9 +499,11 @@ void Plugin076_ResetMultipliers() {
   if (Plugin_076_hlw) {
     Plugin_076_hlw->resetMultipliers();
     Plugin076_SaveMultipliers();
+#ifndef BUILD_NO_DEBUG
     if (PLUGIN_076_DEBUG){
       addLog(LOG_LEVEL_INFO, F("P076: Reset Multipliers to DEFAULT"));
     }
+#endif
   }
 }
 

--- a/src/_P077_CSE7766.ino
+++ b/src/_P077_CSE7766.ino
@@ -286,7 +286,9 @@ boolean Plugin_077(uint8_t function, struct EventStruct *event, String &string) 
   */
 
   case PLUGIN_READ: {
+    #ifndef BUILD_NO_DEBUG
     addLog(LOG_LEVEL_DEBUG_DEV, F("CSE: plugin read"));
+    #endif
     //        sendData(event);
     //        Variables set in PLUGIN_SERIAL_IN as soon as there are new values!
     //        UserVar[event->BaseVarIndex] = energy_voltage;
@@ -303,49 +305,50 @@ boolean Plugin_077(uint8_t function, struct EventStruct *event, String &string) 
       success = true;
       /* ONLINE CHECKSUMMING by Bartłomiej Zimoń */
       if (P077_data->processSerialData()) {
+        #ifndef BUILD_NO_DEBUG
         addLog(LOG_LEVEL_DEBUG, F("CSE: packet found"));
         if (CseReceived(event)) {
           if (loglevelActiveFor(LOG_LEVEL_DEBUG_DEV)) {
             String log = F("CSE: adjustment ");
             log += P077_data->adjustment;
-            addLog(LOG_LEVEL_DEBUG_DEV, log);
+            addLogMove(LOG_LEVEL_DEBUG_DEV, log);
             log = F("CSE: voltage_cycle ");
             log += P077_data->voltage_cycle;
-            addLog(LOG_LEVEL_DEBUG_DEV, log);
+            addLogMove(LOG_LEVEL_DEBUG_DEV, log);
             log = F("CSE: current_cycle ");
             log += P077_data->current_cycle;
-            addLog(LOG_LEVEL_DEBUG_DEV, log);
+            addLogMove(LOG_LEVEL_DEBUG_DEV, log);
             log = F("CSE: power_cycle ");
             log += P077_data->power_cycle;
-            addLog(LOG_LEVEL_DEBUG_DEV, log);
+            addLogMove(LOG_LEVEL_DEBUG_DEV, log);
             log = F("CSE: cf_pulses ");
             log += P077_data->cf_pulses;
-            addLog(LOG_LEVEL_DEBUG_DEV, log);
+            addLogMove(LOG_LEVEL_DEBUG_DEV, log);
           }
 
           if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
             String log = F("CSE voltage: ");
             log += P077_data->energy_voltage;
-            addLog(LOG_LEVEL_DEBUG, log);
+            addLogMove(LOG_LEVEL_DEBUG, log);
             log = F("CSE power: ");
             log += P077_data->energy_power;
-            addLog(LOG_LEVEL_DEBUG, log);
+            addLogMove(LOG_LEVEL_DEBUG, log);
             log = F("CSE current: ");
             log += P077_data->energy_current;
-            addLog(LOG_LEVEL_DEBUG, log);
+            addLogMove(LOG_LEVEL_DEBUG, log);
             log = F("CSE pulses: ");
             log += P077_data->cf_pulses;
-            addLog(LOG_LEVEL_DEBUG, log);
+            addLogMove(LOG_LEVEL_DEBUG, log);
           }
         }
-
+        #endif
         // new packet received, update values
         UserVar[event->BaseVarIndex] = P077_data->energy_voltage;
         UserVar[event->BaseVarIndex + 1] = P077_data->energy_power;
         UserVar[event->BaseVarIndex + 2] = P077_data->energy_current;
         UserVar[event->BaseVarIndex + 3] = P077_data->cf_pulses;
 
-
+#ifndef BUILD_NO_DEBUG
         if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
           String log = F("CSE: time ");
           log += P077_data->t_max;
@@ -353,18 +356,19 @@ boolean Plugin_077(uint8_t function, struct EventStruct *event, String &string) 
           log += P077_data->t_pkt;
           log += '/';
           log += P077_data->t_all;
-          addLog(LOG_LEVEL_DEBUG, log);
+          addLogMove(LOG_LEVEL_DEBUG, log);
           log = F("CSE: bytes ");
           log += P077_data->count_bytes;
           log += '/';
           log += P077_data->count_max;
           log += '/';
           log += Serial.available();
-          addLog(LOG_LEVEL_DEBUG, log);
+          addLogMove(LOG_LEVEL_DEBUG, log);
           log = F("CSE: nr ");
           log += P077_data->count_pkt;
-          addLog(LOG_LEVEL_DEBUG, log);
+          addLogMove(LOG_LEVEL_DEBUG, log);
         }
+#endif
         P077_data->t_all = 0;
         P077_data->count_bytes = 0;
       }
@@ -381,7 +385,9 @@ bool CseReceived(struct EventStruct *event) {
     return false;
   }
   if (!P077_data->processCseReceived(event)) {
+    #ifndef BUILD_NO_DEBUG
     addLog(LOG_LEVEL_DEBUG, F("CSE: Abnormal hardware"));
+    #endif
     return false;
   }
   return true;

--- a/src/_P078_Eastron.ino
+++ b/src/_P078_Eastron.ino
@@ -297,7 +297,7 @@ float p078_readVal(uint8_t query, uint8_t node, unsigned int model) {
     log += p078_getQueryString(query);
     log += F(": ");
     log += _tempvar;
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
   return _tempvar;
 }

--- a/src/_P079_Wemos_Motorshield.ino
+++ b/src/_P079_Wemos_Motorshield.ino
@@ -334,8 +334,8 @@ boolean Plugin_079(uint8_t function, struct EventStruct *event, String& string)
         if (parse_error == true) {
           String ErrorStr = ModeStr;
           ErrorStr += F(": CMD Syntax Error");
-          addLog(LOG_LEVEL_INFO, ErrorStr);
           SendStatus(event, ErrorStr + F(" <br>")); // Reply (echo) to sender. This will print message on browser.
+          addLogMove(LOG_LEVEL_INFO, ErrorStr);
         }
         else {
           switch (motor_dir) {
@@ -409,7 +409,7 @@ boolean Plugin_079(uint8_t function, struct EventStruct *event, String& string)
           ModeStr += paramDirection;
           ModeStr += F(", Spd=");
           ModeStr += paramSpeed;
-          addLog(LOG_LEVEL_INFO, ModeStr);          
+          addLogMove(LOG_LEVEL_INFO, ModeStr);          
         }
 
         success = true;

--- a/src/_P080_DallasIButton.ino
+++ b/src/_P080_DallasIButton.ino
@@ -122,6 +122,7 @@ boolean Plugin_080(uint8_t function, struct EventStruct *event, String& string)
         }
         Dallas_startConversion(addr, Plugin_080_DallasPin, Plugin_080_DallasPin);
 
+        #ifndef BUILD_NO_DEBUG
         if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
           String log = F("DS   : iButton: ");
 
@@ -130,8 +131,9 @@ boolean Plugin_080(uint8_t function, struct EventStruct *event, String& string)
           } else {
             log += F("Not Present!");
           }
-          addLog(LOG_LEVEL_DEBUG, log);
+          addLogMove(LOG_LEVEL_DEBUG, log);
         }
+        #endif
       }
       break;
     }

--- a/src/_P081_Cron.ino
+++ b/src/_P081_Cron.ino
@@ -290,13 +290,17 @@ boolean Plugin_081(uint8_t function, struct EventStruct *event, String& string)
           const bool   cron_elapsed = (next_exec_time <= current_time);
 
           if (cron_elapsed) {
+            #ifndef BUILD_NO_DEBUG
             addLog(LOG_LEVEL_DEBUG, F("Cron Elapsed"));
+            #endif
 
             time_t last_exec_time = next_exec_time;
             next_exec_time = P081_computeNextCronTime(event->TaskIndex, current_time);
             P081_setCronExecTimes(event, last_exec_time, next_exec_time);
 
+            #ifndef BUILD_NO_DEBUG
             addLog(LOG_LEVEL_DEBUG, String(F("Next execution:")) + ESPEasy_time::getDateTimeString(*gmtime(&next_exec_time)));
+            #endif
 
             if (function != PLUGIN_TIME_CHANGE) {
               if (Settings.UseRules) {

--- a/src/_P082_GPS.ino
+++ b/src/_P082_GPS.ino
@@ -364,7 +364,7 @@ boolean Plugin_082(uint8_t function, struct EventStruct *event, String& string) 
           // Fix status changed, send events.
           if (Settings.UseRules) {
             String event = curFixStatus ? F("GPS#GotFix") : F("GPS#LostFix");
-            eventQueue.add(event);
+            eventQueue.addMove(std::move(event));
           }
           activeFix = curFixStatus;
         }
@@ -437,7 +437,7 @@ boolean Plugin_082(uint8_t function, struct EventStruct *event, String& string) 
                   if (Settings.UseRules) {
                     String eventString = F("GPS#travelled=");
                     eventString += distance;
-                    eventQueue.add(eventString);
+                    eventQueue.addMove(std::move(eventString));
                   }
 
                   if (loglevelActiveFor(LOG_LEVEL_INFO)) {

--- a/src/_P082_GPS.ino
+++ b/src/_P082_GPS.ino
@@ -386,20 +386,26 @@ boolean Plugin_082(uint8_t function, struct EventStruct *event, String& string) 
               distance = P082_data->distanceSinceLast(P082_TIMEOUT);
             }
             success = true;
+            #ifndef BUILD_NO_DEBUG
             addLog(LOG_LEVEL_DEBUG, F("GPS: Position update."));
+            #endif
           }
 
           if (P082_data->gps->altitude.isUpdated()) {
             // ToDo make unit selectable
             P082_setOutputValue(event, static_cast<uint8_t>(P082_query::P082_QUERY_ALT), P082_data->gps->altitude.meters());
             success = true;
+            #ifndef BUILD_NO_DEBUG
             addLog(LOG_LEVEL_DEBUG, F("GPS: Altitude update."));
+            #endif
           }
 
           if (P082_data->gps->speed.isUpdated()) {
             // ToDo make unit selectable
             P082_setOutputValue(event, static_cast<uint8_t>(P082_query::P082_QUERY_SPD), P082_data->gps->speed.mps());
+            #ifndef BUILD_NO_DEBUG
             addLog(LOG_LEVEL_DEBUG, F("GPS: Speed update."));
+            #endif
             success = true;
           }
         }
@@ -438,7 +444,7 @@ boolean Plugin_082(uint8_t function, struct EventStruct *event, String& string) 
                     String log = F("GPS: Distance trigger : ");
                     log += distance;
                     log += F(" m");
-                    addLog(LOG_LEVEL_INFO, log);
+                    addLogMove(LOG_LEVEL_INFO, log);
                   }
                 }
               }
@@ -549,6 +555,7 @@ void P082_setOutputValue(struct EventStruct *event, uint8_t outputType, float va
 }
 
 void P082_logStats(struct EventStruct *event) {
+  #ifndef BUILD_NO_DEBUG
   if (!loglevelActiveFor(LOG_LEVEL_DEBUG)) { return; }
   P082_data_struct *P082_data =
     static_cast<P082_data_struct *>(getPluginTaskData(event->TaskIndex));
@@ -573,8 +580,9 @@ void P082_logStats(struct EventStruct *event) {
     log += P082_data->gps->failedChecksum();
     log += F(" invalid: ");
     log += P082_data->gps->invalidData();
-    addLog(LOG_LEVEL_DEBUG, log);
+    addLogMove(LOG_LEVEL_DEBUG, log);
   }
+  #endif
 }
 
 void P082_html_show_satStats(struct EventStruct *event, bool tracked, bool onlyGPS) {

--- a/src/_P083_SGP30.ino
+++ b/src/_P083_SGP30.ino
@@ -163,10 +163,10 @@ boolean Plugin_083(uint8_t function, struct EventStruct *event, String& string)
             if (loglevelActiveFor(LOG_LEVEL_INFO)) {
               String log = F("SGP30: TVOC: ");
               log += UserVar[P083_TVOC];
-              addLog(LOG_LEVEL_INFO, log);
+              addLogMove(LOG_LEVEL_INFO, log);
               log  = F("SGP30: eCO2: ");
               log += UserVar[P083_ECO2];
-              addLog(LOG_LEVEL_INFO, log);
+              addLogMove(LOG_LEVEL_INFO, log);
             }
             success = true;
             break;

--- a/src/_P084_VEML6070.ino
+++ b/src/_P084_VEML6070.ino
@@ -128,7 +128,7 @@ boolean Plugin_084(uint8_t function, struct EventStruct *event, String& string)
         if (loglevelActiveFor(LOG_LEVEL_INFO)) {
           String log = F("VEML6070: UV: ");
           log += formatUserVarNoCheck(event->TaskIndex, 0);
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
 
         success = true;
@@ -185,7 +185,7 @@ double VEML6070_UvRiskLevel(uint16_t uv_level)
     if (loglevelActiveFor(LOG_LEVEL_INFO)) {
       String log = F("VEML6070 out of range: ");
       log += risk;
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
 
     return 99;

--- a/src/_P086_Homie.ino
+++ b/src/_P086_Homie.ino
@@ -171,7 +171,7 @@ boolean Plugin_086(uint8_t function, struct EventStruct *event, String& string)
           log += x+1;
           log += F(": ");
           log += formatUserVarNoCheck(event->TaskIndex, x);
-          addLog(LOG_LEVEL_INFO,log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
         success = true;
         break;
@@ -246,7 +246,7 @@ boolean Plugin_086(uint8_t function, struct EventStruct *event, String& string)
                     if (loglevelActiveFor(LOG_LEVEL_INFO)) {
                       log += F(" integer/float set to ");
                       log += floatValue;
-                      addLog(LOG_LEVEL_INFO,log);
+                      addLogMove(LOG_LEVEL_INFO, log);
                     }
                     UserVar[userVarIndex]=floatValue;
                   } else { // float conversion failed!
@@ -254,14 +254,14 @@ boolean Plugin_086(uint8_t function, struct EventStruct *event, String& string)
                       log += F(" parameter:");
                       log += parameter;
                       log += F(" not a float value!");
-                      addLog(LOG_LEVEL_ERROR,log);
+                      addLogMove(LOG_LEVEL_ERROR, log);
                     }
                   }
                 } else {
                   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
                     log += F(" value:");
                     log += UserVar[userVarIndex];
-                    addLog(LOG_LEVEL_INFO,log);
+                    addLogMove(LOG_LEVEL_INFO, log);
                   }
                 }
                 break;
@@ -276,7 +276,7 @@ boolean Plugin_086(uint8_t function, struct EventStruct *event, String& string)
                 if (loglevelActiveFor(LOG_LEVEL_INFO)) {
                   log += F(" boolean set to ");
                   log += floatValue;
-                  addLog(LOG_LEVEL_INFO,log);
+                  addLogMove(LOG_LEVEL_INFO, log);
                 }
                 break;
 
@@ -286,7 +286,7 @@ boolean Plugin_086(uint8_t function, struct EventStruct *event, String& string)
                 if (loglevelActiveFor(LOG_LEVEL_INFO)) {
                   log += F(" string set to ");
                   log += parameter;
-                  addLog(LOG_LEVEL_INFO,log);
+                  addLogMove(LOG_LEVEL_INFO, log);
                 }
                 break;
 
@@ -306,7 +306,7 @@ boolean Plugin_086(uint8_t function, struct EventStruct *event, String& string)
                   log += floatValue;
                   log += ' ';
                   log += wrap_braces(parameter);
-                  addLog(LOG_LEVEL_INFO,log);
+                  addLogMove(LOG_LEVEL_INFO, log);
                 }
                 break;
 
@@ -316,7 +316,7 @@ boolean Plugin_086(uint8_t function, struct EventStruct *event, String& string)
                 if (loglevelActiveFor(LOG_LEVEL_INFO)) {
                   log += F(" RGB received ");
                   log += parameter;
-                  addLog(LOG_LEVEL_INFO,log);
+                  addLogMove(LOG_LEVEL_INFO, log);
                 }
                 break;
 
@@ -326,7 +326,7 @@ boolean Plugin_086(uint8_t function, struct EventStruct *event, String& string)
                 if (loglevelActiveFor(LOG_LEVEL_INFO)) {
                   log += F(" HSV received ");
                   log += parameter;
-                  addLog(LOG_LEVEL_INFO,log);
+                  addLogMove(LOG_LEVEL_INFO, log);
                 }
                 break;
             }

--- a/src/_P087_SerialProxy.ino
+++ b/src/_P087_SerialProxy.ino
@@ -210,7 +210,9 @@ boolean Plugin_087(uint8_t function, struct EventStruct *event, String& string) 
       if ((nullptr != P087_data) && P087_data->getSentence(event->String2)) {
         if (Plugin_087_match_all(event->TaskIndex, event->String2)) {
 //          sendData(event);
+#ifndef BUILD_NO_DEBUG
           addLog(LOG_LEVEL_DEBUG, event->String2);
+#endif
           success = true;
         }
       }
@@ -231,7 +233,7 @@ boolean Plugin_087(uint8_t function, struct EventStruct *event, String& string) 
           String param1 = parseStringKeepCase(string, 2);
           parseSystemVariables(param1, false);
           P087_data->sendString(param1);
-          addLog(LOG_LEVEL_INFO, param1);
+          addLogMove(LOG_LEVEL_INFO, param1);
           success = true;
         }
       }

--- a/src/_P090_CCS811.ino
+++ b/src/_P090_CCS811.ino
@@ -202,7 +202,7 @@ boolean Plugin_090(uint8_t function, struct EventStruct *event, String& string)
       if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
         String log = F("CCS811 : Begin exited with: ");
         log += P090_data->myCCS811.getDriverError(returnCode);
-        addLog(LOG_LEVEL_DEBUG, log);
+        addLogMove(LOG_LEVEL_DEBUG, log);
       }
       #endif // ifndef BUILD_NO_DEBUG
       UserVar[event->BaseVarIndex]     = NAN;
@@ -222,7 +222,7 @@ boolean Plugin_090(uint8_t function, struct EventStruct *event, String& string)
         if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
           String log = F("CCS811 : Mode request exited with: ");
           log += P090_data->myCCS811.getDriverError(returnCode);
-          addLog(LOG_LEVEL_DEBUG, log);
+          addLogMove(LOG_LEVEL_DEBUG, log);
         }
       #endif // ifndef BUILD_NO_DEBUG
       } else {
@@ -262,7 +262,7 @@ boolean Plugin_090(uint8_t function, struct EventStruct *event, String& string)
               log += P090_data->myCCS811.getTVOC();
               log += F(", eCO2: ");
               log += P090_data->myCCS811.getCO2();
-              addLog(LOG_LEVEL_INFO, log);
+              addLogMove(LOG_LEVEL_INFO, log);
             }
           }
         }
@@ -307,7 +307,7 @@ boolean Plugin_090(uint8_t function, struct EventStruct *event, String& string)
         if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
           String log = F("CCS811 : Compensating for Temperature: ");
           log += toString(temperature) + temp + F(" & Humidity: ") + toString(humidity) + F("%");
-          addLog(LOG_LEVEL_DEBUG, log);
+          addLogMove(LOG_LEVEL_DEBUG, log);
         }
       #endif // ifndef BUILD_NO_DEBUG
 
@@ -328,7 +328,7 @@ boolean Plugin_090(uint8_t function, struct EventStruct *event, String& string)
           // If the CCS811 found an internal error, print it.
           String log = F("CCS811 : Error: ");
           log += errorMsg;
-          addLog(LOG_LEVEL_ERROR, log);
+          addLogMove(LOG_LEVEL_ERROR, log);
         }
       }
 

--- a/src/_P091_SerSwitch.ino
+++ b/src/_P091_SerSwitch.ino
@@ -313,7 +313,7 @@ boolean Plugin_091(uint8_t function, struct EventStruct *event, String& string)
             Plugin_091_type = Sensor_VType::SENSOR_TYPE_QUAD;
             break;
         }
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
 
         success = true;
         Plugin_091_init = true;
@@ -439,7 +439,7 @@ boolean Plugin_091(uint8_t function, struct EventStruct *event, String& string)
                       log += F(" r3:");
                       log += Plugin_091_switchstate[3];
                     }
-                    addLog(LOG_LEVEL_INFO, log);
+                    addLogMove(LOG_LEVEL_INFO, log);
                     if ( (Plugin_091_ostate[0] != Plugin_091_switchstate[0]) || (Plugin_091_ostate[1] != Plugin_091_switchstate[1]) || (Plugin_091_ostate[2] != Plugin_091_switchstate[2]) || (Plugin_091_ostate[3] != Plugin_091_switchstate[3]) ) {
                       event->sensorType = Plugin_091_type;
                       sendData(event);
@@ -495,7 +495,7 @@ boolean Plugin_091(uint8_t function, struct EventStruct *event, String& string)
                               }
                           }
                           event->sensorType = Plugin_091_type;
-                          addLog(LOG_LEVEL_INFO, log);
+                          addLogMove(LOG_LEVEL_INFO, log);
                           sendData(event);
                         }
                       }
@@ -529,7 +529,7 @@ boolean Plugin_091(uint8_t function, struct EventStruct *event, String& string)
                               }
                           }
                           event->sensorType = Plugin_091_type;
-                          addLog(LOG_LEVEL_INFO, log);
+                          addLogMove(LOG_LEVEL_INFO, log);
                           sendData(event);
                         }
                       }
@@ -624,11 +624,13 @@ boolean Plugin_091(uint8_t function, struct EventStruct *event, String& string)
                 sendData(event);
               }
             }
-            String log = F("SerSW   : SetSwitch r");
-            log += rnum;
-            log += ':';
-            log += rcmd;
-            addLog(LOG_LEVEL_INFO, log);
+            if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+              String log = F("SerSW   : SetSwitch r");
+              log += rnum;
+              log += ':';
+              log += rcmd;
+              addLogMove(LOG_LEVEL_INFO, log);
+            }
           }
 
           if ( command == F("relaypulse") )
@@ -671,14 +673,16 @@ boolean Plugin_091(uint8_t function, struct EventStruct *event, String& string)
               }
             }
 
-            String log = F("SerSW   : SetSwitchPulse r");
-            log += rnum;
-            log += ':';
-            log += rcmd;
-            log += F(" Pulsed for ");
-            log += String(event->Par3);
-            log += F(" mS");
-            addLog(LOG_LEVEL_INFO, log);
+            if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+              String log = F("SerSW   : SetSwitchPulse r");
+              log += rnum;
+              log += ':';
+              log += rcmd;
+              log += F(" Pulsed for ");
+              log += String(event->Par3);
+              log += F(" mS");
+              addLogMove(LOG_LEVEL_INFO, log);
+            }
           }
 
           if ( command == F("relaylongpulse") )
@@ -722,18 +726,19 @@ boolean Plugin_091(uint8_t function, struct EventStruct *event, String& string)
               }
             }
 
-            String log = F("SerSW   : SetSwitchPulse r");
-            log += rnum;
-            log += ':';
-            log += rcmd;
-            log += F(" Pulse for ");
-            log += String(event->Par3);
-            log += F(" sec");
-            addLog(LOG_LEVEL_INFO, log);
+            if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+              String log = F("SerSW   : SetSwitchPulse r");
+              log += rnum;
+              log += ':';
+              log += rcmd;
+              log += F(" Pulse for ");
+              log += String(event->Par3);
+              log += F(" sec");
+              addLogMove(LOG_LEVEL_INFO, log);
+            }
           }
           if ( command == F("ydim") ) // deal with dimmer command
           {
-            String log = F("SerSW   : SetDim ");
             if (( (Plugin_091_globalpar0 == SER_SWITCH_YEWE) && (Plugin_091_numrelay > 1)) || (Plugin_091_globalpar0 == SER_SWITCH_WIFIDIMMER)) { // only on tuya dimmer
               success = true;
 
@@ -753,11 +758,13 @@ boolean Plugin_091(uint8_t function, struct EventStruct *event, String& string)
                 event->sensorType = Plugin_091_type;
                 sendData(event);
               }
-              log += event->Par1;
-              addLog(LOG_LEVEL_INFO, log);
+              if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+                String log = F("SerSW   : SetDim ");
+                log += event->Par1;
+                addLogMove(LOG_LEVEL_INFO, log);
+              }
             } else {
-              log = F("\nYDim not supported");
-              SendStatus(event, log);
+              SendStatus(event, F("\nYDim not supported"));
             }
           }
 
@@ -801,12 +808,14 @@ boolean Plugin_091(uint8_t function, struct EventStruct *event, String& string)
           }
         }
 
-        String log = F("SerSW   : SetSwitchPulse r");
-        log += rnum;
-        log += ':';
-        log += rcmd;
-        log += F(" Pulse ended");
-        addLog(LOG_LEVEL_INFO, log);
+        if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+          String log = F("SerSW   : SetSwitchPulse r");
+          log += rnum;
+          log += ':';
+          log += rcmd;
+          log += F(" Pulse ended");
+          addLogMove(LOG_LEVEL_INFO, log);
+        }
 
         break;
       }

--- a/src/_P092_DLbus.ino
+++ b/src/_P092_DLbus.ino
@@ -378,7 +378,7 @@ boolean Plugin_092(uint8_t function, struct EventStruct *event, String& string)
         }
         log += F(" IdxCRC:");
         log += P092_data->P092_DataSettings.IdxCRC;
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
 # endif // PLUGIN_092_DEBUG
       UserVar[event->BaseVarIndex] = NAN;
@@ -391,7 +391,7 @@ boolean Plugin_092(uint8_t function, struct EventStruct *event, String& string)
       if (loglevelActiveFor(LOG_LEVEL_INFO)) {
         String log = F("PLUGIN_092_INIT Task:");
         log += event->TaskIndex;
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
 
       if (P092_init) {
@@ -474,7 +474,7 @@ boolean Plugin_092(uint8_t function, struct EventStruct *event, String& string)
           if (loglevelActiveFor(LOG_LEVEL_INFO)) {
             String log = F("Received data OK TI:");
             log += event->TaskIndex;
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
           }
         }
         P092_data->P092_ReceivedOK = success;
@@ -497,7 +497,7 @@ boolean Plugin_092(uint8_t function, struct EventStruct *event, String& string)
       if (loglevelActiveFor(LOG_LEVEL_INFO)) {
         String log = F("PLUGIN_092_READ Task:");
         log += event->TaskIndex;
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
 
       if (!NetworkConnected()) {
@@ -523,7 +523,7 @@ boolean Plugin_092(uint8_t function, struct EventStruct *event, String& string)
           log += P092_data->DLbus_Data->ISR_DLB_Pin;
           log += F(" Setting:");
           log += CONFIG_PIN1;
-          addLog(LOG_LEVEL_ERROR, log);
+          addLogMove(LOG_LEVEL_ERROR, log);
         }
         return false;
       }

--- a/src/_P094_CULReader.ino
+++ b/src/_P094_CULReader.ino
@@ -257,7 +257,7 @@ boolean Plugin_094(uint8_t function, struct EventStruct *event, String& string) 
         if ((nullptr != P094_data)) {
           const uint32_t debug_count = P094_data->getDebugCounter();
           event->String2.reserve(P094_DEBUG_SENTENCE_LENGTH);
-          event->String2 = String(debug_count);
+          event->String2 += String(debug_count);
           event->String2 += '_';
           const char c = '0' + debug_count % 10;
           for (long i = event->String2.length(); i < P094_DEBUG_SENTENCE_LENGTH; ++i) {

--- a/src/_P094_CULReader.ino
+++ b/src/_P094_CULReader.ino
@@ -233,7 +233,7 @@ boolean Plugin_094(uint8_t function, struct EventStruct *event, String& string) 
                     log += F("...");
                     log += event->String2.substring(messageLength - 40);
                   }
-                  addLog(LOG_LEVEL_INFO, log);
+                  addLogMove(LOG_LEVEL_INFO, log);
                 }
               }
               // Filter length options:
@@ -267,7 +267,7 @@ boolean Plugin_094(uint8_t function, struct EventStruct *event, String& string) 
             String log = F("CUL Reader: Sending: ");
             log += event->String2.substring(0, 20);
             log += F("...");
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
           }
 //          sendData_checkDuplicates(event, event->String2.substring(0, 22));
           sendData(event);
@@ -288,7 +288,7 @@ boolean Plugin_094(uint8_t function, struct EventStruct *event, String& string) 
             String param1 = parseStringKeepCase(string, 2);
             parseSystemVariables(param1, false);
             P094_data->sendString(param1);
-            addLog(LOG_LEVEL_INFO, param1);
+            addLogMove(LOG_LEVEL_INFO, param1);
             success = true;
           }
         }

--- a/src/_P095_ILI9341.ino
+++ b/src/_P095_ILI9341.ino
@@ -477,7 +477,7 @@ boolean Plugin_095(uint8_t function, struct EventStruct *event, String& string)
             String log2  = F("Parsed command = \"");
             log2 += string;
             log2 += F("\"");
-            addLog(LOG_LEVEL_INFO, log2);
+            addLogMove(LOG_LEVEL_INFO, log2);
           }
         } 
         else 

--- a/src/_P097_Esp32Touch.ino
+++ b/src/_P097_Esp32Touch.ino
@@ -153,10 +153,10 @@ boolean Plugin_097(uint8_t function, struct EventStruct *event, String& string)
                 if (Settings.UseRules) {
                   String eventString;
                   eventString.reserve(32);
-                  eventString  = getTaskDeviceName(event->TaskIndex);
+                  eventString += getTaskDeviceName(event->TaskIndex);
                   eventString += F("#Duration=");
                   eventString += timePassedSince(p097_timestamp[t]);
-                  eventQueue.add(eventString);
+                  eventQueue.addMove(std::move(eventString));
                 }
               }
               bitClear(p097_pinTouchedPrev, t);

--- a/src/_P097_Esp32Touch.ino
+++ b/src/_P097_Esp32Touch.ino
@@ -179,7 +179,7 @@ boolean Plugin_097(uint8_t function, struct EventStruct *event, String& string)
         log += formatGpioName_ADC(CONFIG_PIN1);
         log += F(": ");
         log += raw_value;
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
       success = true;
       break;

--- a/src/_P099_XPT2046Touch.ino
+++ b/src/_P099_XPT2046Touch.ino
@@ -424,8 +424,6 @@ boolean Plugin_099(uint8_t function, struct EventStruct *event, String& string)
     {
       String command;
       String subcommand;
-      String arguments;
-      arguments.reserve(24);
 
       int argIndex = string.indexOf(',');
       if (argIndex) {
@@ -439,23 +437,19 @@ boolean Plugin_099(uint8_t function, struct EventStruct *event, String& string)
         }
         if (command.equals(F("touch"))) {
           if(subcommand.equals(F("rot"))) { // touch,rot,<0..3> : Set rotation to 0, 90, 180, 270 degrees
-            arguments = parseString(string, 3);
-            uint8_t rot_ = static_cast<uint8_t>(arguments.toInt() % 4);
+            uint8_t rot_ = static_cast<uint8_t>(parseString(string, 3).toInt() % 4);
 
             P099_data->setRotation(rot_);
             success = true;
           } else if (subcommand.equals(F("flip"))) { // touch,flip,<0|1> : Flip rotation by 0 or 180 degrees
-            arguments = parseString(string, 3);
-            bool flip_ = (arguments.toInt() > 0);
+            bool flip_ = (parseString(string, 3).toInt() > 0);
 
             P099_data->setRotationFlipped(flip_);
             success = true;
           } else if (subcommand.equals(F("enable"))) { // touch,enable,<objectName> : Enables a disabled objectname (with a leading underscore)
-            arguments = parseString(string, 3);
-            success = P099_data->setTouchObjectState(arguments, true, P099_CONFIG_OBJECTCOUNT);
+            success = P099_data->setTouchObjectState(parseString(string, 3), true, P099_CONFIG_OBJECTCOUNT);
           } else if (subcommand.equals(F("disable"))) { // touch,disable,<objectName> : Disables an enabled objectname (without a leading underscore)
-            arguments = parseString(string, 3);
-            success = P099_data->setTouchObjectState(arguments, false, P099_CONFIG_OBJECTCOUNT);
+            success = P099_data->setTouchObjectState(parseString(string, 3), false, P099_CONFIG_OBJECTCOUNT);
           }
         }
       }
@@ -528,7 +522,7 @@ boolean Plugin_099(uint8_t function, struct EventStruct *event, String& string)
                         P099_data->TouchTimers[selectedObjectIndex] = 0;
                         String eventCommand;
                         eventCommand.reserve(48);
-                        eventCommand = getTaskDeviceName(event->TaskIndex);
+                        eventCommand += getTaskDeviceName(event->TaskIndex);
                         eventCommand += '#';
                         eventCommand += selectedObjectName;
                         eventCommand += '='; // Add arguments
@@ -537,14 +531,14 @@ boolean Plugin_099(uint8_t function, struct EventStruct *event, String& string)
                         } else {
                           eventCommand += (P099_data->TouchStates[selectedObjectIndex] ? '1' : '0'); // Act like a button, 1 = On, 0 = Off
                         }
-                        eventQueue.add(eventCommand);
+                        eventQueue.addMove(std::move(eventCommand));
                       }
                     }
                   } else {
                     // Matching object is found, send <TaskDeviceName>#<ObjectName> event with x, y and z as %eventvalue1/2/3%
                     String eventCommand;
                     eventCommand.reserve(48);
-                    eventCommand = getTaskDeviceName(event->TaskIndex);
+                    eventCommand += getTaskDeviceName(event->TaskIndex);
                     eventCommand += '#';
                     eventCommand += selectedObjectName;
                     eventCommand += '='; // Add arguments
@@ -553,7 +547,7 @@ boolean Plugin_099(uint8_t function, struct EventStruct *event, String& string)
                     eventCommand += y;
                     eventCommand += ',';
                     eventCommand += z;
-                    eventQueue.add(eventCommand);
+                    eventQueue.addMove(std::move(eventCommand));
                   }
                 }
               }

--- a/src/_P099_XPT2046Touch.ino
+++ b/src/_P099_XPT2046Touch.ino
@@ -360,9 +360,11 @@ boolean Plugin_099(uint8_t function, struct EventStruct *event, String& string)
         addHtmlError(error);
       }
 #ifdef PLUGIN_099_DEBUG
-      String log = F("p099_data save size: ");
-      log += sizeof(P099_data->StoredSettings);
-      addLog(LOG_LEVEL_INFO, log);
+      if (logLevelActiveFor(LOG_LEVEL_INFO)) {
+        String log = F("p099_data save size: ");
+        log += sizeof(P099_data->StoredSettings);
+        addLogMove(LOG_LEVEL_INFO, log);
+      }
 #endif // PLUGIN_099_DEBUG
       SaveCustomTaskSettings(event->TaskIndex, reinterpret_cast<const uint8_t *>(&(P099_data->StoredSettings)), sizeof(P099_data->StoredSettings) /*+ sizeof(P099_data->TouchObjects)*/);
       delete P099_data;
@@ -496,7 +498,7 @@ boolean Plugin_099(uint8_t function, struct EventStruct *event, String& string)
                 log += x;
                 log += F(", y= ");
                 log += y;
-                addLog(LOG_LEVEL_INFO, log);
+                addLogMove(LOG_LEVEL_INFO, log);
               }
             }
 

--- a/src/_P100_DS2423_counter.ino
+++ b/src/_P100_DS2423_counter.ino
@@ -142,7 +142,7 @@ boolean Plugin_100(uint8_t function, struct EventStruct *event, String& string)
             log += F(" (");
             log += Dallas_format_address(addr);
             log += ')';
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
           }
         }
       }

--- a/src/_P101_WakeOnLan.ino
+++ b/src/_P101_WakeOnLan.ino
@@ -205,7 +205,7 @@ boolean Plugin_101(uint8_t function, struct EventStruct *event, String& string)
         msgStr  = wolStr;
         msgStr += F("Loaded Default IP = ");
         msgStr += F(IP_STR_DEF_P101);
-        addLog(LOG_LEVEL_INFO, msgStr);
+        addLogMove(LOG_LEVEL_INFO, msgStr);
       }
       else if (strlen(ipString) < IP_MIN_SIZE_P101) { // IP Address too short, load default value. Warn User.
         strcpy_P(ipString, String(F(IP_STR_DEF_P101)).c_str());
@@ -216,7 +216,7 @@ boolean Plugin_101(uint8_t function, struct EventStruct *event, String& string)
         msgStr   += F("[");
         msgStr   += F(IP_STR_DEF_P101);
         msgStr   += F("]");
-        addLog(LOG_LEVEL_INFO, msgStr);
+        addLogMove(LOG_LEVEL_INFO, msgStr);
       }
       else if (!validateIp(ipString)) { // Unexpected IP Address value. Leave as-is, but Warn User.
         msgStr    = F("WARNING, Please Review IP Address. ");
@@ -225,7 +225,7 @@ boolean Plugin_101(uint8_t function, struct EventStruct *event, String& string)
         msgStr   += F("[");
         msgStr   += ipString;
         msgStr   += F("]");
-        addLog(LOG_LEVEL_INFO, msgStr);
+        addLogMove(LOG_LEVEL_INFO, msgStr);
       }
 
       // Check MAC Address.
@@ -250,7 +250,7 @@ boolean Plugin_101(uint8_t function, struct EventStruct *event, String& string)
         msgStr   += F("[");
         msgStr   += macString;
         msgStr   += F("]");
-        addLog(LOG_LEVEL_INFO, msgStr);
+        addLogMove(LOG_LEVEL_INFO, msgStr);
       }
 
       // Save the user's IP and MAC Address parameters into Custom Settings.
@@ -340,7 +340,7 @@ boolean Plugin_101(uint8_t function, struct EventStruct *event, String& string)
           msgStr     += F("Error, MAC Addr Invalid [");
           msgStr     += paramMac;
           msgStr     += F("]");
-          addLog(LOG_LEVEL_INFO, msgStr);
+          addLogMove(LOG_LEVEL_INFO, msgStr);
         }
 
         // Validate IP Address.
@@ -350,7 +350,7 @@ boolean Plugin_101(uint8_t function, struct EventStruct *event, String& string)
           msgStr     += F("Error, IP Addr Invalid [");
           msgStr     += paramIp;
           msgStr     += F("]");
-          addLog(LOG_LEVEL_INFO, msgStr);
+          addLogMove(LOG_LEVEL_INFO, msgStr);
         }
 
         // Validate UDP Port.
@@ -360,7 +360,7 @@ boolean Plugin_101(uint8_t function, struct EventStruct *event, String& string)
           msgStr     += F("Error, Port Invalid [");
           msgStr     += paramPort;
           msgStr     += F("]");
-          addLog(LOG_LEVEL_INFO, msgStr);
+          addLogMove(LOG_LEVEL_INFO, msgStr);
         }
 
         // If no errors we can send Magic Packet.
@@ -378,7 +378,7 @@ boolean Plugin_101(uint8_t function, struct EventStruct *event, String& string)
           msgStr += paramIp;
           msgStr += F(", Port= ");
           msgStr += paramPort;
-          addLog(LOG_LEVEL_INFO, msgStr);
+          addLogMove(LOG_LEVEL_INFO, msgStr);
 
           // Send Magic Packet.
           if (WiFi.status() == WL_CONNECTED) {
@@ -391,13 +391,13 @@ boolean Plugin_101(uint8_t function, struct EventStruct *event, String& string)
             if (!WOL.sendMagicPacket(paramMac, paramPort.toInt())) {
               msgStr  = wolStr;
               msgStr += F("Error, Magic Packet Failed (check parameters)");
-              addLog(LOG_LEVEL_INFO, msgStr);
+              addLogMove(LOG_LEVEL_INFO, msgStr);
             }
           }
           else {
             msgStr  = wolStr;
             msgStr += F("Error, WiFi Off-Line");
-            addLog(LOG_LEVEL_INFO, msgStr);
+            addLogMove(LOG_LEVEL_INFO, msgStr);
           }
         }
       }

--- a/src/_P103_Atlas_EZO_pH_ORP_EC_DO.ino
+++ b/src/_P103_Atlas_EZO_pH_ORP_EC_DO.ino
@@ -148,7 +148,9 @@ boolean Plugin_103(uint8_t function, struct EventStruct *event, String &string)
 
       addRowLabel(F("Board restart code"));
 
+      #ifndef BUILD_NO_DEBUG
       addLog(LOG_LEVEL_DEBUG, boardStatus);
+      #endif
 
       char *statuschar = strchr(statussensordata, ',');
 
@@ -344,7 +346,9 @@ boolean Plugin_103(uint8_t function, struct EventStruct *event, String &string)
 
     if((board_type == EC) && isFormItemChecked(F("Plugin_103_enable_set_probe_type")))
     {
+      #ifndef BUILD_NO_DEBUG
       addLog(LOG_LEVEL_DEBUG, F("isFormItemChecked"));
+      #endif
       String probeType(F("K,"));
       probeType += webArg(F("Plugin_103_ec_probe_type"));
       char setProbeTypeCmd[ATLAS_EZO_RETURN_ARRAY_SIZE] = {0};
@@ -496,11 +500,13 @@ bool _P103_send_I2C_command(uint8_t I2Caddress, const String &cmd, char *sensord
   uint8_t i2c_response_code = 0;
   uint8_t in_char = 0;
 
+#ifndef BUILD_NO_DEBUG
   String log = F("> cmd = ");
   log += cmd;
-  addLog(LOG_LEVEL_DEBUG, log);
+  addLogMove(LOG_LEVEL_DEBUG, log);
 
-  addLog(LOG_LEVEL_DEBUG, String(cmd));
+//  addLog(LOG_LEVEL_DEBUG, String(cmd));
+#endif
   Wire.beginTransmission(I2Caddress);
   Wire.write(cmd.c_str());
   error = Wire.endTransmission();
@@ -557,22 +563,30 @@ bool _P103_send_I2C_command(uint8_t I2Caddress, const String &cmd, char *sensord
       {
       case 1:
       {
+        #ifndef BUILD_NO_DEBUG
         String log = F("< success, answer = ");
         log += sensordata;
-        addLog(LOG_LEVEL_DEBUG, log);
+        addLogMove(LOG_LEVEL_DEBUG, log);
+        #endif
         break;
       }
 
       case 2:
+        #ifndef BUILD_NO_DEBUG
         addLog(LOG_LEVEL_DEBUG, F("< command failed"));
+        #endif
         return false;
 
       case 254:
+        #ifndef BUILD_NO_DEBUG
         addLog(LOG_LEVEL_DEBUG_MORE, F("< command pending"));
+        #endif
         break;
 
       case 255:
+        #ifndef BUILD_NO_DEBUG
         addLog(LOG_LEVEL_DEBUG, F("< no data"));
+        #endif
         return false;
       }
     }

--- a/src/_P104_max7219_Dotmatrix.ino
+++ b/src/_P104_max7219_Dotmatrix.ino
@@ -245,7 +245,7 @@ boolean Plugin_104(uint8_t function, struct EventStruct *event, String& string) 
         log.reserve(38);
         log  = F("dotmatrix: PLUGIN_INIT numDevices: ");
         log += numDevices;
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
       # endif // ifdef P104_DEBUG
 

--- a/src/_P105_AHT.ino
+++ b/src/_P105_AHT.ino
@@ -195,13 +195,13 @@ boolean Plugin_105(uint8_t function, struct EventStruct *event, String& string)
           log  = P105_data->getDeviceName();
           log += F(" : Addr: 0x");
           log += String(PCONFIG(0), HEX);
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
           log  = P105_data->getDeviceName();
           log += F(" : Temperature: ");
           log += formatUserVarNoCheck(event->TaskIndex, 0);
           log += F(" : Humidity: ");
           log += formatUserVarNoCheck(event->TaskIndex, 1);
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
         success = true;
       }

--- a/src/_P107_SI1145.ino
+++ b/src/_P107_SI1145.ino
@@ -91,13 +91,13 @@ boolean Plugin_107(uint8_t function, struct EventStruct *event, String& string)
       if (loglevelActiveFor(LOG_LEVEL_INFO)) {
         String log = F("SI1145: Visible: ");
         log += formatUserVarNoCheck(event->TaskIndex, 0);
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
         log  = F("SI1145: Infrared: ");
         log += formatUserVarNoCheck(event->TaskIndex, 1);
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
         log  = F("SI1145: UV index: ");
         log += formatUserVarNoCheck(event->TaskIndex, 2);
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
       success = true;
       break;

--- a/src/_P109_ThermOLED.ino
+++ b/src/_P109_ThermOLED.ino
@@ -292,13 +292,15 @@ boolean Plugin_109(byte function, struct EventStruct *event, String& string)
       uint8_t OLED_contrast = Settings.TaskDevicePluginConfig[event->TaskIndex][3];
       P109_setContrast(OLED_contrast);
 
-      String logstr = F("Thermo : Btn L:");
-      logstr += Settings.TaskDevicePin1[event->TaskIndex];
-      logstr += F("R:");
-      logstr += Settings.TaskDevicePin2[event->TaskIndex];
-      logstr += F("M:");
-      logstr += Settings.TaskDevicePin3[event->TaskIndex];
-      addLog(LOG_LEVEL_INFO, logstr);
+      if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+        String logstr = F("Thermo : Btn L:");
+        logstr += Settings.TaskDevicePin1[event->TaskIndex];
+        logstr += F("R:");
+        logstr += Settings.TaskDevicePin2[event->TaskIndex];
+        logstr += F("M:");
+        logstr += Settings.TaskDevicePin3[event->TaskIndex];
+        addLogMove(LOG_LEVEL_INFO, logstr);
+      }
 
       if (validGpio(Settings.TaskDevicePin1[event->TaskIndex]) )
       {
@@ -339,11 +341,13 @@ boolean Plugin_109(byte function, struct EventStruct *event, String& string)
         P109_setHeatRelay(byte(UserVar[event->BaseVarIndex + 1]));
       }
 
-      logstr  = F("Thermo : Starting status S:");
-      logstr += toString(UserVar[event->BaseVarIndex]);
-      logstr += F(", R:");
-      logstr += toString(UserVar[event->BaseVarIndex + 1]);
-      addLog(LOG_LEVEL_INFO, logstr);
+      if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+        String logstr  = F("Thermo : Starting status S:");
+        logstr += toString(UserVar[event->BaseVarIndex]);
+        logstr += F(", R:");
+        logstr += toString(UserVar[event->BaseVarIndex + 1]);
+        addLogMove(LOG_LEVEL_INFO, logstr);
+      }
 
       Plugin_109_changed    = 1;
       Plugin_109_buttons[0] = 0; Plugin_109_buttons[1] = 0; Plugin_109_buttons[2] = 0;
@@ -509,8 +513,7 @@ boolean Plugin_109(byte function, struct EventStruct *event, String& string)
               f.close();
               flashCount();
             }
-            String logstr = F("Thermo : Save UserVars to SPIFFS");
-            addLog(LOG_LEVEL_INFO, logstr);
+            addLog(LOG_LEVEL_INFO, F("Thermo : Save UserVars to SPIFFS"));
           }
         }
         success = true;
@@ -890,12 +893,15 @@ void P109_setSetpoint(String sptemp) {
 
 void P109_setHeatRelay(byte state) {
   uint8_t relaypin = Settings.TaskDevicePluginConfig[Plugin_109_taskindex][4];
-  String  logstr   = F("Thermo : Set Relay");
 
-  logstr += relaypin;
-  logstr += F("=");
-  logstr += state;
-  addLog(LOG_LEVEL_INFO, logstr);
+  if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+    String  logstr   = F("Thermo : Set Relay");
+
+    logstr += relaypin;
+    logstr += F("=");
+    logstr += state;
+    addLogMove(LOG_LEVEL_INFO, logstr);
+  }
 
   if (relaypin != -1) {
     pinMode(relaypin, OUTPUT);

--- a/src/_P111_RC522_RFID.ino
+++ b/src/_P111_RC522_RFID.ino
@@ -196,7 +196,7 @@ boolean Plugin_111(uint8_t function, struct EventStruct *event, String& string)
               log += F(" card: ");
               log += P111_data->getCardName();
             }
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
           }
 
           if (new_key && !removedTag) { // Removal event sent from PLUGIN_TIMER_IN, if any

--- a/src/_P112_AS7265x.ino
+++ b/src/_P112_AS7265x.ino
@@ -424,7 +424,7 @@ void queueEvent(taskIndex_t TaskIndex, int wavelength, float value) {
   RuleEvent += wavelength;
   RuleEvent += '=';
   RuleEvent += toString(value, 2);
-  eventQueue.add(RuleEvent);
+  eventQueue.addMove(std::move(RuleEvent));
 }
 
 #endif // USES_P112

--- a/src/_P112_AS7265x.ino
+++ b/src/_P112_AS7265x.ino
@@ -269,23 +269,23 @@ boolean Plugin_112(uint8_t function, struct EventStruct *event, String& string)
           if (loglevelActiveFor(LOG_LEVEL_INFO)) {
             String log = F("AS7265X: AMS Device Type: 0x");
             log += P112_data->sensor.getDeviceType();
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
 
             log = F("AS7265X: AMS Hardware Version: 0x");
             log += P112_data->sensor.getHardwareVersion();
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
 
             log = F("AS7265X: AMS Major Firmware Version: 0x");
             log += P112_data->sensor.getMajorFirmwareVersion();
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
 
             log = F("AS7265X: AMS Patch Firmware Version: 0x");
             log += P112_data->sensor.getPatchFirmwareVersion();
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
 
             log = F("AS7265X: AMS Build Firmware Version: 0x");
             log += P112_data->sensor.getBuildFirmwareVersion();
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
           }
 
           success = true;

--- a/src/_P114_VEML6075.ino
+++ b/src/_P114_VEML6075.ino
@@ -134,8 +134,6 @@ boolean Plugin_114(uint8_t function, struct EventStruct *event, String& string)
         return success;
       }
 
-      String log;
-
       float UVA     = 0.0f;
       float UVB     = 0.0f;
       float UVIndex = 0.0f;
@@ -146,8 +144,9 @@ boolean Plugin_114(uint8_t function, struct EventStruct *event, String& string)
         UserVar[event->BaseVarIndex + 2] = UVIndex;
 
         if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+          String log;
           if (log.reserve(130)) {
-            log  = F("VEML6075: Address: 0x");
+            String log  = F("VEML6075: Address: 0x");
             log += String(PCONFIG(0), HEX);
             log += F(" / Integration Time: ");
             log += PCONFIG(1);
@@ -161,7 +160,7 @@ boolean Plugin_114(uint8_t function, struct EventStruct *event, String& string)
             log += UserVar[event->BaseVarIndex + 1];
             log += F(" / UVIndex: ");
             log += UserVar[event->BaseVarIndex + 2];
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
           }
         }
 

--- a/src/_P115_MAX1704x_v2.ino
+++ b/src/_P115_MAX1704x_v2.ino
@@ -156,7 +156,7 @@ boolean Plugin_115(uint8_t function, struct EventStruct *event, String& string)
           log += P115_data->alert;
           log += F(" Rate: ");
           log += P115_data->changeRate;
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
         success = true;
       }

--- a/src/_P118_Itho.ino
+++ b/src/_P118_Itho.ino
@@ -160,7 +160,9 @@ boolean Plugin_118(byte function, struct EventStruct *event, String& string)
       // If configured interrupt pin differs from configured, release old pin first
       if ((Settings.TaskDevicePin1[event->TaskIndex] != Plugin_118_IRQ_pin) && (Plugin_118_IRQ_pin != -1))
       {
+        #ifndef BUILD_NO_DEBUG
         addLog(LOG_LEVEL_DEBUG, F("IO-PIN changed, deatachinterrupt old pin"));
+        #endif
         detachInterrupt(Plugin_118_IRQ_pin);
       }
       LoadCustomTaskSettings(event->TaskIndex, (byte *)&PLUGIN_118_ExtraSettings, sizeof(PLUGIN_118_ExtraSettings));
@@ -204,7 +206,9 @@ boolean Plugin_118(byte function, struct EventStruct *event, String& string)
       if  ((PLUGIN_118_OldState != PLUGIN_118_State) || ((PLUGIN_118_Timer > 0) && (PLUGIN_118_Timer % 2 == 0)) ||
            (PLUGIN_118_OldLastIDindex != PLUGIN_118_LastIDindex) || PLUGIN_118_InitRunned)
       {
+        #ifndef BUILD_NO_DEBUG
         addLog(LOG_LEVEL_DEBUG, F("UPDATE by PLUGIN_ONCE_A_SECOND"));
+        #endif
         PLUGIN_118_Publishdata(event);
         sendData(event);
 
@@ -245,7 +249,9 @@ boolean Plugin_118(byte function, struct EventStruct *event, String& string)
 
     case PLUGIN_READ: {
       // This ensures that even when Values are not changing, data is send at the configured interval for aquisition
+      #ifndef BUILD_NO_DEBUG
       addLog(LOG_LEVEL_DEBUG, F("UPDATE by PLUGIN_READ"));
+      #endif
       PLUGIN_118_Publishdata(event);
 
       // sendData(event); //SV - Added to send status every xx secnds as set within plugin
@@ -422,8 +428,10 @@ ICACHE_RAM_ATTR void PLUGIN_118_ITHOinterrupt()
 
 void PLUGIN_118_ITHOcheck()
 {
+  #ifndef BUILD_NO_DEBUG
   if (PLUGIN_118_Log) { addLog(LOG_LEVEL_DEBUG, "RF signal received"); } // All logs statements contain if-statement to disable logging to
                                                                          // reduce log clutter when many RF sources are present
+  #endif
 
   if (PLUGIN_118_rf.checkForNewPacket())
   {
@@ -541,7 +549,9 @@ void PLUGIN_118_ITHOcheck()
       }
     }
 
-    if (PLUGIN_118_Log) { addLog(LOG_LEVEL_DEBUG, log2); }
+    if (PLUGIN_118_Log) { 
+      addLogMove(LOG_LEVEL_DEBUG, log2);
+    }
   }
 }
 
@@ -556,13 +566,13 @@ void PLUGIN_118_Publishdata(struct EventStruct *event)
   if (logLevelActiveFor(LOG_LEVEL_DEBUG)) {
     String log = F("State: ");
     log += UserVar[event->BaseVarIndex];
-    addLog(LOG_LEVEL_DEBUG, log);
+    addLogMove(LOG_LEVEL_DEBUG, log);
     log  = F("Timer: ");
     log += UserVar[event->BaseVarIndex + 1];
-    addLog(LOG_LEVEL_DEBUG, log);
+    addLogMove(LOG_LEVEL_DEBUG, log);
     log  = F("LastIDindex: ");
     log += UserVar[event->BaseVarIndex + 2];
-    addLog(LOG_LEVEL_DEBUG, log);
+    addLogMove(LOG_LEVEL_DEBUG, log);
   }
 #endif // ifndef BUILD_NO_DEBUG
 }
@@ -572,8 +582,8 @@ void PLUGIN_118_PluginWriteLog(const String& command)
   String log = F("Send Itho command for: ");
 
   log += command;
-  addLog(LOG_LEVEL_INFO, log);
   printWebString += log;
+  addLogMove(LOG_LEVEL_INFO, log);
 }
 
 #endif // USES_P118

--- a/src/_P124_MultiRelay.ino
+++ b/src/_P124_MultiRelay.ino
@@ -196,11 +196,13 @@ boolean Plugin_124(uint8_t function, struct EventStruct *event, String& string)
       }
 
       if (P124_data->isInitialized()) {
-        String log;
-        log.reserve(46);
-        log  = F("MultiRelay: Initialized, firmware version: ");
-        log += P124_data->getFirmwareVersion();
-        addLog(LOG_LEVEL_INFO, log);
+        if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+          String log;
+          log.reserve(46);
+          log  = F("MultiRelay: Initialized, firmware version: ");
+          log += P124_data->getFirmwareVersion();
+          addLogMove(LOG_LEVEL_INFO, log);
+        }
 
         if (bitRead(P124_CONFIG_FLAGS, P124_FLAGS_INIT_RELAYS) &&
             (!bitRead(P124_InitializedRelays, event->TaskIndex) ||
@@ -288,13 +290,15 @@ boolean Plugin_124(uint8_t function, struct EventStruct *event, String& string)
 
       # ifdef P124_DEBUG_LOG
       addLog(LOG_LEVEL_INFO, string);
-      String log = F("Par1..3:");
-      log += event->Par1;
-      log += ',';
-      log += event->Par2;
-      log += ',';
-      log += event->Par3;
-      addLog(LOG_LEVEL_INFO, log);
+      if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+        String log = F("Par1..3:");
+        log += event->Par1;
+        log += ',';
+        log += event->Par2;
+        log += ',';
+        log += event->Par3;
+        addLogMove(LOG_LEVEL_INFO, log);
+      }
       # endif // ifdef P124_DEBUG_LOG
 
       String command = parseString(string, 1);

--- a/src/src/Commands/Blynk.cpp
+++ b/src/src/Commands/Blynk.cpp
@@ -104,7 +104,9 @@ bool Blynk_get(const String& command, controllerIndex_t controllerIndex, float *
               pass.c_str(),
               command.c_str(),
               hostname.c_str());
+#ifndef BUILD_NO_DEBUG
     addLog(LOG_LEVEL_DEBUG, request);
+#endif
     client.print(request);
   }
   bool success = !MustCheckReply;
@@ -116,21 +118,28 @@ bool Blynk_get(const String& command, controllerIndex_t controllerIndex, float *
       delay(1);
     }
 
+    #ifndef BUILD_NO_DEBUG
     char log[80] = { 0 };
+    #endif
     timer = millis() + 1500;
 
     // Read all the lines of the reply from server and log them
     while (client_available(client) && !success && !timeOutReached(timer)) {
       String line;
       safeReadStringUntil(client, line, '\n');
+      #ifndef BUILD_NO_DEBUG
       addLog(LOG_LEVEL_DEBUG_MORE, line);
+      #endif
 
       // success ?
       if (line.substring(0, 15) == F("HTTP/1.1 200 OK")) {
+        #ifndef BUILD_NO_DEBUG
         strcpy_P(log, PSTR("HTTP : Success"));
+        #endif
 
         if (!data) { success = true; }
       }
+      #ifndef BUILD_NO_DEBUG
       else if (line.substring(0, 24) == F("HTTP/1.1 400 Bad Request")) {
         strcpy_P(log, PSTR("HTTP : Unauthorized"));
       }
@@ -138,6 +147,7 @@ bool Blynk_get(const String& command, controllerIndex_t controllerIndex, float *
         strcpy_P(log, PSTR("HTTP : Unauthorized"));
       }
       addLog(LOG_LEVEL_DEBUG, log);
+      #endif
 
       // data only
       if (data && line.startsWith("["))
@@ -152,8 +162,10 @@ bool Blynk_get(const String& command, controllerIndex_t controllerIndex, float *
 
         char value_char[5] = { 0 };
         strValue.toCharArray(value_char, 5);
+        #ifndef BUILD_NO_DEBUG
         sprintf_P(log, PSTR("Blynk get - %s => %s"), command.c_str(), value_char);
         addLog(LOG_LEVEL_DEBUG, log);
+        #endif
       }
       delay(0);
     }

--- a/src/src/Commands/Diagnostic.cpp
+++ b/src/src/Commands/Diagnostic.cpp
@@ -167,27 +167,29 @@ const __FlashStringHelper * Command_JSONPortStatus(struct EventStruct *event, co
 
 void createLogPortStatus(std::map<uint32_t, portStatusStruct>::iterator it)
 {  
-  String log = F("PortStatus detail: ");
+  if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+    String log = F("PortStatus detail: ");
 
-  log += F("Port=");
-  log += getPortFromKey(it->first);
-  log += F(" State=");
-  log += it->second.state;
-  log += F(" Output=");
-  log += it->second.output;
-  log += F(" Mode=");
-  log += it->second.mode;
-  log += F(" Task=");
-  log += it->second.task;
-  log += F(" Monitor=");
-  log += it->second.monitor;
-  log += F(" Command=");
-  log += it->second.command;
-  log += F(" Init=");
-  log += it->second.init;
-  log += F(" PreviousTask=");
-  log += it->second.previousTask;
-  addLog(LOG_LEVEL_INFO, log);
+    log += F("Port=");
+    log += getPortFromKey(it->first);
+    log += F(" State=");
+    log += it->second.state;
+    log += F(" Output=");
+    log += it->second.output;
+    log += F(" Mode=");
+    log += it->second.mode;
+    log += F(" Task=");
+    log += it->second.task;
+    log += F(" Monitor=");
+    log += it->second.monitor;
+    log += F(" Command=");
+    log += it->second.command;
+    log += F(" Init=");
+    log += it->second.init;
+    log += F(" PreviousTask=");
+    log += it->second.previousTask;
+    addLogMove(LOG_LEVEL_INFO, log);
+  }
 }
 
 void debugPortStatus(std::map<uint32_t, portStatusStruct>::iterator it)
@@ -196,13 +198,15 @@ void debugPortStatus(std::map<uint32_t, portStatusStruct>::iterator it)
 }
 
 void logPortStatus(const String& from) {
-  String log;
+  if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+    String log;
 
-  log  = F("PortStatus structure: Called from=");
-  log += from;
-  log += F(" Count=");
-  log += globalMapPortStatus.size();
-  addLog(LOG_LEVEL_INFO, log);
+    log  = F("PortStatus structure: Called from=");
+    log += from;
+    log += F(" Count=");
+    log += globalMapPortStatus.size();
+    addLogMove(LOG_LEVEL_INFO, log);
+  }
 
   for (std::map<uint32_t, portStatusStruct>::iterator it = globalMapPortStatus.begin(); it != globalMapPortStatus.end(); ++it) {
     debugPortStatus(it);

--- a/src/src/Commands/GPIO.cpp
+++ b/src/src/Commands/GPIO.cpp
@@ -89,7 +89,7 @@ bool gpio_monitor_helper(int port, struct EventStruct *event, const char *Line)
       log += F(" port #"); 
       log += port; 
       log += F(": added to monitor list.");
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
     String dummy;
     SendStatusOnlyIfNeeded(event, SEARCH_PIN_STATE, key, dummy, 0);
@@ -141,7 +141,7 @@ bool gpio_unmonitor_helper(int port, struct EventStruct *event, const char *Line
       log += F(" port #");
       log += port;
       log += F(": removed from monitor list.");
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
 
     return true;
@@ -302,7 +302,7 @@ const __FlashStringHelper * Command_GPIO_RTTTL(struct EventStruct *event, const 
     log += event->Par1;
     log += F(" melody: ");
     log += melody;
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
 
   if (play_rtttl(event->Par1, melody.c_str())) {
@@ -627,7 +627,7 @@ range_pattern_helper_data range_helper_shared(pluginID_t plugin, uint8_t pin1, u
     if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
       String log = data.logPrefix;
       log += F(": pin numbers out of range.");
-      addLog(LOG_LEVEL_ERROR, log);
+      addLogMove(LOG_LEVEL_ERROR, log);
     }
     return data;
   }
@@ -687,7 +687,7 @@ range_pattern_helper_data range_pattern_helper_shared(pluginID_t plugin, struct 
       if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
         String log = data.logPrefix;
         log += F(": write value must be 0 or 1.");
-        addLog(LOG_LEVEL_ERROR, log);
+        addLogMove(LOG_LEVEL_ERROR, log);
       }
       return data;
     }

--- a/src/src/Commands/HTTP.cpp
+++ b/src/src/Commands/HTTP.cpp
@@ -23,13 +23,15 @@ const __FlashStringHelper * Command_HTTP_SendToHTTP(struct EventStruct *event, c
 	if (NetworkConnected()) {
 		const String host = parseString(Line, 2);
 		const int port = parseCommandArgumentInt(Line, 2);
+		#ifndef BUILD_NO_DEBUG
 		if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
 			String log = F("SendToHTTP: Host: ");
 			log += host;
 			log += F(" port: ");
 			log += port;
-			addLog(LOG_LEVEL_DEBUG, log);
+			addLogMove(LOG_LEVEL_DEBUG, log);
 		}
+		#endif
 		if (port < 0 || port > 65535) return return_command_failed();
 		// FIXME TD-er: This is not using the tolerant settings option.
     // String path = tolerantParseStringKeepCase(Line, 4);
@@ -38,7 +40,7 @@ const __FlashStringHelper * Command_HTTP_SendToHTTP(struct EventStruct *event, c
 		if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
 			String log = F("SendToHTTP: Path: ");
 			log += path;
-			addLog(LOG_LEVEL_DEBUG, log);
+			addLogMove(LOG_LEVEL_DEBUG, log);
 		}
 #endif
 		WiFiClient client;

--- a/src/src/Commands/InternalCommands.cpp
+++ b/src/src/Commands/InternalCommands.cpp
@@ -90,11 +90,11 @@ bool checkNrArguments(const char *cmd, const String& Line, int nrArguments) {
         }
         log += F(" lineLength=");
         log += Line.length();
-        addLog(LOG_LEVEL_ERROR, log);
+        addLogMove(LOG_LEVEL_ERROR, log);
         log  = F("Line: _");
         log += Line;
         log += '_';
-        addLog(LOG_LEVEL_ERROR, log);
+        addLogMove(LOG_LEVEL_ERROR, log);
 
         if (!Settings.TolerantLastArgParse()) {
           log = F("Command not executed!");
@@ -102,7 +102,7 @@ bool checkNrArguments(const char *cmd, const String& Line, int nrArguments) {
           log = F("Command executed, but may fail.");
         }
         log += F(" See: https://github.com/letscontrolit/ESPEasy/issues/2724");
-        addLog(LOG_LEVEL_ERROR, log);
+        addLogMove(LOG_LEVEL_ERROR, log);
       }
     }
     #endif
@@ -577,24 +577,28 @@ bool ExecuteCommand(taskIndex_t            taskIndex,
   delay(0);
 
   if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
-    String log = F("Command: ");
-    log += cmd;
-    addLog(LOG_LEVEL_DEBUG, log);
+    {
+      String log = F("Command: ");
+      log += cmd;
+      addLogMove(LOG_LEVEL_DEBUG, log);
+    }
 #ifndef BUILD_NO_DEBUG
     addLog(LOG_LEVEL_DEBUG, Line); // for debug purposes add the whole line.
-    String parameters;
-    parameters.reserve(64);
-    parameters += F("Par1: ");
-    parameters += TempEvent.Par1;
-    parameters += F(" Par2: ");
-    parameters += TempEvent.Par2;
-    parameters += F(" Par3: ");
-    parameters += TempEvent.Par3;
-    parameters += F(" Par4: ");
-    parameters += TempEvent.Par4;
-    parameters += F(" Par5: ");
-    parameters += TempEvent.Par5;
-    addLog(LOG_LEVEL_DEBUG, parameters);
+    {
+      String parameters;
+      parameters.reserve(64);
+      parameters += F("Par1: ");
+      parameters += TempEvent.Par1;
+      parameters += F(" Par2: ");
+      parameters += TempEvent.Par2;
+      parameters += F(" Par3: ");
+      parameters += TempEvent.Par3;
+      parameters += F(" Par4: ");
+      parameters += TempEvent.Par4;
+      parameters += F(" Par5: ");
+      parameters += TempEvent.Par5;
+      addLogMove(LOG_LEVEL_DEBUG, parameters);
+    }
 #endif // ifndef BUILD_NO_DEBUG
   }
 
@@ -632,7 +636,7 @@ bool ExecuteCommand(taskIndex_t            taskIndex,
         log += action;
         log += F(" to: ");
         log += tmpAction;
-        addLog(LOG_LEVEL_ERROR, log);
+        addLogMove(LOG_LEVEL_ERROR, log);
       }
     }
     #endif

--- a/src/src/Commands/InternalCommands.cpp
+++ b/src/src/Commands/InternalCommands.cpp
@@ -176,7 +176,7 @@ bool do_command_case_check(command_case_data         & data,
   // The data struct is re-used on each attempt to process an internal command.
   // Re-initialize the only two members that may have been altered by a previous call.
   data.retval = false;
-  data.status.clear();
+  data.status = String();
   if (!data.cmd_lc.equals(cmd_test)) {
     return false;
   }

--- a/src/src/Commands/MQTT.cpp
+++ b/src/src/Commands/MQTT.cpp
@@ -76,8 +76,11 @@ boolean MQTTsubscribe(controllerIndex_t controller_idx, const char* topic, boole
   if (MQTTclient.subscribe(topic)) {
     Scheduler.setIntervalTimerOverride(ESPEasy_Scheduler::IntervalTimer_e::TIMER_MQTT, 10); // Make sure the MQTT is being processed as soon as possible.
     scheduleNextMQTTdelayQueue();
-    String log = F("Subscribed to: ");  log += topic;
-    addLog(LOG_LEVEL_INFO, log);
+    if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+      String log = F("Subscribed to: ");  
+      log += topic;
+      addLogMove(LOG_LEVEL_INFO, log);
+    }
     return true;
   }
   addLog(LOG_LEVEL_ERROR, F("MQTT : subscribe failed"));

--- a/src/src/ControllerQueue/C018_queue_element.cpp
+++ b/src/src/ControllerQueue/C018_queue_element.cpp
@@ -22,7 +22,7 @@ C018_queue_element::C018_queue_element(struct EventStruct *event, uint8_t sample
     if (loglevelActiveFor(LOG_LEVEL_INFO)) {
       String log = F("C018 queue element: ");
       log += packed;
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
   # endif // USES_PACKED_RAW_DATA
 }

--- a/src/src/ControllerQueue/ControllerDelayHandlerStruct.h
+++ b/src/src/ControllerQueue/ControllerDelayHandlerStruct.h
@@ -110,7 +110,7 @@ struct ControllerDelayHandlerStruct {
       log += F(" items ");
       log += freeHeap;
       log += F(" free");
-      addLog(LOG_LEVEL_DEBUG, log);
+      addLogMove(LOG_LEVEL_DEBUG, log);
     }
 #endif // ifndef BUILD_NO_DEBUG
     return true;
@@ -138,7 +138,7 @@ struct ControllerDelayHandlerStruct {
             const cpluginID_t cpluginID = getCPluginID_from_ControllerIndex(it->controller_idx);
             String log = get_formatted_Controller_number(cpluginID);
             log += F(" : Remove duplicate");
-            addLog(LOG_LEVEL_DEBUG, log);
+            addLogMove(LOG_LEVEL_DEBUG, log);
           }
 #endif // ifndef BUILD_NO_DEBUG
           return true;
@@ -180,7 +180,7 @@ struct ControllerDelayHandlerStruct {
       const cpluginID_t cpluginID = getCPluginID_from_ControllerIndex(element.controller_idx);
       String log = get_formatted_Controller_number(cpluginID);
       log += F(" : queue full");
-      addLog(LOG_LEVEL_DEBUG, log);
+      addLogMove(LOG_LEVEL_DEBUG, log);
     }
 #endif // ifndef BUILD_NO_DEBUG
     return false;

--- a/src/src/ControllerQueue/MQTT_queue_element.cpp
+++ b/src/src/ControllerQueue/MQTT_queue_element.cpp
@@ -27,8 +27,16 @@ MQTT_queue_element::MQTT_queue_element(int         ctrl_idx,
   // Copy in the scope of the constructor, so we might store it in the 2nd heap
   #ifdef USE_SECOND_HEAP
   HeapSelectIram ephemeral;
-  _topic = topic;
-  _payload = payload;
+  if (topic.length() && !mmu_is_iram(&(topic[0]))) {
+    _topic = topic;
+  } else {
+    _topic = std::move(topic);  
+  }
+  if (payload.length() && !mmu_is_iram(&(payload[0]))) {
+    _payload = payload;
+  } else {
+    _payload = std::move(payload);
+  }
   #else
   _topic = std::move(topic);
   _payload = std::move(payload);

--- a/src/src/ControllerQueue/SimpleQueueElement_string_only.cpp
+++ b/src/src/ControllerQueue/SimpleQueueElement_string_only.cpp
@@ -6,10 +6,15 @@ simple_queue_element_string_only::simple_queue_element_string_only(int ctrl_idx,
 {
   #ifdef USE_SECOND_HEAP
   HeapSelectIram ephemeral;
-  #endif
-
-  // Copy in the scope of the constructor, so we might store it in the 2nd heap
+  if (req.length() > 0 && !mmu_is_iram(&(req[0]))) {
+    // The string was not allocated on the 2nd heap, so copy instead of move
+    txt = req;
+  } else {
+    txt = std::move(req);
+  }
+  #else
   txt = std::move(req);
+  #endif
 }
 
 size_t simple_queue_element_string_only::getSize() const {

--- a/src/src/ControllerQueue/queue_element_formatted_uservar.cpp
+++ b/src/src/ControllerQueue/queue_element_formatted_uservar.cpp
@@ -48,12 +48,17 @@ queue_element_formatted_uservar& queue_element_formatted_uservar::operator=(queu
   sensorType     = other.sensorType;
   valueCount     = other.valueCount;
 
-  #ifdef USE_SECOND_HEAP
-  HeapSelectIram ephemeral;
-  #endif // ifdef USE_SECOND_HEAP
-
   for (size_t i = 0; i < VARS_PER_TASK; ++i) {
+    #ifdef USE_SECOND_HEAP
+    HeapSelectIram ephemeral;
+    if (other.txt[i].length() && !mmu_is_iram(&(other.txt[i][0]))) {
+      txt[i] = other.txt[i];
+    } else {
+      txt[i] = std::move(other.txt[i]);
+    }
+    #else
     txt[i] = std::move(other.txt[i]);
+    #endif // ifdef USE_SECOND_HEAP
   }
   return *this;
 }

--- a/src/src/DataStructs/ESPEasy_EventStruct.cpp
+++ b/src/src/DataStructs/ESPEasy_EventStruct.cpp
@@ -30,6 +30,10 @@ void EventStruct::setTaskIndex(taskIndex_t taskIndex) {
   sensorType   = Sensor_VType::SENSOR_TYPE_NOT_SET;
 }
 
+void EventStruct::clear() {
+  *this = EventStruct();
+}
+
 Sensor_VType EventStruct::getSensorType() {
   const int tmp_idx = idx;
   checkDeviceVTypeForTask(this);

--- a/src/src/DataStructs/ESPEasy_EventStruct.cpp
+++ b/src/src/DataStructs/ESPEasy_EventStruct.cpp
@@ -8,8 +8,6 @@
 
 #include "../../_Plugin_Helper.h"
 
-EventStruct::EventStruct() {}
-
 EventStruct::EventStruct(taskIndex_t taskIndex) :
   TaskIndex(taskIndex), BaseVarIndex(taskIndex * VARS_PER_TASK) 
 {}

--- a/src/src/DataStructs/ESPEasy_EventStruct.h
+++ b/src/src/DataStructs/ESPEasy_EventStruct.h
@@ -41,6 +41,8 @@ public:
 
   void setTaskIndex(taskIndex_t taskIndex);
 
+  void clear();
+
   // Check (and update) sensorType if not set, plus return (corrected) sensorType
   Sensor_VType getSensorType();
 

--- a/src/src/DataStructs/ESPEasy_EventStruct.h
+++ b/src/src/DataStructs/ESPEasy_EventStruct.h
@@ -18,7 +18,7 @@
 \*********************************************************************************************/
 struct EventStruct
 {
-  EventStruct();
+  EventStruct() = default;
   // Delete the copy constructor
   EventStruct(const struct EventStruct& event) = delete;
 private:

--- a/src/src/DataStructs/EthernetEventData.cpp
+++ b/src/src/DataStructs/EthernetEventData.cpp
@@ -88,7 +88,9 @@ void EthernetEventData_t::setEthConnected() {
 void EthernetEventData_t::setEthServicesInitialized() {
   if (!unprocessedEthEvents() && !EthServicesInitialized()) {
     if (EthGotIP() && EthConnected()) {
+      #ifndef BUILD_NO_DEBUG
       addLog(LOG_LEVEL_DEBUG, F("Eth : Eth services initialized"));
+      #endif
       bitSet(ethStatus, ESPEASY_ETH_SERVICES_INITIALIZED);
       ethConnectInProgress = false;
     }

--- a/src/src/DataStructs/EventQueue.cpp
+++ b/src/src/DataStructs/EventQueue.cpp
@@ -24,12 +24,16 @@ void EventQueueStruct::add(const __FlashStringHelper * event)
 
 void EventQueueStruct::addMove(String&& event)
 {
+  if (!event.length()) return;
   #ifdef USE_SECOND_HEAP
   HeapSelectIram ephemeral;
-  _eventQueue.push_back(event);
-  #else
-  _eventQueue.emplace_back(std::move(event));
+  if (!mmu_is_iram(&(event[0]))) {
+    // Wrap in String constructor to make sure it is stored in the 2nd heap.
+    _eventQueue.push_back(String(event));
+    return;
+  }
   #endif
+  _eventQueue.emplace_back(std::move(event));
 }
 
 bool EventQueueStruct::getNext(String& event)

--- a/src/src/DataStructs/LogStruct.cpp
+++ b/src/src/DataStructs/LogStruct.cpp
@@ -94,7 +94,6 @@ void LogStruct::clearExpiredEntries() {
   while (maxLoops > 0) {
     --maxLoops;
     if (isEmpty() ||  // Nothing left
-        timeStamp[read_idx] == 0 || // Already reset entry
         (timePassedSince(timeStamp[read_idx]) < LOG_BUFFER_EXPIRE)) // Expired
     {
       return;
@@ -106,7 +105,7 @@ void LogStruct::clearExpiredEntries() {
 void LogStruct::clearOldest() {
   if (!isEmpty()) {
     is_full = false;
-    Message[read_idx].clear();
+    Message[read_idx] = String();
     timeStamp[read_idx] = 0;
     log_level[read_idx] = 0;
     read_idx  = nextIndex(read_idx);

--- a/src/src/DataStructs/LogStruct.h
+++ b/src/src/DataStructs/LogStruct.h
@@ -14,7 +14,7 @@
   #define LOG_BUFFER_EXPIRE         30000  // Time after which a buffered log item is considered expired.
 #else
   #ifdef USE_SECOND_HEAP
-    #define LOG_STRUCT_MESSAGE_LINES 30
+    #define LOG_STRUCT_MESSAGE_LINES 60
   #else
     #if defined(PLUGIN_BUILD_TESTING) || defined(PLUGIN_BUILD_DEV)
       #define LOG_STRUCT_MESSAGE_LINES 10
@@ -32,20 +32,29 @@ struct LogStruct {
 
     // Read the next item and append it to the given string.
     // Returns whether new lines are available.
-    bool get(String& output, const String& lineEnd);
+//    bool get(String& output, const String& lineEnd);
 
+    // Returns whether a line was retrieved.
     bool getNext(bool& logLinesAvailable, unsigned long& timestamp, String& message, uint8_t& loglevel);
 
-    bool isEmpty();
+    bool isEmpty() const;
+
+    bool isFull() const;
 
     bool logActiveRead();
 
   private:
-    void add_start(const uint8_t logLevel);
 
-    String formatLine(int index, const String& lineEnd);
+    void add_end(const uint8_t loglevel);
 
     void clearExpiredEntries();
+
+    void clearOldest();
+
+    static int nextIndex(int idx) {
+//      return ((++idx) == LOG_STRUCT_MESSAGE_LINES) ? 0 : idx;
+      return (idx + 1) % LOG_STRUCT_MESSAGE_LINES;
+    }
 
     String Message[LOG_STRUCT_MESSAGE_LINES];
     unsigned long timeStamp[LOG_STRUCT_MESSAGE_LINES] = {0};
@@ -53,6 +62,7 @@ struct LogStruct {
     int read_idx = 0;
     unsigned long lastReadTimeStamp = 0;
     uint8_t log_level[LOG_STRUCT_MESSAGE_LINES] = {0};
+    bool is_full = false;
 
 };
 

--- a/src/src/DataStructs/LogStruct.h
+++ b/src/src/DataStructs/LogStruct.h
@@ -28,6 +28,7 @@
 struct LogStruct {
     
     void add(const uint8_t loglevel, const String& line);
+    void add(const uint8_t loglevel, String&& line);
 
     // Read the next item and append it to the given string.
     // Returns whether new lines are available.
@@ -40,6 +41,8 @@ struct LogStruct {
     bool logActiveRead();
 
   private:
+    void add_start(const uint8_t logLevel);
+
     String formatLine(int index, const String& lineEnd);
 
     void clearExpiredEntries();

--- a/src/src/DataStructs/Modbus.cpp
+++ b/src/src/DataStructs/Modbus.cpp
@@ -97,7 +97,7 @@ bool Modbus::handle() {
   unsigned int RXavailable = 0;
 
   #ifndef BUILD_NO_DEBUG
-  LogString.clear();
+  LogString = String();
   #endif
   int64_t rxValue = 0;
 

--- a/src/src/DataStructs/Modbus.cpp
+++ b/src/src/DataStructs/Modbus.cpp
@@ -34,20 +34,31 @@ bool Modbus::begin(uint8_t function, uint8_t ModbusID, uint16_t ModbusRegister, 
   ModbusClient->flush();
 
   if (ModbusClient->connected()) {
+    #ifndef BUILD_NO_DEBUG
     LogString += F(" already connected. ");
+    #endif
   } else {
-    LogString += F("connect: ");      LogString += IPaddress;
+    #ifndef BUILD_NO_DEBUG
+    LogString += F("connect: ");
+    LogString += IPaddress;
+    #endif
 
     if (ModbusClient->connect(IPaddress, 502) != 1) {
+      #ifndef BUILD_NO_DEBUG
       LogString += F(" fail. ");
+      #endif
       TXRXstate  = MODBUS_IDLE;
       errcnt++;
 
+      #ifndef BUILD_NO_DEBUG
       if (LogString.length() > 1) { addLog(LOG_LEVEL_DEBUG, LogString); }
+      #endif
       return false;
     }
   }
+  #ifndef BUILD_NO_DEBUG
   LogString += F(" OK, sending read request: ");
+  #endif
 
   sendBuffer[6] = ModbusID;
   sendBuffer[7] = function;
@@ -68,20 +79,26 @@ bool Modbus::begin(uint8_t function, uint8_t ModbusID, uint16_t ModbusRegister, 
   ModbusClient->flush();
   ModbusClient->write(&sendBuffer[0], sizeof(sendBuffer));
 
+  #ifndef BUILD_NO_DEBUG
   for (unsigned int i = 0; i < sizeof(sendBuffer); i++) {
     LogString += ((unsigned int)(sendBuffer[i]));
     LogString += ' ';
   }
+  #endif
   TXRXstate = MODBUS_RECEIVE;
-
+  
+  #ifndef BUILD_NO_DEBUG
   if (LogString.length() > 1) { addLog(LOG_LEVEL_DEBUG, LogString); }
+  #endif
   return true;
 }
 
 bool Modbus::handle() {
   unsigned int RXavailable = 0;
 
+  #ifndef BUILD_NO_DEBUG
   LogString.clear();
+  #endif
   int64_t rxValue = 0;
 
   switch (TXRXstate) {
@@ -103,16 +120,25 @@ bool Modbus::handle() {
 
       if  (ModbusClient->available() < 9) { break; }
 
+      #ifndef BUILD_NO_DEBUG
       LogString += F("reading bytes: ");
+      #endif
 
       for (int a = 0; a < 9; a++) {
         payLoad    = ModbusClient->read();
-        LogString += (payLoad);  LogString += ' ';
+        #ifndef BUILD_NO_DEBUG
+        LogString += (payLoad);
+        LogString += ' ';
+        #endif
       }
+      #ifndef BUILD_NO_DEBUG
       LogString += F("> ");
+      #endif
 
       if (payLoad > 8) {
+        #ifndef BUILD_NO_DEBUG
         LogString += F("Payload too large !? ");
+        #endif
         errcnt++;
         TXRXstate = MODBUS_IDLE;
       }
@@ -131,8 +157,10 @@ bool Modbus::handle() {
         rxValue = rxValue << 8;
         char a = ModbusClient->read();
         rxValue    = rxValue | a;
+        #ifndef BUILD_NO_DEBUG
         LogString += static_cast<int>(a);  
         LogString += ' ';
+        #endif
       }
 
       switch (incomingValue) {
@@ -156,8 +184,10 @@ bool Modbus::handle() {
           break;
       }
 
+      #ifndef BUILD_NO_DEBUG
       LogString += F("value: "); 
       LogString += result;
+      #endif
 
       // if ((systemTimePresent()) && (hour() == 0)) errcnt = 0;
 
@@ -167,19 +197,25 @@ bool Modbus::handle() {
       break;
 
     default:
+      #ifndef BUILD_NO_DEBUG
       LogString += F("default. ");
+      #endif
       TXRXstate  = MODBUS_IDLE;
       break;
   }
-
+  #ifndef BUILD_NO_DEBUG
   if (LogString.length() > 1) { addLog(LOG_LEVEL_DEBUG, LogString); }
+  #endif
   return true;
 }
 
 bool Modbus::hasTimeout()
 {
   if   ((millis() - timeout) > 10000) { // too many bytes or timeout
-    LogString += F("Modbus RX timeout. "); LogString += String(ModbusClient->available());
+    #ifndef BUILD_NO_DEBUG
+    LogString += F("Modbus RX timeout. "); 
+    LogString += String(ModbusClient->available());
+    #endif
     errcnt++;
     TXRXstate = MODBUS_IDLE;
     return true;

--- a/src/src/DataStructs/Modbus.h
+++ b/src/src/DataStructs/Modbus.h
@@ -59,7 +59,9 @@ private:
   WiFiClient *ModbusClient;             // pointer to tcp client
   unsigned int errcnt;
   char sendBuffer[12] =  { 0, 1, 0, 0, 0, 6, 0x7e, 4, 0x9d, 7, 0, 1 };
+  #ifndef BUILD_NO_DEBUG
   String LogString;                     // for debug logging
+  #endif
   unsigned long timeout;                // send and read timeout
   MODBUS_states_t TXRXstate;            // state for handle() state machine
   unsigned int RXavailable;

--- a/src/src/DataStructs/RTC_cache_handler_struct.cpp
+++ b/src/src/DataStructs/RTC_cache_handler_struct.cpp
@@ -149,13 +149,15 @@ bool RTC_cache_handler_struct::flush() {
 
       if ((bytesWriten < RTC_cache.writePos) /*|| (fw.size() == filesize)*/) {
           #ifdef RTC_STRUCT_DEBUG
-        String log = F("RTC  : error writing file. Size before: ");
-        log += filesize;
-        log += F(" after: ");
-        log += fw.size();
-        log += F(" writen: ");
-        log += bytesWriten;
-        addLog(LOG_LEVEL_ERROR, log);
+          if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
+            String log = F("RTC  : error writing file. Size before: ");
+            log += filesize;
+            log += F(" after: ");
+            log += fw.size();
+            log += F(" writen: ");
+            log += bytesWriten;
+            addLogMove(LOG_LEVEL_ERROR, log);
+          }
           #endif // ifdef RTC_STRUCT_DEBUG
         fw.close();
 
@@ -232,9 +234,11 @@ bool RTC_cache_handler_struct::deleteOldestCacheBlock() {
       writeerror = false;
       if (tryDeleteFile(fname)) {
           #ifdef RTC_STRUCT_DEBUG
-        String log = F("RTC  : Removed file from FS: ");
-        log += fname;
-        addLog(LOG_LEVEL_INFO, String(log));
+          if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+            String log = F("RTC  : Removed file from FS: ");
+            log += fname;
+            addLogMove(LOG_LEVEL_INFO, log);
+          }
           #endif // ifdef RTC_STRUCT_DEBUG
         updateRTC_filenameCounters();
         return true;
@@ -441,7 +445,7 @@ void RTC_cache_handler_struct::rtc_debug_log(const String& description, size_t n
       log += ' ';
       log += nrBytes;
       log += F(" bytes");
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
   }
 }

--- a/src/src/DataStructs/Web_StreamingBuffer.cpp
+++ b/src/src/DataStructs/Web_StreamingBuffer.cpp
@@ -113,7 +113,9 @@ Web_StreamingBuffer& Web_StreamingBuffer::addFlashString(PGM_P str) {
   }
 */
   // FIXME TD-er: Not sure what happens, but streaming large flash chunks does cause allocation issues.
-  const bool stream_P = ESP.getFreeHeap() > 4000 && length < (2 * CHUNKED_BUFFER_SIZE);
+  const bool stream_P = ESP.getFreeHeap() > 4000 && 
+                        length > (CHUNKED_BUFFER_SIZE >> 2) &&
+                        length < (2 * CHUNKED_BUFFER_SIZE);
 
   if (stream_P && ((this->buf.length() + length) > CHUNKED_BUFFER_SIZE)) {
     // Do not copy to the internal buffer, but stream immediately.

--- a/src/src/DataStructs/Web_StreamingBuffer.cpp
+++ b/src/src/DataStructs/Web_StreamingBuffer.cpp
@@ -302,7 +302,7 @@ void Web_StreamingBuffer::sendContentBlocking(String& data) {
     log += ESP.getFreeHeap();
     log += F(" chunk size:");
     log += length;
-    addLog(LOG_LEVEL_DEBUG_DEV, log);
+    addLogMove(LOG_LEVEL_DEBUG_DEV, log);
   }
 #endif // ifndef BUILD_NO_DEBUG
   const uint32_t freeBeforeSend = ESP.getFreeHeap();

--- a/src/src/ESPEasyCore/Controller.cpp
+++ b/src/src/ESPEasyCore/Controller.cpp
@@ -75,7 +75,7 @@ void sendData(struct EventStruct *event)
         if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
           String log = F("Invalid value detected for controller ");
           log += getCPluginNameFromProtocolIndex(ProtocolIndex);
-          addLog(LOG_LEVEL_DEBUG, log);
+          addLogMove(LOG_LEVEL_DEBUG, log);
         }
       }
 #endif // ifndef BUILD_NO_DEBUG
@@ -244,17 +244,21 @@ bool MQTTConnect(controllerIndex_t controller_idx)
     updateMQTTclient_connected();
     return false;
   }
-  String log = F("MQTT : Connected to broker with client ID: ");
+  if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+    String log = F("MQTT : Connected to broker with client ID: ");
 
-  log += clientid;
-  addLog(LOG_LEVEL_INFO, log);
+    log += clientid;
+    addLogMove(LOG_LEVEL_INFO, log);
+  }
   String subscribeTo = ControllerSettings.Subscribe;
 
   parseSystemVariables(subscribeTo, false);
   MQTTclient.subscribe(subscribeTo.c_str());
-  log  = F("Subscribed to: ");
-  log += subscribeTo;
-  addLog(LOG_LEVEL_INFO, log);
+  if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+    String log  = F("Subscribed to: ");
+    log += subscribeTo;
+    addLogMove(LOG_LEVEL_INFO, log);
+  }
 
   updateMQTTclient_connected();
   statusLED(true);

--- a/src/src/ESPEasyCore/ESPEasyEth.cpp
+++ b/src/src/ESPEasyCore/ESPEasyEth.cpp
@@ -41,7 +41,7 @@ void ethSetupStaticIPconfig() {
     log += formatIP(subnet);
     log += F(" DNS: ");
     log += formatIP(dns);
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
   ETH.config(ip, gw, subnet, dns);
 }
@@ -83,7 +83,7 @@ void ethPrintSettings() {
       log += String(Settings.ETH_Pin_mdio);
       log += F(" Power Pin: ");
       log += String(Settings.ETH_Pin_power);
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
   }
 }

--- a/src/src/ESPEasyCore/ESPEasyRules.cpp
+++ b/src/src/ESPEasyCore/ESPEasyRules.cpp
@@ -124,7 +124,7 @@ void rulesProcessing(const String& event) {
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
     String log = F("EVENT: ");
     log += event;
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
 
   if (Settings.OldRulesEngine()) {
@@ -159,7 +159,7 @@ void rulesProcessing(const String& event) {
     log += F(" Processing time:");
     log += timePassedSince(timer);
     log += F(" milliSeconds");
-    addLog(LOG_LEVEL_DEBUG, log);
+    addLogMove(LOG_LEVEL_DEBUG, log);
   }
 #endif // ifndef BUILD_NO_DEBUG
   STOP_TIMER(RULES_PROCESSING);
@@ -342,7 +342,7 @@ bool rules_replace_common_mistakes(const String& from, const String& to, String&
       log += F("' in: '");
       log += line;
       log += '\'';
-      addLog(LOG_LEVEL_ERROR, log);
+      addLogMove(LOG_LEVEL_ERROR, log);
     }
   }
   line.replace(from, to);
@@ -448,7 +448,7 @@ bool parse_bitwise_functions(const String& cmd_s_lower, const String& arg1, cons
       }
     }
     log += '}';
-    addLog(LOG_LEVEL_DEBUG, log);
+    addLogMove(LOG_LEVEL_DEBUG, log);
   }
   #endif
 
@@ -811,7 +811,7 @@ void parseCompleteNonCommentLine(String& line, const String& event,
     log += isCommand ? 0 : 1;
     log += F(": ");
     log += line;
-    addLog(LOG_LEVEL_DEBUG_DEV, log);
+    addLogMove(LOG_LEVEL_DEBUG_DEV, log);
   }
 #endif // ifndef BUILD_NO_DEBUG
 }
@@ -857,7 +857,7 @@ void processMatchedRule(String& action, const String& event,
             log += check;
             log += F("]=");
             log += boolToString(condition[ifBlock - 1]);
-            addLog(LOG_LEVEL_DEBUG, log);
+            addLogMove(LOG_LEVEL_DEBUG, log);
           }
 #endif // ifndef BUILD_NO_DEBUG
         }
@@ -884,7 +884,7 @@ void processMatchedRule(String& action, const String& event,
             log += check;
             log += F("]=");
             log += boolToString(condition[ifBlock - 1]);
-            addLog(LOG_LEVEL_DEBUG, log);
+            addLogMove(LOG_LEVEL_DEBUG, log);
           }
 #endif // ifndef BUILD_NO_DEBUG
         } else {
@@ -897,7 +897,7 @@ void processMatchedRule(String& action, const String& event,
           String log  = F("Lev.");
           log += String(ifBlock);
           log += F(": Error: IF Nesting level exceeded!");
-          addLog(LOG_LEVEL_ERROR, log);
+          addLogMove(LOG_LEVEL_ERROR, log);
         }
       }
       isCommand = false;
@@ -917,7 +917,7 @@ void processMatchedRule(String& action, const String& event,
       log += String(ifBlock);
       log += F(": [else]=");
       log += boolToString(condition[ifBlock - 1] == ifBranche[ifBlock - 1]);
-      addLog(LOG_LEVEL_DEBUG, log);
+      addLogMove(LOG_LEVEL_DEBUG, log);
     }
 #endif // ifndef BUILD_NO_DEBUG
   }
@@ -941,7 +941,7 @@ void processMatchedRule(String& action, const String& event,
     if (loglevelActiveFor(LOG_LEVEL_INFO)) {
       String actionlog = F("ACT  : ");
       actionlog += action;
-      addLog(LOG_LEVEL_INFO, actionlog);
+      addLogMove(LOG_LEVEL_INFO, actionlog);
     }
 
     ExecuteCommand_all(EventValueSource::Enum::VALUE_SOURCE_RULES, action.c_str());
@@ -1077,7 +1077,7 @@ bool conditionMatchExtended(String& check) {
       log += debugstr;
       log += ' ';
       log += wrap_String(check, '"');
-      addLog(LOG_LEVEL_DEBUG, log);
+      addLogMove(LOG_LEVEL_DEBUG, log);
     }
     #endif // ifndef BUILD_NO_DEBUG
     condAnd = check.indexOf(F(" and "));
@@ -1242,7 +1242,7 @@ void logtimeStringToSeconds(const String& tBuf, int hours, int minutes, int seco
     } else {
       log += F("invalid");
     }
-    addLog(LOG_LEVEL_DEBUG, log);
+    addLogMove(LOG_LEVEL_DEBUG, log);
   }
 
   #endif // ifndef BUILD_NO_DEBUG
@@ -1423,7 +1423,7 @@ bool conditionMatch(const String& check) {
     log += wrap_String(check.substring(posStart, posEnd), ' '); // Compare
     log += compareTimes ? String(timeInSec2) : doubleToString(Value2, 6, trimTrailingZeros);
     log += ')';
-    addLog(LOG_LEVEL_DEBUG, log);
+    addLogMove(LOG_LEVEL_DEBUG, log);
   }
   #else // ifndef BUILD_NO_DEBUG
   (void)compareTimes; // To avoid compiler warning

--- a/src/src/ESPEasyCore/ESPEasyRules.cpp
+++ b/src/src/ESPEasyCore/ESPEasyRules.cpp
@@ -252,7 +252,7 @@ String rulesProcessingFile(const String& fileName, const String& event) {
           }
 
           // Prepare for new line
-          line = EMPTY_STRING;
+          line.clear();
           line.reserve(longestLineSize);
           firstNonSpaceRead = false;
           commentFound      = false;

--- a/src/src/ESPEasyCore/ESPEasyRules.cpp
+++ b/src/src/ESPEasyCore/ESPEasyRules.cpp
@@ -1468,10 +1468,10 @@ void createRuleEvents(struct EventStruct *event) {
       addLog(LOG_LEVEL_ERROR, F("Not enough memory for event"));
       return;
     }
-    eventString  = getTaskDeviceName(event->TaskIndex);
-    eventString += F("#");
+    eventString += getTaskDeviceName(event->TaskIndex);
+    eventString += '#';
     eventString += ExtraTaskSettings.TaskDeviceValueNames[0];
-    eventString += F("=");
+    eventString += '=';
     eventString += '`';
     if (appendCompleteStringvalue) {
       eventString += event->String2;
@@ -1485,7 +1485,7 @@ void createRuleEvents(struct EventStruct *event) {
   } else if (Settings.CombineTaskValues_SingleEvent(event->TaskIndex)) {
     String eventString;
     eventString.reserve(128); // Enough for most use cases, prevent lots of memory allocations.
-    eventString  = getTaskDeviceName(event->TaskIndex);
+    eventString += getTaskDeviceName(event->TaskIndex);
     eventString += F("#All=");
 
     for (uint8_t varNr = 0; varNr < valueCount; varNr++) {
@@ -1499,10 +1499,10 @@ void createRuleEvents(struct EventStruct *event) {
     for (uint8_t varNr = 0; varNr < valueCount; varNr++) {
       String eventString;
       eventString.reserve(64); // Enough for most use cases, prevent lots of memory allocations.
-      eventString  = getTaskDeviceName(event->TaskIndex);
-      eventString += F("#");
+      eventString += getTaskDeviceName(event->TaskIndex);
+      eventString += '#';
       eventString += ExtraTaskSettings.TaskDeviceValueNames[varNr];
-      eventString += F("=");
+      eventString += '=';
       eventString += formatUserVarNoCheck(event, varNr);
       eventQueue.addMove(std::move(eventString));
     }

--- a/src/src/ESPEasyCore/ESPEasyWiFiEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWiFiEvent.cpp
@@ -181,7 +181,7 @@ void WiFiEvent(WiFiEvent_t event, WiFiEventInfo_t info) {
       {
         String log = F("UNKNOWN WIFI/ETH EVENT: ");
         log += event;
-        addLog(LOG_LEVEL_ERROR, log);
+        addLogMove(LOG_LEVEL_ERROR, log);
       }
       break;
   }
@@ -310,7 +310,7 @@ void WiFiEvent(system_event_id_t event, system_event_info_t info) {
       {
         String log = F("UNKNOWN WIFI/ETH EVENT: ");
         log += event;
-        addLog(LOG_LEVEL_ERROR, log);
+        addLogMove(LOG_LEVEL_ERROR, log);
       }
       break;
   }
@@ -369,7 +369,7 @@ void onWiFiScanDone(void *arg, STATUS status) {
     if (loglevelActiveFor(LOG_LEVEL_INFO)) {
       String log = F("WiFi : Scan finished, found: ");
       log += scanCount;
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
   }
 

--- a/src/src/ESPEasyCore/ESPEasyWifi.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi.cpp
@@ -343,7 +343,7 @@ void WiFiConnectRelaxed() {
         log += F(" DHCP_t/o");
       }
       
-      addLog(LOG_LEVEL_ERROR, log);
+      addLogMove(LOG_LEVEL_ERROR, log);
     }
     return;
   }
@@ -390,7 +390,7 @@ void AttemptWiFiConnect() {
       log += candidate.toString();
       log += F(" attempt #");
       log += WiFiEventData.wifi_connect_attempt;
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
     WiFiEventData.markWiFiBegin();
     if (prepareWiFi()) {
@@ -511,7 +511,7 @@ bool checkAndResetWiFi() {
 
   // Call for reset first, to make sure a syslog call will not try to send.
   resetWiFi();
-  addLog(LOG_LEVEL_INFO, log);
+  addLogMove(LOG_LEVEL_INFO, log);
   return true;
 }
 
@@ -687,7 +687,7 @@ void SetWiFiTXpower(float dBm, float rssi) {
           log += toString(rssi, 0);
           log += F("dBm");
         }
-        addLog(LOG_LEVEL_DEBUG, log);
+        addLogMove(LOG_LEVEL_DEBUG, log);
       }
     }
   }
@@ -805,7 +805,7 @@ bool WiFiScanAllowed() {
         log += F(" DHCP_t/o");
       }
       
-      addLog(LOG_LEVEL_ERROR, log);
+      addLogMove(LOG_LEVEL_ERROR, log);
     }
     return false;
   }
@@ -851,7 +851,7 @@ void WifiScan(bool async, uint8_t channel) {
       String log;
       log = F("WiFi : Start network scan channel ");
       log += channel;
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
   }
   bool show_hidden         = true;
@@ -1019,7 +1019,7 @@ void setAPinternal(bool enable)
         log += softAPSSID;
         log += F(" with address ");
         log += WiFi.softAPIP().toString();
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
     } else {
       if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
@@ -1027,7 +1027,7 @@ void setAPinternal(bool enable)
         log += softAPSSID;
         log += F(" IP: ");
         log += apIP.toString();
-        addLog(LOG_LEVEL_ERROR, log);
+        addLogMove(LOG_LEVEL_ERROR, log);
       }
     }
     #ifdef ESP32
@@ -1290,7 +1290,7 @@ void setupStaticIPconfig() {
     log += formatIP(subnet);
     log += F(" DNS: ");
     log += formatIP(dns);
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
   WiFi.config(ip, gw, subnet, dns);
 }
@@ -1346,7 +1346,7 @@ void logConnectionStatus() {
       log += SDKwifiStatusToString(sdk_wifistatus);
       log += F(" Arduino status: ");
       log += ArduinoWifiStatusToString(arduino_corelib_wifistatus);
-      addLog(LOG_LEVEL_ERROR, log);
+      addLogMove(LOG_LEVEL_ERROR, log);
     }
   }
   #endif
@@ -1356,7 +1356,7 @@ void logConnectionStatus() {
     log += ArduinoWifiStatusToString(WiFi.status());
     log += F(" ESPeasy internal wifi status: ");
     log += ESPeasyWifiStatusToString();
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
 /*
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {

--- a/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
@@ -166,7 +166,7 @@ void handle_unprocessedNetworkEvents()
           #ifdef ESP32
           wifilog += ArduinoWifiStatusToString(WiFi.status());
           #endif
-          addLog(LOG_LEVEL_DEBUG, wifilog);
+          addLogMove(LOG_LEVEL_DEBUG, wifilog);
         }
       }
       #endif // ifndef BUILD_NO_DEBUG
@@ -240,7 +240,7 @@ void processDisconnect() {
     } else {
       log += F(" Connected for a long time...");
     }
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
 
 
@@ -322,7 +322,7 @@ void processConnect() {
       log += String(static_cast<int32_t>(connect_duration / 1000));
       log += F(" ms");
     }
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
 
   if (Settings.UseRules) {
@@ -388,7 +388,7 @@ void processGotIP() {
       log += static_cast<int32_t>(dhcp_duration / 1000);
       log += F(" ms");
     }
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
 
   // Might not work in core 2.5.0
@@ -400,7 +400,7 @@ void processGotIP() {
     if (loglevelActiveFor(LOG_LEVEL_INFO)) {
       String log = F("IP   : Fixed IP octet:");
       log += formatIP(ip);
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
     WiFi.config(ip, gw, subnet, NetworkDnsIP(0), NetworkDnsIP(1));
   }
@@ -451,7 +451,7 @@ void processDisconnectAPmode() {
     log += WiFiEventData.lastMacDisconnectedAPmode.toString();
     log += F(" Connected devices: ");
     log += nrStationsConnected;
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
 }
 
@@ -467,7 +467,7 @@ void processConnectAPmode() {
     log += WiFiEventData.lastMacConnectedAPmode.toString();
     log += F(" Connected devices: ");
     log += WiFi.softAPgetStationNum();
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
 
   #ifdef FEATURE_DNS_SERVER
@@ -530,7 +530,7 @@ void processScanDone() {
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
     String log = F("WiFi : Scan finished, found: ");
     log += scanCompleteStatus;
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
 
   WiFi_AP_Candidates.process_WiFiscan(scanCompleteStatus);
@@ -613,7 +613,7 @@ void processEthernetGotIP() {
         log += F(" ms");
       }
 
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
   }
 

--- a/src/src/ESPEasyCore/ESPEasy_Log.cpp
+++ b/src/src/ESPEasyCore/ESPEasy_Log.cpp
@@ -300,5 +300,5 @@ void addToLogMove(uint8_t logLevel, String&& string)
     Logging.add(logLevel, std::move(string));
   }
   // Make sure the string may no longer keep up memory
-  string.clear();
+  string = String();
 }

--- a/src/src/ESPEasyCore/ESPEasy_Log.cpp
+++ b/src/src/ESPEasyCore/ESPEasy_Log.cpp
@@ -107,7 +107,7 @@ void updateLogLevelCache() {
 }
 
 bool loglevelActiveFor(uint8_t logLevel) {
-  return loglevelActive(logLevel, highest_active_log_level);
+  return logLevel <= highest_active_log_level;
 }
 
 uint8_t getSerialLogLevel() {
@@ -156,12 +156,7 @@ bool loglevelActiveFor(uint8_t destination, uint8_t logLevel) {
     default:
       return false;
   }
-  return loglevelActive(logLevel, logLevelSettings);
-}
-
-
-bool loglevelActive(uint8_t logLevel, uint8_t logLevelSettings) {
-  return (logLevel <= logLevelSettings);
+  return logLevel <= logLevelSettings;
 }
 
 void addLog(uint8_t logLevel, const __FlashStringHelper *str)

--- a/src/src/ESPEasyCore/ESPEasy_Log.h
+++ b/src/src/ESPEasyCore/ESPEasy_Log.h
@@ -47,10 +47,11 @@ bool loglevelActive(uint8_t logLevel, uint8_t logLevelSettings);
 void addLog(uint8_t loglevel, const __FlashStringHelper *str);
 void addLog(uint8_t logLevel, const char *line);
 void addLog(uint8_t loglevel, const String& string);
+void addLog(uint8_t loglevel, String&& string);
 
 void addToLog(uint8_t loglevel, const __FlashStringHelper *str);
-
 void addToLog(uint8_t loglevel, const String& string);
+void addToLog(uint8_t loglevel, String&& string);
 
 
 #endif 

--- a/src/src/ESPEasyCore/ESPEasy_Log.h
+++ b/src/src/ESPEasyCore/ESPEasy_Log.h
@@ -18,6 +18,9 @@
 #define LOG_TO_SDCARD         4
 
 
+// Move the log String so it does not have to be copied in the web log
+#define addLogMove(L, S)  addToLogMove(L, std::move(S))
+
 /********************************************************************************************\
   Logging
   \*********************************************************************************************/
@@ -44,14 +47,12 @@ bool loglevelActiveFor(uint8_t destination, uint8_t logLevel);
 
 bool loglevelActive(uint8_t logLevel, uint8_t logLevelSettings);
 
-void addLog(uint8_t loglevel, const __FlashStringHelper *str);
+void addLog(uint8_t logLevel, const __FlashStringHelper *str);
 void addLog(uint8_t logLevel, const char *line);
-void addLog(uint8_t loglevel, const String& string);
-void addLog(uint8_t loglevel, String&& string);
+void addLog(uint8_t logLevel, String&& string);
 
-void addToLog(uint8_t loglevel, const __FlashStringHelper *str);
-void addToLog(uint8_t loglevel, const String& string);
-void addToLog(uint8_t loglevel, String&& string);
+void addLog(uint8_t logLevel, const String& string);
+void addToLogMove(uint8_t logLevel, String&& string);
 
 
 #endif 

--- a/src/src/ESPEasyCore/ESPEasy_Log.h
+++ b/src/src/ESPEasyCore/ESPEasy_Log.h
@@ -45,8 +45,6 @@ uint8_t getWebLogLevel();
 bool loglevelActiveFor(uint8_t destination, uint8_t logLevel);
 
 
-bool loglevelActive(uint8_t logLevel, uint8_t logLevelSettings);
-
 void addLog(uint8_t logLevel, const __FlashStringHelper *str);
 void addLog(uint8_t logLevel, const char *line);
 void addLog(uint8_t logLevel, String&& string);

--- a/src/src/ESPEasyCore/ESPEasy_setup.cpp
+++ b/src/src/ESPEasyCore/ESPEasy_setup.cpp
@@ -170,10 +170,10 @@ void ESPEasy_setup()
     log += F(" (");
     log += getSystemLibraryString();
     log += ')';
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
     log  = F("INIT : Free RAM:");
     log += FreeMem();
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
 
   readBootCause();
@@ -218,7 +218,7 @@ void ESPEasy_setup()
     RTC.deepSleepState = 0;
     saveToRTC();
 
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
   #ifndef BUILD_NO_RAM_TRACKER
   logMemUsageAfter(F("RTC init"));
@@ -322,7 +322,7 @@ void ESPEasy_setup()
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
     String log  = F("INIT : Free RAM:");
     log += FreeMem();
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
 
   if (Settings.UseSerial && (Settings.SerialLogLevel >= LOG_LEVEL_DEBUG_MORE)) {
@@ -355,7 +355,7 @@ void ESPEasy_setup()
     log += F(" (");
     log += getSystemLibraryString();
     log += ')';
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
 
   if (deviceCount + 1 >= PLUGIN_MAX) {
@@ -447,8 +447,7 @@ void ESPEasy_setup()
 
   if (UseRTOSMultitasking) {
     if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-      String log = F("RTOS : Launching tasks");
-      addLog(LOG_LEVEL_INFO, log);
+      addLog(LOG_LEVEL_INFO, F("RTOS : Launching tasks"));
     }
     xTaskCreatePinnedToCore(RTOS_TaskServers, "RTOS_TaskServers", 16384, nullptr, 1, nullptr, 1);
     xTaskCreatePinnedToCore(RTOS_TaskSerial,  "RTOS_TaskSerial",  8192,  nullptr, 1, nullptr, 1);

--- a/src/src/Globals/CPlugins.cpp
+++ b/src/src/Globals/CPlugins.cpp
@@ -178,7 +178,7 @@ bool CPluginCall(protocolIndex_t protocolIndex, CPlugin::Function Function, stru
         while (log.length() < 73) log += ' ';
         log += getCPluginNameFromProtocolIndex(protocolIndex);
 
-        addLog(LOG_LEVEL_DEBUG, log);
+        addLogMove(LOG_LEVEL_DEBUG, log);
       }
     }
     #endif
@@ -271,7 +271,7 @@ protocolIndex_t getProtocolIndex(cpluginID_t cpluginID)
         log += String(cpluginID);
         log += F(" p_index: ");
         log += String(it->second);
-        addLog(LOG_LEVEL_ERROR, log);
+        addLogMove(LOG_LEVEL_ERROR, log);
       }
       #endif
       return it->second;
@@ -308,8 +308,10 @@ bool addCPlugin(cpluginID_t cpluginID, protocolIndex_t x) {
     CPlugin_id_to_ProtocolIndex[cpluginID] = x;
     return true;
   }
-  String log = F("System: Error - Too many C-Plugins. CPLUGIN_MAX = ");
-  log += CPLUGIN_MAX;
-  addLog(LOG_LEVEL_ERROR, log);
+  if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
+    String log = F("System: Error - Too many C-Plugins. CPLUGIN_MAX = ");
+    log += CPLUGIN_MAX;
+    addLogMove(LOG_LEVEL_ERROR, log);
+  }
   return false;
 }

--- a/src/src/Globals/Plugins.cpp
+++ b/src/src/Globals/Plugins.cpp
@@ -535,7 +535,7 @@ bool PluginCall(uint8_t Function, struct EventStruct *event, String& str)
               while (log.length() < 73) log += ' ';
               log += getPluginNameFromDeviceIndex(getDeviceIndex_from_TaskIndex(taskIndex));
 
-              addLog(LOG_LEVEL_DEBUG, log);
+              addLogMove(LOG_LEVEL_DEBUG, log);
             }
           }
         }
@@ -703,8 +703,10 @@ bool addPlugin(pluginID_t pluginID, deviceIndex_t x) {
     Plugin_id_to_DeviceIndex[pluginID] = x;
     return true;
   }
-  String log = F("System: Error - Too many Plugins. PLUGIN_MAX = ");
-  log += PLUGIN_MAX;
-  addLog(LOG_LEVEL_ERROR, log);
+  if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
+    String log = F("System: Error - Too many Plugins. PLUGIN_MAX = ");
+    log += PLUGIN_MAX;
+    addLogMove(LOG_LEVEL_ERROR, log);
+  }
   return false;
 }

--- a/src/src/Globals/RamTracker.cpp
+++ b/src/src/Globals/RamTracker.cpp
@@ -81,7 +81,7 @@ RamTracker::RamTracker(void) {
   writePtr = 0;
 
   for (int i = 0; i < TRACES; i++) {
-    traces[i].clear();
+    traces[i] = String();
     tracesMemory[i] = 0xffffffff; // init with best case memory values, so they get replaced if memory goes lower
   }
 
@@ -97,7 +97,7 @@ void RamTracker::registerRamState(const String& s) {   // store function
   int bestCase = bestCaseTrace();                      // find best case memory trace
 
   if (ESP.getFreeHeap() < tracesMemory[bestCase]) {    // compare to current memory value
-    traces[bestCase].clear();
+    traces[bestCase] = String();
     readPtr          = writePtr + 1;                   // read out buffer, oldest value first
 
     if (readPtr >= TRACEENTRIES) { 
@@ -135,7 +135,7 @@ void RamTracker::getTraceBuffer() {
       retval += ' ';
       retval += traces[i];
       addLogMove(LOG_LEVEL_DEBUG_DEV, retval);
-      retval.clear();
+      retval = String();
     }
   }
 #endif // ifndef BUILD_NO_DEBUG

--- a/src/src/Globals/RamTracker.cpp
+++ b/src/src/Globals/RamTracker.cpp
@@ -24,19 +24,31 @@ void checkRAM(const String &flashString, int a ) {
   checkRAM(flashString, String(a));
 }
 
+void checkRAM(const __FlashStringHelper * flashString, const String& a) {
+  checkRAM(String(flashString), a);
+}
+
+void checkRAM(const __FlashStringHelper * flashString, const __FlashStringHelper * a) {
+  String s = flashString;
+  s += F(" (");
+  s += a;
+  s += ')';
+  checkRAM(std::move(s));
+}
+
 void checkRAM(const String& flashString, const String &a ) {
   String s = flashString;
   s += F(" (");
   s += a;
   s += ')';
-  checkRAM(s);
+  checkRAM(std::move(s));
 }
 
 void checkRAM(const __FlashStringHelper * descr ) {
   checkRAM(String(descr));
 }
 
-void checkRAM(const String& descr ) {
+void checkRAM(String&& descr ) {
   if (Settings.EnableRAMTracking())
     myRamTracker.registerRamState(descr);
   
@@ -44,12 +56,12 @@ void checkRAM(const String& descr ) {
   if (freeRAM <= lowestRAM)
   {
     lowestRAM = freeRAM;
-    lowestRAMfunction = descr;
+    lowestRAMfunction = std::move(descr);
   }
   uint32_t freeStack = getFreeStackWatermark();
   if (freeStack <= lowestFreeStack) {
     lowestFreeStack = freeStack;
-    lowestFreeStackfunction = descr;
+    lowestFreeStackfunction = std::move(descr);
   }
 }
 

--- a/src/src/Globals/RamTracker.cpp
+++ b/src/src/Globals/RamTracker.cpp
@@ -134,7 +134,7 @@ void RamTracker::getTraceBuffer() {
       retval += String(tracesMemory[i]);
       retval += ' ';
       retval += traces[i];
-      addLog(LOG_LEVEL_DEBUG_DEV, retval);
+      addLogMove(LOG_LEVEL_DEBUG_DEV, retval);
       retval.clear();
     }
   }

--- a/src/src/Globals/RamTracker.h
+++ b/src/src/Globals/RamTracker.h
@@ -50,11 +50,16 @@ void checkRAMtoLog(void);
 void checkRAM(const String& flashString,
               int           a);
 
+void checkRAM(const __FlashStringHelper * flashString,
+              const String& a);
+void checkRAM(const __FlashStringHelper * flashString,
+              const __FlashStringHelper * a);
 void checkRAM(const String& flashString,
               const String& a);
 
+
 void checkRAM(const __FlashStringHelper *  descr);
-void checkRAM(const String& descr);
+void checkRAM(String&& descr);
 #endif
 
 

--- a/src/src/Helpers/Dallas1WireHelper.cpp
+++ b/src/src/Helpers/Dallas1WireHelper.cpp
@@ -335,6 +335,7 @@ bool Dallas_readTemp(const uint8_t ROM[8], float *value, int8_t gpio_pin_rx, int
 
   bool crc_ok = Dallas_crc8(ScratchPad);
 
+  #ifndef BUILD_NO_DEBUG
   if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
     String log = F("DS: SP: ");
 
@@ -359,8 +360,9 @@ bool Dallas_readTemp(const uint8_t ROM[8], float *value, int8_t gpio_pin_rx, int
     log += ll2String(presence_start, DEC);
     log += ',';
     log += ll2String(presence_end, DEC);
-    addLog(LOG_LEVEL_DEBUG, log);
+    addLogMove(LOG_LEVEL_DEBUG, log);
   }
+  #endif
 
   if (!crc_ok)
   {
@@ -436,7 +438,7 @@ bool Dallas_readiButton(const uint8_t addr[8], int8_t gpio_pin_rx, int8_t gpio_p
       found = true;
     }
   }
-  addLog(LOG_LEVEL_INFO, log);
+  addLogMove(LOG_LEVEL_INFO, log);
   return found;
 }
 

--- a/src/src/Helpers/ESPEasy_Storage.cpp
+++ b/src/src/Helpers/ESPEasy_Storage.cpp
@@ -676,7 +676,7 @@ String LoadStringArray(SettingsType::Enum settingsType, int index, String string
             #endif
 
             strings[stringCount] = tmpString;
-            tmpString.clear();
+            tmpString = String();
             tmpString.reserve(estimatedStringSize);
             ++stringCount;
           } else {

--- a/src/src/Helpers/ESPEasy_Storage.cpp
+++ b/src/src/Helpers/ESPEasy_Storage.cpp
@@ -67,7 +67,7 @@ String FileError(int line, const char *fname)
   err += fname;
   err += F(" in ");
   err += line;
-  addLog(LOG_LEVEL_ERROR, err);
+  addLogMove(LOG_LEVEL_ERROR, err);
   return err;
 }
 
@@ -340,10 +340,10 @@ void fileSystemCheck()
 
     if (loglevelActiveFor(LOG_LEVEL_INFO)) {
       String log = F("FS   : Mount successful, used ");
-      log = log + fs_info.usedBytes;
-      log = log + F(" bytes of ");
-      log = log + fs_info.totalBytes;
-      addLog(LOG_LEVEL_INFO, log);
+      log += fs_info.usedBytes;
+      log += F(" bytes of ");
+      log += fs_info.totalBytes;
+      addLogMove(LOG_LEVEL_INFO, log);
     }
 
     // Run garbage collection before any file is open.
@@ -367,7 +367,7 @@ void fileSystemCheck()
   {
     String log = F("FS   : Mount failed");
     serialPrintln(log);
-    addLog(LOG_LEVEL_ERROR, log);
+    addLogMove(LOG_LEVEL_ERROR, log);
     ResetFactory();
   }
 }
@@ -608,7 +608,7 @@ bool getAndLogSettingsParameters(bool read, SettingsType::Enum settingsType, int
     log += SettingsType::getSettingsTypeString(settingsType);
     log += F(" index: ");
     log += index;
-    addLog(LOG_LEVEL_DEBUG_DEV, log);
+    addLogMove(LOG_LEVEL_DEBUG_DEV, log);
   }
 #endif // ifndef BUILD_NO_DEBUG
   return SettingsType::getSettingsParameters(settingsType, index, offset, max_size);
@@ -1098,7 +1098,7 @@ String doSaveToFile(const char *fname, int index, const uint8_t *memAddress, int
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
     String log = F("SaveToFile: free stack: ");
     log += getCurrentFreeStack();
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
   #endif
   delay(1);
@@ -1140,7 +1140,7 @@ String doSaveToFile(const char *fname, int index, const uint8_t *memAddress, int
       log += index;
       log += F(" size: ");
       log += datasize;
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
     #endif
   } else {
@@ -1160,7 +1160,7 @@ String doSaveToFile(const char *fname, int index, const uint8_t *memAddress, int
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
     String log = F("SaveToFile: free stack after: ");
     log += getCurrentFreeStack();
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
   #endif
 

--- a/src/src/Helpers/ESPEasy_checks.cpp
+++ b/src/src/Helpers/ESPEasy_checks.cpp
@@ -95,9 +95,9 @@ void run_compiletime_checks() {
   // Has to be round up to multiple of 4.
   #if ESP_IDF_VERSION_MAJOR > 3
   // String class has increased with 4 bytes
-  const unsigned int LogStructSize = ((12u + 21 * LOG_STRUCT_MESSAGE_LINES) + 3) & ~3;
+  const unsigned int LogStructSize = ((13u + 21 * LOG_STRUCT_MESSAGE_LINES) + 3) & ~3;
   #else
-  const unsigned int LogStructSize = ((12u + 17 * LOG_STRUCT_MESSAGE_LINES) + 3) & ~3;
+  const unsigned int LogStructSize = ((13u + 17 * LOG_STRUCT_MESSAGE_LINES) + 3) & ~3;
   #endif
   check_size<LogStruct,                             LogStructSize>(); // Is not stored
   check_size<DeviceStruct,                          8u>(); // Is not stored

--- a/src/src/Helpers/ESPEasy_checks.cpp
+++ b/src/src/Helpers/ESPEasy_checks.cpp
@@ -187,7 +187,7 @@ String ReportOffsetErrorInStruct(const String& structname, size_t offset) {
 *  Not a member function to be able to use the F-macro
 \*********************************************************************************************/
 bool SettingsCheck(String& error) {
-  error.clear();
+  error = String();
   #ifndef LIMIT_BUILD_SIZE
 #ifdef esp8266
   size_t offset = offsetof(SettingsStruct, ResetFactoryDefaultPreference);

--- a/src/src/Helpers/ESPEasy_time.cpp
+++ b/src/src/Helpers/ESPEasy_time.cpp
@@ -208,7 +208,7 @@ unsigned long ESPEasy_time::now() {
           log += F(" Source: ");
           log += toString(timeSource);
         }
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
 
       time_zone.applyTimeZone(unixTime_d);
@@ -229,7 +229,7 @@ unsigned long ESPEasy_time::now() {
     if (loglevelActiveFor(LOG_LEVEL_INFO)) {
       String log = F("Local time: ");
       log += getDateTimeString('-', ':', ' ');
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
     {
       // Notify plugins the time has been set.
@@ -323,7 +323,7 @@ bool ESPEasy_time::getNtpTime(double& unixTime_d)
 
   if (!hostReachable(timeServerIP)) {
     log += F(" unreachable");
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
     return false;
   }
 
@@ -379,7 +379,7 @@ bool ESPEasy_time::getNtpTime(double& unixTime_d)
           String log = F("NTP  : NTP host (");
           log += timeServerIP.toString();
           log += F(") unsynchronized");
-          addLog(LOG_LEVEL_ERROR, log);
+          addLogMove(LOG_LEVEL_ERROR, log);
         }
         if (!useNTPpool) {
           // Does not make sense to try it very often if a single host is used which is not synchronized.
@@ -447,7 +447,7 @@ bool ESPEasy_time::getNtpTime(double& unixTime_d)
         }
         log += doubleToString(fractpart, 3);
         log += F(" seconds");
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
       udp.stop();
       timeSource = timeSource_t::NTP_time_source;
@@ -793,7 +793,7 @@ bool ESPEasy_time::ExtRTC_get(uint32_t &unixtime)
   if (unixtime != 0) {
     String log = F("ExtRTC: Read external time source: ");
     log += unixtime;
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
     return true;
   }
   addLog(LOG_LEVEL_ERROR, F("ExtRTC: Cannot get time from external time source"));
@@ -863,7 +863,7 @@ bool ESPEasy_time::ExtRTC_set(uint32_t unixtime)
   if (timeAdjusted) {
     String log = F("ExtRTC: External time source set to: ");
     log += unixtime;
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
     return true;
   }
   addLog(LOG_LEVEL_ERROR, F("ExtRTC: Cannot set time to external time source"));

--- a/src/src/Helpers/ESPEasy_time_zone.cpp
+++ b/src/src/Helpers/ESPEasy_time_zone.cpp
@@ -53,6 +53,7 @@ void ESPEasy_time_zone::setTimeZone(const TimeChangeRule& dstStart, const TimeCh
 }
 
 void ESPEasy_time_zone::logTimeZoneInfo() {
+  if (!loglevelActiveFor(LOG_LEVEL_INFO)) return;
   String log = F("Current Time Zone: ");
 
   if (m_std.offset != m_dst.offset) {
@@ -80,7 +81,7 @@ void ESPEasy_time_zone::logTimeZoneInfo() {
   log += F(" offset: ");
   log += m_std.offset;
   log += F(" min");
-  addLog(LOG_LEVEL_INFO, log);
+  addLogMove(LOG_LEVEL_INFO, log);
 }
 
 

--- a/src/src/Helpers/Hardware.cpp
+++ b/src/src/Helpers/Hardware.cpp
@@ -196,7 +196,7 @@ void initI2C() {
     if (loglevelActiveFor(LOG_LEVEL_INFO)) {
       String log = F("INIT : I2C custom clockstretchlimit:");
       log += Settings.WireClockStretchLimit;
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
       #if defined(ESP8266)
     Wire.setClockStretchLimit(Settings.WireClockStretchLimit);
@@ -902,7 +902,7 @@ void addButtonRelayRule(uint8_t buttonNumber, int relay_gpio) {
   String result = appendLineToFile(fileName, rule);
 
   if (result.length() > 0) {
-    addLog(LOG_LEVEL_ERROR, result);
+    addLogMove(LOG_LEVEL_ERROR, result);
   }
 }
 

--- a/src/src/Helpers/MDNS_Helper.cpp
+++ b/src/src/Helpers/MDNS_Helper.cpp
@@ -32,7 +32,7 @@ void set_mDNS() {
         else {
           log += F("mDNS failed");
         }
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
       if (mDNS_init) {
         MDNS.addService(F("http"), F("tcp"), Settings.WebserverPort);

--- a/src/src/Helpers/Misc.cpp
+++ b/src/src/Helpers/Misc.cpp
@@ -503,7 +503,7 @@ void logMemUsageAfter(const __FlashStringHelper *function, int value) {
       while (log.length() < 55) { log += ' '; }
       log += F("diff: ");
       log += last_freemem - freemem_end;
-      addLog(LOG_LEVEL_DEBUG, log);
+      addLogMove(LOG_LEVEL_DEBUG, log);
     }
   }
 

--- a/src/src/Helpers/Modbus_RTU.cpp
+++ b/src/src/Helpers/Modbus_RTU.cpp
@@ -62,7 +62,7 @@ bool ModbusRTU_struct::init(const ESPEasySerialPort port, const int16_t serial_r
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
     String log; // = F("Modbus detected: ");
     log += detected_device_description;
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
     modbus_log_MEI(_modbus_address);
   }
   return true;
@@ -618,7 +618,7 @@ void ModbusRTU_struct::modbus_log_MEI(uint8_t slaveAddress) {
         String log = MEI_objectid_to_name(object_id);
         log += F(": ");
         log += result;
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
     } else {
       switch (process_result) {

--- a/src/src/Helpers/Modbus_RTU.cpp
+++ b/src/src/Helpers/Modbus_RTU.cpp
@@ -19,7 +19,7 @@ void ModbusRTU_struct::reset() {
     delete easySerial;
     easySerial = nullptr;
   }
-  detected_device_description.clear();
+  detected_device_description = String();
 
   for (int i = 0; i < 8; ++i) {
     _sendframe[i] = 0;

--- a/src/src/Helpers/Networking.cpp
+++ b/src/src/Helpers/Networking.cpp
@@ -244,7 +244,7 @@ void checkUDP()
 #endif // ifndef BUILD_NO_DEBUG
                 {
                   #ifdef USE_SECOND_HEAP
-                  // HeapSelectIram ephemeral;
+                  HeapSelectIram ephemeral;
                   // TD-er: Disabled for now as it is suspect for crashes.
                   #endif
 

--- a/src/src/Helpers/Networking.cpp
+++ b/src/src/Helpers/Networking.cpp
@@ -153,7 +153,7 @@ void updateUDPport()
       if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
         String log = F("UDP : Cannot bind to ESPEasy p2p UDP port ");
         log += String(Settings.UDPPort);
-        addLog(LOG_LEVEL_ERROR, log);
+        addLogMove(LOG_LEVEL_ERROR, log);
       }
     } else {
       lastUsedUDPPort = Settings.UDPPort;
@@ -161,7 +161,7 @@ void updateUDPport()
       if (loglevelActiveFor(LOG_LEVEL_INFO)) {
         String log = F("UDP : Start listening on port ");
         log += String(Settings.UDPPort);
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
     }
   }
@@ -291,7 +291,7 @@ void checkUDP()
                   log += formatIP(ip);
                   log += ',';
                   log += unit;
-                  addLog(LOG_LEVEL_DEBUG_MORE, log);
+                  addLogMove(LOG_LEVEL_DEBUG_MORE, log);
                 }
 #endif // ifndef BUILD_NO_DEBUG
                 break;
@@ -413,7 +413,7 @@ void sendUDP(uint8_t unit, const uint8_t *data, uint8_t size)
   if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE)) {
     String log = F("UDP  : Send UDP message to ");
     log += unit;
-    addLog(LOG_LEVEL_DEBUG_MORE, log);
+    addLogMove(LOG_LEVEL_DEBUG_MORE, log);
   }
 #endif // ifndef BUILD_NO_DEBUG
 
@@ -1081,10 +1081,12 @@ bool hostReachable(const String& hostname) {
   if (resolveHostByName(hostname.c_str(), remote_addr)) {
     return hostReachable(remote_addr);
   }
-  String log = F("Hostname cannot be resolved: ");
+  if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
+    String log = F("Hostname cannot be resolved: ");
 
-  log += hostname;
-  addLog(LOG_LEVEL_ERROR, log);
+    log += hostname;
+    addLogMove(LOG_LEVEL_ERROR, log);
+  }
   return false;
 }
 
@@ -1207,7 +1209,7 @@ bool downloadFile(const String& url, String file_save, const String& user, const
     log += ':';
     log += port;
     log += uri;
-    addLog(LOG_LEVEL_ERROR, log);
+    addLogMove(LOG_LEVEL_ERROR, log);
   }
 
   if (file_save.isEmpty()) {

--- a/src/src/Helpers/OTA.cpp
+++ b/src/src/Helpers/OTA.cpp
@@ -100,7 +100,7 @@ void ArduinoOTAInit()
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
     String log = F("OTA  : Arduino OTA enabled on port ");
     log += ARDUINO_OTA_PORT;
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
 }
 

--- a/src/src/Helpers/PeriodicalActions.cpp
+++ b/src/src/Helpers/PeriodicalActions.cpp
@@ -220,7 +220,7 @@ void runEach30Seconds()
 
   //    log += F(" ListenInterval ");
   //    log += WiFi.getListenInterval();
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
   }
   WiFi_AP_Candidates.purge_expired();
@@ -304,7 +304,7 @@ void processMQTTdelayQueue() {
       String log = F("MQTT : process MQTT queue not published, ");
       log += MQTTDelayHandler->sendQueue.size();
       log += F(" items left in queue");
-      addLog(LOG_LEVEL_DEBUG, log);
+      addLogMove(LOG_LEVEL_DEBUG, log);
     }
 #endif // ifndef BUILD_NO_DEBUG
   }
@@ -320,7 +320,7 @@ void updateMQTTclient_connected() {
       if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
         String connectionError = F("MQTT : Connection lost, state: ");
         connectionError += getMQTT_state();
-        addLog(LOG_LEVEL_ERROR, connectionError);
+        addLogMove(LOG_LEVEL_ERROR, connectionError);
       }
       MQTTclient_must_send_LWT_connected = false;
     } else {
@@ -396,7 +396,7 @@ void logTimerStatistics() {
   if (loglevelActiveFor(loglevel)) {
     String queueLog = F("Scheduler stats: (called/tasks/max_length/idle%) ");
     queueLog += Scheduler.getQueueStats();
-    addLog(loglevel, queueLog);
+    addLogMove(loglevel, queueLog);
   }
 #endif
 }
@@ -421,7 +421,7 @@ void updateLoopStats_30sec(uint8_t loglevel) {
     log += loopCounterMax;
     log += F(" loopCounterLast: ");
     log += loopCounterLast;
-    addLog(loglevel, log);
+    addLogMove(loglevel, log);
   }
 #endif
   loop_usec_duration_total = 0;

--- a/src/src/Helpers/Rules_calculate.cpp
+++ b/src/src/Helpers/Rules_calculate.cpp
@@ -619,7 +619,7 @@ int CalculateParam(const String& TmpStr) {
         log += TmpStr;
         log += F(" = ");
         log += round(param);
-        addLog(LOG_LEVEL_DEBUG, log);
+        addLogMove(LOG_LEVEL_DEBUG, log);
       }
 #endif // ifndef BUILD_NO_DEBUG
     }
@@ -669,7 +669,7 @@ CalculateReturnCode Calculate(const String& input,
       log += doubleToString(result, 6, trimTrailingZeros);
       #endif // ifndef BUILD_NO_DEBUG
 
-      addLog(LOG_LEVEL_ERROR, log);
+      addLogMove(LOG_LEVEL_ERROR, log);
     }
   }
   return returnCode;

--- a/src/src/Helpers/Scheduler.cpp
+++ b/src/src/Helpers/Scheduler.cpp
@@ -687,7 +687,7 @@ static bool checkRulesTimerIndex(unsigned int timerIndex) {
     if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
       String log = F("TIMER: invalid timer number ");
       log += timerIndex;
-      addLog(LOG_LEVEL_ERROR, log);
+      addLogMove(LOG_LEVEL_ERROR, log);
     }
     return false;
   }

--- a/src/src/Helpers/StringConverter.cpp
+++ b/src/src/Helpers/StringConverter.cpp
@@ -1092,7 +1092,7 @@ bool GetArgv(const char *string, String& argvString, unsigned int argc, char sep
   int  pos_begin, pos_end;
   bool hasArgument = GetArgvBeginEnd(string, argc, pos_begin, pos_end, separator);
 
-  argvString.clear();
+  argvString = String();
 
   if (!hasArgument) { return false; }
 

--- a/src/src/Helpers/StringConverter.cpp
+++ b/src/src/Helpers/StringConverter.cpp
@@ -347,7 +347,7 @@ String doFormatUserVar(struct EventStruct *event, uint8_t rel_index, bool mustCh
       log += rel_index + 1;
       log += F(" type: ");
       log += getSensorTypeLabel(sensorType);
-      addLog(LOG_LEVEL_ERROR, log);
+      addLogMove(LOG_LEVEL_ERROR, log);
     }
     #endif // ifndef BUILD_NO_DEBUG
     return EMPTY_STRING;
@@ -374,7 +374,7 @@ String doFormatUserVar(struct EventStruct *event, uint8_t rel_index, bool mustCh
       log += event->TaskIndex;
       log += F(" varnumber: ");
       log += rel_index;
-      addLog(LOG_LEVEL_DEBUG, log);
+      addLogMove(LOG_LEVEL_DEBUG, log);
     }
 #endif // ifndef BUILD_NO_DEBUG
     f = 0;

--- a/src/src/Helpers/StringParser.cpp
+++ b/src/src/Helpers/StringParser.cpp
@@ -508,7 +508,7 @@ void transformValue(
           logFormatted += newString;
           logFormatted += value;
           logFormatted += '\'';
-          addLog(LOG_LEVEL_DEBUG, logFormatted);
+          addLogMove(LOG_LEVEL_DEBUG, logFormatted);
         }
 #endif // ifndef BUILD_NO_DEBUG
       }
@@ -525,7 +525,7 @@ void transformValue(
       String logParsed = F("DEBUG DEV: Parsed String='");
       logParsed += newString;
       logParsed += '\'';
-      addLog(LOG_LEVEL_DEBUG_DEV, logParsed);
+      addLogMove(LOG_LEVEL_DEBUG_DEV, logParsed);
     }
 #endif // ifndef BUILD_NO_DEBUG
   }

--- a/src/src/Helpers/StringParser.cpp
+++ b/src/src/Helpers/StringParser.cpp
@@ -278,7 +278,7 @@ void transformValue(
             }
 
             if (value == F("0")) {
-              value.clear();
+              value = String();
             } else {
               const int valueLength = value.length();
 
@@ -666,7 +666,7 @@ bool findNextDevValNameInString(const String& input, int& startpos, int& endpos,
     format    = valueName.substring(hashpos + 1);
     valueName = valueName.substring(0, hashpos);
   } else {
-    format.clear();
+    format = String();
   }
   deviceName.toLowerCase();
   valueName.toLowerCase();

--- a/src/src/Helpers/SystemVariables.cpp
+++ b/src/src/Helpers/SystemVariables.cpp
@@ -44,7 +44,7 @@ String getReplacementString(const String& format, String& s) {
     log += R;
     log += F(" offset: ");
     log += ESPEasy_time::getSecOffset(R);
-    addLog(LOG_LEVEL_DEBUG, log);
+    addLogMove(LOG_LEVEL_DEBUG, log);
   }
 #endif // ifndef BUILD_NO_DEBUG
   return R;

--- a/src/src/Helpers/WebServer_commandHelper.cpp
+++ b/src/src/Helpers/WebServer_commandHelper.cpp
@@ -22,7 +22,7 @@ HandledWebCommand_result handle_command_from_web(EventValueSource::Enum source, 
 
   bool handledCmd = false;
   bool sendOK     = false;
-  printWebString.clear();
+  printWebString = String();
   printToWeb     = false;
   printToWebJSON = false;
 

--- a/src/src/Helpers/WiFi_AP_CandidatesList.cpp
+++ b/src/src/Helpers/WiFi_AP_CandidatesList.cpp
@@ -230,7 +230,7 @@ void WiFi_AP_CandidatesList::loadCandidatesFromScanned() {
   if (scanned_new.size() > 0) {
     // We have new scans to process.
     #ifdef USE_SECOND_HEAP
-    // HeapSelectIram ephemeral;
+    HeapSelectIram ephemeral;
     // TD-er: Disabled for now as it is suspect for crashes
     #endif
     purge_expired();

--- a/src/src/Helpers/WiFi_AP_CandidatesList.cpp
+++ b/src/src/Helpers/WiFi_AP_CandidatesList.cpp
@@ -239,7 +239,7 @@ void WiFi_AP_CandidatesList::loadCandidatesFromScanned() {
       if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
         String log = F("WiFi : Scan result: ");
         log += scan->toString();
-        addLog(LOG_LEVEL_DEBUG, log);
+        addLogMove(LOG_LEVEL_DEBUG, log);
       }
       #endif // ifndef BUILD_NO_DEBUG
 
@@ -301,7 +301,7 @@ void WiFi_AP_CandidatesList::loadCandidatesFromScanned() {
     if (bestCandidate.usable()) {
       String log = F("WiFi : Best AP candidate: ");
       log += bestCandidate.toString();
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
   }
   candidates.sort();

--- a/src/src/Helpers/_CPlugin_DomoticzHelper.cpp
+++ b/src/src/Helpers/_CPlugin_DomoticzHelper.cpp
@@ -172,7 +172,7 @@ String formatDomoticzSensorType(struct EventStruct *event) {
         log += static_cast<uint8_t>(event->sensorType);
         log += F(" idx: ");
         log += event->idx;
-        addLog(LOG_LEVEL_ERROR, log);
+        addLogMove(LOG_LEVEL_ERROR, log);
       }
       # endif // ifndef BUILD_NO_DEBUG
       break;
@@ -196,7 +196,7 @@ String formatDomoticzSensorType(struct EventStruct *event) {
       log += event->idx;
       log += F(" values: ");
       log += values;
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
     # endif // ifndef BUILD_NO_DEBUG
   }

--- a/src/src/Helpers/_CPlugin_Helper.cpp
+++ b/src/src/Helpers/_CPlugin_Helper.cpp
@@ -253,7 +253,7 @@ void log_connecting_to(const __FlashStringHelper * prefix, int controller_number
     log += get_formatted_Controller_number(controller_number);
     log += F(" connecting to ");
     log += ControllerSettings.getHostPortString();
-    addLog(LOG_LEVEL_DEBUG, log);
+    addLogMove(LOG_LEVEL_DEBUG, log);
   }
 }
 
@@ -268,7 +268,7 @@ void log_connecting_fail(const __FlashStringHelper * prefix, int controller_numb
     log += F("/");
     log += Settings.ConnectionFailuresThreshold;
     log += F(")");
-    addLog(LOG_LEVEL_ERROR, log);
+    addLogMove(LOG_LEVEL_ERROR, log);
   }
 }
 
@@ -350,7 +350,7 @@ bool send_via_http(const String& logIdentifier, WiFiClient& client, const String
       log += '/';
       log += postStr.length();
       log += ')';
-      addLog(LOG_LEVEL_ERROR, log);
+      addLogMove(LOG_LEVEL_ERROR, log);
     }
     success = false;
   }
@@ -364,7 +364,7 @@ bool send_via_http(const String& logIdentifier, WiFiClient& client, const String
       log += '/';
       log += postStr.length();
       log += ')';
-      addLog(LOG_LEVEL_DEBUG, log);
+      addLogMove(LOG_LEVEL_DEBUG, log);
     }
   }
 #endif // ifndef BUILD_NO_DEBUG
@@ -408,7 +408,7 @@ bool send_via_http(const String& logIdentifier, WiFiClient& client, const String
           log += logIdentifier;
           log += F(" Success! ");
           log += line;
-          addLog(LOG_LEVEL_DEBUG, log);
+          addLogMove(LOG_LEVEL_DEBUG, log);
         }
       } else if (line.startsWith(F("HTTP/1.1 4"))) {
         if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
@@ -416,7 +416,7 @@ bool send_via_http(const String& logIdentifier, WiFiClient& client, const String
           log += logIdentifier;
           log += F(" Error: ");
           log += line;
-          addLog(LOG_LEVEL_ERROR, log);
+          addLogMove(LOG_LEVEL_ERROR, log);
         }
 #ifndef BUILD_NO_DEBUG
         addLog(LOG_LEVEL_DEBUG_MORE, postStr);
@@ -433,7 +433,7 @@ bool send_via_http(const String& logIdentifier, WiFiClient& client, const String
     String log = F("HTTP : ");
     log += logIdentifier;
     log += F(" closing connection");
-    addLog(LOG_LEVEL_DEBUG, log);
+    addLogMove(LOG_LEVEL_DEBUG, log);
   }
 #endif // ifndef BUILD_NO_DEBUG
 #ifdef ESP8266
@@ -579,7 +579,7 @@ String send_via_http(const String& logIdentifier,
         log += ' ';
         log += response;
       }
-      addLog(loglevel, log);
+      addLogMove(loglevel, log);
     }
   } else {
     if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
@@ -589,7 +589,7 @@ String send_via_http(const String& logIdentifier,
       log += HttpMethod;
       log += F("... failed, error: ");
       log += http.errorToString(httpCode);
-      addLog(LOG_LEVEL_ERROR, log);
+      addLogMove(LOG_LEVEL_ERROR, log);
     }
   }
   http.end();

--- a/src/src/Helpers/_CPlugin_Helper.cpp
+++ b/src/src/Helpers/_CPlugin_Helper.cpp
@@ -50,7 +50,7 @@ bool safeReadStringUntil(Stream     & input,
   const unsigned long timer           = start + timeout;
   unsigned long backgroundtasks_timer = start + 10;
 
-  str.clear();
+  str = String();
 
   do {
     // read character

--- a/src/src/Helpers/_CPlugin_LoRa_TTN_helper.cpp
+++ b/src/src/Helpers/_CPlugin_LoRa_TTN_helper.cpp
@@ -34,7 +34,7 @@ String getPackedFromPlugin(struct EventStruct *event, uint8_t sampleSetCount)
       log += F(" RAW: ");
       log += raw_packed;
     }
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
 
   if (raw_packed.length() > 0) {

--- a/src/src/Helpers/_Internal_GPIO_pulseHelper.cpp
+++ b/src/src/Helpers/_Internal_GPIO_pulseHelper.cpp
@@ -262,7 +262,7 @@ void Internal_GPIO_pulseHelper::doPulseStepProcessing(int pStep)
       if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
         String log; log.reserve(48);
         log = F("_P003:PLUGIN_TIMER_IN: Invalid processingStep: "); log += pStep;
-        addLog(LOG_LEVEL_ERROR, log);
+        addLogMove(LOG_LEVEL_ERROR, log);
       }
       break;
     }
@@ -337,7 +337,7 @@ void Internal_GPIO_pulseHelper::processStablePulse(int pinState, uint64_t pulseC
           log.reserve(48);
           log  = F("_P003:PLUGIN_TIMER_IN: Invalid modeType: ");
           log += static_cast<int>(config.interruptPinMode);
-          addLog(LOG_LEVEL_ERROR, log);
+          addLogMove(LOG_LEVEL_ERROR, log);
         }
         break;
       }
@@ -451,7 +451,7 @@ void Internal_GPIO_pulseHelper::doStatisticLogging(uint8_t logLevel)
       log += ISRdata.pulseTotalCounter;         log += F("] [");
       log += pulseModeData.pulseLowTime / 1000L;  log += '|';
       log += pulseModeData.pulseHighTime / 1000L; log += ']';
-      addLog(logLevel, log);
+      addLogMove(logLevel, log);
     }
   }
 }
@@ -477,7 +477,7 @@ void Internal_GPIO_pulseHelper::doTimingLogging(uint8_t logLevel)
         if (pStep < P003_PSTEP_MAX) { log += '|'; }
       }
       log += ']';
-      addLog(logLevel, log);
+      addLogMove(logLevel, log);
     }
   }
 }

--- a/src/src/Helpers/_Plugin_Helper_serial.cpp
+++ b/src/src/Helpers/_Plugin_Helper_serial.cpp
@@ -36,7 +36,7 @@ void serialHelper_log_GpioDescription(ESPEasySerialPort typeHint, int config_pin
   if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
     String log = F("Serial : ");
     log += serialHelper_getGpioDescription(typeHint, config_pin1, config_pin2, " ");
-    addLog(LOG_LEVEL_DEBUG, log);
+    addLogMove(LOG_LEVEL_DEBUG, log);
   }
 }
 

--- a/src/src/PluginStructs/P016_data_struct.cpp
+++ b/src/src/PluginStructs/P016_data_struct.cpp
@@ -61,7 +61,7 @@ tCommandLinesV2::tCommandLinesV2(const tCommandLinesV1& lineV1, uint8_t i)
     }
     #  endif // ifdef PLUGIN_016_DEBUG
   }
-  addLog(LOG_LEVEL_INFO, log);
+  addLogMove(LOG_LEVEL_INFO, log);
 }
 
 # endif // ifdef P16_SETTINGS_V1
@@ -185,7 +185,7 @@ void P016_data_struct::AddCode(uint64_t Code, decode_type_t DecodeType, uint16_t
       log += uint64ToString(Code, 16);
       log += F(" to index ");
       log += _index;
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
   }
   # endif // PLUGIN_016_DEBUG
@@ -235,7 +235,7 @@ void P016_data_struct::ExecuteCode(uint64_t Code, decode_type_t DecodeType, uint
             if (!_success) {
               log += F(" FAILED!");
             }
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
           }
         }
         # endif // PLUGIN_016_DEBUG
@@ -258,7 +258,7 @@ void P016_data_struct::ExecuteCode(uint64_t Code, decode_type_t DecodeType, uint
         log += F(" Code: 0x");
         log += uint64ToString(CommandLines[i].Code, 16);
         log += '}';
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
     }
     # endif // PLUGIN_016_DEBUG

--- a/src/src/PluginStructs/P020_data_struct.cpp
+++ b/src/src/PluginStructs/P020_data_struct.cpp
@@ -109,7 +109,7 @@ void P020_Task::discardClientIn() {
 }
 
 void P020_Task::clearBuffer() {
-  serial_buffer.clear();
+  serial_buffer = String();
   serial_buffer.reserve(P020_DATAGRAM_MAX_SIZE);
 }
 

--- a/src/src/PluginStructs/P028_data_struct.cpp
+++ b/src/src/PluginStructs/P028_data_struct.cpp
@@ -197,7 +197,7 @@ bool P028_data_struct::updateMeasurements(float tempOffset, unsigned long task_i
   }
 
   if (logAdded && loglevelActiveFor(LOG_LEVEL_INFO)) {
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
   return true;
 }
@@ -220,9 +220,11 @@ bool P028_data_struct::check() {
         if (sensorID != chip_id) {
           sensorID = static_cast<BMx_ChipId>(chip_id);
           setUninitialized();
-          String log = F("BMx280 : Detected ");
-          log += getFullDeviceName();
-          addLog(LOG_LEVEL_INFO, log);
+          if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+            String log = F("BMx280 : Detected ");
+            log += getFullDeviceName();
+            addLogMove(LOG_LEVEL_INFO, log);
+          }
         }
       } else {
         sensorID = Unknown_DEVICE;
@@ -241,7 +243,7 @@ bool P028_data_struct::check() {
       log += F(", failed");
     }
     log += ')';
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
     return false;
   }
   return wire_status;

--- a/src/src/PluginStructs/P035_data_struct.cpp
+++ b/src/src/PluginStructs/P035_data_struct.cpp
@@ -425,11 +425,10 @@ void P035_data_struct::printToLog(const String& protocol, const String& data, in
     tmp += F(" Repeats: ");
     tmp += repeats;
   }
-  addLog(LOG_LEVEL_INFO, tmp);
-
   if (printToWeb) {
     printWebString = tmp;
   }
+  addLogMove(LOG_LEVEL_INFO, tmp);
 }
 
 # ifdef P035_DEBUG_LOG

--- a/src/src/PluginStructs/P036_data_struct.cpp
+++ b/src/src/PluginStructs/P036_data_struct.cpp
@@ -536,7 +536,7 @@ tFontSettings P036_data_struct::CalculateFontSettings(uint8_t lDefaultLines)
     log += iLinesPerFrame;
     log += F(" DefaultLines:");
     log += lDefaultLines;
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
 # endif // PLUGIN_036_DEBUG
   
@@ -585,7 +585,7 @@ uint8_t P036_data_struct::display_scroll(ePageScrollSpeed lscrollspeed, int lTas
     if (log.reserve(128)) { // estimated
       log = F("Start Scrolling: Speed: ");
       log += static_cast<int>(lscrollspeed);
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
   }
 # endif // PLUGIN_036_DEBUG
@@ -608,7 +608,7 @@ uint8_t P036_data_struct::display_scroll(ePageScrollSpeed lscrollspeed, int lTas
     String log;
     log  = F("PageScrollTime: ");
     log += iPageScrollTime;
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
 # endif // PLUGIN_036_DEBUG
 
@@ -673,7 +673,7 @@ uint8_t P036_data_struct::display_scroll(ePageScrollSpeed lscrollspeed, int lTas
             log += ScrollingLines.Line[j].Width;
             log += F(" dPix: ");
             log += ScrollingLines.Line[j].dPix;
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
           }
         }
 # endif // PLUGIN_036_DEBUG
@@ -711,11 +711,11 @@ uint8_t P036_data_struct::display_scroll(ePageScrollSpeed lscrollspeed, int lTas
           log += String(F(" PixLength: ")) + String(PixLengthLineIn);
           log += String(F(" AvgPixPerChar: ")) + String(fAvgPixPerChar);
           log += String(F(" CharsRemoved: ")) + String(iCharToRemove);
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
           log  = String(F(" -> Changed to: ")) + String(ScrollingPages.LineIn[j]);
           log += String(F(" Length: ")) + String(ScrollingPages.LineIn[j].length());
           log += String(F(" PixLength: ")) + String(display->getStringWidth(ScrollingPages.LineIn[j]));
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
       }
 # endif // PLUGIN_036_DEBUG
@@ -757,11 +757,11 @@ uint8_t P036_data_struct::display_scroll(ePageScrollSpeed lscrollspeed, int lTas
           log += String(F(" PixLength: ")) + String(PixLengthLineOut);
           log += String(F(" AvgPixPerChar: ")) + String(fAvgPixPerChar);
           log += String(F(" CharsRemoved: ")) + String(iCharToRemove);
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
           log  = String(F(" -> Changed to: ")) + String(ScrollingPages.LineOut[j]);
           log += String(F(" Length: ")) + String(ScrollingPages.LineOut[j].length());
           log += String(F(" PixLength: ")) + String(display->getStringWidth(ScrollingPages.LineOut[j]));
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
       }
 # endif // PLUGIN_036_DEBUG

--- a/src/src/PluginStructs/P036_data_struct.cpp
+++ b/src/src/PluginStructs/P036_data_struct.cpp
@@ -580,7 +580,7 @@ uint8_t P036_data_struct::display_scroll(ePageScrollSpeed lscrollspeed, int lTas
   int iCharToRemove;
 
 # ifdef PLUGIN_036_DEBUG
-  if (loglevelActive(LOG_LEVEL_INFO)) {
+  if (loglevelActiveFor(LOG_LEVEL_INFO)) {
     String log;
     if (log.reserve(128)) { // estimated
       log = F("Start Scrolling: Speed: ");
@@ -604,7 +604,7 @@ uint8_t P036_data_struct::display_scroll(ePageScrollSpeed lscrollspeed, int lTas
   int iScrollTime = static_cast<float>(lTaskTimer * 1000 - iPageScrollTime - 2 * P36_WaitScrollLines * 100) / 100; // scrollTime in ms
 
 # ifdef PLUGIN_036_DEBUG
-  if (loglevelActive(LOG_LEVEL_INFO)) {
+  if (loglevelActiveFor(LOG_LEVEL_INFO)) {
     String log;
     log  = F("PageScrollTime: ");
     log += iPageScrollTime;
@@ -665,7 +665,7 @@ uint8_t P036_data_struct::display_scroll(ePageScrollSpeed lscrollspeed, int lTas
         ScrollingLines.Line[j].dPix = (static_cast<float>(PixLengthLineIn - getDisplaySizeSettings(disp_resolution).Width)) / iScrollTime;
 
 # ifdef PLUGIN_036_DEBUG
-        if (loglevelActive(LOG_LEVEL_INFO)) {
+        if (loglevelActiveFor(LOG_LEVEL_INFO)) {
           String log;
           if (log.reserve(128)) { // estimated
             log  = String(F("Line: ")) + String(j + 1);
@@ -702,7 +702,7 @@ uint8_t P036_data_struct::display_scroll(ePageScrollSpeed lscrollspeed, int lTas
         ScrollingPages.LineIn[j] = ScrollingPages.LineIn[j].substring(iCharToRemove);
       }
 # ifdef PLUGIN_036_DEBUG
-      if (loglevelActive(LOG_LEVEL_INFO)) {
+      if (loglevelActiveFor(LOG_LEVEL_INFO)) {
         String log;
         if (log.reserve(128)) { // estimated
           log  = String(F("Line: ")) + String(j + 1);
@@ -748,7 +748,7 @@ uint8_t P036_data_struct::display_scroll(ePageScrollSpeed lscrollspeed, int lTas
         ScrollingPages.LineOut[j] = ScrollingPages.LineOut[j].substring(iCharToRemove);
       }
 # ifdef PLUGIN_036_DEBUG
-      if (loglevelActive(LOG_LEVEL_INFO)) {
+      if (loglevelActiveFor(LOG_LEVEL_INFO)) {
         String log;
         if (log.reserve(128)) { // estimated
           log  = String(F("Line: ")) + String(j + 1);

--- a/src/src/PluginStructs/P044_data_struct.cpp
+++ b/src/src/PluginStructs/P044_data_struct.cpp
@@ -122,7 +122,7 @@ void P044_Task::clearBuffer() {
     maxMessageSize = _min(serial_buffer.length(), P044_DATAGRAM_MAX_SIZE);
   }
 
-  serial_buffer.clear();
+  serial_buffer = String();
   serial_buffer.reserve(maxMessageSize);
 }
 

--- a/src/src/PluginStructs/P053_data_struct.cpp
+++ b/src/src/PluginStructs/P053_data_struct.cpp
@@ -73,7 +73,7 @@ P053_data_struct::P053_data_struct(
     log += _resetPin;
     log += ' ';
     log += _pwrPin;
-    addLog(LOG_LEVEL_DEBUG, log);
+    addLogMove(LOG_LEVEL_DEBUG, log);
   }
   # endif // ifndef BUILD_NO_DEBUG
 
@@ -131,14 +131,16 @@ void P053_data_struct::SerialRead16(uint16_t& value, uint16_t *checksum)
 
   # ifdef P053_LOW_LEVEL_DEBUG
 
-  // Low-level logging to see data from sensor
-  String log = F("PMSx003 : uint8_t high=0x");
-  log += String(data_high, HEX);
-  log += F(" uint8_t low=0x");
-  log += String(data_low, HEX);
-  log += F(" result=0x");
-  log += String(value, HEX);
-  addLog(LOG_LEVEL_INFO, log);
+  if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+    // Low-level logging to see data from sensor
+    String log = F("PMSx003 : uint8_t high=0x");
+    log += String(data_high, HEX);
+    log += F(" uint8_t low=0x");
+    log += String(data_low, HEX);
+    log += F(" result=0x");
+    log += String(value, HEX);
+    addLogMove(LOG_LEVEL_INFO, log);
+  }
   # endif // ifdef P053_LOW_LEVEL_DEBUG
 }
 
@@ -243,7 +245,7 @@ bool P053_data_struct::processData(struct EventStruct *event) {
       log.reserve(34);
       log  = F("PMSx003 : invalid framelength - ");
       log += framelength;
-      addLog(LOG_LEVEL_ERROR, log);
+      addLogMove(LOG_LEVEL_ERROR, log);
     }
     return false;
   }
@@ -286,7 +288,7 @@ bool P053_data_struct::processData(struct EventStruct *event) {
       log += data[PMS_PM2_5_ug_m3_normal];
       log += F(", pm10a=");
       log += data[PMS_PM10_0_ug_m3_normal];
-      addLog(LOG_LEVEL_DEBUG, log);
+      addLogMove(LOG_LEVEL_DEBUG, log);
     }
   }
 
@@ -310,7 +312,7 @@ bool P053_data_struct::processData(struct EventStruct *event) {
       log += data[PMS_cnt5_0_100ml];
       log += F(", 10um=");
       log += data[PMS_cnt10_0_100ml];
-      addLog(LOG_LEVEL_DEBUG, log);
+      addLogMove(LOG_LEVEL_DEBUG, log);
     }
   }
 
@@ -329,7 +331,7 @@ bool P053_data_struct::processData(struct EventStruct *event) {
         log += F(", hcho=");
         log += static_cast<float>(data[PMS_Formaldehyde_mg_m3]) / 1000.0f;
       }
-      addLog(LOG_LEVEL_DEBUG, log);
+      addLogMove(LOG_LEVEL_DEBUG, log);
     }
   }
   #   endif // ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
@@ -352,7 +354,7 @@ bool P053_data_struct::processData(struct EventStruct *event) {
         log = F("PMSx003 : Less than ");
         log += _delay_read_after_wakeup_ms / 1000ul;
         log += F(" sec since sensor wakeup => Ignoring sample");
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
     }
     return false;
@@ -491,7 +493,7 @@ bool P053_data_struct::checkAndClearValuesReceived(struct EventStruct *event) {
       String log = F("PMSx003: Oversampling using ");
       log += _values_received;
       log += F(" samples");
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
   }
   # endif // ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS

--- a/src/src/PluginStructs/P062_data_struct.cpp
+++ b/src/src/PluginStructs/P062_data_struct.cpp
@@ -115,7 +115,7 @@ void P062_data_struct::loadTouchObjects(taskIndex_t taskIndex) {
   # ifdef PLUGIN_062_DEBUG
   String log = F("P062 DEBUG loadTouchObjects size: ");
   log += sizeof(StoredSettings);
-  addLog(LOG_LEVEL_INFO, log);
+  addLogMove(LOG_LEVEL_INFO, log);
   # endif // PLUGIN_062_DEBUG
   LoadCustomTaskSettings(taskIndex, reinterpret_cast<uint8_t *>(&StoredSettings), sizeof(StoredSettings));
 }

--- a/src/src/PluginStructs/P073_data_struct.cpp
+++ b/src/src/PluginStructs/P073_data_struct.cpp
@@ -315,7 +315,7 @@ void P073_data_struct::NextScroll() {
 }
 
 void P073_data_struct::setTextToScroll(const String& text) {
-  _textToScroll.clear();
+  _textToScroll = String();
 
   if (!text.isEmpty()) {
     const int bufToFill = getBufferLength(displayModel);

--- a/src/src/PluginStructs/P073_data_struct.cpp
+++ b/src/src/PluginStructs/P073_data_struct.cpp
@@ -386,7 +386,7 @@ void P073_data_struct::LogBufferContent(String prefix) {
       log += ',';
       log += showperiods[i] ? F(".") : F("");
     }
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
 }
 

--- a/src/src/PluginStructs/P082_data_struct.cpp
+++ b/src/src/PluginStructs/P082_data_struct.cpp
@@ -167,7 +167,7 @@ bool P082_data_struct::loop() {
           // Full sentence received
 # ifdef P082_SEND_GPS_TO_LOG
           _lastSentence    = _currentSentence;
-          _currentSentence.clear();
+          _currentSentence = String();
 # endif // ifdef P082_SEND_GPS_TO_LOG
           completeSentence = true;
         } else {

--- a/src/src/PluginStructs/P087_data_struct.cpp
+++ b/src/src/PluginStructs/P087_data_struct.cpp
@@ -108,7 +108,7 @@ bool P087_data_struct::loop() {
 
           for (size_t i = 0; i < length && valid; ++i) {
             if ((sentence_part[i] > 127) || (sentence_part[i] < 32)) {
-              sentence_part.clear();
+              sentence_part = String();
               ++sentences_received_error;
               valid = false;
             }
@@ -117,7 +117,7 @@ bool P087_data_struct::loop() {
           if (valid) {
             fullSentenceReceived = true;
             last_sentence = sentence_part;
-            sentence_part.clear();
+            sentence_part = String();
           }
           break;
         }
@@ -146,7 +146,7 @@ bool P087_data_struct::getSentence(String& string) {
   if (string.isEmpty()) {
     return false;
   }
-  last_sentence.clear();
+  last_sentence = String();
   return true;
 }
 

--- a/src/src/PluginStructs/P087_data_struct.cpp
+++ b/src/src/PluginStructs/P087_data_struct.cpp
@@ -59,7 +59,7 @@ void P087_data_struct::post_init() {
       capture_index_used[index] = true;
     }
   }
-  addLog(LOG_LEVEL_DEBUG, log);
+  addLogMove(LOG_LEVEL_DEBUG, log);
 }
 
 bool P087_data_struct::isInitialized() const {
@@ -75,7 +75,7 @@ void P087_data_struct::sendString(const String& data) {
       if (loglevelActiveFor(LOG_LEVEL_INFO)) {
         String log = F("Proxy: Sending: ");
         log += data;
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
     }
   }
@@ -303,7 +303,7 @@ bool P087_data_struct::matchRegexp(String& received) const {
               // Found a match. Now check if it is supposed to be one or not.
               if (capture_index_must_not_match[n]) {
                 log += F(" (!=)");
-                addLog(LOG_LEVEL_INFO, log);
+                addLogMove(LOG_LEVEL_INFO, log);
                 return false;
               } else {
                 match_result = true;
@@ -319,7 +319,7 @@ bool P087_data_struct::matchRegexp(String& received) const {
               }
               log += _lines[lines_index];
             }
-            addLog(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, log);
           }
         }
       }
@@ -329,13 +329,15 @@ bool P087_data_struct::matchRegexp(String& received) const {
     char result = ms.Match(_lines[P087_REGEX_POS].c_str());
 
     if (result == REGEXP_MATCHED) {
+      #ifndef BUILD_NO_DEBUG
       if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
         String log = F("Match at: ");
         log += ms.MatchStart;
         log += F(" Match Length: ");
         log += ms.MatchLength;
-        addLog(LOG_LEVEL_DEBUG, log);
+        addLogMove(LOG_LEVEL_DEBUG, log);
       }
+      #endif
       match_result = true;
     }
   }

--- a/src/src/PluginStructs/P092_data_struct.cpp
+++ b/src/src/PluginStructs/P092_data_struct.cpp
@@ -633,7 +633,7 @@ void P092_data_struct::Plugin_092_StartReceiving(taskIndex_t taskindex) {
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
     String log = F("P092_receiving ... TaskIndex:");
     log += taskindex;
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
 
   while ((timePassedSince(start) < 100) && (DLbus_Data->ISR_PulseCount == 0)) {
@@ -740,7 +740,7 @@ boolean P092_data_struct::P092_GetData(int OptionIdx, int CurIdx, sP092_ReadData
     else {
       log += F("nan");
     }
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
   return result;
 }

--- a/src/src/PluginStructs/P094_data_struct.cpp
+++ b/src/src/PluginStructs/P094_data_struct.cpp
@@ -77,7 +77,7 @@ void P094_data_struct::sendString(const String& data) {
       if (loglevelActiveFor(LOG_LEVEL_INFO)) {
         String log = F("Proxy: Sending: ");
         log += data;
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
     }
   }
@@ -294,7 +294,7 @@ bool P094_data_struct::parsePacket(const String& received) const {
         log += formatToHex_decimal(packet_header[P094_meter_type]);
         log += F(" RSSI: ");
         log += formatToHex_decimal(packet_header[P094_rssi]);
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
     }
 
@@ -358,7 +358,7 @@ bool P094_data_struct::parsePacket(const String& received) const {
                     if (!match) { log += F(" expected NO MATCH"); }
                     break;
                 }
-                addLog(LOG_LEVEL_INFO, log);
+                addLogMove(LOG_LEVEL_INFO, log);
               }
             }
 

--- a/src/src/PluginStructs/P094_data_struct.cpp
+++ b/src/src/PluginStructs/P094_data_struct.cpp
@@ -114,7 +114,7 @@ bool P094_data_struct::loop() {
 
           for (size_t i = 0; i < length && valid; ++i) {
             if ((sentence_part[i] > 127) || (sentence_part[i] < 32)) {
-              sentence_part.clear();
+              sentence_part = String();
               ++sentences_received_error;
               valid = false;
             }
@@ -151,7 +151,7 @@ const String& P094_data_struct::peekSentence() const {
 
 void P094_data_struct::getSentence(String& string, bool appendSysTime) {
   string = std::move(sentence_part);
-  sentence_part.clear(); // FIXME TD-er: Should not be needed as move already cleared it.
+  sentence_part = String(); // FIXME TD-er: Should not be needed as move already cleared it.
   if (appendSysTime) {
     // Unix timestamp = 10 decimals + separator
     if (string.reserve(sentence_part.length() + 11)) {

--- a/src/src/PluginStructs/P099_data_struct.cpp
+++ b/src/src/PluginStructs/P099_data_struct.cpp
@@ -82,9 +82,11 @@ bool P099_data_struct::isInitialized() const {
  */
 void P099_data_struct::loadTouchObjects(taskIndex_t taskIndex) {
 #ifdef PLUGIN_099_DEBUG
-  String log = F("P099 DEBUG loadTouchObjects size: ");
-  log += sizeof(StoredSettings);
-  addLog(LOG_LEVEL_INFO, log);
+  if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+    String log = F("P099 DEBUG loadTouchObjects size: ");
+    log += sizeof(StoredSettings);
+    addLogMove(LOG_LEVEL_INFO, log);
+  }
 #endif // PLUGIN_099_DEBUG
   LoadCustomTaskSettings(taskIndex, reinterpret_cast<uint8_t *>(&StoredSettings), sizeof(StoredSettings));
 
@@ -125,9 +127,11 @@ void P099_data_struct::setRotation(uint8_t n) {
   if (isInitialized()) {
     touchscreen->setRotation(n);
 #ifdef PLUGIN_099_DEBUG
-    String log = F("P099 DEBUG Rotation set: ");
-    log += n;
-    addLog(LOG_LEVEL_INFO, log);
+    if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+      String log = F("P099 DEBUG Rotation set: ");
+      log += n;
+      addLogMove(LOG_LEVEL_INFO, log);
+    }
 #endif // PLUGIN_099_DEBUG
   }
 }
@@ -139,9 +143,11 @@ void P099_data_struct::setRotationFlipped(bool flipped) {
   if (isInitialized()) {
     touchscreen->setRotationFlipped(flipped);
 #ifdef PLUGIN_099_DEBUG
-    String log = F("P099 DEBUG RotationFlipped set: ");
-    log += flipped;
-    addLog(LOG_LEVEL_INFO, log);
+    if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+      String log = F("P099 DEBUG RotationFlipped set: ");
+      log += flipped;
+      addLogMove(LOG_LEVEL_INFO, log);
+    }
 #endif // PLUGIN_099_DEBUG
   }
 }
@@ -188,27 +194,29 @@ bool P099_data_struct::isValidAndTouchedTouchObject(uint16_t x, uint16_t y, Stri
         selected            = true;
       }
 #ifdef PLUGIN_099_DEBUG
-      String log = F("P099 DEBUG Touched: obj: ");
-      log += objectName;
-      log += ',';
-      log += StoredSettings.TouchObjects[objectNr].top_left.x;
-      log += ',';
-      log += StoredSettings.TouchObjects[objectNr].top_left.y;
-      log += ',';
-      log += StoredSettings.TouchObjects[objectNr].bottom_right.x;
-      log += ',';
-      log += StoredSettings.TouchObjects[objectNr].bottom_right.y;
-      log += F(" surface:");
-      log += SurfaceAreas[objectNr];
-      log += F(" x,y:");
-      log += x;
-      log += ',';
-      log += y;
-      log += F(" sel:");
-      log += selectedObjectName;
-      log += '/';
-      log += selectedObjectIndex;
-      addLog(LOG_LEVEL_INFO, log);
+      if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+        String log = F("P099 DEBUG Touched: obj: ");
+        log += objectName;
+        log += ',';
+        log += StoredSettings.TouchObjects[objectNr].top_left.x;
+        log += ',';
+        log += StoredSettings.TouchObjects[objectNr].top_left.y;
+        log += ',';
+        log += StoredSettings.TouchObjects[objectNr].bottom_right.x;
+        log += ',';
+        log += StoredSettings.TouchObjects[objectNr].bottom_right.y;
+        log += F(" surface:");
+        log += SurfaceAreas[objectNr];
+        log += F(" x,y:");
+        log += x;
+        log += ',';
+        log += y;
+        log += F(" sel:");
+        log += selectedObjectName;
+        log += '/';
+        log += selectedObjectIndex;
+        addLogMove(LOG_LEVEL_INFO, log);
+      }
 #endif // PLUGIN_099_DEBUG
     }
   }
@@ -240,16 +248,18 @@ bool P099_data_struct::setTouchObjectState(String touchObject, bool state, uint8
       }
       StoredSettings.TouchObjects[objectNr].objectname[P099_MaxObjectNameLength - 1] = 0; // Just to be safe
 #ifdef PLUGIN_099_DEBUG
-      String log = F("P099 setTouchObjectState: obj: ");
-      log += thisObject;
-      if (success) {
-      log += F(", new state: ");
-      log += (state ? F("en") : F("dis"));
-      log += F("abled.");
-      } else {
-        log += F("failed!");
+      if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+        String log = F("P099 setTouchObjectState: obj: ");
+        log += thisObject;
+        if (success) {
+          log += F(", new state: ");
+          log += (state ? F("en") : F("dis"));
+          log += F("abled.");
+        } else {
+          log += F("failed!");
+        }
+        addLogMove(LOG_LEVEL_INFO, log);
       }
-      addLog(LOG_LEVEL_INFO, log);
 #endif // PLUGIN_099_DEBUG
       // break; // Only first one found is processed
     }

--- a/src/src/PluginStructs/P099_data_struct.cpp
+++ b/src/src/PluginStructs/P099_data_struct.cpp
@@ -227,7 +227,7 @@ bool P099_data_struct::isValidAndTouchedTouchObject(uint16_t x, uint16_t y, Stri
  * Set the enabled/disabled state by inserting or deleting an underscore '_' as the first character of the object name.
  * Checks if the name doesn't exceed the max. length.
  */
-bool P099_data_struct::setTouchObjectState(String touchObject, bool state, uint8_t checkObjectCount) {
+bool P099_data_struct::setTouchObjectState(const String& touchObject, bool state, uint8_t checkObjectCount) {
   if (touchObject.isEmpty() || touchObject.substring(0, 1) == F("_")) return false;
   String findObject = (state ? F("_") : F("")); // When enabling, try to find a disabled object
   findObject += touchObject;

--- a/src/src/PluginStructs/P099_data_struct.h
+++ b/src/src/PluginStructs/P099_data_struct.h
@@ -48,7 +48,7 @@ struct P099_data_struct : public PluginTaskData_base
   void setRotationFlipped(bool _flipped);
   bool isCalibrationActive();
   bool isValidAndTouchedTouchObject(uint16_t x, uint16_t y, String &selectedObjectName, int &selectedObjectIndex, uint8_t checkObjectCount);
-  bool setTouchObjectState(String touchObject, bool state, uint8_t checkObjectCount);
+  bool setTouchObjectState(const String& touchObject, bool state, uint8_t checkObjectCount);
   void scaleRawToCalibrated(uint16_t &x, uint16_t &y);
 
   // This is initialized by calling init()

--- a/src/src/PluginStructs/P104_data_struct.cpp
+++ b/src/src/PluginStructs/P104_data_struct.cpp
@@ -161,7 +161,6 @@ void P104_data_struct::loadSettings() {
 
     {
       String buffer;
-      buffer.reserve(bufferSize + 1);
       buffer = String(settingsBuffer);
       # ifdef P104_DEBUG_DEV
 
@@ -200,7 +199,6 @@ void P104_data_struct::loadSettings() {
       }
 
       while (offset2 > -1) {
-        tmp.reserve(offset2 - prev2);
         tmp = buffer.substring(prev2, offset2);
         # ifdef P104_DEBUG_DEV
 
@@ -296,7 +294,6 @@ void P104_data_struct::loadSettings() {
             loadOffset    += sizeof(bufferSize);
             LoadFromFile(SettingsType::Enum::CustomTaskSettings_Type, taskIndex, (uint8_t *)settingsBuffer, structDataSize, loadOffset);
             settingsBuffer[bufferSize + 1] = '\0'; // Terminate string
-            buffer.reserve(bufferSize + 1);
             buffer = String(settingsBuffer);
           }
         }
@@ -1569,7 +1566,7 @@ String P104_data_struct::enquoteString(const String& input) {
  * saveSettings gather the zones data from the UI and store in customsettings
  **************************************/
 bool P104_data_struct::saveSettings() {
-  error = EMPTY_STRING; // Clear
+  error = String(); // Clear
   String zbuffer;
 
   # ifdef P104_DEBUG_DEV

--- a/src/src/PluginStructs/P104_data_struct.cpp
+++ b/src/src/PluginStructs/P104_data_struct.cpp
@@ -137,15 +137,17 @@ void P104_data_struct::loadSettings() {
     }
     structDataSize = bufferSize;
     # ifdef P104_DEBUG_DEV
-    String log;
+    {
+      String log;
 
-    if (loglevelActiveFor(LOG_LEVEL_INFO) &&
-        log.reserve(54)) {
-      log  = F("P104: loadSettings stored Size: ");
-      log += structDataSize;
-      log += F(" taskindex: ");
-      log += taskIndex;
-      addLog(LOG_LEVEL_INFO, log);
+      if (loglevelActiveFor(LOG_LEVEL_INFO) &&
+          log.reserve(54)) {
+        log  = F("P104: loadSettings stored Size: ");
+        log += structDataSize;
+        log += F(" taskindex: ");
+        log += taskIndex;
+        addLogMove(LOG_LEVEL_INFO, log);
+      }
     }
     # endif // ifdef P104_DEBUG_DEV
 
@@ -163,6 +165,7 @@ void P104_data_struct::loadSettings() {
       buffer = String(settingsBuffer);
       # ifdef P104_DEBUG_DEV
 
+      String log;
       if (loglevelActiveFor(LOG_LEVEL_INFO)) {
         log  = F("P104: loadSettings bufferSize: ");
         log += bufferSize;
@@ -176,7 +179,7 @@ void P104_data_struct::loadSettings() {
       if (loglevelActiveFor(LOG_LEVEL_INFO)) {
         log += F(" trimmed: ");
         log += buffer.length();
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
       # endif // ifdef P104_DEBUG_DEV
 
@@ -205,7 +208,7 @@ void P104_data_struct::loadSettings() {
           log  = F("P104: reading string: ");
           log += tmp;
           log.replace(P104_FIELD_SEP, P104_FIELD_DISP);
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
         # endif // ifdef P104_DEBUG_DEV
 
@@ -305,7 +308,7 @@ void P104_data_struct::loadSettings() {
           String log;
           log  = F("dotmatrix: parsed zone: ");
           log += zoneIndex;
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
         # endif // ifdef P104_DEBUG
       }
@@ -322,7 +325,7 @@ void P104_data_struct::loadSettings() {
 
       // log += F(" struct size: ");
       // log += sizeof(P104_zone_struct);
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
     # endif // ifdef P104_DEBUG_DEV
 
@@ -347,7 +350,7 @@ void P104_data_struct::loadSettings() {
       log += zoneIndex;
       log += F(" expected: ");
       log += expectedZones;
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
     # endif // ifdef P104_DEBUG_DEV
   }
@@ -372,7 +375,7 @@ void P104_data_struct::configureZones() {
       log.reserve(45)) {
     log  = F("P104: configureZones to do: ");
     log += zones.size();
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
   # endif // ifdef P104_DEBUG_DEV
 
@@ -465,7 +468,7 @@ void P104_data_struct::configureZones() {
         log += expectedZones;
         log += F(" offset: ");
         log += zoneOffset;
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
       # endif // ifdef P104_DEBUG_DEV
 
@@ -536,7 +539,7 @@ void P104_data_struct::displayOneZoneText(uint8_t                 zone,
     log += F("' -> '");
     log += sZoneBuffers[zone];
     log += '\'';
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
   }
 
   P->displayZoneText(zone,
@@ -746,7 +749,7 @@ void P104_data_struct::displayBarGraph(uint8_t                 zone,
           log += F(" bsize: ");
           log += barGraphs.size();
         }
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
     }
     #  endif // ifdef P104_DEBUG
@@ -842,7 +845,7 @@ void P104_data_struct::displayBarGraph(uint8_t                 zone,
     #  ifdef P104_DEBUG
 
     if (logAllText && loglevelActiveFor(LOG_LEVEL_INFO)) {
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
     #  endif // ifdef P104_DEBUG
     modulesOnOff(zstruct._startModule, zstruct._startModule + zstruct.size - 1, MD_MAX72XX::MD_ON);  // Continue updates on modules
@@ -1211,7 +1214,7 @@ bool P104_data_struct::handlePluginWrite(taskIndex_t   taskIndex,
       if (!success) { log += F("NOT "); }
       log += F("succesful: ");
       log += string;
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
   }
 
@@ -1505,7 +1508,7 @@ void P104_data_struct::checkRepeatTimer(uint8_t z) {
           log += F(" (");
           log += (timePassedSince(it->_repeatTimer) / 1000.0f); // Decimals can be useful here
           log += ')';
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
         }
         # endif // ifdef P104_DEBUG
 
@@ -1570,13 +1573,15 @@ bool P104_data_struct::saveSettings() {
   String zbuffer;
 
   # ifdef P104_DEBUG_DEV
-  String log;
+  {
+    String log;
 
-  if (loglevelActiveFor(LOG_LEVEL_INFO) &&
-      log.reserve(64)) {
-    log  = F("P104: saving zones, count: ");
-    log += expectedZones;
-    addLog(LOG_LEVEL_INFO, log);
+    if (loglevelActiveFor(LOG_LEVEL_INFO) &&
+        log.reserve(64)) {
+      log  = F("P104: saving zones, count: ");
+      log += expectedZones;
+      addLogMove(LOG_LEVEL_INFO, log);
+    }
   }
   # endif // ifdef P104_DEBUG_DEV
 
@@ -1598,9 +1603,9 @@ bool P104_data_struct::saveSettings() {
       #  ifdef P104_DEBUG_DEV
 
       if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-        log  = F("P104: insert before zone: ");
+        String log  = F("P104: insert before zone: ");
         log += (zoneIndex + 1);
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
       #  endif // ifdef P104_DEBUG_DEV
     }
@@ -1613,9 +1618,9 @@ bool P104_data_struct::saveSettings() {
       # ifdef P104_DEBUG_DEV
 
       if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-        log  = F("P104: read zone: ");
+        String log  = F("P104: read zone: ");
         log += (zoneIndex + 1);
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
       # endif // ifdef P104_DEBUG_DEV
       zones.push_back(P104_zone_struct(zoneIndex + 1));
@@ -1642,9 +1647,9 @@ bool P104_data_struct::saveSettings() {
     # ifdef P104_DEBUG_DEV
 
     if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-      log  = F("P104: add zone: ");
+      String log  = F("P104: add zone: ");
       log += (zoneIndex + 1);
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
     # endif // ifdef P104_DEBUG_DEV
 
@@ -1657,9 +1662,9 @@ bool P104_data_struct::saveSettings() {
       #  ifdef P104_DEBUG_DEV
 
       if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-        log  = F("P104: insert after zone: ");
+        String log  = F("P104: insert after zone: ");
         log += (zoneIndex + 2);
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
       #  endif // ifdef P104_DEBUG_DEV
     }
@@ -1761,7 +1766,7 @@ bool P104_data_struct::saveSettings() {
           log += bufferSize;
           log += F(" offset: ");
           log += saveOffset;
-          addLog(LOG_LEVEL_INFO, log);
+          addLogMove(LOG_LEVEL_INFO, log);
           zbuffer.replace(P104_FIELD_SEP, P104_FIELD_DISP);
           addLog(LOG_LEVEL_INFO, zbuffer);
         }

--- a/src/src/PluginStructs/P104_data_struct.cpp
+++ b/src/src/PluginStructs/P104_data_struct.cpp
@@ -313,7 +313,7 @@ void P104_data_struct::loadSettings() {
         # endif // ifdef P104_DEBUG
       }
 
-      buffer.clear();        // Free some memory
+      buffer = String();        // Free some memory
     }
 
     delete[] settingsBuffer; // Release allocated buffer

--- a/src/src/PluginStructs/P105_data_struct.cpp
+++ b/src/src/PluginStructs/P105_data_struct.cpp
@@ -117,12 +117,12 @@ bool P105_data_struct::updateMeasurements(unsigned long task_index) {
     if (!device.initialize()) {
       log  = getDeviceName();
       log += F(" : unable to initialize");
-      addLog(LOG_LEVEL_ERROR, log);
+      addLogMove(LOG_LEVEL_ERROR, log);
       return false;
     }
     log  = getDeviceName();
     log += F(" : initialized");
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
 
     trigger_time = current_time;
     state        = AHTx_state::AHTx_Trigger_measurement;
@@ -158,6 +158,7 @@ bool P105_data_struct::updateMeasurements(unsigned long task_index) {
     last_measurement = current_time;
     state            = AHTx_state::AHTx_New_values;
 
+    #ifndef BUILD_NO_DEBUG
     if (loglevelActiveFor(LOG_LEVEL_DEBUG)) { // Log raw measuerd values only on level DEBUG
       String log;
       log.reserve(50);                        // Prevent re-allocation
@@ -167,8 +168,9 @@ bool P105_data_struct::updateMeasurements(unsigned long task_index) {
       log += F("% temperature ");
       log += device.getTemperature();
       log += 'C';
-      addLog(LOG_LEVEL_DEBUG, log);
+      addLogMove(LOG_LEVEL_DEBUG, log);
     }
+    #endif
 
     return true;
   }
@@ -179,7 +181,7 @@ bool P105_data_struct::updateMeasurements(unsigned long task_index) {
     log.reserve(15); // Prevent re-allocation
     log  = getDeviceName();
     log += F(" : reset");
-    addLog(LOG_LEVEL_ERROR, log);
+    addLogMove(LOG_LEVEL_ERROR, log);
     device.softReset();
 
     state = AHTx_state::AHTx_Uninitialized;

--- a/src/src/PluginStructs/P105_data_struct.cpp
+++ b/src/src/PluginStructs/P105_data_struct.cpp
@@ -115,7 +115,7 @@ bool P105_data_struct::updateMeasurements(unsigned long task_index) {
     log.reserve(30);
 
     if (!device.initialize()) {
-      log  = getDeviceName();
+      log += getDeviceName();
       log += F(" : unable to initialize");
       addLogMove(LOG_LEVEL_ERROR, log);
       return false;
@@ -162,7 +162,7 @@ bool P105_data_struct::updateMeasurements(unsigned long task_index) {
     if (loglevelActiveFor(LOG_LEVEL_DEBUG)) { // Log raw measuerd values only on level DEBUG
       String log;
       log.reserve(50);                        // Prevent re-allocation
-      log  = getDeviceName();
+      log += getDeviceName();
       log += F(" : humidity ");
       log += device.getHumidity();
       log += F("% temperature ");
@@ -179,7 +179,7 @@ bool P105_data_struct::updateMeasurements(unsigned long task_index) {
     // should not happen
     String log;
     log.reserve(15); // Prevent re-allocation
-    log  = getDeviceName();
+    log += getDeviceName();
     log += F(" : reset");
     addLogMove(LOG_LEVEL_ERROR, log);
     device.softReset();

--- a/src/src/PluginStructs/P110_data_struct.cpp
+++ b/src/src/PluginStructs/P110_data_struct.cpp
@@ -14,10 +14,12 @@ bool P110_data_struct::begin() {
   sensor.setAddress(i2cAddress); // Initialize for configured address
 
   if (!sensor.init()) {
-    String log = F("VL53L0X: Sensor not found, init failed for 0x");
-    log += String(i2cAddress, HEX);
-    addLog(LOG_LEVEL_INFO, log);
-    addLog(LOG_LEVEL_INFO, sensor.getInitResult());
+    if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+      String log = F("VL53L0X: Sensor not found, init failed for 0x");
+      log += String(i2cAddress, HEX);
+      addLogMove(LOG_LEVEL_INFO, log);
+      addLog(LOG_LEVEL_INFO, sensor.getInitResult());
+    }
     initState = false;
     return initState;
   }
@@ -53,7 +55,7 @@ long P110_data_struct::readDistance() {
     log += String(i2cAddress, HEX);
     log += F(" init: ");
     log += String(initState, BIN);
-    addLog(LOG_LEVEL_DEBUG, log);
+    addLogMove(LOG_LEVEL_DEBUG, log);
   }
 #endif // P110_DEBUG_DEBUG
 
@@ -62,12 +64,12 @@ long P110_data_struct::readDistance() {
     dist = sensor.readRangeSingleMillimeters();
     if (sensor.timeoutOccurred()) {
       #ifdef P110_DEBUG_DEBUG
-      addLog(LOG_LEVEL_DEBUG, "VL53L0X: TIMEOUT");
+      addLog(LOG_LEVEL_DEBUG, F("VL53L0X: TIMEOUT"));
       #endif // P110_DEBUG_DEBUG
       success = false;
     } else if ( dist >= 8190 ) {
       #ifdef P110_DEBUG_DEBUG
-      addLog(LOG_LEVEL_DEBUG, "VL53L0X: NO MEASUREMENT");
+      addLog(LOG_LEVEL_DEBUG, F("VL53L0X: NO MEASUREMENT"));
       #endif // P110_DEBUG_DEBUG
       success = false;
     }
@@ -81,7 +83,7 @@ long P110_data_struct::readDistance() {
     log += String(range, BIN);
     log += F(" / Distance: ");
     log += dist;
-    addLog(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, log);
 #endif // P110_DEBUG
   }
   return dist;

--- a/src/src/PluginStructs/P111_data_struct.cpp
+++ b/src/src/PluginStructs/P111_data_struct.cpp
@@ -46,9 +46,11 @@ uint8_t P111_data_struct::readCardStatus(unsigned long *key, bool *removedTag) {
     {
       errorCount++;
       removedState = false;
-      String log = F("MFRC522: Read error: ");
-      log += errorCount;
-      addLog(LOG_LEVEL_ERROR, log);
+      if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
+        String log = F("MFRC522: Read error: ");
+        log += errorCount;
+        addLogMove(LOG_LEVEL_ERROR, log);
+      }
       break;
     } 
     case 2: // No tag found
@@ -90,9 +92,11 @@ String P111_data_struct::getCardName() {
 \*********************************************************************************************/
 bool P111_data_struct::reset(int8_t csPin, int8_t resetPin) {
   if (resetPin != -1) {
-    String log = F("MFRC522: Reset on pin: ");
-    log += resetPin;
-    addLog(LOG_LEVEL_INFO, log);
+    if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+      String log = F("MFRC522: Reset on pin: ");
+      log += resetPin;
+      addLogMove(LOG_LEVEL_INFO, log);
+    }
     pinMode(resetPin, OUTPUT);
     digitalWrite(resetPin, LOW);
     delay(100);
@@ -118,19 +122,20 @@ bool P111_data_struct::reset(int8_t csPin, int8_t resetPin) {
     
     // When 0x00 or 0xFF is returned, communication probably failed
     if ((v == 0x00) || (v == 0xFF)) {
-      String log=F("MFRC522: Communication failure, is the MFRC522 properly connected?");
-      addLog(LOG_LEVEL_ERROR,log);
+      addLog(LOG_LEVEL_ERROR, F("MFRC522: Communication failure, is the MFRC522 properly connected?"));
       return false;
     } else {
-      String log=F("MFRC522: Software Version: ");
-      if (v == 0x91)
-        log+=F(" = v1.0");
-      else if (v == 0x92)
-        log+=F(" = v2.0");
-      else
-        log+=F(" (unknown),probably a chinese clone?");
-            
-      addLog(LOG_LEVEL_INFO, log);
+      if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+        String log=F("MFRC522: Software Version: ");
+        if (v == 0x91)
+          log+=F(" = v1.0");
+        else if (v == 0x92)
+          log+=F(" = v2.0");
+        else
+          log+=F(" (unknown),probably a chinese clone?");
+              
+        addLogMove(LOG_LEVEL_INFO, log);
+      }
     }
     return true;
   }

--- a/src/src/PluginStructs/P113_data_struct.cpp
+++ b/src/src/PluginStructs/P113_data_struct.cpp
@@ -13,9 +13,11 @@ bool P113_data_struct::begin() {
   sensor.setI2CAddress(i2cAddress); // Initialize for configured address
 
   if (sensor.begin() != 0) {
-    String log = F("VL53L1X: Sensor not found, init failed for 0x");
-    log += String(i2cAddress, HEX);
-    addLog(LOG_LEVEL_INFO, log);
+    if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+      String log = F("VL53L1X: Sensor not found, init failed for 0x");
+      log += String(i2cAddress, HEX);
+      addLogMove(LOG_LEVEL_INFO, log);
+    }
     initState = false;
     return initState;
   }
@@ -66,7 +68,7 @@ uint16_t P113_data_struct::readDistance() {
     log += String(i2cAddress, HEX);
     log += F(" init: ");
     log += String(initState, BIN);
-    addLog(LOG_LEVEL_DEBUG, log);
+    addLogMove(LOG_LEVEL_DEBUG, log);
   }
   # endif // P113_DEBUG_DEBUG
 
@@ -81,15 +83,17 @@ uint16_t P113_data_struct::readDistance() {
   }
 
   # ifdef P113_DEBUG
-  log  = F("VL53L1X: Address: 0x");
-  log += String(i2cAddress, HEX);
-  log += F(" / Timing: ");
-  log += String(timing, DEC);
-  log += F(" / Long Range: ");
-  log += String(range, BIN);
-  log += F(" / Distance: ");
-  log += distance;
-  addLog(LOG_LEVEL_INFO, log);
+  if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+    log  = F("VL53L1X: Address: 0x");
+    log += String(i2cAddress, HEX);
+    log += F(" / Timing: ");
+    log += String(timing, DEC);
+    log += F(" / Long Range: ");
+    log += String(range, BIN);
+    log += F(" / Distance: ");
+    log += distance;
+    addLogMove(LOG_LEVEL_INFO, log);
+  }
   # endif // P113_DEBUG
 
   return distance;

--- a/src/src/PluginStructs/P114_data_struct.cpp
+++ b/src/src/PluginStructs/P114_data_struct.cpp
@@ -17,18 +17,19 @@ bool P114_data_struct::read_sensor(float& _UVA, float& _UVB, float& _UVIndex) {
     initialised = init_sensor(); // Check id device is present
   }
 
-  String log;
 
-
+  #ifndef BUILD_NO_DEBUG
   if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+    String log;
     log.reserve(40);
     log  = F("VEML6075: i2caddress: 0x");
     log += String(i2cAddress, HEX);
-    addLog(LOG_LEVEL_DEBUG, log);
+    addLogMove(LOG_LEVEL_DEBUG, log);
     log  = F("VEML6075: initialized: ");
     log += String(initialised ? F("true") : F("false"));
-    addLog(LOG_LEVEL_DEBUG, log);
+    addLogMove(LOG_LEVEL_DEBUG, log);
   }
+  #endif
 
   if (initialised) {
     for (int j = 0; j < 5; j++) {
@@ -45,11 +46,13 @@ bool P114_data_struct::read_sensor(float& _UVA, float& _UVB, float& _UVIndex) {
 
     // float UVASensitivity = 0.93/(static_cast<float>(IT + 1)); // UVA light sensitivity increases with integration time
     // float UVBSensitivity = 2.10/(static_cast<float>(IT + 1)); // UVB light sensitivity increases with integration time
+    #ifndef BUILD_NO_DEBUG
     if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
-      log  = F("VEML6075: IT raw: 0x");
+      String log  = F("VEML6075: IT raw: 0x");
       log += String(IT + 1, HEX);
-      addLog(LOG_LEVEL_DEBUG, log);
+      addLogMove(LOG_LEVEL_DEBUG, log);
     }
+    #endif
     return true;
   }
   return false;
@@ -61,10 +64,9 @@ bool P114_data_struct::read_sensor(float& _UVA, float& _UVB, float& _UVIndex) {
 bool P114_data_struct::init_sensor() {
   uint16_t deviceID = I2C_readS16_LE_reg(i2cAddress, VEML6075_UV_ID);
 
-  String log;
-
-
+  #ifndef BUILD_NO_DEBUG
   if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+    String log;
     log.reserve(60);
     log  = F("VEML6075: ID: 0x");
     log += String(deviceID, HEX);
@@ -72,32 +74,40 @@ bool P114_data_struct::init_sensor() {
     log += String(i2cAddress, HEX);
     log += F(" / 0x");
     log += String(VEML6075_UV_ID, HEX);
-    addLog(LOG_LEVEL_DEBUG, log);
+    addLogMove(LOG_LEVEL_DEBUG, log);
   }
+  #endif
 
   if (deviceID != 0x26) {
-    log.reserve(60);
-    log  = F("VEML6075: wrong deviceID: ");
-    log += String(deviceID, HEX);
-    addLog(LOG_LEVEL_ERROR, log);
+    if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
+      String log;
+      log.reserve(60);
+      log  = F("VEML6075: wrong deviceID: ");
+      log += String(deviceID, HEX);
+      addLogMove(LOG_LEVEL_ERROR, log);
+    }
     return false;
   } else {
-    log.reserve(60);
 
     // log  = F("VEML6075: found deviceID: 0x");
     // log += String(deviceID, HEX);
 
     if (!I2C_write16_LE_reg(i2cAddress, VEML6075_UV_CONF, (IT << 4) | (HD << 3))) { // Bit 3 must be 0, bit 0 is 0 for run and 1 for
       // shutdown, LS Byte
-      log  = F("VEML6075: setup failed!!");
-      log += F(" / CONF: ");
-      log += String(static_cast<uint16_t>(IT << 4) | (HD << 3), BIN);
-      addLog(LOG_LEVEL_ERROR, log);
+      if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
+        String log;
+        log.reserve(60);
+        log  = F("VEML6075: setup failed!!");
+        log += F(" / CONF: ");
+        log += String(static_cast<uint16_t>(IT << 4) | (HD << 3), BIN);
+        addLogMove(LOG_LEVEL_ERROR, log);
+      }
       return false;
     } else if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+      String log;
       log  = F("VEML6075: sensor initialised / CONF: ");
       log += String((uint16_t)(IT << 4) | (HD << 3), BIN);
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
   }
   return true;

--- a/src/src/PluginStructs/P119_data_struct.cpp
+++ b/src/src/PluginStructs/P119_data_struct.cpp
@@ -29,14 +29,14 @@ P119_data_struct::~P119_data_struct() {
 // Initialize sensor and read data from ITG3205
 // **************************************************************************/
 bool P119_data_struct::read_sensor() {
-  # if PLUGIN_119_DEBUG
+  #ifdef PLUGIN_119_DEBUG
   String log;
   # endif // if PLUGIN_119_DEBUG
 
   if (!initialized()) {
     init_sensor();
 
-    # if PLUGIN_119_DEBUG
+    #ifdef PLUGIN_119_DEBUG
 
     if (loglevelActiveFor(LOG_LEVEL_DEBUG) &&
         log.reserve(55)) {
@@ -46,7 +46,7 @@ bool P119_data_struct::read_sensor() {
       log += String(initialized() ? F("true") : F("false"));
       log += F(", ID=0x");
       log += String(itg3205->readWhoAmI(), HEX);
-      addLog(LOG_LEVEL_DEBUG, log);
+      addLogMove(LOG_LEVEL_DEBUG, log);
     }
     # endif // if PLUGIN_119_DEBUG
   }
@@ -71,7 +71,7 @@ bool P119_data_struct::read_sensor() {
       _aUsed = 0;
     }
 
-    # if PLUGIN_119_DEBUG
+    #ifdef PLUGIN_119_DEBUG
 
     if (loglevelActiveFor(LOG_LEVEL_DEBUG) &&
         log.reserve(40)) {
@@ -83,7 +83,7 @@ bool P119_data_struct::read_sensor() {
       log += itg3205->g.y;
       log += F(", Z: ");
       log += itg3205->g.z;
-      addLog(LOG_LEVEL_DEBUG, log);
+      addLogMove(LOG_LEVEL_DEBUG, log);
     }
     # endif // if PLUGIN_119_DEBUG
     return true;
@@ -110,7 +110,7 @@ bool P119_data_struct::read_data(int& X, int& Y, int& Z) {
     Y /= _aMax;
     Z /= _aMax;
 
-    # if PLUGIN_119_DEBUG
+    #ifdef PLUGIN_119_DEBUG
 
     if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
       String log;
@@ -122,7 +122,7 @@ bool P119_data_struct::read_data(int& X, int& Y, int& Z) {
         log += Y;
         log += F(", Z: ");
         log += Z;
-        addLog(LOG_LEVEL_DEBUG, log);
+        addLogMove(LOG_LEVEL_DEBUG, log);
       }
     }
     # endif // if PLUGIN_119_DEBUG
@@ -147,15 +147,17 @@ bool P119_data_struct::init_sensor() {
     return false;
   }
 
+  #ifdef PLUGIN_119_DEBUG
   if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
     String log;
 
     if (log.reserve(25)) {
       log  = F("ITG3205: Address: 0x");
       log += String(_i2cAddress, HEX);
-      addLog(LOG_LEVEL_DEBUG, log);
+      addLogMove(LOG_LEVEL_DEBUG, log);
     }
   }
+  #endif
 
   return true;
 }

--- a/src/src/PluginStructs/P119_data_struct.h
+++ b/src/src/PluginStructs/P119_data_struct.h
@@ -5,7 +5,7 @@
 
 #ifdef USES_P119
 
-# define PLUGIN_119_DEBUG  false // set to true for extra log info in the debug
+// # define PLUGIN_119_DEBUG  // set to true for extra log info in the debug
 
 # include <vector>
 # include "ITG3205.h"

--- a/src/src/PluginStructs/P120_data_struct.cpp
+++ b/src/src/PluginStructs/P120_data_struct.cpp
@@ -77,7 +77,7 @@ bool P120_data_struct::read_sensor(struct EventStruct *event) {
       log += String(initialized() ? F("true") : F("false"));
       log += F(", ID=0x");
       log += String(adxl345->getDevID(), HEX);
-      addLog(LOG_LEVEL_DEBUG, log);
+      addLogMove(LOG_LEVEL_DEBUG, log);
     }
     # endif // if PLUGIN_120_DEBUG
   }
@@ -109,7 +109,7 @@ bool P120_data_struct::read_sensor(struct EventStruct *event) {
       log += _y;
       log += F(", Z: ");
       log += _z;
-      addLog(LOG_LEVEL_DEBUG, log);
+      addLogMove(LOG_LEVEL_DEBUG, log);
     }
     # endif // if PLUGIN_120_DEBUG
 
@@ -151,7 +151,7 @@ bool P120_data_struct::read_data(struct EventStruct *event, int& X, int& Y, int&
         log += Y;
         log += F(", Z: ");
         log += Z;
-        addLog(LOG_LEVEL_DEBUG, log);
+        addLogMove(LOG_LEVEL_DEBUG, log);
       }
     }
     # endif // if PLUGIN_120_DEBUG
@@ -171,15 +171,17 @@ bool P120_data_struct::init_sensor(struct EventStruct *event) {
 
   if (initialized()) {
     uint8_t act = 0, freeFall = 0, singleTap = 0, doubleTap = 0;
-    String  log = F("ADXL345: Initializing sensor for ");
+    if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+      String  log = F("ADXL345: Initializing sensor for ");
 
-    if (i2c_mode) {
-      log += F("I2C");
-    } else {
-      log += F("SPI");
+      if (i2c_mode) {
+        log += F("I2C");
+      } else {
+        log += F("SPI");
+      }
+      log += F("...");
+      addLogMove(LOG_LEVEL_INFO, log);
     }
-    log += F("...");
-    addLog(LOG_LEVEL_INFO, log);
     adxl345->powerOn();
     adxl345->setRangeSetting(2 ^ (get2BitFromUL(P120_CONFIG_FLAGS1, P120_FLAGS1_RANGE) + 1)); // Range is stored in 2 bits, only 4 possible
                                                                                               // options
@@ -258,6 +260,7 @@ bool P120_data_struct::init_sensor(struct EventStruct *event) {
     return false;
   }
 
+  #ifndef BUILD_NO_DEBUG
   if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
     String log;
 
@@ -273,9 +276,10 @@ bool P120_data_struct::init_sensor(struct EventStruct *event) {
         log += _cs_pin;
         # endif // ifdef USES_P125
       }
-      addLog(LOG_LEVEL_DEBUG, log);
+      addLogMove(LOG_LEVEL_DEBUG, log);
     }
   }
+  #endif
 
   return true;
 }

--- a/src/src/PluginStructs/P121_data_struct.cpp
+++ b/src/src/PluginStructs/P121_data_struct.cpp
@@ -34,7 +34,7 @@ bool P121_data_struct::begin(int taskid)
         log += toString(sensor.min_value);
         log += F(" Resolution:   "); 
         log += toString(sensor.resolution);
-        addLog(LOG_LEVEL_DEBUG, log);
+        addLogMove(LOG_LEVEL_DEBUG, log);
       }
       #endif
     }

--- a/src/src/PluginStructs/P124_data_struct.cpp
+++ b/src/src/PluginStructs/P124_data_struct.cpp
@@ -19,11 +19,13 @@ P124_data_struct::P124_data_struct(int8_t  i2c_address,
       uint8_t _new_address = _i2c_address == 0x18 ? 0x11 : _i2c_address + 1; // Set to next address
       relay->changeI2CAddress(_new_address, _i2c_address);
       # ifndef BUILD_NO_DEBUG
-      String log = F("MultiRelay: Change I2C address 0x");
-      log += String(_i2c_address, HEX);
-      log += F(" to 0x");
-      log += String(_new_address, HEX);
-      addLog(LOG_LEVEL_INFO, log);
+      if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+        String log = F("MultiRelay: Change I2C address 0x");
+        log += String(_i2c_address, HEX);
+        log += F(" to 0x");
+        log += String(_new_address, HEX);
+        addLogMove(LOG_LEVEL_INFO, log);
+      }
       # endif // ifndef BUILD_NO_DEBUG
     }
   }

--- a/src/src/WebServer/AccessControl.cpp
+++ b/src/src/WebServer/AccessControl.cpp
@@ -109,7 +109,7 @@ boolean clientIPallowed()
     response += formatIP(low);
     response += F(" - ");
     response += formatIP(high);
-    addLog(LOG_LEVEL_ERROR, response);
+    addLogMove(LOG_LEVEL_ERROR, response);
   }
   return false;
 }

--- a/src/src/WebServer/ControlPage.cpp
+++ b/src/src/WebServer/ControlPage.cpp
@@ -41,7 +41,7 @@ void handle_control() {
 
   TXBuffer.endStream();
 
-  printWebString.clear();
+  printWebString = String();
   printToWeb     = false;
   printToWebJSON = false;
 }

--- a/src/src/WebServer/CustomPage.cpp
+++ b/src/src/WebServer/CustomPage.cpp
@@ -153,7 +153,7 @@ bool handle_custom(const String& path) {
           line += c;
           if (c == '\n') {
             addHtml(parseTemplate(line));
-            line = String();
+            line.clear();
             line.reserve(128);
           }
         }

--- a/src/src/WebServer/CustomPage.cpp
+++ b/src/src/WebServer/CustomPage.cpp
@@ -153,7 +153,7 @@ bool handle_custom(const String& path) {
           line += c;
           if (c == '\n') {
             addHtml(parseTemplate(line));
-            line.clear();
+            line = String();
             line.reserve(128);
           }
         }

--- a/src/src/WebServer/DevicesPage.cpp
+++ b/src/src/WebServer/DevicesPage.cpp
@@ -182,7 +182,7 @@ void handle_devices() {
   if (loglevelActiveFor(LOG_LEVEL_DEBUG_DEV)) {
     String log = F("DEBUG: String size:");
     log += String(TXBuffer.sentBytes);
-    addLog(LOG_LEVEL_DEBUG_DEV, log);
+    addLogMove(LOG_LEVEL_DEBUG_DEV, log);
   }
 # endif // ifndef BUILD_NO_DEBUG
   sendHeadandTail_stdtemplate(_TAIL);

--- a/src/src/WebServer/LoadFromFS.cpp
+++ b/src/src/WebServer/LoadFromFS.cpp
@@ -94,7 +94,7 @@ bool loadFromFS(String path) {
   if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
     String log = F("HTML : Request file ");
     log += path;
-    addLog(LOG_LEVEL_DEBUG, log);
+    addLogMove(LOG_LEVEL_DEBUG, log);
   }
 #endif // ifndef BUILD_NO_DEBUG
 

--- a/src/src/WebServer/Log.cpp
+++ b/src/src/WebServer/Log.cpp
@@ -78,7 +78,7 @@ void handle_log_JSON() {
     if (Logging.getNext(logLinesAvailable, lastTimeStamp, message, loglevel)) {
       addHtml('{');
       stream_next_json_object_value(F("timestamp"), lastTimeStamp);
-      stream_next_json_object_value(F("text"),  message);
+      stream_next_json_object_value(F("text"),  std::move(message));
       stream_last_json_object_value(F("level"), loglevel);
       if (logLinesAvailable) {
         addHtml(',', '\n');

--- a/src/src/WebServer/RootPage.cpp
+++ b/src/src/WebServer/RootPage.cpp
@@ -86,9 +86,8 @@ void handle_root() {
 
   TXBuffer.startStream();
 
-  String  sCommand;
   boolean rebootCmd = false;
-  sCommand  = webArg(F("cmd"));
+  String sCommand  = webArg(F("cmd"));
   rebootCmd = strcasecmp_P(sCommand.c_str(), PSTR("reboot")) == 0;
   sendHeadandTail_stdtemplate(_HEAD, rebootCmd);
   {
@@ -152,27 +151,21 @@ void handle_root() {
 
       if (wdcounter > 0)
       {
-        String html;
-        html.reserve(32);
-        html += getCPUload();
-        html += F("% (LC=");
-        html += getLoopCountPerSec();
-        html += ')';
-        addHtml(html);
+        addHtml(String(getCPUload()));
+        addHtml(F("% (LC="));
+        addHtmlInt(getLoopCountPerSec());
+        addHtml(')');
       }
       {
         addRowLabel(LabelType::FREE_MEM);
-        String html;
-        html.reserve(64);
-        html += freeMem;
+        addHtmlInt(freeMem);
         #ifndef BUILD_NO_RAM_TRACKER
-        html += F(" (");
-        html += lowestRAM;
-        html += F(" - ");
-        html += lowestRAMfunction;
-        html += ')';
+        addHtml(F(" ("));
+        addHtmlInt(lowestRAM);
+        addHtml(F(" - "));
+        addHtml(lowestRAMfunction);
+        addHtml(')');
         #endif
-        addHtml(html);
       }
       {
         #ifdef USE_SECOND_HEAP
@@ -181,17 +174,14 @@ void handle_root() {
       }
       {
         addRowLabel(LabelType::FREE_STACK);
-        String html;
-        html.reserve(64);
-        html += String(getCurrentFreeStack());
+        addHtmlInt(getCurrentFreeStack());
         #ifndef BUILD_NO_RAM_TRACKER
-        html += F(" (");
-        html += String(lowestFreeStack);
-        html += F(" - ");
-        html += String(lowestFreeStackfunction);
-        html += ')';
+        addHtml(F(" ("));
+        addHtmlInt(lowestFreeStack);
+        addHtml(F(" - "));
+        addHtml(lowestFreeStackfunction);
+        addHtml(')');
         #endif
-        addHtml(html);
       }
 
   #ifdef HAS_ETHERNET
@@ -202,13 +192,10 @@ void handle_root() {
       {
         addRowLabelValue(LabelType::IP_ADDRESS);
         addRowLabel(LabelType::WIFI_RSSI);
-        String html;
-        html.reserve(32);
-        html += String(WiFi.RSSI());
-        html += F(" dBm (");
-        html += WiFi.SSID();
-        html += ')';
-        addHtml(html);
+        addHtmlInt(WiFi.RSSI());
+        addHtml(F(" dBm ("));
+        addHtml(WiFi.SSID());
+        addHtml(')');
       }
 
   #ifdef HAS_ETHERNET
@@ -221,14 +208,11 @@ void handle_root() {
       #ifdef FEATURE_MDNS
       {
         addRowLabel(LabelType::M_DNS);
-        String html;
-        html.reserve(64);
-        html += F("<a href='http://");
-        html += getValue(LabelType::M_DNS);
-        html += F("'>");
-        html += getValue(LabelType::M_DNS);
-        html += F("</a>");
-        addHtml(html);
+        addHtml(F("<a href='http://"));
+        addHtml(getValue(LabelType::M_DNS));
+        addHtml(F("'>"));
+        addHtml(getValue(LabelType::M_DNS));
+        addHtml(F("</a>"));
       }
       #endif // ifdef FEATURE_MDNS
 

--- a/src/src/WebServer/RootPage.cpp
+++ b/src/src/WebServer/RootPage.cpp
@@ -265,7 +265,7 @@ void handle_root() {
           addHtml(F("<TR><TD colspan='2'>Command Output<BR><textarea readonly rows='10' wrap='on'>"));
           addHtml(printWebString);
           addHtml(F("</textarea>"));
-          printWebString.clear();
+          printWebString = String();
         }
       }
       html_end_table();
@@ -342,7 +342,7 @@ void handle_root() {
       html_end_form();
     }
 
-    printWebString.clear();
+    printWebString = String();
     printToWeb     = false;
     sendHeadandTail_stdtemplate(_TAIL);
   }

--- a/src/src/WebServer/Rules.cpp
+++ b/src/src/WebServer/Rules.cpp
@@ -51,7 +51,7 @@ void handle_rules() {
     if (loglevelActiveFor(LOG_LEVEL_INFO)) {
       String log = F("Rules : Create new file: ");
       log += fileName;
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
     fs::File f = tryOpenFile(fileName, "w");
 

--- a/src/src/WebServer/SetupPage.cpp
+++ b/src/src/WebServer/SetupPage.cpp
@@ -119,7 +119,7 @@ void handle_setup() {
               if (loglevelActiveFor(LOG_LEVEL_INFO)) {
                 String reconnectlog = F("WIFI : Credentials Changed, retry connection. SSID: ");
                 reconnectlog += ssid;
-                addLog(LOG_LEVEL_INFO, reconnectlog);
+                addLogMove(LOG_LEVEL_INFO, reconnectlog);
               }
               status       = HANDLE_SETUP_CONNECTING_STAGE;
               refreshCount = 0;

--- a/src/src/WebServer/SysInfoPage.cpp
+++ b/src/src/WebServer/SysInfoPage.cpp
@@ -543,7 +543,7 @@ void handle_sysinfo_ESP_Board() {
 
   addRowLabel(LabelType::ESP_CHIP_ID);
   {
-    addHtml(getChipId());
+    addHtmlInt(getChipId());
     addHtml(F(" (0x"));
     String espChipId(getChipId(), HEX);
     espChipId.toUpperCase();

--- a/src/src/WebServer/SysInfoPage.cpp
+++ b/src/src/WebServer/SysInfoPage.cpp
@@ -304,27 +304,20 @@ void handle_sysinfo_basicInfo() {
 
   if (wdcounter > 0)
   {
-    String html;
-    html.reserve(32);
-    html += getCPUload();
-    html += F("% (LC=");
-    html += getLoopCountPerSec();
-    html += ')';
-    addHtml(html);
+    addHtml(String(getCPUload()));
+    addHtml(F("% (LC="));
+    addHtmlInt(getLoopCountPerSec());
+    addHtml(')');
   }
   addRowLabelValue(LabelType::CPU_ECO_MODE);
 
 
   addRowLabel(F("Boot"));
   {
-    String html;
-    html.reserve(64);
-
-    html += getLastBootCauseString();
-    html += F(" (");
-    html += RTC.bootCounter;
-    html += ')';
-    addHtml(html);
+    addHtml(getLastBootCauseString());
+    addHtml(F(" ("));
+    addHtmlInt(static_cast<uint32_t>(RTC.bootCounter));
+    addHtml(')');
   }
   addRowLabelValue(LabelType::RESET_REASON);
   addRowLabelValue(LabelType::LAST_TASK_BEFORE_REBOOT);
@@ -342,18 +335,14 @@ void handle_sysinfo_memory() {
   int freeMem = ESP.getFreeHeap();
   addRowLabel(LabelType::FREE_MEM);
   {
-    String html;
-    html.reserve(64);
-
-    html += freeMem;
+    addHtmlInt(freeMem);
 # ifndef BUILD_NO_RAM_TRACKER
-    html += F(" (");
-    html += lowestRAM;
-    html += F(" - ");
-    html += lowestRAMfunction;
-    html += ')';
+    addHtml(F(" ("));
+    addHtmlInt(lowestRAM);
+    addHtml(F(" - "));
+    addHtml(lowestRAMfunction);
+    addHtml(')');
 # endif // ifndef BUILD_NO_RAM_TRACKER
-    addHtml(html);
   }
 # if defined(CORE_POST_2_5_0) || defined(ESP32)
  #  ifndef LIMIT_BUILD_SIZE
@@ -375,17 +364,14 @@ void handle_sysinfo_memory() {
 
   addRowLabel(LabelType::FREE_STACK);
   {
-    String html;
-    html.reserve(64);
-    html += getCurrentFreeStack();
+    addHtmlInt(getCurrentFreeStack());
 # ifndef BUILD_NO_RAM_TRACKER
-    html += F(" (");
-    html += lowestFreeStack;
-    html += F(" - ");
-    html += lowestFreeStackfunction;
-    html += ')';
+    addHtml(F(" ("));
+    addHtmlInt(lowestFreeStack);
+    addHtml(F(" - "));
+    addHtml(lowestFreeStackfunction);
+    addHtml(')');
 # endif // ifndef BUILD_NO_RAM_TRACKER
-    addHtml(html);
   }
 
 # if defined(ESP32) && defined(ESP32_ENABLE_PSRAM)
@@ -448,14 +434,10 @@ void handle_sysinfo_Network() {
   addRowLabel(LabelType::SSID);
   if (showWiFiConnectionInfo)
   {
-    String html;
-    html.reserve(64);
-
-    html += WiFi.SSID();
-    html += F(" (");
-    html += WiFi.BSSIDstr();
-    html += ')';
-    addHtml(html);
+    addHtml(WiFi.SSID());
+    addHtml(F(" ("));
+    addHtml(WiFi.BSSIDstr());
+    addHtml(')');
   } else addHtml('-');
 
   addRowLabel(getLabel(LabelType::CHANNEL));
@@ -561,15 +543,12 @@ void handle_sysinfo_ESP_Board() {
 
   addRowLabel(LabelType::ESP_CHIP_ID);
   {
-    String html;
-    html.reserve(32);
-    html += getChipId();
-    html += F(" (0x");
+    addHtml(getChipId());
+    addHtml(F(" (0x"));
     String espChipId(getChipId(), HEX);
     espChipId.toUpperCase();
-    html += espChipId;
-    html += ')';
-    addHtml(html);
+    addHtml(espChipId);
+    addHtml(')');
   }
 
   addRowLabel(LabelType::ESP_CHIP_FREQ);

--- a/src/src/WebServer/ToolsPage.cpp
+++ b/src/src/WebServer/ToolsPage.cpp
@@ -57,7 +57,7 @@ void handle_tools() {
     addHtml(F("<TR><TD colspan='2'>Command Output<BR><textarea readonly rows='10' wrap='on'>"));
     addHtml(printWebString);
     addHtml(F("</textarea>"));
-    printWebString.clear();
+    printWebString = String();
   }
 
 
@@ -177,7 +177,7 @@ void handle_tools() {
   html_end_form();
   sendHeadandTail_stdtemplate(_TAIL);
   TXBuffer.endStream();
-  printWebString.clear();
+  printWebString = String();
   printToWeb     = false;
 }
 

--- a/src/src/WebServer/UploadPage.cpp
+++ b/src/src/WebServer/UploadPage.cpp
@@ -27,7 +27,7 @@ void handle_upload() {
             "<form enctype='multipart/form-data' method='post'><p>Upload settings file:<br><input type='file' name='datafile' size='40'></p><div><input class='button link' type='submit' value='Upload'></div><input type='hidden' name='edit' value='1'></form>"));
   sendHeadandTail_stdtemplate(true);
   TXBuffer.endStream();
-  printWebString.clear();
+  printWebString = String();
   printToWeb     = false;
 }
 
@@ -64,7 +64,7 @@ void handle_upload_post() {
   addHtml(F("Upload finished"));
   sendHeadandTail_stdtemplate(true);
   TXBuffer.endStream();
-  printWebString.clear();
+  printWebString = String();
   printToWeb     = false;
 }
 

--- a/src/src/WebServer/UploadPage.cpp
+++ b/src/src/WebServer/UploadPage.cpp
@@ -113,7 +113,7 @@ void handleFileUpload() {
     if (loglevelActiveFor(LOG_LEVEL_INFO)) {
       String log = F("Upload: START, filename: ");
       log += upload.filename;
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
     valid        = false;
     uploadResult = uploadResult_e::UploadStarted;
@@ -167,7 +167,7 @@ void handleFileUpload() {
     if (loglevelActiveFor(LOG_LEVEL_INFO)) {
       String log = F("Upload: WRITE, Bytes: ");
       log += upload.currentSize;
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
   }
   else if (upload.status == UPLOAD_FILE_END)
@@ -177,7 +177,7 @@ void handleFileUpload() {
     if (loglevelActiveFor(LOG_LEVEL_INFO)) {
       String log = F("Upload: END, Size: ");
       log += upload.totalSize;
-      addLog(LOG_LEVEL_INFO, log);
+      addLogMove(LOG_LEVEL_INFO, log);
     }
   }
 

--- a/src/src/WebServer/WebServer.cpp
+++ b/src/src/WebServer/WebServer.cpp
@@ -354,21 +354,25 @@ void getWebPageTemplateDefault(const String& tmplName, WebTemplateParser& parser
 
     getWebPageTemplateDefaultHead(parser, !addMeta, !addJS);
 
-    #ifndef WEBPAGE_TEMPLATE_AP_HEADER
-    parser.process(F("<body><header class='apheader'>"
-              "<h1>Welcome to ESP Easy Mega AP</h1>"));
-    #else
-    parser.process(F(WEBPAGE_TEMPLATE_AP_HEADER));
-    #endif
+    if (!parser.isTail()) {
+      #ifndef WEBPAGE_TEMPLATE_AP_HEADER
+      parser.process(F("<body><header class='apheader'>"
+                "<h1>Welcome to ESP Easy Mega AP</h1>"));
+      #else
+      parser.process(F(WEBPAGE_TEMPLATE_AP_HEADER));
+      #endif
 
-    parser.process(F("</header>"));
+      parser.process(F("</header>"));
+    }
     getWebPageTemplateDefaultContentSection(parser);
     getWebPageTemplateDefaultFooter(parser);
   }
   else if (tmplName == F("TmplMsg"))
   {
     getWebPageTemplateDefaultHead(parser, !addMeta, !addJS);
-    parser.process(F("<body>"));
+    if (!parser.isTail()) {
+      parser.process(F("<body>"));
+    }
     getWebPageTemplateDefaultHeader(parser, F("{{name}}"), false);
     getWebPageTemplateDefaultContentSection(parser);
     getWebPageTemplateDefaultFooter(parser);
@@ -385,8 +389,10 @@ void getWebPageTemplateDefault(const String& tmplName, WebTemplateParser& parser
   else // all other template names e.g. TmplStd
   {
     getWebPageTemplateDefaultHead(parser, addMeta, addJS);
-    parser.process(F("<body class='bodymenu'>"
-              "<span class='message' id='rbtmsg'></span>"));
+    if (!parser.isTail()) {
+      parser.process(F("<body class='bodymenu'>"
+                "<span class='message' id='rbtmsg'></span>"));
+    }
     getWebPageTemplateDefaultHeader(parser, F("{{name}} {{logo}}"), true);
     getWebPageTemplateDefaultContentSection(parser);
     getWebPageTemplateDefaultFooter(parser);
@@ -395,6 +401,7 @@ void getWebPageTemplateDefault(const String& tmplName, WebTemplateParser& parser
 }
 
 void getWebPageTemplateDefaultHead(WebTemplateParser& parser, bool addMeta, bool addJS) {
+  if (parser.isTail()) return;
   parser.process(F("<!DOCTYPE html><html lang='en'>"
             "<head>"
             "<meta charset='utf-8'/>"
@@ -411,6 +418,7 @@ void getWebPageTemplateDefaultHead(WebTemplateParser& parser, bool addMeta, bool
 
 void getWebPageTemplateDefaultHeader(WebTemplateParser& parser, const __FlashStringHelper * title, bool addMenu) {
   {
+    if (parser.isTail()) return;
   #ifndef WEBPAGE_TEMPLATE_DEFAULT_HEADER
     parser.process(F("<header class='headermenu'><h1>ESP Easy Mega: "));
     parser.process(title);
@@ -440,6 +448,7 @@ void getWebPageTemplateDefaultContentSection(WebTemplateParser& parser) {
 }
 
 void getWebPageTemplateDefaultFooter(WebTemplateParser& parser) {
+  if (!parser.isTail()) return;
   #ifndef WEBPAGE_TEMPLATE_DEFAULT_FOOTER
   parser.process(F("<footer>"
             "<br>"

--- a/src/src/WebServer/WebServer.cpp
+++ b/src/src/WebServer/WebServer.cpp
@@ -947,7 +947,7 @@ void getStorageTableSVG(SettingsType::Enum settingsType) {
   if (struct_size != 0) {
     String text;
     text.reserve(32);
-    text = formatHumanReadable(struct_size, 1024);
+    text += formatHumanReadable(struct_size, 1024);
     text += '/';
     text += formatHumanReadable(max_size, 1024);
     text += F(" per item");

--- a/src/src/WebServer/WebServer.cpp
+++ b/src/src/WebServer/WebServer.cpp
@@ -142,7 +142,7 @@ void sendHeadandTail_stdtemplate(boolean Tail, boolean rebooting) {
           log += F("' length: ");
           log += webArg(i).length();
         }
-        addLog(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, log);
       }
     }
     #endif // ifndef BUILD_NO_DEBUG

--- a/src/src/WebServer/WebServer.cpp
+++ b/src/src/WebServer/WebServer.cpp
@@ -88,9 +88,7 @@ void sendHeadandTail(const __FlashStringHelper * tmplName, boolean Tail, boolean
   }
   #endif // ifdef USES_TIMING_STATS
   {
-    String fileName = tmplName;
-
-    fileName += F(".htm");
+    const String fileName = String(tmplName) + F(".htm");
     fs::File f = tryOpenFile(fileName, "r");
 
     WebTemplateParser templateParser(Tail, rebooting);

--- a/src/src/WebServer/WebServer.cpp
+++ b/src/src/WebServer/WebServer.cpp
@@ -348,11 +348,6 @@ void setWebserverRunning(bool state) {
 
 void getWebPageTemplateDefault(const String& tmplName, WebTemplateParser& parser)
 {
-  #ifdef USE_SECOND_HEAP
-  // Store template in 2nd heap
-  HeapSelectIram ephemeral;
-  #endif
-
   const bool addJS   = true;
   const bool addMeta = true;
 

--- a/src/src/WebServer/WebTemplateParser.cpp
+++ b/src/src/WebServer/WebTemplateParser.cpp
@@ -352,7 +352,7 @@ void WebTemplateParser::getWebPageTemplateVar(const String& varName)
     if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
       String log = F("Templ: Unknown Var : ");
       log += varName;
-      addLog(LOG_LEVEL_ERROR, log);
+      addLogMove(LOG_LEVEL_ERROR, log);
     }
     #endif // ifndef BUILD_NO_DEBUG
 

--- a/src/src/WebServer/WebTemplateParser.cpp
+++ b/src/src/WebServer/WebTemplateParser.cpp
@@ -130,7 +130,7 @@ bool WebTemplateParser::process(const char c) {
           } else if (Tail == contentVarFound) {
             processVarName();
           }
-          varName.clear();
+          varName = String();
         }
       }
       break;

--- a/src/src/WebServer/WebTemplateParser.h
+++ b/src/src/WebServer/WebTemplateParser.h
@@ -32,6 +32,8 @@ public:
   bool process(PGM_P str);
   bool process(const String& str);
 
+  bool isTail() const { return Tail; }
+
 private:
 
   void processVarName();


### PR DESCRIPTION
By allowing to use `std::move` a number of copy operations can be reduced when handling log.

Main improvements:
- Lots of String copy operations are no longer performed.
- Memory allocated by long living Strings is now actually freed
- When using 2nd heap, a lot more will actually be stored there and moved instead of copied if it was already present on the 2nd heap.
- Lots of `.reserve` calls on Strings (e.g. for logs) were immediately after the reserve truncated and later resized again
- Quite a lot of debug logs were not excluded from builds when `BUILD_NO_DEBUG` was defined.