### PR TITLE
Allow OTA attempt even when not enough space

### DIFF
--- a/src/src/WebServer/ToolsPage.cpp
+++ b/src/src/WebServer/ToolsPage.cpp
@@ -150,7 +150,7 @@ void handle_tools() {
         }
       } else {
         html_B(F("WARNING"));
-        addHtml(F(" OTA not possible."));
+        addHtml(F("Not enough space to safely update. Update might fail. "));
       }
       addHtml(F(" Max sketch size: "));
       addHtmlInt(maxSketchSize / 1024);

--- a/src/src/WebServer/ToolsPage.cpp
+++ b/src/src/WebServer/ToolsPage.cpp
@@ -150,7 +150,7 @@ void handle_tools() {
         }
       } else {
         html_B(F("WARNING"));
-        addHtml(F("Not enough space to safely update. Update might fail. "));
+        addHtml(F(" Not enough space to safely update. Update might fail. "));
       }
       addHtml(F(" Max sketch size: "));
       addHtmlInt(maxSketchSize / 1024);

--- a/src/src/WebServer/WebServer.cpp
+++ b/src/src/WebServer/WebServer.cpp
@@ -302,10 +302,10 @@ void WebServerInit()
     # ifndef NO_HTTP_UPDATER
     uint32_t maxSketchSize;
     bool     use2step;
-
-    if (OTA_possible(maxSketchSize, use2step)) {
+  //allow OTA to smaller version of ESPEasy/other firmware
+    //if (OTA_possible(maxSketchSize, use2step)) {
       httpUpdater.setup(&web_server);
-    }
+    //}
     # endif // ifndef NO_HTTP_UPDATER
   }
   #endif    // if defined(ESP8266)


### PR DESCRIPTION
Now OTA is possible on smaller flash size even when there's not enough space to fit normal ESPEasy image. Very useful if you want to flash custom/minimal build.

I still plan to investigate whether it's possible to wipe settings partition and expand OTA partition from program level(so we could flash even bigger images at the cost of erasing settings), but we have to start somewhere, right?

Partial solution to #3926 