### PR TITLE
[Build] Enable Notifiers in Energy build

### DIFF
--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -1195,6 +1195,9 @@ To create/register a plugin, you have to :
 
 // Collection of all energy related plugins.
 #ifdef PLUGIN_ENERGY_COLLECTION
+   #ifndef NOTIFIER_SET_STABLE
+     #define NOTIFIER_SET_STABLE
+   #endif
    #ifndef USES_P025
      #define USES_P025   // ADS1115
    #endif


### PR DESCRIPTION
The Notifiers seem to have been left out of the `Energy` builds since these where added, but they can be useful for many of the sensors that are included here. And there is enough available space in the .bin files, for now.

Initiated by this [comment](https://github.com/letscontrolit/ESPEasy/issues/3943#issuecomment-1038001513)