### PR TITLE
[ESP32] Add GPIO37/38 as input

### DIFF
--- a/src/src/Helpers/Hardware.cpp
+++ b/src/src/Helpers/Hardware.cpp
@@ -1014,7 +1014,7 @@ bool getGpioInfo(int gpio, int& pinnr, bool& input, bool& output, bool& warning)
 
   if (gpio == 37 || gpio == 38) {
     // Pins are not present on the ESP32
-    input  = false;
+    input  = true;
     output = false;
   }
 


### PR DESCRIPTION
There are a number of boards (eg. from Heltec) that support GPIO37 and GPIO38 at least as ADC1 input. So enable them here.