### PR TITLE
[WiFi] Fix connecting to strongest WiFi AP

### DIFF
--- a/src/src/DataStructs/WiFi_AP_Candidate.cpp
+++ b/src/src/DataStructs/WiFi_AP_Candidate.cpp
@@ -83,7 +83,7 @@ bool WiFi_AP_Candidate::operator<(const WiFi_AP_Candidate& other) const {
 }
 
 bool WiFi_AP_Candidate::operator==(const WiFi_AP_Candidate& other) const {
-  return bssid_match(other.bssid) && ssid.equals(other.ssid) && key.equals(other.key);
+  return bssid_match(other.bssid) && ssid.equals(other.ssid);// && key.equals(other.key);
 }
 
 bool WiFi_AP_Candidate::usable() const {

--- a/src/src/ESPEasyCore/ESPEasyWifi.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi.cpp
@@ -367,6 +367,10 @@ void AttemptWiFiConnect() {
     return;
   }
 
+  if (WiFiEventData.wifiConnectInProgress) {
+    return;
+  }
+
   if (WiFiEventData.wifiSetupConnect) {
     // wifiSetupConnect is when run from the setup page.
     RTC.clearLastWiFi(); // Force slow connect
@@ -376,8 +380,6 @@ void AttemptWiFiConnect() {
       WiFiEventData.timerAPoff.setMillisFromNow(WIFI_RECONNECT_WAIT + WIFI_AP_OFF_TIMER_DURATION);
     }
   }
-
-  WiFiEventData.markWiFiTurnOn();
 
   if (WiFi_AP_Candidates.getNext(WiFiScanAllowed())) {
     const WiFi_AP_Candidate candidate = WiFi_AP_Candidates.getCurrent();
@@ -400,6 +402,7 @@ void AttemptWiFiConnect() {
       SetWiFiTXpower(tx_pwr, candidate.rssi);
       // Start connect attempt now, so no longer needed to attempt new connection.
       WiFiEventData.wifiConnectAttemptNeeded = false;
+      WiFiEventData.wifiConnectInProgress = true;
       if (candidate.allowQuickConnect() && !candidate.isHidden) {
         WiFi.begin(candidate.ssid.c_str(), candidate.key.c_str(), candidate.channel, candidate.bssid.mac);
       } else {

--- a/src/src/ESPEasyCore/ESPEasyWifi.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi.cpp
@@ -325,9 +325,6 @@ void WiFiConnectRelaxed() {
     return;
   }
   if (WiFiEventData.unprocessedWifiEvents()) {
-    handle_unprocessedNetworkEvents();
-  }
-  if (WiFiEventData.unprocessedWifiEvents()) {
     if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
       String log = F("WiFi : Connecting not possible, unprocessed WiFi events: ");
       if (!WiFiEventData.processedConnect) {

--- a/src/src/Helpers/WiFi_AP_CandidatesList.cpp
+++ b/src/src/Helpers/WiFi_AP_CandidatesList.cpp
@@ -105,6 +105,7 @@ void WiFi_AP_CandidatesList::process_WiFiscan(const bss_info& ap) {
 
 void WiFi_AP_CandidatesList::after_process_WiFiscan() {
   scanned_new.sort();
+  scanned_new.unique();
   _mustLoadCredentials = true;
   WiFi.scanDelete();
 }
@@ -243,11 +244,21 @@ void WiFi_AP_CandidatesList::loadCandidatesFromScanned() {
       }
       #endif // ifndef BUILD_NO_DEBUG
 
+      // Check to see if it is already present, if so, remove existing one.
+      for (auto tmp = scanned.begin(); tmp != scanned.end();) {
+        if (*tmp == *scan) {
+          tmp = scanned.erase(tmp);
+        } else {
+          ++tmp;
+        }
+      }
+
       // We copy instead of move, to make sure it is stored on the 2nd heap.
       scanned.push_back(*scan);
       scan = scanned_new.erase(scan);
     }
     scanned.sort();
+    scanned.unique();
   }
 
   if (candidates.size() > 1) {
@@ -305,6 +316,7 @@ void WiFi_AP_CandidatesList::loadCandidatesFromScanned() {
     }
   }
   candidates.sort();
+  candidates.unique();
   addFromRTC();
   purge_unusable();
 }


### PR DESCRIPTION
- Prevent duplicate entries in AP scan results: This also prevents issues where an AP changed channel and has worse RSSI. The previous known one may be attempted to connect to for ages until it expired.
- Properly keep track if ongoing WiFi connect in progress.

The last one may otherwise try the next best candidate, which in a typical mesh setup, or any setup where multiple APs with the same SSID are present, is not the one with the strongest WiFi signal.