### PR TITLE
[MQTT] Reduce rate of MQTT reconnects when failing to reconnect

### DIFF
--- a/platformio_esp82xx_envs.ini
+++ b/platformio_esp82xx_envs.ini
@@ -4,6 +4,16 @@
 ; *********************************************************************
 
 
+[hard_esp82xx_3_0_0]
+platform                  = ${beta_platform.platform}
+platform_packages         = ${beta_platform.platform_packages}
+build_flags               = ${beta_platform.build_flags}
+                            -DBUILD_NO_DEBUG
+                            -DPLUGIN_BUILD_CUSTOM
+lib_ignore                = ${esp8266_custom_common.lib_ignore}
+extra_scripts             = ${esp8266_custom_common.extra_scripts}
+
+
 [hard_esp82xx]
 platform                  = ${regular_platform.platform}
 platform_packages         = ${regular_platform.platform_packages}
@@ -773,10 +783,8 @@ build_flags               = ${regular_platform.build_flags}
 ; GPIO12 Red Led and Relay (0 = Off, 1 = On)
 ; GPIO13 Blue Led (0 = On, 1 = Off)
 [env:hard_SONOFF_POW_4M1M]
-extends                   = esp8266_4M1M, hard_esp82xx
-platform                  = ${hard_esp82xx.platform}
-platform_packages         = ${hard_esp82xx.platform_packages}
-build_flags               = ${hard_esp82xx.build_flags} 
+extends                   = esp8266_4M1M, hard_esp82xx_3_0_0
+build_flags               = ${hard_esp82xx_3_0_0.build_flags}
                             ${esp8266_4M1M.build_flags}
                             -D PLUGIN_SET_SONOFF_POW
 

--- a/src/src/ESPEasyCore/Controller.cpp
+++ b/src/src/ESPEasyCore/Controller.cpp
@@ -169,7 +169,12 @@ void MQTTDisconnect()
 \*********************************************************************************************/
 bool MQTTConnect(controllerIndex_t controller_idx)
 {
+  if (MQTTclient_next_connect_attempt.isSet() && !MQTTclient_next_connect_attempt.timeoutReached(timermqtt_interval)) {
+    return false;
+  }
+  MQTTclient_next_connect_attempt.setNow();
   ++mqtt_reconnect_count;
+
   MakeControllerSettings(ControllerSettings); //-V522
 
   if (!AllocatedControllerSettings()) {
@@ -210,8 +215,10 @@ bool MQTTConnect(controllerIndex_t controller_idx)
   bool    willRetain           = ControllerSettings.mqtt_willRetain() && ControllerSettings.mqtt_sendLWT();
   bool    cleanSession         = ControllerSettings.mqtt_cleanSession(); // As suggested here:
 
+  if (MQTTclient_should_reconnect) {
+    addLog(LOG_LEVEL_ERROR, F("MQTT : Intentional reconnect"));
+  }
   // https://github.com/knolleary/pubsubclient/issues/458#issuecomment-493875150
-
   if (hasControllerCredentialsSet(controller_idx, ControllerSettings)) {
     MQTTresult =
       MQTTclient.connect(clientid.c_str(),
@@ -242,6 +249,7 @@ bool MQTTConnect(controllerIndex_t controller_idx)
   if (!MQTTresult) {
     MQTTclient.disconnect();
     updateMQTTclient_connected();
+
     return false;
   }
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
@@ -356,9 +364,6 @@ bool MQTTCheck(controllerIndex_t controller_idx)
 
     if (MQTTclient_should_reconnect || !MQTTclient.connected())
     {
-      if (MQTTclient_should_reconnect) {
-        addLog(LOG_LEVEL_ERROR, F("MQTT : Intentional reconnect"));
-      }
       return MQTTConnect(controller_idx);
     }
 

--- a/src/src/Globals/MQTT.cpp
+++ b/src/src/Globals/MQTT.cpp
@@ -12,6 +12,7 @@ bool MQTTclient_should_reconnect        = true;
 bool MQTTclient_must_send_LWT_connected = false;
 bool MQTTclient_connected               = false;
 int  mqtt_reconnect_count               = 0;
+LongTermTimer MQTTclient_next_connect_attempt;
 #endif // USES_MQTT
 
 #ifdef USES_P037

--- a/src/src/Globals/MQTT.h
+++ b/src/src/Globals/MQTT.h
@@ -9,6 +9,8 @@
 # include <WiFiClient.h>
 # include <PubSubClient.h>
 
+#include "../Helpers/LongTermTimer.h"
+
 // MQTT client
 extern WiFiClient   mqtt;
 extern PubSubClient MQTTclient;
@@ -16,6 +18,7 @@ extern bool MQTTclient_should_reconnect;
 extern bool MQTTclient_must_send_LWT_connected;
 extern bool MQTTclient_connected;
 extern int  mqtt_reconnect_count;
+extern LongTermTimer MQTTclient_next_connect_attempt;
 #endif // USES_MQTT
 
 #ifdef USES_P037

--- a/src/src/Helpers/PeriodicalActions.cpp
+++ b/src/src/Helpers/PeriodicalActions.cpp
@@ -62,6 +62,7 @@ void run50TimesPerSecond() {
     CPluginCall(CPlugin::Function::CPLUGIN_FIFTY_PER_SECOND, 0, dummy);
     STOP_TIMER(CPLUGIN_CALL_50PS);
   }
+  processNextEvent();
 }
 
 /*********************************************************************************************\
@@ -91,7 +92,6 @@ void run10TimesPerSecond() {
     CPluginCall(CPlugin::Function::CPLUGIN_TEN_PER_SECOND, 0, dummy);
     STOP_TIMER(CPLUGIN_CALL_10PS);
   }
-  processNextEvent();
   
   #ifdef USES_C015
   if (NetworkConnected())

--- a/src/src/Helpers/Scheduler.cpp
+++ b/src/src/Helpers/Scheduler.cpp
@@ -265,6 +265,9 @@ void ESPEasy_Scheduler::handle_schedule() {
     // Make sure normal scheduled jobs run at higher priority.
     // backgroundtasks();
     process_system_event_queue();
+
+    // System events may have added one or more rule events, try to process those
+    processNextEvent();
     last_system_event_run = millis();
     STOP_TIMER(HANDLE_SCHEDULER_IDLE);
     return;


### PR DESCRIPTION
Also process rules events more frequently.
Rules events were processed at 10 times per second, moved it to 50/sec.
Rules events are now also being processed when a loop has nothing else to process.

The reconnect attempt is blocking, thus lots of other actions have to be done to keep up.
This may cause the event queue to be filled up and thus the unit runs out of memory and crashes.
By dynamically lowering the reconnect rate, this no longer causes crashes.