### PR TITLE
[Build] Disable test_X_beta_ESP8266 builds due to build size

### DIFF
--- a/platformio_esp82xx_envs.ini
+++ b/platformio_esp82xx_envs.ini
@@ -3,17 +3,6 @@
 ; pre_custom_esp82xx.py or Custom.h                                   ;
 ; *********************************************************************
 
-
-[hard_esp82xx_3_0_0]
-platform                  = ${beta_platform.platform}
-platform_packages         = ${beta_platform.platform_packages}
-build_flags               = ${beta_platform.build_flags}
-                            -DBUILD_NO_DEBUG
-                            -DPLUGIN_BUILD_CUSTOM
-lib_ignore                = ${esp8266_custom_common.lib_ignore}
-extra_scripts             = ${esp8266_custom_common.extra_scripts}
-
-
 [hard_esp82xx]
 platform                  = ${regular_platform.platform}
 platform_packages         = ${regular_platform.platform_packages}
@@ -614,107 +603,107 @@ build_flags               = ${testing_alt_wifi.build_flags}
 ;lib_ignore                = ESP32_ping, ESP32WebServer, ServoESP32, ESP32HTTPUpdateServer, IRremoteESP8266, HeatpumpIRLittleFS(esp8266)
 
 
-[env:test_A_beta_ESP8266_4M1M]
-extends                   = esp8266_4M1M
-platform                  = ${testing_beta.platform}
-platform_packages         = ${testing_beta.platform_packages}
-build_flags               = ${testing_beta.build_flags}
-                            ${esp8266_4M1M.build_flags}
-                            -DLIMIT_BUILD_SIZE
-                            -DTESTING_USE_RTTTL
+;[env:test_A_beta_ESP8266_4M1M]
+;extends                   = esp8266_4M1M
+;platform                  = ${testing_beta.platform}
+;platform_packages         = ${testing_beta.platform_packages}
+;build_flags               = ${testing_beta.build_flags}
+;                            ${esp8266_4M1M.build_flags}
+;                            -DLIMIT_BUILD_SIZE
+;                            -DTESTING_USE_RTTTL
 
-[env:test_B_beta_ESP8266_4M1M]
-extends                   = esp8266_4M1M
-platform                  = ${testing_beta.platform}
-platform_packages         = ${testing_beta.platform_packages}
-build_flags               = ${testing_beta.build_flags}
-                            ${esp8266_4M1M.build_flags}
-                            -DLIMIT_BUILD_SIZE
-                            -DPLUGIN_BUILD_TESTING_B
+;[env:test_B_beta_ESP8266_4M1M]
+;extends                   = esp8266_4M1M
+;platform                  = ${testing_beta.platform}
+;platform_packages         = ${testing_beta.platform_packages}
+;build_flags               = ${testing_beta.build_flags}
+;                            ${esp8266_4M1M.build_flags}
+;                            -DLIMIT_BUILD_SIZE
+;                            -DPLUGIN_BUILD_TESTING_B
 
-[env:test_C_beta_ESP8266_4M1M]
-extends                   = esp8266_4M1M
-platform                  = ${testing_beta.platform}
-platform_packages         = ${testing_beta.platform_packages}
-build_flags               = ${testing_beta.build_flags}
-                            ${esp8266_4M1M.build_flags}
-                            -DLIMIT_BUILD_SIZE
-                            -DPLUGIN_BUILD_TESTING_C
-                            -DTESTING_USE_RTTTL
+;[env:test_C_beta_ESP8266_4M1M]
+;extends                   = esp8266_4M1M
+;platform                  = ${testing_beta.platform}
+;platform_packages         = ${testing_beta.platform_packages}
+;build_flags               = ${testing_beta.build_flags}
+;                            ${esp8266_4M1M.build_flags}
+;                            -DLIMIT_BUILD_SIZE
+;                            -DPLUGIN_BUILD_TESTING_C
+;                            -DTESTING_USE_RTTTL
 
-[env:test_D_beta_ESP8266_4M1M]
-extends                   = esp8266_4M1M
-platform                  = ${testing_beta.platform}
-platform_packages         = ${testing_beta.platform_packages}
-build_flags               = ${testing_beta.build_flags}
-                            ${esp8266_4M1M.build_flags}
-                            -DLIMIT_BUILD_SIZE
-                            -DPLUGIN_BUILD_TESTING_D
-                            -DTESTING_USE_RTTTL
+;[env:test_D_beta_ESP8266_4M1M]
+;extends                   = esp8266_4M1M
+;platform                  = ${testing_beta.platform}
+;platform_packages         = ${testing_beta.platform_packages}
+;build_flags               = ${testing_beta.build_flags}
+;                            ${esp8266_4M1M.build_flags}
+;                            -DLIMIT_BUILD_SIZE
+;                            -DPLUGIN_BUILD_TESTING_D
+;                            -DTESTING_USE_RTTTL
 
-[env:test_E_beta_ESP8266_4M1M]
-extends                   = esp8266_4M1M
-platform                  = ${testing_beta.platform}
-platform_packages         = ${testing_beta.platform_packages}
-build_flags               = ${testing_beta.build_flags}
-                            ${esp8266_4M1M.build_flags}
-                            -DLIMIT_BUILD_SIZE
-                            -DPLUGIN_BUILD_TESTING_E
-                            -DTESTING_USE_RTTTL
+;[env:test_E_beta_ESP8266_4M1M]
+;extends                   = esp8266_4M1M
+;platform                  = ${testing_beta.platform}
+;platform_packages         = ${testing_beta.platform_packages}
+;build_flags               = ${testing_beta.build_flags}
+;                            ${esp8266_4M1M.build_flags}
+;                            -DLIMIT_BUILD_SIZE
+;                            -DPLUGIN_BUILD_TESTING_E
+;                            -DTESTING_USE_RTTTL
 
 ; Test: 16M version -- LittleFS --------------
 ; LittleFS is determined by using "LittleFS" in the pio env name
-[env:test_A_beta_ESP8266_16M_LittleFS]
-extends                   = esp8266_16M
-platform                  = ${testing_beta.platform}
-platform_packages         = ${testing_beta.platform_packages}
-build_flags               = ${testing_beta.build_flags}
-                            ${esp8266_16M.build_flags} 
-                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22y
-lib_ignore                = ESP32_ping, ESP32WebServer, ServoESP32, ESP32HTTPUpdateServer, IRremoteESP8266, HeatpumpIR
+;[env:test_A_beta_ESP8266_16M_LittleFS]
+;extends                   = esp8266_16M
+;platform                  = ${testing_beta.platform}
+;platform_packages         = ${testing_beta.platform_packages}
+;build_flags               = ${testing_beta.build_flags}
+;                            ${esp8266_16M.build_flags} 
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22y
+;lib_ignore                = ESP32_ping, ESP32WebServer, ServoESP32, ESP32HTTPUpdateServer, IRremoteESP8266, HeatpumpIR
 
-[env:test_B_beta_ESP8266_16M_LittleFS]
-extends                   = esp8266_16M
-platform                  = ${testing_beta.platform}
-platform_packages         = ${testing_beta.platform_packages}
-build_flags               = ${testing_beta.build_flags}
-                            ${esp8266_16M.build_flags} 
-                            -DPLUGIN_BUILD_TESTING_B
-                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22y
-lib_ignore                = ESP32_ping, ESP32WebServer, ServoESP32, ESP32HTTPUpdateServer, IRremoteESP8266, HeatpumpIR
+;[env:test_B_beta_ESP8266_16M_LittleFS]
+;extends                   = esp8266_16M
+;platform                  = ${testing_beta.platform}
+;platform_packages         = ${testing_beta.platform_packages}
+;build_flags               = ${testing_beta.build_flags}
+;                            ${esp8266_16M.build_flags} 
+;                            -DPLUGIN_BUILD_TESTING_B
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22y
+;lib_ignore                = ESP32_ping, ESP32WebServer, ServoESP32, ESP32HTTPUpdateServer, IRremoteESP8266, HeatpumpIR
 
-[env:test_C_beta_ESP8266_16M_LittleFS]
-extends                   = esp8266_16M
-platform                  = ${testing_beta.platform}
-platform_packages         = ${testing_beta.platform_packages}
-build_flags               = ${testing_beta.build_flags}
-                            ${esp8266_16M.build_flags} 
-                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22y
-                            -DPLUGIN_BUILD_TESTING_C
-                            -DTESTING_USE_RTTTL
-lib_ignore                = ESP32_ping, ESP32WebServer, ServoESP32, ESP32HTTPUpdateServer, IRremoteESP8266, HeatpumpIR
+;[env:test_C_beta_ESP8266_16M_LittleFS]
+;extends                   = esp8266_16M
+;platform                  = ${testing_beta.platform}
+;platform_packages         = ${testing_beta.platform_packages}
+;build_flags               = ${testing_beta.build_flags}
+;                            ${esp8266_16M.build_flags} 
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22y
+;                            -DPLUGIN_BUILD_TESTING_C
+;                            -DTESTING_USE_RTTTL
+;lib_ignore                = ESP32_ping, ESP32WebServer, ServoESP32, ESP32HTTPUpdateServer, IRremoteESP8266, HeatpumpIR
 
-[env:test_D_beta_ESP8266_16M_LittleFS]
-extends                   = esp8266_16M
-platform                  = ${testing_beta.platform}
-platform_packages         = ${testing_beta.platform_packages}
-build_flags               = ${testing_beta.build_flags}
-                            ${esp8266_16M.build_flags} 
-                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22y
-                            -DPLUGIN_BUILD_TESTING_D
-                            -DTESTING_USE_RTTTL
-lib_ignore                = ESP32_ping, ESP32WebServer, ServoESP32, ESP32HTTPUpdateServer, IRremoteESP8266, HeatpumpIR
+;[env:test_D_beta_ESP8266_16M_LittleFS]
+;extends                   = esp8266_16M
+;platform                  = ${testing_beta.platform}
+;platform_packages         = ${testing_beta.platform_packages}
+;build_flags               = ${testing_beta.build_flags}
+;                            ${esp8266_16M.build_flags} 
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22y
+;                            -DPLUGIN_BUILD_TESTING_D
+;                            -DTESTING_USE_RTTTL
+;lib_ignore                = ESP32_ping, ESP32WebServer, ServoESP32, ESP32HTTPUpdateServer, IRremoteESP8266, HeatpumpIR
 
-[env:test_E_beta_ESP8266_16M_LittleFS]
-extends                   = esp8266_16M
-platform                  = ${testing_beta.platform}
-platform_packages         = ${testing_beta.platform_packages}
-build_flags               = ${testing_beta.build_flags}
-                            ${esp8266_16M.build_flags} 
-                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22y
-                            -DPLUGIN_BUILD_TESTING_E
-                            -DTESTING_USE_RTTTL
-lib_ignore                = ESP32_ping, ESP32WebServer, ServoESP32, ESP32HTTPUpdateServer, IRremoteESP8266, HeatpumpIR
+;[env:test_E_beta_ESP8266_16M_LittleFS]
+;extends                   = esp8266_16M
+;platform                  = ${testing_beta.platform}
+;platform_packages         = ${testing_beta.platform_packages}
+;build_flags               = ${testing_beta.build_flags}
+;                            ${esp8266_16M.build_flags} 
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22y
+;                            -DPLUGIN_BUILD_TESTING_E
+;                            -DTESTING_USE_RTTTL
+;lib_ignore                = ESP32_ping, ESP32WebServer, ServoESP32, ESP32HTTPUpdateServer, IRremoteESP8266, HeatpumpIR
 
 
 
@@ -783,8 +772,8 @@ build_flags               = ${regular_platform.build_flags}
 ; GPIO12 Red Led and Relay (0 = Off, 1 = On)
 ; GPIO13 Blue Led (0 = On, 1 = Off)
 [env:hard_SONOFF_POW_4M1M]
-extends                   = esp8266_4M1M, hard_esp82xx_3_0_0
-build_flags               = ${hard_esp82xx_3_0_0.build_flags}
+extends                   = esp8266_4M1M, hard_esp82xx
+build_flags               = ${hard_esp82xx.build_flags}
                             ${esp8266_4M1M.build_flags}
                             -D PLUGIN_SET_SONOFF_POW
 


### PR DESCRIPTION
Also the 2nd heap feature introduced in the `beta` builds isn't working as stable as I hoped. So disabled for now.