### PR TITLE
nicer header for "normal" tables

### DIFF
--- a/src/src/WebServer/DevicesPage.cpp
+++ b/src/src/WebServer/DevicesPage.cpp
@@ -1262,23 +1262,22 @@ void devicePage_show_task_values(taskIndex_t taskIndex, deviceIndex_t DeviceInde
 
   if (!Device[DeviceIndex].Custom && (valueCount > 0))
   {
-    addFormSubHeader(F("Values"));
     html_end_table();
     html_table_class_normal();
-
     // table header
-    addHtml(F("<TR><TH style='width:30px;' align='center'>#"));
-    html_table_header(F("Name"));
+    addFormHeader(F("Values"));
+
+    addHtml(F("<TR><TD><H3>#</H3></TD><TD><H3>Name</H3></TD>"));
 
     if (Device[DeviceIndex].FormulaOption)
     {
-      html_table_header(F("Formula"), F("EasyFormula"), 0);
+       addHtml(F("<TD><H3>Formula</H3></TD>"));
     }
 
     if (Device[DeviceIndex].configurableDecimals())
     {
-      html_table_header(F("Decimals"), 30);
-    }
+       addHtml(F("<TD style='width:30px;''><H3>Decimals</H3></TD>"));
+    } 
 
     // table body
     for (uint8_t varNr = 0; varNr < valueCount; varNr++)

--- a/src/src/WebServer/DevicesPage.cpp
+++ b/src/src/WebServer/DevicesPage.cpp
@@ -1276,7 +1276,7 @@ void devicePage_show_task_values(taskIndex_t taskIndex, deviceIndex_t DeviceInde
 
     if (Device[DeviceIndex].configurableDecimals())
     {
-       addHtml(F("<TD style='width:30px;''><H3>Decimals</H3></TD>"));
+       addHtml(F("<TD style='width:30px;'><H3>Decimals</H3></TD>"));
     } 
 
     // table body

--- a/src/src/WebServer/HTML_wrappers.cpp
+++ b/src/src/WebServer/HTML_wrappers.cpp
@@ -199,11 +199,12 @@ void html_table_header(const __FlashStringHelper * label, const String& helpButt
 void html_table_header(const String& label, const String& helpButton, const String& rtdHelpButton, int width) {
   addHtml(F("<TH"));
 
-  if (width > 0) {
+  if (width > 0 && width < 99999) {
     addHtml(F(" style='width:"));
     addHtmlInt(width);
     addHtml(F("px;'"));
   }
+  if (width == 99999){addHtml(F(" colspan='100%' style='text-align: left'"));}
   addHtml('>');
   addHtml(label);
 

--- a/src/src/WebServer/Markup.cpp
+++ b/src/src/WebServer/Markup.cpp
@@ -559,8 +559,7 @@ void addFormHeader(const __FlashStringHelper *header,
                    const __FlashStringHelper *rtdHelpButton)
 {
   html_TR();
-  html_table_header(header, helpButton, rtdHelpButton, 225);
-  html_table_header(F(""));
+  html_table_header(header, helpButton, rtdHelpButton, 99999);
 }
 
 /*


### PR DESCRIPTION
I changed the header since the name + symbols where only in the first column which looked like this:

<img width="560" alt="Bildschirmfoto 2022-04-03 um 14 44 13" src="https://user-images.githubusercontent.com/33860956/161428700-9e46758d-bdce-4513-bc27-3d9db91851ae.png">

Now it looks like this:
<img width="560" alt="Bildschirmfoto 2022-04-03 um 14 44 32" src="https://user-images.githubusercontent.com/33860956/161428707-bd6e675a-5e2d-47eb-b8a4-b5b281fa2934.png">


I also changed the tables for editing the devices because the value section was never quite right in my opinion.
before:
<img width="280" alt="Bildschirmfoto 2022-04-03 um 14 30 24" src="https://user-images.githubusercontent.com/33860956/161428596-43df6e19-bed0-40f9-ba51-8770c571c71b.png">

After:

<img width="278" alt="Bildschirmfoto 2022-04-03 um 14 29 01" src="https://user-images.githubusercontent.com/33860956/161428600-70f86d7c-ad9d-45ab-96ba-cae41743a4b6.png">

the approach is a bit questionable but i am still a beginner...

