### PR TITLE
[Eth] Fix loosing DNS info when disabling WiFi after ETH got IP

### DIFF
--- a/src/src/Commands/Common.cpp
+++ b/src/src/Commands/Common.cpp
@@ -60,7 +60,7 @@ const __FlashStringHelper * return_see_serial(struct EventStruct *event)
 }
 
 String Command_GetORSetIP(struct EventStruct *event,
-                          const String      & targetDescription,
+                          const __FlashStringHelper * targetDescription,
                           const char         *Line,
                           uint8_t               *IP,
                           const IPAddress   & dhcpIP,
@@ -98,7 +98,7 @@ String Command_GetORSetIP(struct EventStruct *event,
 }
 
 String Command_GetORSetString(struct EventStruct *event,
-                              const String      & targetDescription,
+                              const __FlashStringHelper * targetDescription,
                               const char         *Line,
                               char               *target,
                               size_t              len,
@@ -134,7 +134,7 @@ String Command_GetORSetString(struct EventStruct *event,
 }
 
 String Command_GetORSetBool(struct EventStruct *event,
-                            const String      & targetDescription,
+                            const __FlashStringHelper * targetDescription,
                             const char         *Line,
                             bool               *value,
                             int                 arg)
@@ -167,8 +167,9 @@ String Command_GetORSetBool(struct EventStruct *event,
   return return_command_success();
 }
 
-String Command_GetORSetUint8_t(struct EventStruct *event,
-                            const String      & targetDescription,
+String Command_GetORSetETH(struct EventStruct *event,
+                            const __FlashStringHelper * targetDescription,
+                            const __FlashStringHelper * valueToString,
                             const char         *Line,
                             uint8_t            *value,
                             int                 arg)
@@ -186,21 +187,33 @@ String Command_GetORSetUint8_t(struct EventStruct *event,
       if (validIntFromString(TmpStr1, tmp_int)) {
         *value = static_cast<uint8_t>(tmp_int);
       }
-      else if (strcmp_P(PSTR("WIFI"), TmpStr1.c_str()) == 0) { *value = 0; }
-      else if (strcmp_P(PSTR("ETHERNET"), TmpStr1.c_str()) == 0) { *value = 1; }
+
+      // FIXME TD-er: This should not be in a generic function, but rather pre-processed in the command itself
+
+
+      // WiFi/Eth mode
+      else if (TmpStr1.equals(F("wifi"))) { *value = 0; }
+      else if (TmpStr1.equals(F("ethernet"))) { *value = 1; }
+
+      // ETH clockMode
+      else if (TmpStr1.startsWith(F("ext"))) { *value = 0; }
+      else if (TmpStr1.indexOf(F("gpio0"))  != -1) { *value = 1; }
+      else if (TmpStr1.indexOf(F("gpio16")) != -1) { *value = 2; }
+      else if (TmpStr1.indexOf(F("gpio17")) != -1) { *value = 3; }
     }
   }
 
+  String result = targetDescription;
   if (hasArgument) {
-    String result = targetDescription;
     result += *value;
-    return return_result(event, result);
+  } else {
+    result += valueToString;
   }
-  return return_command_success();
+  return return_result(event, result);
 }
 
 String Command_GetORSetInt8_t(struct EventStruct *event,
-                            const String      & targetDescription,
+                            const __FlashStringHelper * targetDescription,
                             const char         *Line,
                             int8_t             *value,
                             int                 arg)

--- a/src/src/Commands/Common.h
+++ b/src/src/Commands/Common.h
@@ -18,14 +18,14 @@ String return_result(struct EventStruct *event,
 const __FlashStringHelper * return_see_serial(struct EventStruct *event);
 
 String Command_GetORSetIP(struct EventStruct *event,
-                          const String      & targetDescription,
+                          const __FlashStringHelper * targetDescription,
                           const char         *Line,
                           uint8_t               *IP,
                           const IPAddress&    dhcpIP,
                           int                 arg);
 
 String Command_GetORSetString(struct EventStruct *event,
-                              const String      & targetDescription,
+                              const __FlashStringHelper * targetDescription,
                               const char         *Line,
                               char               *target,
                               size_t              len,
@@ -33,19 +33,20 @@ String Command_GetORSetString(struct EventStruct *event,
                               );
 
 String Command_GetORSetBool(struct EventStruct *event,
-                            const String      & targetDescription,
+                            const __FlashStringHelper * targetDescription,
                             const char         *Line,
                             bool               *value,
                             int                 arg);
 
-String Command_GetORSetUint8_t(struct EventStruct *event,
-                            const String      & targetDescription,
+String Command_GetORSetETH(struct EventStruct *event,
+                            const __FlashStringHelper * targetDescription,
+                            const __FlashStringHelper * valueToString,
                             const char         *Line,
                             uint8_t            *value,
                             int                 arg);
 
 String Command_GetORSetInt8_t(struct EventStruct *event,
-                            const String      & targetDescription,
+                            const __FlashStringHelper * targetDescription,
                             const char         *Line,
                             int8_t             *value,
                             int                 arg);

--- a/src/src/Commands/InternalCommands.cpp
+++ b/src/src/Commands/InternalCommands.cpp
@@ -299,6 +299,7 @@ bool executeInternalCommand(command_case_data & data)
       COMMAND_CASE_R(  "ethgateway", Command_ETH_Gateway,    1); // Network Command
       COMMAND_CASE_R(   "ethsubnet", Command_ETH_Subnet,     1); // Network Command  
       COMMAND_CASE_R(      "ethdns", Command_ETH_DNS,        1); // Network Command
+      COMMAND_CASE_A("ethdisconnect", Command_ETH_Disconnect, 0); // Network Command
       COMMAND_CASE_R( "ethwifimode", Command_ETH_Wifi_Mode,  1); // Network Command
     #endif // HAS_ETHERNET
       COMMAND_CASE_R("erasesdkwifi", Command_WiFi_Erase,     0); // WiFi.h

--- a/src/src/Commands/Networks.cpp
+++ b/src/src/Commands/Networks.cpp
@@ -2,6 +2,9 @@
 
 #include "../../ESPEasy_common.h"
 #include "../Commands/Common.h"
+#include "../ESPEasyCore/ESPEasyNetwork.h"
+#include "../ESPEasyCore/ESPEasyEth.h"
+#include "../Globals/NetworkState.h"
 #include "../Globals/Settings.h"
 #include "../WebServer/AccessControl.h"
 
@@ -25,22 +28,22 @@ String Command_AccessInfo_Clear (struct EventStruct *event, const char* Line)
 
 String Command_DNS (struct EventStruct *event, const char* Line)
 {
-  return Command_GetORSetIP(event, F("DNS:"), Line, Settings.DNS,WiFi.dnsIP(0),1);
+  return Command_GetORSetIP(event, F("DNS:"), Line, Settings.DNS, NetworkDnsIP(0), 1);
 }
 
 String Command_Gateway (struct EventStruct *event, const char* Line)
 {
-  return Command_GetORSetIP(event, F("Gateway:"), Line, Settings.Gateway,WiFi.gatewayIP(),1);
+  return Command_GetORSetIP(event, F("Gateway:"), Line, Settings.Gateway, NetworkGatewayIP(),1);
 }
 
 String Command_IP (struct EventStruct *event, const char* Line)
 {
-  return Command_GetORSetIP(event, F("IP:"), Line, Settings.IP,WiFi.localIP(),1);
+  return Command_GetORSetIP(event, F("IP:"), Line, Settings.IP, NetworkLocalIP(),1);
 }
 
 String Command_Subnet (struct EventStruct *event, const char* Line)
 {
-  return Command_GetORSetIP(event, F("Subnet:"), Line, Settings.Subnet,WiFi.subnetMask(),1);
+  return Command_GetORSetIP(event, F("Subnet:"), Line, Settings.Subnet, NetworkSubnetMask(), 1);
 }
 
 #ifdef HAS_ETHERNET
@@ -71,7 +74,12 @@ String Command_ETH_Phy_Type (struct EventStruct *event, const char* Line)
 
 String Command_ETH_Clock_Mode (struct EventStruct *event, const char* Line)
 {
-  return Command_GetORSetUint8_t(event, F("ETH_Clock_Mode:"), Line, reinterpret_cast<uint8_t*>(&Settings.ETH_Clock_Mode),1);
+  return Command_GetORSetETH(event, 
+                             F("ETH_Clock_Mode:"), 
+                             toString(Settings.ETH_Clock_Mode),
+                             Line, 
+                             reinterpret_cast<uint8_t*>(&Settings.ETH_Clock_Mode),
+                             1);
 }
 
 String Command_ETH_IP (struct EventStruct *event, const char* Line)
@@ -96,7 +104,34 @@ String Command_ETH_DNS (struct EventStruct *event, const char* Line)
 
 String Command_ETH_Wifi_Mode (struct EventStruct *event, const char* Line)
 {
-  return Command_GetORSetUint8_t(event, F("NetworkMedium:"), Line, reinterpret_cast<uint8_t*>(&Settings.NetworkMedium),1);
+  const NetworkMedium_t orig_medium = Settings.NetworkMedium;
+  const String result = Command_GetORSetETH(event, 
+                             F("NetworkMedium:"), 
+                             toString(active_network_medium),
+                             Line, 
+                             reinterpret_cast<uint8_t*>(&Settings.NetworkMedium), 
+                             1);
+  if (orig_medium != Settings.NetworkMedium) {
+    if (!isValid(Settings.NetworkMedium)) {
+      Settings.NetworkMedium = orig_medium;
+      return return_command_failed();
+    }
+    setNetworkMedium(Settings.NetworkMedium);
+  }
+  
+  return result;
+}
+
+String Command_ETH_Disconnect (struct EventStruct *event, const char* Line)
+{
+
+  ethPower(0);
+  delay(400);
+//  ethPower(1);
+  setNetworkMedium(NetworkMedium_t::Ethernet);
+  ETHConnectRelaxed();
+
+  return return_command_success();
 }
 
 #endif

--- a/src/src/Commands/Networks.h
+++ b/src/src/Commands/Networks.h
@@ -21,5 +21,6 @@ String Command_ETH_Gateway (struct EventStruct *event, const char* Line);
 String Command_ETH_Subnet (struct EventStruct *event, const char* Line);
 String Command_ETH_DNS (struct EventStruct *event, const char* Line);
 String Command_ETH_Wifi_Mode (struct EventStruct *event, const char* Line);
+String Command_ETH_Disconnect (struct EventStruct *event, const char* Line);
 
 #endif // COMMAND_NETWORKS_H

--- a/src/src/DataStructs/EthernetEventData.cpp
+++ b/src/src/DataStructs/EthernetEventData.cpp
@@ -50,6 +50,7 @@ void EthernetEventData_t::markEthBegin() {
   last_eth_connect_attempt_moment.setNow();
   eth_considered_stable = false;
   ethConnectInProgress  = true;
+  eth_dhcp_retries = 0;
   ++eth_connect_attempt;
 }
 

--- a/src/src/DataStructs/EthernetEventData.cpp
+++ b/src/src/DataStructs/EthernetEventData.cpp
@@ -50,7 +50,6 @@ void EthernetEventData_t::markEthBegin() {
   last_eth_connect_attempt_moment.setNow();
   eth_considered_stable = false;
   ethConnectInProgress  = true;
-  eth_dhcp_retries = 0;
   ++eth_connect_attempt;
 }
 

--- a/src/src/DataStructs/EthernetEventData.h
+++ b/src/src/DataStructs/EthernetEventData.h
@@ -50,6 +50,7 @@ struct EthernetEventData_t {
   unsigned int  eth_connect_attempt   = 0;
   bool          eth_considered_stable = false;
   int           eth_reconnects        = -1; // First connection attempt is not a reconnect.
+  unsigned int  eth_dhcp_retries      = 0;
 
   LongTermTimer           lastConnectMoment;
   LongTermTimer           lastDisconnectMoment;
@@ -57,6 +58,8 @@ struct EthernetEventData_t {
   LongTermTimer           lastGetIPmoment;
   LongTermTimer::Duration lastConnectedDuration_us = 0ll;
 
+  IPAddress dns0_cache;
+  IPAddress dns1_cache;
 
   // Semaphore like bools for processing data gathered from Eth events.
   bool processedConnect          = true;

--- a/src/src/DataStructs/EthernetEventData.h
+++ b/src/src/DataStructs/EthernetEventData.h
@@ -50,7 +50,6 @@ struct EthernetEventData_t {
   unsigned int  eth_connect_attempt   = 0;
   bool          eth_considered_stable = false;
   int           eth_reconnects        = -1; // First connection attempt is not a reconnect.
-  unsigned int  eth_dhcp_retries      = 0;
 
   LongTermTimer           lastConnectMoment;
   LongTermTimer           lastDisconnectMoment;

--- a/src/src/DataStructs/WiFiEventData.h
+++ b/src/src/DataStructs/WiFiEventData.h
@@ -92,6 +92,7 @@ struct WiFiEventData_t {
   MAC_address             lastMacConnectedAPmode;
   MAC_address             lastMacDisconnectedAPmode;
 
+
   // processDisconnect() may clear all WiFi settings, resulting in clearing processedDisconnect
   // This can cause recursion, so a semaphore is needed here.
   LongTermTimer           processingDisconnect;

--- a/src/src/ESPEasyCore/ESPEasyEth.cpp
+++ b/src/src/ESPEasyCore/ESPEasyEth.cpp
@@ -4,6 +4,7 @@
 
 #include "../CustomBuild/ESPEasyLimits.h"
 #include "../ESPEasyCore/ESPEasyNetwork.h"
+#include "../ESPEasyCore/ESPEasyWifi.h"
 #include "../ESPEasyCore/ESPEasy_Log.h"
 #include "../ESPEasyCore/ESPEasyGPIO.h"
 #include "../Globals/ESPEasyWiFiEvent.h"
@@ -12,6 +13,7 @@
 #include "../Helpers/StringConverter.h"
 
 #include <ETH.h>
+#include <lwip/dns.h>
 #if ESP_IDF_VERSION_MAJOR > 3
  #include <esp_eth_phy.h>
 #else
@@ -47,6 +49,32 @@ void ethSetupStaticIPconfig() {
     addLogMove(LOG_LEVEL_INFO, log);
   }
   ETH.config(ip, gw, subnet, dns);
+}
+
+void ethSetDNS(const IPAddress dns0, const IPAddress dns1) 
+{
+  ip_addr_t d;
+  d.type = IPADDR_TYPE_V4;
+
+  if(dns0 != (uint32_t)0x00000000 && dns0 != INADDR_NONE) {
+    // Set DNS0-Server
+    d.u_addr.ip4.addr = static_cast<uint32_t>(dns0);
+    dns_setserver(0, &d);
+  }
+
+  if(dns1 != (uint32_t)0x00000000 && dns1 != INADDR_NONE) {
+    // Set DNS1-Server
+    d.u_addr.ip4.addr = static_cast<uint32_t>(dns1);
+    dns_setserver(1, &d);
+  }
+
+  if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+    String log = F("ETH IP   : Set DNS: ");
+    log += formatIP(dns0);
+    log += '/';
+    log += formatIP(dns1);
+    addLogMove(LOG_LEVEL_INFO, log);
+  }
 }
 
 bool ethCheckSettings() {
@@ -116,11 +144,19 @@ bool ETHConnectRelaxed() {
     EthEventData.ethInitSuccess = false;
     return false;
   }
-  if (Settings.ETH_Pin_power >= 0) {
-    GPIO_Write(PLUGIN_GPIO, Settings.ETH_Pin_power, 1, PIN_MODE_OUTPUT);
-    delay(100); // Give the Eth module some time to power on.
-  }
+  // Re-register event listener
+  #if defined(ESP32)
+  removeWiFiEventHandler();
+  #endif
+
+  ethPower(true);
   EthEventData.markEthBegin();
+
+  // Re-register event listener
+  #if defined(ESP32)
+  registerWiFiEventHandler();
+  #endif
+
   if (!EthEventData.ethInitSuccess) {
     EthEventData.ethInitSuccess = ETH.begin( 
       Settings.ETH_Phy_Addr,
@@ -131,13 +167,47 @@ bool ETHConnectRelaxed() {
       (eth_clock_mode_t)Settings.ETH_Clock_Mode);
   }
   if (EthEventData.ethInitSuccess) {
-    EthEventData.ethConnectAttemptNeeded = false;
+    // FIXME TD-er: Not sure if this is correctly set to false
+    //EthEventData.ethConnectAttemptNeeded = false;
+
     if (EthLinkUp()) {
       // We might miss the connected event, since we are already connected.
       EthEventData.markConnected();
     }
   }
   return EthEventData.ethInitSuccess;
+}
+
+void ethPower(bool enable) {
+  if (Settings.ETH_Pin_power != -1) {
+    if (GPIO_Internal_Read(Settings.ETH_Pin_power) == enable) {
+      // Already the desired state
+      return;
+    }
+    EthEventData.ethInitSuccess = false;
+    EthEventData.clearAll();
+    if (!enable) {
+      #ifdef ESP_IDF_VERSION_MAJOR
+      // FIXME TD-er: See: https://github.com/espressif/arduino-esp32/issues/6105
+      // Need to store the last link state, as it will be cleared after destructing the object.
+      EthEventData.setEthDisconnected();
+      if (ETH.linkUp()) {
+        EthEventData.setEthConnected();
+      }
+      #endif
+      ETH = ETHClass();
+    }
+
+    GPIO_Write(1, Settings.ETH_Pin_power, enable ? 1 : 0);
+    if (!enable) {
+      if (Settings.ETH_Clock_Mode == EthClockMode_t::Ext_crystal_osc) {
+        delay(600); // Give some time to discharge any capacitors
+        // Delay is needed to make sure no clock signal remains present which may cause the ESP to boot into flash mode.
+      }
+    } else {
+      delay(400); // LAN chip needs to initialize before calling Eth.begin()
+    }
+  }
 }
 
 bool ETHConnected() {

--- a/src/src/ESPEasyCore/ESPEasyEth.h
+++ b/src/src/ESPEasyCore/ESPEasyEth.h
@@ -9,11 +9,13 @@
 
 bool     ethUseStaticIP();
 void     ethSetupStaticIPconfig();
+void     ethSetDNS(const IPAddress dns0, const IPAddress dns1);
 bool     ethCheckSettings();
 bool     ethPrepare();
 void     ethPrintSettings();
 bool     ETHConnectRelaxed();
 bool     ETHConnected();
+void     ethPower(bool enable);
 MAC_address ETHMacAddress();
 
 #endif // ifdef HAS_ETHERNET

--- a/src/src/ESPEasyCore/ESPEasyWifi.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi.cpp
@@ -555,9 +555,7 @@ void removeWiFiEventHandler()
 
 void registerWiFiEventHandler()
 {
-#if defined(ESP32)
   wm_event_id = WiFi.onEvent(WiFiEvent);
-#endif
 }
 #endif
 

--- a/src/src/ESPEasyCore/ESPEasyWifi.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi.cpp
@@ -547,6 +547,21 @@ void resetWiFi() {
   initWiFi();
 }
 
+#ifdef ESP32
+void removeWiFiEventHandler()
+{
+  WiFi.removeEvent(wm_event_id);
+}
+
+void registerWiFiEventHandler()
+{
+#if defined(ESP32)
+  wm_event_id = WiFi.onEvent(WiFiEvent);
+#endif
+}
+#endif
+
+
 void initWiFi()
 {
 #ifdef ESP8266

--- a/src/src/ESPEasyCore/ESPEasyWifi.h
+++ b/src/src/ESPEasyCore/ESPEasyWifi.h
@@ -107,6 +107,12 @@ bool prepareWiFi();
 bool checkAndResetWiFi();
 void resetWiFi();
 void initWiFi();
+
+#ifdef ESP32
+void removeWiFiEventHandler();
+void registerWiFiEventHandler();
+#endif
+
 #ifdef ESP8266
 void SetWiFiTXpower();
 void SetWiFiTXpower(float dBm); // 0-20.5

--- a/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
@@ -6,6 +6,7 @@
 
 #include "../ESPEasyCore/ESPEasy_Log.h"
 #include "../ESPEasyCore/ESPEasyNetwork.h"
+#include "../ESPEasyCore/ESPEasyEth.h"
 #include "../ESPEasyCore/ESPEasyWifi.h"
 #include "../ESPEasyCore/ESPEasyWiFiEvent.h"
 #include "../Globals/ESPEasyWiFiEvent.h"
@@ -81,7 +82,6 @@ void handle_unprocessedNetworkEvents()
     }
     EthEventData.setEthServicesInitialized();
   }
-
 #endif
   if (WiFiEventData.unprocessedWifiEvents()) {
     // Process disconnect events before connect events.
@@ -203,6 +203,21 @@ void handle_unprocessedNetworkEvents()
       }
     }
   }
+#ifdef HAS_ETHERNET
+  // Check if DNS is still valid, as this may have been reset by the WiFi module turned off.
+  if (EthEventData.EthServicesInitialized() && 
+      active_network_medium == NetworkMedium_t::Ethernet &&
+      EthEventData.ethInitSuccess) {
+    const IPAddress dns0     = NetworkDnsIP(0);
+    const IPAddress dns1     = NetworkDnsIP(1);
+
+    if (!dns0 && !dns1) {
+      addLog(LOG_LEVEL_ERROR, F("ETH  : DNS server was cleared, use cached DNS IP"));
+      ethSetDNS(EthEventData.dns0_cache, EthEventData.dns1_cache);
+    }
+  }
+#endif
+
   updateUDPport();
 }
 
@@ -567,13 +582,29 @@ void processEthernetDisconnected() {
 }
 
 void processEthernetGotIP() {
-  if (EthEventData.processedGotIP) {
+  if (EthEventData.processedGotIP || !EthEventData.ethInitSuccess) {
     return;
   }
-  IPAddress ip = NetworkLocalIP();
+  const IPAddress ip       = NetworkLocalIP();
+
+  if (!ip) { 
+    return;
+  }
+
   const IPAddress gw       = NetworkGatewayIP();
   const IPAddress subnet   = NetworkSubnetMask();
+
+  IPAddress dns0     = NetworkDnsIP(0);
+  IPAddress dns1     = NetworkDnsIP(1);
   const LongTermTimer::Duration dhcp_duration = EthEventData.lastConnectMoment.timeDiff(EthEventData.lastGetIPmoment);
+
+  if (!dns0 && !dns1) {
+    addLog(LOG_LEVEL_ERROR, F("ETH  : No DNS server received via DHCP, use cached DNS IP"));
+    ethSetDNS(EthEventData.dns0_cache, EthEventData.dns1_cache);
+  } else {
+    EthEventData.dns0_cache = dns0;
+    EthEventData.dns1_cache = dns1;
+  }
 
   if (loglevelActiveFor(LOG_LEVEL_INFO))
   {
@@ -588,13 +619,18 @@ void processEthernetGotIP() {
         log += F("DHCP");
       }
       log += F(" IP: ");
-      log += NetworkLocalIP().toString();
+      log += ip.toString();
       log += ' ';
       log += wrap_braces(NetworkGetHostname());
       log += F(" GW: ");
-      log += NetworkGatewayIP().toString();
+      log += gw.toString();
       log += F(" SN: ");
-      log += NetworkSubnetMask().toString();
+      log += subnet.toString();
+      log += F(" DNS: ");
+      log += dns0.toString();
+      log += '/';
+      log += dns1.toString();
+
       if (EthLinkUp()) {
         if (EthFullDuplex()) {
           log += F(" FULL_DUPLEX");

--- a/src/src/Helpers/StringProvider.cpp
+++ b/src/src/Helpers/StringProvider.cpp
@@ -330,10 +330,22 @@ String getValue(LabelType::Enum label) {
     case LabelType::CHANNEL:                return String(WiFi.channel());
     case LabelType::ENCRYPTION_TYPE_STA:    return // WiFi_AP_Candidates.getCurrent().encryption_type();
                                                    WiFi_encryptionType(WiFiEventData.auth_mode);
-    case LabelType::CONNECTED:              return format_msec_duration(WiFiEventData.lastConnectMoment.millisPassedSince());
+    case LabelType::CONNECTED:
+      #ifdef HAS_ETHERNET
+      if(active_network_medium == NetworkMedium_t::Ethernet) {
+        return format_msec_duration(EthEventData.lastConnectMoment.millisPassedSince());
+      }
+      #endif
+      return format_msec_duration(WiFiEventData.lastConnectMoment.millisPassedSince());
 
     // Use only the nr of seconds to fit it in an int32, plus append '000' to have msec format again.
-    case LabelType::CONNECTED_MSEC:         return String(static_cast<int32_t>(WiFiEventData.lastConnectMoment.millisPassedSince() / 1000ll)) + F("000"); 
+    case LabelType::CONNECTED_MSEC:         
+      #ifdef HAS_ETHERNET
+      if(active_network_medium == NetworkMedium_t::Ethernet) {
+        return String(static_cast<int32_t>(EthEventData.lastConnectMoment.millisPassedSince() / 1000ll)) + F("000"); 
+      }
+      #endif
+      return String(static_cast<int32_t>(WiFiEventData.lastConnectMoment.millisPassedSince() / 1000ll)) + F("000"); 
     case LabelType::LAST_DISCONNECT_REASON: return String(WiFiEventData.lastDisconnectReason);
     case LabelType::LAST_DISC_REASON_STR:   return getLastDisconnectReason();
     case LabelType::NUMBER_RECONNECTS:      return String(WiFiEventData.wifi_reconnects);


### PR DESCRIPTION
Apparently the DNS config gets erased when WiFi is turned off.
Even if you turn off WiFi after the Ethernet module had processed its got IP event.

Improved reliability on Ethernet reconnect and power cycle of the Ethernet module.

Also fixed handling of some ethernet related commands.