### PR TITLE
[MQTT Events] Allow receiving events + eventvalues via MQTT (C005)

### DIFF
--- a/docs/source/Controller/C005.rst
+++ b/docs/source/Controller/C005.rst
@@ -58,6 +58,31 @@ These topics used to receive commands do rely on the topic wildcard ``/#`` at th
 This wildcard is used in the default subscription topic for this MQTT controller.
 If the format of the subscription topic is changed by the user, make sure to keep this wildcard in place for the command handling to work.
 
+.. note:: The value of N in ``cmd_argN`` can also be 0. 
+          The sent message is then the command, where the values in the topic are parameters.
+
+Sending Events
+--------------
+
+Added: 2022/05/02
+
+It can be useful to send events with 0 or more event values in the topic and the message as one of the event values.
+For example with a message like these sent as a retained message, one can let the broker send out a message to the ESPEasy node as soon as it connects.
+
+* Topic: ``ESP_Easy/Bathroom_pir_env/cmd_arg2/event/myevent/2/3``
+* Message: ``1``
+* Full event:  ``myevent=1,2,3``
+
+Since a MQTT topic cannot contain a ``#`` sign in topics (at least, you shouldn't use it), the event sent via MQTT cannot contain a ``#`` character.
+
+Please note that the nr in ``cmd_argN`` is the argument of the command, not the event.
+
+For example sending an event with the event name as message and the values part of the topic:
+
+* Topic: ``ESP_Easy/Bathroom_pir_env/cmd_arg1/event/1/2/3``
+* Message: ``myevent``
+* Full event:  ``myevent=1,2,3``
+
 
 
 

--- a/src/_C005.cpp
+++ b/src/_C005.cpp
@@ -228,7 +228,22 @@ bool C005_parse_command(struct EventStruct *event) {
 
     if ((command.equals(F("event"))) || (command.equals(F("asyncevent")))) {
       if (Settings.UseRules) {
-        eventQueue.addMove(parseStringToEnd(cmd, 2));
+        // Need to sanitize the event a bit to allow for sending event values as MQTT messages.
+        // For example:
+        // Publish topic: espeasy_node/cmd_arg2/event/myevent/2
+        // Message: 1
+        // Actual event:  myevent=1,2
+        cmd = parseStringToEndKeepCase(cmd, 2);
+        String eventName = parseStringKeepCase(cmd, 1);
+        const int equal_pos = eventName.indexOf('=');
+        if (equal_pos == -1) {
+          eventName += '=';
+        }
+        // Need to reconstruct the event to get rid of calls like these:
+        // myevent=,1,2
+        cmd = eventName + parseStringToEndKeepCase(cmd, 2);
+        
+        eventQueue.addMove(std::move(cmd));
       }
     } else {
       ExecuteCommand_all(EventValueSource::Enum::VALUE_SOURCE_MQTT, cmd.c_str());


### PR DESCRIPTION
Ideal to send some event as retained message to a MQTT broker.
This way it is possible to control a node which is only online for a very short moment as those messages will be delivered as soon as the unit connects to the broker.