### PR TITLE
[P031] Fix timing for SHT1X

### DIFF
--- a/src/_P031_SHT1X.ino
+++ b/src/_P031_SHT1X.ino
@@ -140,10 +140,10 @@ public:
   void sendCommand(const uint8_t cmd)
   {
     sendCommandTime = millis();
-    pinMode(_dataPin, OUTPUT);
-
+    
     // Transmission Start sequence
     digitalWrite(_dataPin, HIGH);
+    pinMode(_dataPin, OUTPUT);
     digitalWrite(_clockPin, HIGH);
     P031_DELAY_LONGER_CABLES
     digitalWrite(_dataPin, LOW);
@@ -159,10 +159,11 @@ public:
     p031_shiftOut(_dataPin, _clockPin, MSBFIRST, cmd);
 
     // Wait for ACK
+    pinMode(_dataPin, input_mode);
     bool ackerror = false;
     digitalWrite(_clockPin, HIGH);
     P031_DELAY_LONGER_CABLES
-    pinMode(_dataPin, input_mode);
+
     if (digitalRead(_dataPin) != LOW) ackerror = true;
     digitalWrite(_clockPin, LOW);
     P031_DELAY_LONGER_CABLES


### PR DESCRIPTION
Hello.

This fixes some timing problems I'm having with this SHT1X sensor: https://www.adafruit.com/product/1298
I'm using NodeMCU v3.

Before this patch I was getting: **SHT1X : Sensor did not ACK command**

After applying it everything runs as expected.

![image](https://user-images.githubusercontent.com/72836/166444466-3221ce80-51a6-4994-8590-ffb01b0d135e.png)

Cheers,
Mateusz