### PR TITLE
[Build] Include Display plugin-set in ESP32 Display build

### DIFF
--- a/platformio_esp32_envs.ini
+++ b/platformio_esp32_envs.ini
@@ -187,6 +187,7 @@ board                     = esp32_4M
 lib_deps                  = ${esp32_common.lib_deps}, ServoESP32
 build_flags               = ${esp32_common.build_flags}  
                             -DFEATURE_ARDUINO_OTA
+                            -DPLUGIN_DISPLAY_COLLECTION
 
 
 [env:custom_ESP32_4M316k_ETH]


### PR DESCRIPTION
The flag `-D PLUGIN_DISPLAY_COLLECTION` seems to have been accidentally dropped from the `DISPLAY` configuration when restructuring the ESP32 build configurations.