### PR TITLE
Access extra GPS values + document setLevel command

### DIFF
--- a/docs/source/Plugin/P000_commands.repl
+++ b/docs/source/Plugin/P000_commands.repl
@@ -50,7 +50,6 @@
     See also ``AccessInfo``.
 
     ``ClearAccessBlock``"
-    
     "
     ClearPassword","
     :red:`Internal`","
@@ -68,9 +67,16 @@
     "
     Config","
     :red:`Internal`","
-    Remote config of a task.    TODO: Describe command syntax.
+    Remote config of a task. 
+    This allows for actually change the config as stored in the settings for a task.
 
-    ``Config``"
+    The syntax is like ``config,task,<taskname>,<actual config command>``
+
+    Right now only the ``Regulator - Level Control`` plugin (P021) supports this via its ``SetLevel`` command.
+
+    Later other config options might be added, like ``SetInterval`` or other generic options.
+
+    Example for the task named 'VoltageLevel': ``config,task,VoltageLevel,SetLevel,22``"
     "
     ControllerDisable","
     :red:`Internal`","

--- a/docs/source/Plugin/P053.rst
+++ b/docs/source/Plugin/P053.rst
@@ -97,6 +97,8 @@ In some setups this may also make the counted values appear lower, since the sen
 When the smaller particles all stick together thus no small particles will be observed by the sensor, the reading may be (much) lower than it actually should be.
 Try to have the sensor running in environments with relatively low humidity (less than 80%).
 
+A very good video describing hazards of dust particles: `Sabine Hossenfelder - How bad is Diesel? <https://www.youtube.com/watch?v=apbS205t53w>`_
+
 Air Quality Index
 """""""""""""""""
 
@@ -108,6 +110,8 @@ For example the UK guidelines of average daily exposure on Wikipedia:
 Source: `Wikipedia - Air Quality Index <https://en.wikipedia.org/wiki/Air_quality_index#United_Kingdom>`_
 
 Such an Air Quality Index can then be used to indicate the maximum exposure (in days per year) which can be considered safe.
+
+A website to check your local air quality: `IQAir <https://www.iqair.com/>`
 
 Temperature/Humidity
 ^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/Plugin/P082.rst
+++ b/docs/source/Plugin/P082.rst
@@ -157,6 +157,7 @@ Each of the 4 task values can be set to a specific measurement value.
 * Distance (ODO) - Trip distance in meters
 * Distance from Reference Point - See the Reference Point setting.
 
+
 Most units of measure are clear, but some may need a bit more explanation.
 
 **HDOP**
@@ -188,6 +189,30 @@ For a 3D position fix, at least 4 satellites must be tracked.
 
 If just the bare minimum of satellites is being tracked, the GPS receiver may loose its fix quite often.
 
+Access To All Measurement Values
+""""""""""""""""""""""""""""""""
+
+Added: 2022/05/13
+
+All mentioned measurement values are processed from the GPS.
+So even though not all values will be made available as a task value (and thus sent to connected controllers), the other values can still be referred to via the ``[taskname#valuename]`` notation.
+
+To access via this notation, one must use these virtual task value names:
+
+* Longitude: ``long``
+* Latitude:  ``lat``
+* Altitude:  ``alt``
+* Speed (m/s): ``spd``
+* Satellites Visible: ``sat_vis``
+* Satellites Tracked: ``sat_tr``
+* HDOP: ``hdop``
+* Fix Quality: ``fix_qual``
+* Max SNR in dBHz: ``snr_max``
+* Checksum Fail:   ``chksum_fail``
+* Distance (ODO):  ``dist``
+* Distance from Reference Point: ``dist_ref``
+
+For example, to access the Longitude on a task named ``gps``, one can use ``[gps#long]`` regardless whether it is set as an output task value.
 
 
 Distance Update Interval

--- a/src/_P021_Level.ino
+++ b/src/_P021_Level.ino
@@ -124,7 +124,7 @@ boolean Plugin_021(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
-    case PLUGIN_GET_CONFIG:
+    case PLUGIN_GET_CONFIG_VALUE:
     {
       String command = parseString(string, 1);
 

--- a/src/_P082_GPS.ino
+++ b/src/_P082_GPS.ino
@@ -150,6 +150,32 @@ boolean Plugin_082(uint8_t function, struct EventStruct *event, String& string) 
       break;
     }
 
+    case PLUGIN_GET_CONFIG_VALUE:
+    {
+      P082_data_struct *P082_data =
+        static_cast<P082_data_struct *>(getPluginTaskData(event->TaskIndex));
+
+      if ((nullptr != P082_data) && P082_data->isInitialized()) {
+        const P082_query query = Plugin_082_from_valuename(string);
+        if (query != P082_query::P082_NR_OUTPUT_OPTIONS) {
+          const float value = P082_data->_cache[static_cast<uint8_t>(query)];
+          int nrDecimals = 2;
+          if (query == P082_query::P082_QUERY_LONG || query == P082_query::P082_QUERY_LAT) {
+            nrDecimals = 6;
+          } else if (query == P082_query::P082_QUERY_SATVIS || 
+                     query == P082_query::P082_QUERY_SATUSE || 
+                     query == P082_query::P082_QUERY_FIXQ || 
+                     query == P082_query::P082_QUERY_CHKSUM_FAIL) {
+            nrDecimals = 0;
+          }
+
+          string = toString(value, nrDecimals);
+          success = true;
+        }
+      }
+      break;
+    }
+
     case PLUGIN_WEBFORM_SHOW_CONFIG:
     {
       string += serialHelper_getSerialTypeLabel(event);

--- a/src/src/DataStructs/TimingStats.cpp
+++ b/src/src/DataStructs/TimingStats.cpp
@@ -92,7 +92,7 @@ const __FlashStringHelper * getPluginFunctionName(int function) {
     case PLUGIN_SET_CONFIG:            return F("SET_CONFIG");
     case PLUGIN_GET_DEVICEGPIONAMES:   return F("GET_DEVICEGPIONAMES");
     case PLUGIN_EXIT:                  return F("EXIT");
-    case PLUGIN_GET_CONFIG:            return F("GET_CONFIG");
+    case PLUGIN_GET_CONFIG_VALUE:      return F("GET_CONFIG");
     case PLUGIN_UNCONDITIONAL_POLL:    return F("UNCONDITIONAL_POLL");
     case PLUGIN_REQUEST:               return F("REQUEST");
   }
@@ -126,7 +126,7 @@ bool mustLogFunction(int function) {
     case PLUGIN_SET_CONFIG:            return false;
     case PLUGIN_GET_DEVICEGPIONAMES:   return false;
     case PLUGIN_EXIT:                  return false;
-    case PLUGIN_GET_CONFIG:            return false;
+    case PLUGIN_GET_CONFIG_VALUE:      return false;
     case PLUGIN_UNCONDITIONAL_POLL:    return false;
     case PLUGIN_REQUEST:               return true;
   }

--- a/src/src/DataTypes/ESPEasy_plugin_functions.h
+++ b/src/src/DataTypes/ESPEasy_plugin_functions.h
@@ -27,12 +27,12 @@
 #define PLUGIN_CLOCK_IN                    20 // Called every new minute
 #define PLUGIN_TIMER_IN                    21 // Called with a previously defined event at a specific time, set via setPluginTaskTimer
 #define PLUGIN_FIFTY_PER_SECOND            22 // Called 50 times per second
-#define PLUGIN_SET_CONFIG                  23 // Counterpart of PLUGIN_GET_CONFIG to allow to set a config via a command.
+#define PLUGIN_SET_CONFIG                  23 // Counterpart of PLUGIN_GET_CONFIG_VALUE to allow to set a config via a command.
 #define PLUGIN_GET_DEVICEGPIONAMES         24 // Allow for specific formatting of the label for standard pin configuration (e.g. "GPIO <- TX")
 #define PLUGIN_EXIT                        25 // Called when a task no longer is enabled (or deleted)
-#define PLUGIN_GET_CONFIG                  26 // Similar to PLUGIN_WRITE, but meant to fetch some information. Must return success = true when it can handle the command.
+#define PLUGIN_GET_CONFIG_VALUE            26 // Similar to PLUGIN_WRITE, but meant to fetch some information. Must return success = true when it can handle the command.  Can also be used to access extra unused task values.
 #define PLUGIN_UNCONDITIONAL_POLL          27 // Used to be called 10x per sec, but no longer used as GPIO related plugins now use a different technique.
-#define PLUGIN_REQUEST                     28 // Specific command to fetch a state (FIXME TD-er: Seems very similar to PLUGIN_GET_CONFIG)
+#define PLUGIN_REQUEST                     28 // Specific command to fetch a state (FIXME TD-er: Seems very similar to PLUGIN_GET_CONFIG_VALUE)
 #define PLUGIN_TIME_CHANGE                 29 // Called when system time is set (e.g. via NTP)
 #define PLUGIN_MONITOR                     30 // Replaces PLUGIN_UNCONDITIONAL_POLL
 #define PLUGIN_SET_DEFAULTS                31 // Called when assigning a plugin to a task, to set some default config.

--- a/src/src/Globals/Plugins.cpp
+++ b/src/src/Globals/Plugins.cpp
@@ -615,7 +615,7 @@ bool PluginCall(uint8_t Function, struct EventStruct *event, String& str)
     }
 
     // Call to specific task not interacting with hardware
-    case PLUGIN_GET_CONFIG:
+    case PLUGIN_GET_CONFIG_VALUE:
     case PLUGIN_GET_DEVICEVALUENAMES:
     case PLUGIN_GET_DEVICEVALUECOUNT:
     case PLUGIN_GET_DEVICEVTYPE:

--- a/src/src/Helpers/Misc.cpp
+++ b/src/src/Helpers/Misc.cpp
@@ -30,8 +30,7 @@ bool remoteConfig(struct EventStruct *event, const String& string)
 
   if (command == F("config"))
   {
-    success = true;
-
+    // Command: "config,task,<taskname>,<actual Set Config command>"
     if (parseString(string, 2) == F("task"))
     {
       String configTaskName = parseStringKeepCase(string, 3);
@@ -41,7 +40,7 @@ bool remoteConfig(struct EventStruct *event, const String& string)
       String configCommand = parseStringToEndKeepCase(string, 4);
 
       if ((configTaskName.isEmpty()) || (configCommand.isEmpty())) {
-        return success; // TD-er: Should this be return false?
+        return success;
       }
       taskIndex_t index = findTaskIndexByName(configTaskName);
 
@@ -50,6 +49,8 @@ bool remoteConfig(struct EventStruct *event, const String& string)
         event->setTaskIndex(index);
         success = PluginCall(PLUGIN_SET_CONFIG, event, configCommand);
       }
+    } else {
+      addLog(LOG_LEVEL_ERROR, F("Expected syntax: config,task,<taskname>,<config command>"));
     }
   }
   return success;

--- a/src/src/Helpers/StringParser.cpp
+++ b/src/src/Helpers/StringParser.cpp
@@ -126,7 +126,7 @@ String parseTemplate_padded(String& tmpString, uint8_t minimal_lineSize, bool us
       {
         // Address a value from a plugin.
         // For example: "[bme#temp]"
-        // If value name is unknown, run a PLUGIN_GET_CONFIG command.
+        // If value name is unknown, run a PLUGIN_GET_CONFIG_VALUE command.
         // For example: "[<taskname>#getLevel]"
         taskIndex_t taskIndex = findTaskIndexByName(deviceName);
 
@@ -147,7 +147,7 @@ String parseTemplate_padded(String& tmpString, uint8_t minimal_lineSize, bool us
             struct EventStruct TempEvent(taskIndex);
             String tmpName = valueName;
 
-            if (PluginCall(PLUGIN_GET_CONFIG, &TempEvent, tmpName))
+            if (PluginCall(PLUGIN_GET_CONFIG_VALUE, &TempEvent, tmpName))
             {
               transformValue(newString, minimal_lineSize, std::move(tmpName), format, tmpString);
             }

--- a/src/src/PluginStructs/P082_data_struct.cpp
+++ b/src/src/PluginStructs/P082_data_struct.cpp
@@ -27,6 +27,16 @@ const __FlashStringHelper * Plugin_082_valuename(P082_query value_nr, bool displ
   return F("");
 }
 
+P082_query Plugin_082_from_valuename(const String& valuename)
+{
+  for (uint8_t query = 0; query < static_cast<uint8_t>(P082_query::P082_NR_OUTPUT_OPTIONS); ++query) {
+    if (valuename.equalsIgnoreCase(Plugin_082_valuename(static_cast<P082_query>(query), false))) {
+      return static_cast<P082_query>(query);
+    }
+  }
+  return P082_query::P082_NR_OUTPUT_OPTIONS;
+}
+
 const __FlashStringHelper* toString(P082_PowerMode mode) {
   switch (mode) {
     case P082_PowerMode::Max_Performance: return F("Max Performance");

--- a/src/src/PluginStructs/P082_data_struct.h
+++ b/src/src/PluginStructs/P082_data_struct.h
@@ -34,6 +34,8 @@ enum class P082_query : uint8_t {
 
 const __FlashStringHelper * Plugin_082_valuename(P082_query value_nr, bool displayString);
 
+P082_query Plugin_082_from_valuename(const String& valuename);
+
 
 enum class P082_PowerMode : uint8_t {
   Max_Performance = 0,

--- a/src/src/WebServer/ToolsPage.cpp
+++ b/src/src/WebServer/ToolsPage.cpp
@@ -43,7 +43,7 @@ void handle_tools() {
   addHtmlAttribute(F("style"), F("width: 98%"));
   addHtmlAttribute(F("type"),  F("text"));
   addHtmlAttribute(F("name"),  F("cmd"));
-  addHtmlAttribute(F("value"), webrequest);
+  addHtmlAttribute(F("value"), webArg(F("cmd")));
   addHtml('>');
 
   html_TR_TD();


### PR DESCRIPTION
The Get/Set config plugin functions were hardly used in ESPEasy.
Currently the `config` command is only implemented for the "Level" plugin, but hardly documented.

Its counterpart, to Get config, is also hardly used, but can be very useful to access values (either settings or unused values) via `[taskname#valuename]` notation.

This is now also added for the many GPS values, as one can only set 4 units of measure as task values.