### PR TITLE
[Settings] Add PCONFIG_ULONG(n), union with PCONFIG_LONG(n)

### DIFF
--- a/src/_Plugin_Helper.h
+++ b/src/_Plugin_Helper.h
@@ -60,6 +60,9 @@
 #ifndef PCONFIG_LONG
   # define PCONFIG_LONG(n) (Settings.TaskDevicePluginConfigLong[event->TaskIndex][(n)])
 #endif // ifndef PCONFIG_LONG
+#ifndef PCONFIG_ULONG
+  # define PCONFIG_ULONG(n) (Settings.TaskDevicePluginConfigULong[event->TaskIndex][(n)])
+#endif // ifndef PCONFIG_ULONG
 #ifndef PIN
 
 // Please note the 'offset' of N compared to normal pin numbering.

--- a/src/src/DataStructs/SettingsStruct.h
+++ b/src/src/DataStructs/SettingsStruct.h
@@ -280,7 +280,7 @@ class SettingsStruct_tmpl
   boolean       TaskDevicePin1Inversed[N_TASKS] = {0};
   float         TaskDevicePluginConfigFloat[N_TASKS][PLUGIN_CONFIGFLOATVAR_MAX];
   union {
-    long     TaskDevicePluginConfigLong[N_TASKS][PLUGIN_CONFIGLONGVAR_MAX];
+    int32_t  TaskDevicePluginConfigLong[N_TASKS][PLUGIN_CONFIGLONGVAR_MAX];
     uint32_t TaskDevicePluginConfigULong[N_TASKS][PLUGIN_CONFIGLONGVAR_MAX];
   };
   uint8_t       TaskDeviceSendDataFlags[N_TASKS] = {0};

--- a/src/src/DataStructs/SettingsStruct.h
+++ b/src/src/DataStructs/SettingsStruct.h
@@ -279,7 +279,10 @@ class SettingsStruct_tmpl
   int16_t       TaskDevicePluginConfig[N_TASKS][PLUGIN_CONFIGVAR_MAX];
   boolean       TaskDevicePin1Inversed[N_TASKS] = {0};
   float         TaskDevicePluginConfigFloat[N_TASKS][PLUGIN_CONFIGFLOATVAR_MAX];
-  long          TaskDevicePluginConfigLong[N_TASKS][PLUGIN_CONFIGLONGVAR_MAX];
+  union {
+    long     TaskDevicePluginConfigLong[N_TASKS][PLUGIN_CONFIGLONGVAR_MAX];
+    uint32_t TaskDevicePluginConfigULong[N_TASKS][PLUGIN_CONFIGLONGVAR_MAX];
+  };
   uint8_t       TaskDeviceSendDataFlags[N_TASKS] = {0};
   uint8_t       OLD_TaskDeviceGlobalSync[N_TASKS] = {0};
   uint8_t       TaskDeviceDataFeed[N_TASKS] = {0};    // When set to 0, only read local connected sensorsfeeds


### PR DESCRIPTION
Feature:
To accompany the `PCONFIG_LONG(n)` macro, and ease the use of this 32 bit storage space as bit flags, a `union` of the same storage is made available as `PCONFIG_ULONG(n)`, so it can be used directly with `set8BitToUL()` and the 2, 3 and 4 bit variants.