### PR TITLE
[Build] Restore ESP32 TEST_E builds and other fix(es)

### DIFF
--- a/platformio_esp32_envs.ini
+++ b/platformio_esp32_envs.ini
@@ -182,6 +182,14 @@ build_flags               = ${esp32_common.build_flags}
                             -DPLUGIN_SET_TEST_D_ESP32
                             -DTESTING_USE_RTTTL
 
+[env:test_E_ESP32_4M316k]
+extends                   = esp32_common
+board                     = esp32_4M
+build_flags               = ${esp32_common.build_flags}  
+                            -DFEATURE_ARDUINO_OTA
+                            -DPLUGIN_SET_TEST_E_ESP32
+                            -DTESTING_USE_RTTTL
+
 
 [env:test_A_ESP32_IRExt_4M316k]
 extends                   = esp32_IRExt
@@ -204,6 +212,12 @@ extends                   = esp32_IRExt
 board                     = esp32_4M
 build_flags               = ${esp32_IRExt.build_flags}
                             -DPLUGIN_SET_TEST_D_ESP32
+
+[env:test_E_ESP32_IRExt_4M316k]
+extends                   = esp32_IRExt
+board                     = esp32_4M
+build_flags               = ${esp32_IRExt.build_flags}
+                            -DPLUGIN_SET_TEST_E_ESP32
 
 [env:energy_ESP32_4M316k]
 extends                   = esp32_common
@@ -255,6 +269,12 @@ build_flags               = ${env:test_C_ESP32_4M316k.build_flags}
 [env:test_D_ESP32_4M316k_ETH]
 extends                   = env:test_D_ESP32_4M316k
 build_flags               = ${env:test_D_ESP32_4M316k.build_flags}
+                            -DHAS_ETHERNET
+                            -DTESTING_USE_RTTTL
+
+[env:test_E_ESP32_4M316k_ETH]
+extends                   = env:test_E_ESP32_4M316k
+build_flags               = ${env:test_E_ESP32_4M316k.build_flags}
                             -DHAS_ETHERNET
                             -DTESTING_USE_RTTTL
 

--- a/platformio_esp32s2_envs.ini
+++ b/platformio_esp32s2_envs.ini
@@ -82,6 +82,13 @@ build_flags               = ${esp32s2_common.build_flags}
                             -DPLUGIN_SET_TEST_D_ESP32
                             -DTESTING_USE_RTTTL
 
+[env:test_E_ESP32s2_4M316k]
+extends                   = esp32s2_common
+board                     = esp32s2
+build_flags               = ${esp32s2_common.build_flags}  
+                            -DPLUGIN_SET_TEST_E_ESP32
+                            -DTESTING_USE_RTTTL
+
 
 [env:energy_ESP32s2_4M316k]
 extends                   = esp32s2_common

--- a/src/src/WebServer/Markup_Forms.cpp
+++ b/src/src/WebServer/Markup_Forms.cpp
@@ -436,9 +436,17 @@ void addFormSelector(const String& label,
                      const String  options[],
                      const int     indices[],
                      int           selectedIndex,
-                     bool          reloadonchange)
+                     bool          reloadonchange
+                     #ifdef ENABLE_TOOLTIPS
+                     , const String& tooltip
+                     #endif // ifdef ENABLE_TOOLTIPS
+                    )
 {
-  addFormSelector(label, id, optionCount, options, indices, nullptr, selectedIndex, reloadonchange);
+  addFormSelector(label, id, optionCount, options, indices, nullptr, selectedIndex, reloadonchange
+                  #ifdef ENABLE_TOOLTIPS
+                  , tooltip
+                  #endif // ifdef ENABLE_TOOLTIPS
+                 );
 }
 
 void addFormSelector(const String  & label,


### PR DESCRIPTION
- The TEST_E builds for ESP32 and ESP32s2 where missing since the last restructure of the builds
- The implementation for a specific `addFormSelector()` was missing after [this change](https://github.com/letscontrolit/ESPEasy/pull/4084/files#diff-4903edeb1d058065de74c44e07dbf1e1dbb271f59287915d04f752c06b65b269R265-R269)