### PR TITLE
[P087] Add 'Serial Config' options

### DIFF
--- a/src/_P087_SerialProxy.ino
+++ b/src/_P087_SerialProxy.ino
@@ -8,6 +8,12 @@
 // Interact with a device connected to serial
 // Allows to redirect data to a controller
 //
+/**
+ * Changelog:
+ * 2022-07-08 tonhuisman: Allow baudrate lowest value to 300 (from 2400)
+ * 2022-07-07 tonhuisman: Add selection for serial protocol configuration (databits, parity, nr. of stopbits)
+ * 2022-07 First recorded changelog
+ **/
 
 
 #include "src/PluginStructs/P087_data_struct.h"
@@ -132,7 +138,7 @@ boolean Plugin_087(uint8_t function, struct EventStruct *event, String& string) 
 
     case PLUGIN_WEBFORM_SHOW_SERIAL_PARAMS:
     {
-      addFormNumericBox(F("Baudrate"), P087_BAUDRATE_LABEL, P087_BAUDRATE, 2400, 115200);
+      addFormNumericBox(F("Baudrate"), P087_BAUDRATE_LABEL, P087_BAUDRATE, 300, 115200);
       addUnit(F("baud"));
       uint8_t serialConfChoice = serialHelper_convertOldSerialConfig(P087_SERIAL_CONFIG);
       serialHelper_serialconfig_webformLoad(event, serialConfChoice);

--- a/src/_P087_SerialProxy.ino
+++ b/src/_P087_SerialProxy.ino
@@ -11,6 +11,7 @@
 /**
  * Changelog:
  * 2022-07-08 tonhuisman: Allow baudrate lowest value to 300 (from 2400)
+ *                        Don't trim off pre/post white-space from string to send
  * 2022-07-07 tonhuisman: Add selection for serial protocol configuration (databits, parity, nr. of stopbits)
  * 2022-07 First recorded changelog
  **/
@@ -240,7 +241,7 @@ boolean Plugin_087(uint8_t function, struct EventStruct *event, String& string) 
           static_cast<P087_data_struct *>(getPluginTaskData(event->TaskIndex));
 
         if ((nullptr != P087_data)) {
-          String param1 = parseStringKeepCase(string, 2);
+          String param1 = parseStringKeepCase(string, 2, ',', false); // Don't trim off white-space
           parseSystemVariables(param1, false);
           P087_data->sendString(param1);
           addLogMove(LOG_LEVEL_INFO, param1);

--- a/src/_P087_SerialProxy.ino
+++ b/src/_P087_SerialProxy.ino
@@ -21,6 +21,7 @@
 
 #define P087_BAUDRATE           PCONFIG_LONG(0)
 #define P087_BAUDRATE_LABEL     PCONFIG_LABEL(0)
+#define P087_SERIAL_CONFIG      PCONFIG_LONG(1)
 
 #define P087_QUERY_VALUE        0 // Temp placement holder until we know what selectors are needed.
 #define P087_NR_OUTPUT_OPTIONS  1
@@ -133,6 +134,8 @@ boolean Plugin_087(uint8_t function, struct EventStruct *event, String& string) 
     {
       addFormNumericBox(F("Baudrate"), P087_BAUDRATE_LABEL, P087_BAUDRATE, 2400, 115200);
       addUnit(F("baud"));
+      uint8_t serialConfChoice = serialHelper_convertOldSerialConfig(P087_SERIAL_CONFIG);
+      serialHelper_serialconfig_webformLoad(event, serialConfChoice);
       break;
     }
 
@@ -148,7 +151,8 @@ boolean Plugin_087(uint8_t function, struct EventStruct *event, String& string) 
     }
 
     case PLUGIN_WEBFORM_SAVE: {
-      P087_BAUDRATE = getFormItemInt(P087_BAUDRATE_LABEL);
+      P087_BAUDRATE      = getFormItemInt(P087_BAUDRATE_LABEL);
+      P087_SERIAL_CONFIG = serialHelper_serialconfig_webformSave();
 
       P087_data_struct *P087_data =
         static_cast<P087_data_struct *>(getPluginTaskData(event->TaskIndex));
@@ -178,7 +182,7 @@ boolean Plugin_087(uint8_t function, struct EventStruct *event, String& string) 
         return success;
       }
 
-      if (P087_data->init(port, serial_rx, serial_tx, P087_BAUDRATE)) {
+      if (P087_data->init(port, serial_rx, serial_tx, P087_BAUDRATE, static_cast<uint8_t>(P087_SERIAL_CONFIG))) {
         LoadCustomTaskSettings(event->TaskIndex, P087_data->_lines, P87_Nlines, 0);
         P087_data->post_init();
         success = true;

--- a/src/src/Helpers/StringConverter.cpp
+++ b/src/src/Helpers/StringConverter.cpp
@@ -640,31 +640,33 @@ String to_internal_string(const String& input, char replaceSpace) {
    IndexFind = 1 => command.
     // FIXME TD-er: parseString* should use index starting at 0.
 \*********************************************************************************************/
-String parseString(const String& string, uint8_t indexFind, char separator) {
-  String result = parseStringKeepCase(string, indexFind, separator);
+String parseString(const String& string, uint8_t indexFind, char separator, bool trimResult) {
+  String result = parseStringKeepCase(string, indexFind, separator, trimResult);
 
   result.toLowerCase();
   return result;
 }
 
-String parseStringKeepCase(const String& string, uint8_t indexFind, char separator) {
+String parseStringKeepCase(const String& string, uint8_t indexFind, char separator, bool trimResult) {
   String result;
 
   if (!GetArgv(string.c_str(), result, indexFind, separator)) {
     return EMPTY_STRING;
   }
-  result.trim();
+  if (trimResult) {
+    result.trim();
+  }
   return stripQuotes(result);
 }
 
-String parseStringToEnd(const String& string, uint8_t indexFind, char separator) {
-  String result = parseStringToEndKeepCase(string, indexFind, separator);
+String parseStringToEnd(const String& string, uint8_t indexFind, char separator, bool trimResult) {
+  String result = parseStringToEndKeepCase(string, indexFind, separator, trimResult);
 
   result.toLowerCase();
   return result;
 }
 
-String parseStringToEndKeepCase(const String& string, uint8_t indexFind, char separator) {
+String parseStringToEndKeepCase(const String& string, uint8_t indexFind, char separator, bool trimResult) {
   // Loop over the arguments to find the first and last pos of the arguments.
   int  pos_begin = string.length();
   int  pos_end = pos_begin;
@@ -691,24 +693,27 @@ String parseStringToEndKeepCase(const String& string, uint8_t indexFind, char se
   }
   String result = string.substring(pos_begin, pos_end);
 
-  result.trim();
+  if (trimResult) {
+    result.trim();
+  }
   return stripQuotes(result);
 }
 
 String tolerantParseStringKeepCase(const char * string,
-                                   uint8_t          indexFind,
-                                   char          separator)
+                                   uint8_t      indexFind,
+                                   char         separator,
+                                   bool         trimResult)
 {
-  return tolerantParseStringKeepCase(String(string), indexFind, separator);
+  return tolerantParseStringKeepCase(String(string), indexFind, separator, trimResult);
 }
 
 
-String tolerantParseStringKeepCase(const String& string, uint8_t indexFind, char separator)
+String tolerantParseStringKeepCase(const String& string, uint8_t indexFind, char separator, bool trimResult)
 {
   if (Settings.TolerantLastArgParse()) {
-    return parseStringToEndKeepCase(string, indexFind, separator);
+    return parseStringToEndKeepCase(string, indexFind, separator, trimResult);
   }
-  return parseStringKeepCase(string, indexFind, separator);
+  return parseStringKeepCase(string, indexFind, separator, trimResult);
 }
 
 // escapes special characters in strings for use in html-forms

--- a/src/src/Helpers/StringConverter.h
+++ b/src/src/Helpers/StringConverter.h
@@ -209,28 +209,34 @@ String to_internal_string(const String& input,
     // FIXME TD-er: parseString* should use index starting at 0.
 \*********************************************************************************************/
 String parseString(const String& string,
-                   uint8_t          indexFind,
-                   char          separator = ',');
+                   uint8_t       indexFind,
+                   char          separator = ',',
+                   bool          trimResult = true);
 
 String parseStringKeepCase(const String& string,
-                           uint8_t          indexFind,
-                           char          separator = ',');
+                           uint8_t       indexFind,
+                           char          separator = ',',
+                           bool          trimResult = true);
 
 String parseStringToEnd(const String& string,
-                        uint8_t          indexFind,
-                        char          separator = ',');
+                        uint8_t       indexFind,
+                        char          separator = ',',
+                        bool          trimResult = true);
 
 String parseStringToEndKeepCase(const String& string,
-                                uint8_t          indexFind,
-                                char          separator = ',');
+                                uint8_t       indexFind,
+                                char          separator = ',',
+                                bool          trimResult = true);
 
 String tolerantParseStringKeepCase(const char * string,
-                                   uint8_t          indexFind,
-                                   char          separator = ',');
+                                   uint8_t      indexFind,
+                                   char         separator = ',',
+                                   bool         trimResult = true);
 
 String tolerantParseStringKeepCase(const String& string,
-                                   uint8_t          indexFind,
-                                   char          separator = ',');
+                                   uint8_t       indexFind,
+                                   char          separator = ',',
+                                   bool          trimResult = true);
 
 // escapes special characters in strings for use in html-forms
 bool   htmlEscapeChar(char    c,

--- a/src/src/PluginStructs/P087_data_struct.cpp
+++ b/src/src/PluginStructs/P087_data_struct.cpp
@@ -24,7 +24,7 @@ void P087_data_struct::reset() {
   }
 }
 
-bool P087_data_struct::init(ESPEasySerialPort port, const int16_t serial_rx, const int16_t serial_tx, unsigned long baudrate) {
+bool P087_data_struct::init(ESPEasySerialPort port, const int16_t serial_rx, const int16_t serial_tx, unsigned long baudrate, uint8_t config) {
   if ((serial_rx < 0) && (serial_tx < 0)) {
     return false;
   }
@@ -32,7 +32,11 @@ bool P087_data_struct::init(ESPEasySerialPort port, const int16_t serial_rx, con
   easySerial = new (std::nothrow) ESPeasySerial(port, serial_rx, serial_tx);
 
   if (isInitialized()) {
-    easySerial->begin(baudrate);
+    # if defined(ESP8266)
+    easySerial->begin(baudrate, (SerialConfig)config);
+    # elif defined(ESP32)
+    easySerial->begin(baudrate, config);
+    # endif // if defined(ESP8266)
     return true;
   }
   return false;

--- a/src/src/PluginStructs/P087_data_struct.h
+++ b/src/src/PluginStructs/P087_data_struct.h
@@ -49,7 +49,8 @@ public:
   bool init(ESPEasySerialPort port, 
             const int16_t serial_rx,
             const int16_t serial_tx,
-            unsigned long baudrate);
+            unsigned long baudrate,
+            uint8_t       config);
 
   // Called after loading the config from the settings.
   // Will interpret some data and load caches.


### PR DESCRIPTION
Resolves #4123 

- Add Serial Config options for configuring the technical serial parameters, like available in the Ser2Net plugin.
- Allow lowest baudrate to be set to 300 (from 2400)
- Don't trim off white-space from `serialproxy_write` command argument (by adding an optional argument to the `parseString()` function family)

TODO:
- [x] Testing by requester ([confirmed](https://github.com/letscontrolit/ESPEasy/issues/4123#issuecomment-1179463613))