### PR TITLE
Allow sysinfo_json page to be enabled separately from the new Web UI

### DIFF
--- a/src/Custom-sample.h
+++ b/src/Custom-sample.h
@@ -255,6 +255,7 @@
 
 //#define WEBPAGE_TEMPLATE_HIDE_HELP_BUTTON
 
+#define SHOW_SYSINFO_JSON   //Enables the sysinfo_json page (by default is enabled when WEBSERVER_NEW_UI is enabled too)
 
 /*
  #######################################################################################################

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -1919,4 +1919,9 @@ To create/register a plugin, you have to :
   #endif
 #endif
 
+// By default we enable the SHOW_SYSINFO_JSON when we enable the WEBSERVER_NEW_UI
+#ifdef WEBSERVER_NEW_UI
+ #define SHOW_SYSINFO_JSON
+#endif
+
 #endif // CUSTOMBUILD_DEFINE_PLUGIN_SETS_H

--- a/src/src/WebServer/SysInfoPage.cpp
+++ b/src/src/WebServer/SysInfoPage.cpp
@@ -47,8 +47,10 @@
 #endif // ifdef ESP32
 
 
-#ifdef WEBSERVER_NEW_UI
 
+
+
+#ifdef SHOW_SYSINFO_JSON
 // ********************************************************************************
 // Web Interface sysinfo page
 // ********************************************************************************
@@ -212,7 +214,7 @@ void handle_sysinfo_json() {
   TXBuffer.endStream();
 }
 
-#endif // WEBSERVER_NEW_UI
+#endif // SHOW_SYSINFO_JSON
 
 #ifdef WEBSERVER_SYSINFO
 

--- a/src/src/WebServer/WebServer.cpp
+++ b/src/src/WebServer/WebServer.cpp
@@ -299,11 +299,13 @@ void WebServerInit()
   web_server.on(F("/i2cscanner_json"),   handle_i2cscanner_json);
   web_server.on(F("/node_list_json"),    handle_nodes_list_json);
   web_server.on(F("/pinstates_json"),    handle_pinstates_json);
-  web_server.on(F("/sysinfo_json"),      handle_sysinfo_json);
   web_server.on(F("/timingstats_json"),  handle_timingstats_json);
   web_server.on(F("/upload_json"),       HTTP_POST, handle_upload_json, handleFileUpload);
   web_server.on(F("/wifiscanner_json"),  handle_wifiscanner_json);
 #endif // WEBSERVER_NEW_UI
+#ifdef SHOW_SYSINFO_JSON
+    web_server.on(F("/sysinfo_json"),      handle_sysinfo_json);
+#endif//SHOW_SYSINFO_JSON
 
   web_server.onNotFound(handleNotFound);
 


### PR DESCRIPTION
I like that page to be available in the standard UI as I used it in my automation.