### PR TITLE
[Rules] Fix matching rules with system variables in on...do

### DIFF
--- a/src/src/Helpers/RulesMatcher.cpp
+++ b/src/src/Helpers/RulesMatcher.cpp
@@ -3,9 +3,10 @@
 #include "../Helpers/ESPEasy_math.h"
 #include "../Helpers/ESPEasy_time_calc.h"
 #include "../Helpers/Numerical.h"
+#include "../Helpers/StringParser.h"
 
 
-bool ruleMatch(const String& event, const String& rule) {
+bool ruleMatch(String event, String rule) {
   #ifndef BUILD_NO_RAM_TRACKER
   checkRAM(F("ruleMatch"));
   #endif // ifndef BUILD_NO_RAM_TRACKER
@@ -15,10 +16,12 @@ bool ruleMatch(const String& event, const String& rule) {
     return true;
   }
 
-  String tmpEvent = event;
-  tmpEvent.trim();
+  rule.trim();
+  parseTemplate(rule);
 
-  if (tmpEvent.equalsIgnoreCase(rule)) {
+  event.trim();
+
+  if (event.equalsIgnoreCase(rule)) {
     return true;
   }
 
@@ -61,7 +64,7 @@ bool ruleMatch(const String& event, const String& rule) {
       // no # sign in rule, use 'wildcard' match on event 'source'
       return event.substring(0, rule.length()).equalsIgnoreCase(rule);
     }
-    return tmpEvent.equalsIgnoreCase(rule);
+    return event.equalsIgnoreCase(rule);
   }
 
 
@@ -75,7 +78,7 @@ bool ruleMatch(const String& event, const String& rule) {
 
       // FIXME TD-er: What to do when trying to match NaN values?
     }
-    tmpEvent = event.substring(0, equal_pos);
+    event = event.substring(0, equal_pos);
   }
 
   // parse rule
@@ -84,10 +87,10 @@ bool ruleMatch(const String& event, const String& rule) {
 
   if (!findCompareCondition(rule, compare, posStart, posEnd)) {
     // No compare condition found, so just check if the event- and rule string match.
-    return tmpEvent.equalsIgnoreCase(rule);
+    return event.equalsIgnoreCase(rule);
   }
 
-  const bool stringMatch = tmpEvent.equalsIgnoreCase(rule.substring(0, posStart));
+  const bool stringMatch = event.equalsIgnoreCase(rule.substring(0, posStart));
   double     ruleValue   = 0;
 
   if (!validDoubleFromString(rule.substring(posEnd), ruleValue)) {

--- a/src/src/Helpers/RulesMatcher.h
+++ b/src/src/Helpers/RulesMatcher.h
@@ -6,8 +6,9 @@
 /********************************************************************************************\
    Check if an event matches to a given rule
  \*********************************************************************************************/
-bool ruleMatch(const String& event,
-               const String& rule);
+// Both strings are copied, since they may need to be trimmed and call parseTemplate
+bool ruleMatch(String event,
+               String rule);
 
 
 bool compareIntValues(char       compare,


### PR DESCRIPTION
Rules like these don't seem to be matched
```
On Clock#Time=All,%sunrise+1h% do
```