### PR TITLE
[P128] Limit build size by optionally including FakeTV effect

### DIFF
--- a/docs/source/Plugin/P128_commands.repl
+++ b/docs/source/Plugin/P128_commands.repl
@@ -136,6 +136,8 @@
     | ``nfx,faketv[,startpixel[,endpixel]]``
     ","
     | Run a fake TV effect on the pixels, optionally specifying a start- end end-pixel. Used for simulating an active TV-set, f.e. when not at home during the evening, to scare off potential burglars.
+    |
+    | NB: This effect may be excluded from the build for size reasons, by default it is **not** included in ESP8266 builds. It *can* be included in self-built Custom builds.
     "
     "
     | ``nfx,simpleclock[,bigtickcolor[,smalltickcolor[,hourcolor[,minutecolor[,secondcolor (set 'off' to disable)[,backgroundcolor]]]]]]``

--- a/src/Custom-sample.h
+++ b/src/Custom-sample.h
@@ -455,6 +455,7 @@ static const char DATA_ESPEASY_DEFAULT_MIN_CSS[] PROGMEM = {
 // #define P128_USES_RGBW
 // #define P128_USES_BRG
 // #define P128_USES_RBG
+// #define P128_ENABLE_FAKETV 1 // Enable(1)/Disable(0) FakeTV effect, disabled by default on ESP8266 (.bin size issue), enabled by default on ESP32
 
 
 // Special plugins needing IR library

--- a/src/_P128_NeoPixelBusFX.ino
+++ b/src/_P128_NeoPixelBusFX.ino
@@ -7,6 +7,8 @@
 // #######################################################################################################
 
 // Changelog:
+// 2022-07-20, tonhuisman Make FakeTV compile-time optional, disabled by default on ESP8266, enabled by default on ESP32
+//                        P128_ENABLE_FAKETV can be set to 0/1 in Custom.h
 // 2022-07-02, tonhuisman Introduce Max Brightness setting for protecting the hardware and power supply (and the eyes :-))
 // 2022-06-12, tonhuisman Optimizations, revert Makuna/NeopixelBus library to 2.6.9 for incompatibilties like [[maybe_unused]] arguments
 // 2022-01-30, tonhuisman Fix JSON message to use proper JSON functions, some bugfixes and small source improvements

--- a/src/src/PluginStructs/P128_data_struct.cpp
+++ b/src/src/PluginStructs/P128_data_struct.cpp
@@ -470,6 +470,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
           : str5i;
     }
 
+    # if P128_ENABLE_FAKETV
     else if (subCommand == F("faketv")) {
       success            = true;
       mode               = P128_modetype::FakeTV;
@@ -485,6 +486,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
           ? pixelCount
           : str4i;
     }
+    # endif // if P128_ENABLE_FAKETV
 
     else if (subCommand == F("fire")) {
       success = true;
@@ -768,9 +770,11 @@ bool P128_data_struct::plugin_fifty_per_second(struct EventStruct *event) {
       dualwipe();
       break;
 
+    # if P128_ENABLE_FAKETV
     case P128_modetype::FakeTV:
       faketv();
       break;
+    # endif // if P128_ENABLE_FAKETV
 
     case P128_modetype::SimpleClock:
       Plugin_128_simpleclock();
@@ -895,6 +899,7 @@ void P128_data_struct::dualwipe(void) {
   }
 }
 
+# if P128_ENABLE_FAKETV
 void P128_data_struct::faketv(void) {
   if (counter20ms >= ftv_holdTime) {
     difference = abs(endpixel - startpixel);
@@ -956,6 +961,8 @@ void P128_data_struct::faketv(void) {
     ftv_pb = ftv_nb;
   }
 }
+
+# endif // if P128_ENABLE_FAKETV
 
 /*
  * Cycles a rainbow over the entire string of LEDs.
@@ -1541,7 +1548,9 @@ const __FlashStringHelper * P128_data_struct::P128_modeType_toString(P128_modety
     case P128_modetype::FireFlicker: return F("fireflicker");
     case P128_modetype::Wipe: return F("wipe");
     case P128_modetype::Dualwipe: return F("dualwipe");
+    # if P128_ENABLE_FAKETV
     case P128_modetype::FakeTV: return F("faketv");
+    # endif // if P128_ENABLE_FAKETV
     case P128_modetype::SimpleClock: return F("simpleclock");
   }
   return F("*unknown*");

--- a/src/src/PluginStructs/P128_data_struct.h
+++ b/src/src/PluginStructs/P128_data_struct.h
@@ -2309,7 +2309,6 @@ private:
   uint16_t difference = 0;
   uint16_t fps        = 50;
   uint16_t colorcount = 0;
-  int8_t   gpioPin    = -1;
 
 # if defined(RGBW) || defined(GRBW)
   RgbwColor rgb_target[ARRAYSIZE],
@@ -2331,11 +2330,12 @@ private:
            rgb_s      = HtmlColor(0xFF0000);
 # endif // if defined(RGBW) || defined(GRBW)
 
-  uint8_t maxBright = 255;
+  int8_t   gpioPin;
+  uint16_t pixelCount;
+  uint8_t  maxBright;
 
   int16_t fadedelay = 20;
 
-  uint16_t pixelCount = ARRAYSIZE;
 
   int8_t defaultspeed  = 25;
   int8_t rainbowspeed  = 1;

--- a/src/src/PluginStructs/P128_data_struct.h
+++ b/src/src/PluginStructs/P128_data_struct.h
@@ -2269,7 +2269,7 @@ const uint8_t PROGMEM ftv_colors[] = {
 # if P128_ENABLE_FAKETV
 #  define NUMPixels (sizeof(ftv_colors) / sizeof(ftv_colors[0]))
 # else // if P128_ENABLE_FAKETV
-#  define NUMPixels (26000 / 8)
+#  define NUMPixels (26000)
 # endif // if P128_ENABLE_FAKETV
 
 enum class P128_modetype {

--- a/src/src/PluginStructs/P128_data_struct.h
+++ b/src/src/PluginStructs/P128_data_struct.h
@@ -4,8 +4,18 @@
 #include "../../_Plugin_Helper.h"
 #ifdef USES_P128
 
+# ifndef P128_ENABLE_FAKETV
+#  if defined(ESP32)
+#   define P128_ENABLE_FAKETV 1 // Enable FakeTV on ESP32 by default
+#  endif // if defined(ESP32)
+#  if defined(ESP8266)
+#   define P128_ENABLE_FAKETV 0 // Disable FakeTV effect on ESP8266 to conserve a chunk of .bin space (~25kB)
+#  endif // if defined(ESP8266)
+# endif // ifndef P128_ENABLE_FAKETV
+
 // This is a copy of faketv.h, as provided by https://github.com/djcysmic/NeopixelBusFX
 
+# if P128_ENABLE_FAKETV
 const uint8_t PROGMEM ftv_gamma8[] = {
   0X01, 0X01, 0X01, 0X02, 0X02, 0X02, 0X03, 0X03, 0X03, 0X04, 0X04, 0X04,
   0X05, 0X05, 0X05, 0X06, 0X06, 0X06, 0X07, 0X07, 0X07, 0X08, 0X08, 0X08,
@@ -28,8 +38,8 @@ const uint8_t PROGMEM ftv_gamma8[] = {
   0XBD, 0XBF, 0XC0, 0XC2, 0XC3, 0XC5, 0XC7, 0XC8, 0XCA, 0XCC, 0XCD, 0XCF,
   0XD1, 0XD2, 0XD4, 0XD6, 0XD7, 0XD9, 0XDB, 0XDC, 0XDE, 0XE0, 0XE1, 0XE3,
   0XE5, 0XE6, 0XE8, 0XEA, 0XEC, 0XED, 0XEF, 0XF1, 0XF3, 0XF4, 0XF6, 0XF8,
-  0XFA, 0XFB, 0XFD, 0XFF },
-                      ftv_colors[] = {
+  0XFA, 0XFB, 0XFD, 0XFF };
+const uint8_t PROGMEM ftv_colors[] = {
   0X8C, 0XD8, 0X8C, 0XF9, 0X8C, 0XD8, 0X84, 0X98, 0X7C, 0X77, 0X64, 0X16,
   0X43, 0X94, 0X4B, 0XB4, 0X43, 0X32, 0X42, 0XF1, 0X53, 0X51, 0X5B, 0X70,
   0X94, 0XF7, 0X8C, 0X94, 0X7C, 0X10, 0X84, 0X31, 0X8C, 0X72, 0X8C, 0X72,
@@ -2197,6 +2207,7 @@ const uint8_t PROGMEM ftv_gamma8[] = {
   0X18, 0XE4, 0X10, 0XA2, 0X10, 0XA2, 0X21, 0XA7, 0X21, 0X66, 0X29, 0X66,
   0X21, 0X86, 0X19, 0X04, 0X29, 0X66, 0X29, 0X45, 0X19, 0X25, 0X21, 0X25,
   0X20, 0XE4, 0X21, 0XA6, 0X29, 0XE7, 0X32, 0X28 };
+# endif // if P128_ENABLE_FAKETV
 
 # include <NeoPixelBrightnessBus.h>
 # include "../../ESPEasy-Globals.h"
@@ -2255,12 +2266,20 @@ const uint8_t PROGMEM ftv_gamma8[] = {
   #  define FEATURE NeoGrbFeature
 # endif // if defined GRB
 
-# define  NUMPixels (sizeof(ftv_colors) / sizeof(ftv_colors[0]))
+# if P128_ENABLE_FAKETV
+#  define NUMPixels (sizeof(ftv_colors) / sizeof(ftv_colors[0]))
+# else // if P128_ENABLE_FAKETV
+#  define NUMPixels (26000 / 8)
+# endif // if P128_ENABLE_FAKETV
 
 enum class P128_modetype {
   Off, On, Fade, ColorFade, Rainbow, Kitt, Comet,
   Theatre, Scan, Dualscan, Twinkle, TwinkleFade, Sparkle, Fire,
-  FireFlicker, Wipe, Dualwipe,  FakeTV, SimpleClock
+  FireFlicker, Wipe, Dualwipe,
+  # if P128_ENABLE_FAKETV
+  FakeTV,
+  # endif // if P128_ENABLE_FAKETV
+  SimpleClock
 };
 
 struct P128_data_struct : public PluginTaskData_base {
@@ -2326,9 +2345,12 @@ private:
 
   uint32_t _counter_mode_step = 0u;
   uint32_t fadetime           = 1000u;
-  uint32_t ftv_holdTime       = 0u;
-  uint32_t pixelNum           = 0u;
+  # if P128_ENABLE_FAKETV
+  uint32_t ftv_holdTime = 0u;
+  # endif // if P128_ENABLE_FAKETV
+  uint32_t pixelNum = 0u;
 
+  # if P128_ENABLE_FAKETV
   uint16_t ftv_pr        = 0;
   uint16_t ftv_pg        = 0;
   uint16_t ftv_pb        = 0; // Prev R, G, B;
@@ -2349,6 +2371,7 @@ private:
   uint8_t  ftv_r8        = 0;
   uint8_t  ftv_g8        = 0;
   uint8_t  ftv_b8        = 0;
+  # endif // if P128_ENABLE_FAKETV
 
   String colorStr;
   String backgroundcolorStr;


### PR DESCRIPTION
- Limit build-size by optionally leaving out FakeTV effect that uses a 26 kB data table (ESP8266: Default excluded, ESP32: Default included)
- Update documentation
- Cherry pick fix for compiler warnings
