### PR TITLE
[Web tools] Fix command via Tools page lower case

### DIFF
--- a/src/src/Helpers/WebServer_commandHelper.cpp
+++ b/src/src/Helpers/WebServer_commandHelper.cpp
@@ -31,7 +31,7 @@ HandledWebCommand_result handle_command_from_web(EventValueSource::Enum source, 
 
   if ((command == F("event")) || (command == F("asyncevent")))
   {
-    eventQueue.addMove(parseStringToEnd(webrequest, 2));
+    eventQueue.addMove(parseStringToEndKeepCase(webrequest, 2));
     handledCmd = true;
     sendOK     = true;
   } else if (command.equals(F("taskrun")) ||


### PR DESCRIPTION
Command via Tools page: `event,test=BlAbLa0000xAB,3,XyZ,5,6,7,8,9,0`
Log:
```
1092723 : Info   : HTTP: event,test=BlAbLa0000xAB,3,XyZ,5,6,7,8,9,0
1092786 : Info   : EVENT: test=blabla0000xab,3,xyz,5,6,7,8,9,0
```