### PR TITLE
[Dallas] Add retry to init read or collect data from temp sensor

### DIFF
--- a/src/_P010_BH1750.ino
+++ b/src/_P010_BH1750.ino
@@ -126,10 +126,10 @@ boolean Plugin_010(uint8_t function, struct EventStruct *event, String& string)
       if (lux != -1) {
         UserVar[event->BaseVarIndex] = lux;
         if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-          String log = F("BH1750 Address: 0x");
-          log += String(address, HEX);
-          log += F(" Mode: 0x");
-          log += String(mode);
+          String log = F("BH1750 Address: ");
+          log += formatToHex(address, 2);
+          log += F(" Mode: ");
+          log += formatToHex(mode, 2);
           log += F(" : Light intensity: ");
           log += formatUserVarNoCheck(event->TaskIndex, 0);
           addLogMove(LOG_LEVEL_INFO, log);

--- a/src/_P017_PN532.ino
+++ b/src/_P017_PN532.ino
@@ -260,11 +260,11 @@ boolean Plugin_017_Init(int8_t resetPin)
   if (versiondata) {
     if (loglevelActiveFor(LOG_LEVEL_INFO)) {
       String log = F("PN532: Found chip PN5");
-      log += String((versiondata >> 24) & 0xFF, HEX);
+      log += formatToHex_no_prefix((versiondata >> 24) & 0xFF, 2);
       log += F(" FW: ");
-      log += String((versiondata >> 16) & 0xFF, HEX);
+      log += formatToHex_no_prefix((versiondata >> 16) & 0xFF, 2);
       log += '.';
-      log += String((versiondata >> 8) & 0xFF, HEX);
+      log += formatToHex_no_prefix((versiondata >> 8) & 0xFF, 2);
       addLogMove(LOG_LEVEL_INFO, log);
     }
   }

--- a/src/_P022_PCA9685.ino
+++ b/src/_P022_PCA9685.ino
@@ -216,8 +216,7 @@ boolean Plugin_022(uint8_t function, struct EventStruct *event, String& string)
         success = true;
 
         // "log" is also sent along with the SendStatusOnlyIfNeeded
-        log  = F("PCA 0x");
-        log += String(address, HEX);
+        log  = formatToHex(address, F("PCA 0x"), 2);
         log += F(": PWM ");
         log += event->Par1;
         const uint32_t dutyCycle       = event->Par2;
@@ -322,8 +321,7 @@ boolean Plugin_022(uint8_t function, struct EventStruct *event, String& string)
           newStatus.state   = event->Par1;
           savePortStatus(key, newStatus);
 
-          log  = F("PCA 0x");
-          log += String(address, HEX);
+          log  = formatToHex(address, F("PCA 0x"), 2);
           log += F(": FREQ ");
           log += event->Par1;
           addLog(LOG_LEVEL_INFO, log);
@@ -333,8 +331,8 @@ boolean Plugin_022(uint8_t function, struct EventStruct *event, String& string)
         }
         else {
           addLog(LOG_LEVEL_ERROR,
-                 String(F("PCA 0x")) +
-                 String(address, HEX) + F(" The frequency ") + String(event->Par1) + F(" is out of range."));
+                 String(F("PCA ")) +
+                 formatToHex(address, 2) + F(" The frequency ") + String(event->Par1) + F(" is out of range."));
         }
       }
 
@@ -350,16 +348,15 @@ boolean Plugin_022(uint8_t function, struct EventStruct *event, String& string)
             P022_data->Plugin_022_Frequency(address, freq);
           }
           P022_data->Plugin_022_writeRegister(address, PCA9685_MODE2, event->Par1);
-          log  = F("PCA 0x");
-          log += String(address, HEX);
-          log += F(": MODE2 0x");
-          log += String(event->Par1, HEX);
+          log  = formatToHex(address, F("PCA 0x"), 2);
+          log += ':';
+          log += formatToHex(event->Par1, F(" MODE2 0x"), 2);
           addLog(LOG_LEVEL_INFO, log);
         }
         else {
-          addLog(LOG_LEVEL_ERROR,
-                 String(F("PCA 0x")) +
-                 String(address, HEX) + F(" MODE2 0x") + String(event->Par1, HEX) + F(" is out of range."));
+          addLog(LOG_LEVEL_ERROR, 
+                 formatToHex(address, F("PCA 0x"), 2) + 
+                 formatToHex(event->Par1, F(" MODE2 0x"), 2) + F(" is out of range."));
         }
       }
 
@@ -384,8 +381,7 @@ boolean Plugin_022(uint8_t function, struct EventStruct *event, String& string)
       if (instanceCommand && (command == F("gpio")))
       {
         success = true;
-        log     = F("PCA 0x");
-        log    += String(address, HEX);
+        log     = formatToHex(address, F("PCA 0x"), 2);
         log    += F(": GPIO ");
         const bool allPins = parseString(string, 2) == F("all");
 
@@ -444,8 +440,7 @@ boolean Plugin_022(uint8_t function, struct EventStruct *event, String& string)
       if (instanceCommand && (command == F("pulse")))
       {
         success = true;
-        log     = F("PCA 0x");
-        log    += String(address, HEX);
+        log     = formatToHex(address, F("PCA 0x"), 2);
         log    += F(": GPIO ");
         log    += event->Par1;
 
@@ -527,8 +522,7 @@ boolean Plugin_022(uint8_t function, struct EventStruct *event, String& string)
         static_cast<P022_data_struct *>(getPluginTaskData(event->TaskIndex));
 
       if (nullptr != P022_data) {
-        String log = F("PCA 0x");
-        log += String(address, HEX);
+        String log = formatToHex(address, F("PCA 0x"), 2);
         log += F(": GPIO ");
         log += event->Par1;
         int autoreset = event->Par4;

--- a/src/_P027_INA219.ino
+++ b/src/_P027_INA219.ino
@@ -133,8 +133,7 @@ boolean Plugin_027(uint8_t function, struct EventStruct *event, String& string)
         String     log;
 
         if (mustLog) {
-          log  = F("INA219 0x");
-          log += String(i2caddr, HEX);
+          log  = formatToHex(i2caddr, F("INA219 0x"), 2);
           log += F(" setting Range to: ");
         }
 
@@ -195,8 +194,7 @@ boolean Plugin_027(uint8_t function, struct EventStruct *event, String& string)
         String     log;
 
         if (mustLog) {
-          log  = F("INA219 0x");
-          log += String(P027_I2C_ADDR, HEX);
+          log  = formatToHex(P027_I2C_ADDR, F("INA219 0x"), 2);
         }
 
         // for backward compability we allow the user to select if only one measurement should be returned

--- a/src/_P028_BME280.ino
+++ b/src/_P028_BME280.ino
@@ -276,8 +276,8 @@ boolean Plugin_028(uint8_t function, struct EventStruct *event, String& string)
 
             if (log.reserve(40)) { // Prevent re-allocation
               log  = P028_data->getDeviceName();
-              log += F(" : Address: 0x");
-              log += String(P028_I2C_ADDRESS, HEX);
+              log += F(" : Address: ");
+              log += formatToHex(P028_I2C_ADDRESS, 2);
               addLogMove(LOG_LEVEL_INFO, log);
 
               // addLogMove does also clear the string.

--- a/src/src/Helpers/Dallas1WireHelper.h
+++ b/src/src/Helpers/Dallas1WireHelper.h
@@ -32,7 +32,10 @@ struct Dallas_SensorData {
 
   uint64_t addr              = 0;
   float    value             = 0.0f;
+  uint32_t start_read_failed = 0;  
+  uint32_t start_read_retry  = 0;  
   uint32_t read_success      = 0;
+  uint32_t read_retry        = 0;
   uint32_t read_failed       = 0;  
   uint8_t  actual_res        = 0;
 

--- a/src/src/Helpers/StringConverter.cpp
+++ b/src/src/Helpers/StringConverter.cpp
@@ -183,8 +183,17 @@ String formatToHex(unsigned long value,
   return result;
 }
 
+String formatToHex(unsigned long value,
+                   const __FlashStringHelper * prefix) {
+  return formatToHex(value, prefix, 0);
+}
+
 String formatToHex(unsigned long value, unsigned int minimal_hex_digits) {
   return formatToHex(value, F("0x"), minimal_hex_digits);
+}
+
+String formatToHex_no_prefix(unsigned long value, unsigned int minimal_hex_digits) {
+  return formatToHex(value, F(""), minimal_hex_digits);
 }
 
 String formatHumanReadable(unsigned long value, unsigned long factor) {
@@ -1100,7 +1109,7 @@ void parseStandardConversions(String& s, bool useURLencode) {
   SMART_CONV(F("%c_m2dh%"),   minutesToDayHour(data.arg1))
   SMART_CONV(F("%c_m2dhm%"),  minutesToDayHourMinute(data.arg1))
   SMART_CONV(F("%c_s2dhms%"), secondsToDayHourMinuteSecond(data.arg1))
-  SMART_CONV(F("%c_2hex%"),   formatToHex(data.arg1, F("")))
+  SMART_CONV(F("%c_2hex%"),   formatToHex_no_prefix(data.arg1))
   #undef SMART_CONV
 
   // Conversions with 2 parameters

--- a/src/src/Helpers/StringConverter.cpp
+++ b/src/src/Helpers/StringConverter.cpp
@@ -166,17 +166,25 @@ unsigned long long hexToULL(const String& input_c, size_t startpos, size_t nrHex
   return hexToULL(input_c.substring(startpos, startpos + nrHexDecimals), nrHexDecimals);
 }
 
-String formatToHex(unsigned long value, const __FlashStringHelper * prefix) {
+String formatToHex(unsigned long value, 
+                   const __FlashStringHelper * prefix,
+                   unsigned int minimal_hex_digits) {
   String result = prefix;
   String hex(value, HEX);
 
   hex.toUpperCase();
+  if (hex.length() < minimal_hex_digits) {
+    const size_t leading_zeros = minimal_hex_digits - hex.length();
+    for (size_t i = 0; i < leading_zeros; ++i) {
+      result += '0';
+    }
+  }
   result += hex;
   return result;
 }
 
-String formatToHex(unsigned long value) {
-  return formatToHex(value, F("0x"));
+String formatToHex(unsigned long value, unsigned int minimal_hex_digits) {
+  return formatToHex(value, F("0x"), minimal_hex_digits);
 }
 
 String formatHumanReadable(unsigned long value, unsigned long factor) {

--- a/src/src/Helpers/StringConverter.h
+++ b/src/src/Helpers/StringConverter.h
@@ -73,9 +73,10 @@ unsigned long long hexToULL(const String& input_c,
                             size_t        nrHexDecimals);
 
 String formatToHex(unsigned long value,
-                   const __FlashStringHelper * prefix);
+                   const __FlashStringHelper * prefix,
+                   unsigned int minimal_hex_digits = 0);
 
-String formatToHex(unsigned long value);
+String formatToHex(unsigned long value, unsigned int minimal_hex_digits = 0);
 
 String formatHumanReadable(unsigned long value,
                            unsigned long factor);

--- a/src/src/Helpers/StringConverter.h
+++ b/src/src/Helpers/StringConverter.h
@@ -74,9 +74,14 @@ unsigned long long hexToULL(const String& input_c,
 
 String formatToHex(unsigned long value,
                    const __FlashStringHelper * prefix,
-                   unsigned int minimal_hex_digits = 0);
+                   unsigned int minimal_hex_digits);
+
+String formatToHex(unsigned long value,
+                   const __FlashStringHelper * prefix);
 
 String formatToHex(unsigned long value, unsigned int minimal_hex_digits = 0);
+
+String formatToHex_no_prefix(unsigned long value, unsigned int minimal_hex_digits = 0);
 
 String formatHumanReadable(unsigned long value,
                            unsigned long factor);

--- a/src/src/Helpers/StringProvider.cpp
+++ b/src/src/Helpers/StringProvider.cpp
@@ -384,19 +384,19 @@ String getValue(LabelType::Enum label) {
     case LabelType::SD_LOG_LEVEL:           return getLogLevelDisplayString(Settings.SDLogLevel);
   #endif // if FEATURE_SD
 
-    case LabelType::ESP_CHIP_ID:            return formatToHex(getChipId());
+    case LabelType::ESP_CHIP_ID:            return formatToHex(getChipId(), 6);
     case LabelType::ESP_CHIP_FREQ:          return String(ESP.getCpuFreqMHz());
     case LabelType::ESP_CHIP_MODEL:         return getChipModel();
     case LabelType::ESP_CHIP_REVISION:      return String(getChipRevision());
     case LabelType::ESP_CHIP_CORES:         return String(getChipCores());
     case LabelType::ESP_BOARD_NAME:         return get_board_name();
     case LabelType::FLASH_CHIP_ID:          return String(getFlashChipId());
-    case LabelType::FLASH_CHIP_VENDOR:      return formatToHex(getFlashChipId() & 0xFF);
+    case LabelType::FLASH_CHIP_VENDOR:      return formatToHex(getFlashChipId() & 0xFF, 2);
     case LabelType::FLASH_CHIP_MODEL:
     {
       const uint32_t flashChipId = getFlashChipId();
       const uint32_t flashDevice = (flashChipId & 0xFF00) | ((flashChipId >> 16) & 0xFF);
-      return formatToHex(flashDevice);
+      return formatToHex(flashDevice, 4);
     }
     case LabelType::FLASH_CHIP_REAL_SIZE:   return String(getFlashRealSizeInBytes());
     case LabelType::FLASH_CHIP_SPEED:       return String(getFlashChipSpeed() / 1000000);

--- a/src/src/PluginStructs/P004_data_struct.cpp
+++ b/src/src/PluginStructs/P004_data_struct.cpp
@@ -55,10 +55,7 @@ bool P004_data_struct::initiate_read() {
         *   11 bits resolution -> 375 ms
         *   12 bits resolution -> 750 ms
         \*********************************************************************************************/
-        uint8_t res = _res;
-
-        if ((res < 9) || (res > 12)) { res = 12; }
-        _timer = millis() + (800 / (1 << (12 - res)));
+        _timer = millis() + (800 / (1 << (12 - _res)));
       }
       _sensors[i].measurementActive = true;
     }

--- a/src/src/PluginStructs/P005_data_struct.cpp
+++ b/src/src/PluginStructs/P005_data_struct.cpp
@@ -258,7 +258,7 @@ bool P005_data_struct::readDHT(struct EventStruct *event) {
       log += F(" bytes:");
       for (int i = 0; i < dht_byte; ++i) {
         log += ' ';
-        log += formatToHex(dht_dat[i]);
+        log += formatToHex_no_prefix(dht_dat[i], 2);
       }
       log += F(" timings:");
       for (int i = 0; i < 16; ++i) {

--- a/src/src/PluginStructs/P128_data_struct.cpp
+++ b/src/src/PluginStructs/P128_data_struct.cpp
@@ -694,15 +694,9 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
 
 void P128_data_struct::rgb2colorStr() {
   colorStr.clear();
-
-  if (rgb.R < 16) { colorStr += '0'; }
-  colorStr += formatToHex(rgb.R, {});
-
-  if (rgb.G < 16) { colorStr += '0'; }
-  colorStr += formatToHex(rgb.G, {});
-
-  if (rgb.B < 16) { colorStr += '0'; }
-  colorStr += formatToHex(rgb.B, {});
+  colorStr += formatToHex_no_prefix(rgb.R, 2);
+  colorStr += formatToHex_no_prefix(rgb.G, 2);
+  colorStr += formatToHex_no_prefix(rgb.B, 2);
 }
 
 bool P128_data_struct::plugin_fifty_per_second(struct EventStruct *event) {

--- a/src/src/WebServer/I2C_Scanner.cpp
+++ b/src/src/WebServer/I2C_Scanner.cpp
@@ -45,7 +45,7 @@ int scanI2CbusForDevices_json( // Utility function for scanning the I2C bus for 
       if ((error == 0) || (error == 4))
       {
         json_open();
-        json_prop(F("addr"), String(formatToHex(address)));
+        json_prop(F("addr"), formatToHex(address, 2));
         #if FEATURE_I2CMULTIPLEXER
         if (muxAddr != -1) {
           if (channel == -1){
@@ -369,7 +369,7 @@ int scanI2CbusForDevices( // Utility function for scanning the I2C bus for valid
           html_TD();
         }
         #endif // if FEATURE_I2CMULTIPLEXER
-        addHtml(formatToHex(address));
+        addHtml(formatToHex(address, 2));
         html_TD();
         String description = getKnownI2Cdevice(address);
 
@@ -386,14 +386,14 @@ int scanI2CbusForDevices( // Utility function for scanning the I2C bus for valid
       {
         html_TR_TD();
         addHtml(F("NACK on transmit data to address "));
-        addHtml(formatToHex(address));
+        addHtml(formatToHex(address, 2));
         break;
       }
       case 4:
       {
         html_TR_TD();
         addHtml(F("SDA low at address "));
-        addHtml(formatToHex(address));
+        addHtml(formatToHex(address, 2));
         I2CForceResetBus_swap_pins(address);
         addHtml(F(" Reset bus attempted"));
         break;

--- a/src/src/WebServer/SysInfoPage.cpp
+++ b/src/src/WebServer/SysInfoPage.cpp
@@ -560,10 +560,8 @@ void handle_sysinfo_ESP_Board() {
   addRowLabel(LabelType::ESP_CHIP_ID);
   {
     addHtmlInt(getChipId());
-    addHtml(F(" (0x"));
-    String espChipId(getChipId(), HEX);
-    espChipId.toUpperCase();
-    addHtml(espChipId);
+    addHtml(' ', '(');
+    addHtml(formatToHex(getChipId(), 6));
     addHtml(')');
   }
 


### PR DESCRIPTION
It appears most of the read errors occur on the first sensor of a task.
So perhaps there is some kind of disturbance on the line or maybe there is some kind of race condition when switching tasks.
This means it can be useful to retry to  start a temperature reading on a sensor or retry to collect data from a sensor as it doesn't happen often (or at least should not happen often)