### PR TITLE
[JSON] Add variables to /json output

### DIFF
--- a/src/src/WebServer/JSON.cpp
+++ b/src/src/WebServer/JSON.cpp
@@ -154,6 +154,8 @@ void handle_json()
         LabelType::SYSTEM_LIBRARIES,
         LabelType::PLUGIN_COUNT,
         LabelType::PLUGIN_DESCRIPTION,
+        LabelType::BUILD_TIME,
+        LabelType::BINARY_FILENAME,
         LabelType::LOCAL_TIME,
         LabelType::TIME_SOURCE,
         LabelType::TIME_WANDER,
@@ -198,6 +200,12 @@ void handle_json()
         LabelType::TIMEZONE_OFFSET,
         LabelType::LATITUDE,
         LabelType::LONGITUDE,
+        LabelType::SYSLOG_LOG_LEVEL,
+        LabelType::SERIAL_LOG_LEVEL,
+        LabelType::WEB_LOG_LEVEL,
+        #if FEATURE_SD
+        LabelType::SD_LOG_LEVEL,
+        #endif // if FEATURE_SD
 
 
         LabelType::MAX_LABEL


### PR DESCRIPTION
Adding these variables:
- Build Time
- Binary Filename
- Syslog Log Level
- Serial Log Level
- Web Log Level
- SD Log Level (Only when the SD feature is available in the build)

Resolves: #4185 