### PR TITLE
Fix github-script@v5 breaking change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,12 +112,12 @@ jobs:
         with:
           result-encoding: string
           script: |
-            const tagRefObj = await github.git.getRef({
+            const tagRefObj = await github.rest.git.getRef({
               ...context.repo,
               ref: context.ref.replace('refs/', '')
             });
 
-            const tagObj = await github.git.getTag({
+            const tagObj = await github.rest.git.getTag({
               ...context.repo,
               tag_sha: tagRefObj.data.object.sha
             });


### PR DESCRIPTION
Looking at dependabot PR changelog
https://github.com/letscontrolit/ESPEasy/pull/4106

Since v5, rest methods have their own namespace
https://github.com/actions/github-script#breaking-changes-in-v5

Fixing latest release that broke on this step
https://github.com/letscontrolit/ESPEasy/runs/7740919347?check_suite_focus=true#step:2:21