### PR TITLE
[Build] Remove NeoPixel plugins from DISPLAY builds

### DIFF
--- a/docs/source/Plugin/_plugin_substitutions_p03x.repl
+++ b/docs/source/Plugin/_plugin_substitutions_p03x.repl
@@ -106,7 +106,7 @@
 .. |P038_type| replace:: :cyan:`Output`
 .. |P038_typename| replace:: :cyan:`Output - NeoPixel (Basic)`
 .. |P038_porttype| replace:: `.`
-.. |P038_status| replace:: :green:`NORMAL` :yellow:`DISPLAY, NEOPIXEL`
+.. |P038_status| replace:: :green:`NORMAL` :yellow:`NEOPIXEL`
 .. |P038_github| replace:: P038_NeoPixel.ino
 .. _P038_github: https://github.com/letscontrolit/ESPEasy/blob/mega/src/_P038_NeoPixel.ino
 .. |P038_usedby| replace:: `NeoPixel RGB and RGBW LEDs and LED Strips`

--- a/docs/source/Plugin/_plugin_substitutions_p04x.repl
+++ b/docs/source/Plugin/_plugin_substitutions_p04x.repl
@@ -15,7 +15,7 @@
 .. |P041_type| replace:: :cyan:`Output`
 .. |P041_typename| replace:: :cyan:`Output - NeoPixel (Word Clock)`
 .. |P041_porttype| replace:: `.`
-.. |P041_status| replace:: :green:`NORMAL` :yellow:`DISPLAY, NEOPIXEL`
+.. |P041_status| replace:: :green:`NORMAL` :yellow:`NEOPIXEL`
 .. |P041_github| replace:: P041_NeoClock.ino
 .. _P041_github: https://github.com/letscontrolit/ESPEasy/blob/mega/src/_P041_NeoClock.ino
 .. |P041_usedby| replace:: `.`
@@ -28,7 +28,7 @@
 .. |P042_type| replace:: :cyan:`Output`
 .. |P042_typename| replace:: :cyan:`Output - NeoPixel (Candle)`
 .. |P042_porttype| replace:: `.`
-.. |P042_status| replace:: :green:`NORMAL` :yellow:`DISPLAY, NEOPIXEL`
+.. |P042_status| replace:: :green:`NORMAL` :yellow:`NEOPIXEL`
 .. |P042_github| replace:: P042_Candle.ino
 .. _P042_github: https://github.com/letscontrolit/ESPEasy/blob/mega/src/_P042_Candle.ino
 .. |P042_usedby| replace:: `.`

--- a/docs/source/Plugin/_plugin_substitutions_p07x.repl
+++ b/docs/source/Plugin/_plugin_substitutions_p07x.repl
@@ -3,7 +3,7 @@
 .. |P070_type| replace:: :cyan:`Output`
 .. |P070_typename| replace:: :cyan:`Output -  NeoPixel Ring Clock`
 .. |P070_porttype| replace:: `.`
-.. |P070_status| replace:: :yellow:`DISPLAY, NEOPIXEL, COLLECTION A`
+.. |P070_status| replace:: :yellow:`NEOPIXEL, COLLECTION A`
 .. |P070_github| replace:: P070_NeoPixel_Clock.ino
 .. _P070_github: https://github.com/letscontrolit/ESPEasy/blob/mega/src/_P070_NeoPixel_Clock.ino
 .. |P070_usedby| replace:: `.`

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -1357,21 +1357,21 @@ To create/register a plugin, you have to :
    #ifndef USES_P036
     #define USES_P036   // FrameOLED
    #endif
-  //  #ifndef USES_P038
-  //   #define USES_P038   // NeoPixel
-  //  #endif
-  //  #ifndef USES_P041
-  //   #define USES_P041   // NeoClock
-  //  #endif
-  //  #ifndef USES_P042
-  //   #define USES_P042   // Candle
-  //  #endif
+   #ifdef USES_P038
+    #undef USES_P038   // DISABLE NeoPixel
+   #endif
+   #ifdef USES_P041
+    #undef USES_P041   // DISABLE NeoClock
+   #endif
+   #ifdef USES_P042
+    #undef USES_P042   // DISABLE Candle
+   #endif
    #ifndef USES_P057
     #define USES_P057   // HT16K33_LED
    #endif
-  //  #ifndef USES_P070
-  //   #define USES_P070   // NeoPixel_Clock
-  //  #endif
+   #ifdef USES_P070
+    #undef USES_P070   // DISABLE NeoPixel_Clock
+   #endif
    #ifndef USES_P075
     #define USES_P075   // Nextion
    #endif

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -1357,21 +1357,21 @@ To create/register a plugin, you have to :
    #ifndef USES_P036
     #define USES_P036   // FrameOLED
    #endif
-   #ifndef USES_P038
-    #define USES_P038   // NeoPixel
-   #endif
-   #ifndef USES_P041
-    #define USES_P041   // NeoClock
-   #endif
-   #ifndef USES_P042
-    #define USES_P042   // Candle
-   #endif
+  //  #ifndef USES_P038
+  //   #define USES_P038   // NeoPixel
+  //  #endif
+  //  #ifndef USES_P041
+  //   #define USES_P041   // NeoClock
+  //  #endif
+  //  #ifndef USES_P042
+  //   #define USES_P042   // Candle
+  //  #endif
    #ifndef USES_P057
     #define USES_P057   // HT16K33_LED
    #endif
-   #ifndef USES_P070
-    #define USES_P070   // NeoPixel_Clock
-   #endif
+  //  #ifndef USES_P070
+  //   #define USES_P070   // NeoPixel_Clock
+  //  #endif
    #ifndef USES_P075
     #define USES_P075   // Nextion
    #endif


### PR DESCRIPTION
To regain some space in the Display builds, the NeoPixel plugins are now excluded from the `DISPLAY` builds.

The NeoPixel plugins are (already) available in a separate set of `NEOPIXEL` builds.