### PR TITLE
Fix boot flash mode for factory firmware

### DIFF
--- a/tools/pio/post_esp32.py
+++ b/tools/pio/post_esp32.py
@@ -40,7 +40,11 @@ def esp32_create_combined_bin(source, target, env):
     flash_size = env.BoardConfig().get("upload.flash_size")
     flash_freq = env.BoardConfig().get("build.f_flash", '40m')
     flash_freq = flash_freq.replace('000000L', 'm')
-    flash_mode = env.BoardConfig().get("build.flash_mode")
+    flash_mode = env.BoardConfig().get("build.flash_mode", "dout")
+    if flash_mode == "qio":
+        flash_mode = "dio"
+    elif flash_mode == "qout":
+        flash_mode = "dout"
     cmd = [
         "--chip",
         chip,


### PR DESCRIPTION
and set default to `dout` if none is set in boards manifest or in platformio.ini

Maybe fixes #4194