### PR TITLE
[Build Version] Generate build version based on date

### DIFF
--- a/platformio_esp82xx_base.ini
+++ b/platformio_esp82xx_base.ini
@@ -37,10 +37,15 @@ lib_ignore                = ${core_stage.lib_ignore}
 
 
 [no_ir]
-lib_ignore                = IRremoteESP8266, HeatpumpIR
+lib_ignore                = IRremoteESP8266
+                            HeatpumpIR
 
 [no_sd]
-lib_ignore                = SD(esp8266), SD, SDFS
+lib_ignore                = ESP8266SdFat
+                            SD(esp8266)
+                            SD
+                            SDFS
+                            LittleFS(esp8266)
 
 [no_littlefs]
 lib_ignore                = LittleFS(esp8266)
@@ -110,6 +115,7 @@ platform                  = ${regular_platform.platform}
 platform_packages         = ${regular_platform.platform_packages}
 build_flags               = ${regular_platform.build_flags}
 lib_ignore                = ${regular_platform.lib_ignore}
+                            ESP8266SdFat
                             SD(esp8266)
                             SD
                             SDFS
@@ -120,6 +126,7 @@ platform                  = ${regular_platform_alt_wifi.platform}
 platform_packages         = ${regular_platform_alt_wifi.platform_packages}
 build_flags               = ${regular_platform_alt_wifi.build_flags}
 lib_ignore                = ${regular_platform_alt_wifi.lib_ignore}
+                            ESP8266SdFat
                             SD(esp8266)
                             SD
                             SDFS
@@ -131,6 +138,7 @@ platform                  = ${beta_platform.platform}
 platform_packages         = ${beta_platform.platform_packages}
 build_flags               = ${beta_platform.build_flags}
 lib_ignore                = ${beta_platform.lib_ignore}
+                            ESP8266SdFat
                             SD(esp8266)
                             SD
                             SDFS
@@ -164,6 +172,7 @@ build_flags               = ${regular_platform_alt_wifi.build_flags}
                             -DLIMIT_BUILD_SIZE
                             -DDISABLE_SC16IS752_Serial
 lib_ignore                = ${regular_platform_alt_wifi.lib_ignore}
+                            ESP8266SdFat
                             SD(esp8266)
                             SD
                             SDFS
@@ -177,6 +186,8 @@ build_flags               = ${beta_platform.build_flags}
                             -DLIMIT_BUILD_SIZE
                             -DDISABLE_SC16IS752_Serial
 lib_ignore                = ${beta_platform.lib_ignore}
+                            ESP8266SdFat
+                            SD(esp8266)
                             SD
                             SDFS
                             LittleFS(esp8266)
@@ -194,6 +205,7 @@ lib_ignore                = ESP32_ping
                             ESP32WebServer
                             ServoESP32
                             ESP32HTTPUpdateServer
+                            ESP8266SdFat
                             SD(esp8266)
                             SD
                             SDFS

--- a/src/_N001_Email.cpp
+++ b/src/_N001_Email.cpp
@@ -20,6 +20,7 @@
 #include "src/Helpers/ESPEasy_Storage.h"
 #include "src/Helpers/ESPEasy_time_calc.h"
 #include "src/Helpers/Networking.h"
+#include "src/Helpers/StringGenerator_System.h"
 #include "src/Helpers/StringParser.h"
 #include "src/Helpers/_CPlugin_Helper.h" // safeReadStringUntil
 #include "src/Helpers/_NPlugin_init.h"
@@ -142,7 +143,7 @@ bool NPlugin_001_send(const NotificationSettingsStruct& notificationsettings, co
 		mailheader.replace(F("$emailfrom"), notificationsettings.Sender);
 		mailheader.replace(F("$ato"), notificationsettings.Receiver);
 		mailheader.replace(F("$subject"), aSub);
-		mailheader.replace(F("$espeasyversion"), String(BUILD));
+		mailheader.replace(F("$espeasyversion"), getSystemBuildString());
 		aMesg.replace(F("\r"), F("<br/>")); // re-write line breaks for Content-type: text/html
 
 		// Wait for Client to Start Sending

--- a/src/_P081_Cron.ino
+++ b/src/_P081_Cron.ino
@@ -163,7 +163,7 @@ boolean Plugin_081(uint8_t function, struct EventStruct *event, String& string)
             P081_setCronExecTimes(event, last_exec_time, next_exec_time);
 
             # ifndef BUILD_NO_DEBUG
-            addLog(LOG_LEVEL_DEBUG, String(F("Next execution:")) + ESPEasy_time::getDateTimeString(*gmtime(&next_exec_time)));
+            addLog(LOG_LEVEL_DEBUG, String(F("Next execution:")) + formatDateTimeString(*gmtime(&next_exec_time)));
             # endif // ifndef BUILD_NO_DEBUG
 
             if (function != PLUGIN_TIME_CHANGE) {

--- a/src/_P082_GPS.ino
+++ b/src/_P082_GPS.ino
@@ -721,7 +721,7 @@ void P082_html_show_stats(struct EventStruct *event) {
 
   if (P082_data->getDateTime(dateTime, age, pps_sync)) {
     dateTime = node_time.addSeconds(dateTime, (age / 1000), false);
-    addHtml(ESPEasy_time::getDateTimeString(dateTime));
+    addHtml(formatDateTimeString(dateTime));
   } else {
     addHtml('-');
   }

--- a/src/src/Commands/Settings.cpp
+++ b/src/src/Commands/Settings.cpp
@@ -4,6 +4,8 @@
 
 #include "../Commands/Common.h"
 
+#include "../CustomBuild/CompiletimeDefines.h"
+
 #include "../ESPEasyCore/ESPEasyNetwork.h"
 #include "../ESPEasyCore/Serial.h"
 
@@ -15,6 +17,7 @@
 #include "../Helpers/Memory.h"
 #include "../Helpers/Misc.h"
 #include "../Helpers/StringConverter.h"
+#include "../Helpers/StringGenerator_System.h"
 
 
 String Command_Settings_Build(struct EventStruct *event, const char* Line)
@@ -94,7 +97,7 @@ const __FlashStringHelper * Command_Settings_Print(struct EventStruct *event, co
 
 	serialPrintln(F("System Info"));
 	serialPrint(F("  IP Address    : ")); serialPrintln(NetworkLocalIP().toString());
-	serialPrint(F("  Build         : ")); serialPrintln(String(static_cast<int>(BUILD)));
+	serialPrint(F("  Build         : ")); serialPrintln(String(get_build_nr()) + '/' + getSystemBuildString());
 	serialPrint(F("  Name          : ")); serialPrintln(Settings.Name);
 	serialPrint(F("  Unit          : ")); serialPrintln(String(static_cast<int>(Settings.Unit)));
 	serialPrint(F("  WifiSSID      : ")); serialPrintln(SecuritySettings.WifiSSID);

--- a/src/src/CustomBuild/CompiletimeDefines.cpp
+++ b/src/src/CustomBuild/CompiletimeDefines.cpp
@@ -29,7 +29,9 @@ uint16_t get_build_nr() {
   return SET_BUILD_VERSION;
   #else
   #pragma message ( "Build is not based on current date" )
-  return BUILD;
+  // Last used version for BUILD was 20116, 
+  // so make sure we can recognize a build not made using the compile time defines.
+  return 20117; 
   #endif
 }
 

--- a/src/src/CustomBuild/CompiletimeDefines.cpp
+++ b/src/src/CustomBuild/CompiletimeDefines.cpp
@@ -1,5 +1,7 @@
 #include "../CustomBuild/CompiletimeDefines.h"
 
+#include "../CustomBuild/ESPEasy_buildinfo.h"
+
 // This file will be "patched" at compiletime by
 // tools/pio/generate-compiletime-defines.py
 // Therefore this one may not include ESPEasy_common.h
@@ -20,6 +22,16 @@
 #define STRINGIFY1(s) #s
 // Uncrustify must not be used on macros, but we're now done, so turn Uncrustify on again.
 // *INDENT-ON*
+
+
+uint16_t get_build_nr() {
+  #ifdef SET_BUILD_VERSION
+  return SET_BUILD_VERSION;
+  #else
+  #pragma message ( "Build is not based on current date" )
+  return BUILD;
+  #endif
+}
 
 const __FlashStringHelper* get_binary_filename() {
  #ifndef SET_BUILD_BINARY_FILENAME

--- a/src/src/CustomBuild/CompiletimeDefines.cpp
+++ b/src/src/CustomBuild/CompiletimeDefines.cpp
@@ -12,15 +12,20 @@
 
 // End of defines being patched by the Python build script.
 
+// Uncrustify must not be used on macros, so turn it off.
+// *INDENT-OFF*
+
 // Need to add quotes around defines as the PIO build tools make it hard to include the string quotes.
 #define STRINGIFY(s) STRINGIFY1(s)
-#define STRINGIFY1(s) # s
+#define STRINGIFY1(s) #s
+// Uncrustify must not be used on macros, but we're now done, so turn Uncrustify on again.
+// *INDENT-ON*
 
 const __FlashStringHelper* get_binary_filename() {
  #ifndef SET_BUILD_BINARY_FILENAME
   return F("firmware.bin");
  #else // ifndef SET_BUILD_BINARY_FILENAME
-  return F(STRINGIFY(SET_BUILD_BINARY_FILENAME));
+  return F(SET_BUILD_BINARY_FILENAME);
  #endif // ifndef SET_BUILD_BINARY_FILENAME
 }
 
@@ -46,7 +51,7 @@ const __FlashStringHelper* get_build_platform() {
  #ifndef SET_BUILD_PLATFORM
   return F("");
   #else // ifndef SET_BUILD_PLATFORM
-  return F(STRINGIFY(SET_BUILD_PLATFORM));
+  return F(SET_BUILD_PLATFORM);
  #endif // ifndef SET_BUILD_PLATFORM
 }
 
@@ -54,13 +59,13 @@ const __FlashStringHelper* get_git_head() {
  #ifndef SET_BUILD_GIT_HEAD
   return F("");
  #else // ifndef SET_BUILD_GIT_HEAD
-  return F(STRINGIFY(SET_BUILD_GIT_HEAD));
+  return F(SET_BUILD_GIT_HEAD);
  #endif // ifndef SET_BUILD_GIT_HEAD
 }
 
 const __FlashStringHelper * get_board_name() {
   #ifdef SET_BOARD_NAME
-  return F(STRINGIFY(SET_BOARD_NAME));
+  return F(SET_BOARD_NAME);
   #elif defined(ARDUINO_BOARD)
   return F(ARDUINO_BOARD);
   #else

--- a/src/src/CustomBuild/CompiletimeDefines.h
+++ b/src/src/CustomBuild/CompiletimeDefines.h
@@ -3,8 +3,10 @@
 
 #include <Arduino.h>
 
-//#include "../../ESPEasy_common.h"
 
+// Build NR is used as a "revision" nr for settings
+// As of 2022-08-18, it is the nr of days since 2022-08-18 + 20200
+uint16_t get_build_nr();
 const __FlashStringHelper * get_binary_filename();
 const __FlashStringHelper * get_build_time();
 const __FlashStringHelper * get_build_date();

--- a/src/src/CustomBuild/ESPEasy_buildinfo.h
+++ b/src/src/CustomBuild/ESPEasy_buildinfo.h
@@ -22,7 +22,7 @@
 
 // Deprecated define.
 // Use get_build_nr() from CustomBuild/CompiletimeDefines.h
-#define BUILD                           20116    // git version e.g. "20103" can be read as "2.1.03" (stored in int16_t)
+//#define BUILD                           20116    // git version e.g. "20103" can be read as "2.1.03" (stored in int16_t)
 
 
 #ifndef BUILD_NOTES

--- a/src/src/CustomBuild/ESPEasy_buildinfo.h
+++ b/src/src/CustomBuild/ESPEasy_buildinfo.h
@@ -20,7 +20,11 @@
 #endif // if defined(ESP32)
 
 
+// Deprecated define.
+// Use get_build_nr() from CustomBuild/CompiletimeDefines.h
 #define BUILD                           20116    // git version e.g. "20103" can be read as "2.1.03" (stored in int16_t)
+
+
 #ifndef BUILD_NOTES
 #if defined(ESP8266)
   # define BUILD_NOTES                 " - Mega"

--- a/src/src/ESPEasyCore/ESPEasy_setup.cpp
+++ b/src/src/ESPEasyCore/ESPEasy_setup.cpp
@@ -4,6 +4,7 @@
 
 #include "../../ESPEasy-Globals.h"
 #include "../../_Plugin_Helper.h"
+#include "../CustomBuild/CompiletimeDefines.h"
 #include "../ESPEasyCore/ESPEasyNetwork.h"
 #include "../ESPEasyCore/ESPEasyRules.h"
 #include "../ESPEasyCore/ESPEasyWifi.h"
@@ -359,7 +360,7 @@ void ESPEasy_setup()
   #endif
 
 
-  if (Settings.Build != BUILD) {
+  if (Settings.Build != get_build_nr()) {
     BuildFixes();
   }
 

--- a/src/src/Helpers/ESPEasy_FactoryDefault.cpp
+++ b/src/src/Helpers/ESPEasy_FactoryDefault.cpp
@@ -3,6 +3,7 @@
 #include "../../ESPEasy_common.h"
 #include "../../_Plugin_Helper.h"
 
+#include "../CustomBuild/CompiletimeDefines.h"
 #include "../CustomBuild/StorageLayout.h"
 
 #include "../DataStructs/ControllerSettingsStruct.h"
@@ -184,7 +185,7 @@ void ResetFactory()
 
   Settings.PID     = ESP_PROJECT_PID;
   Settings.Version = VERSION;
-  Settings.Build   = BUILD;
+  Settings.Build   = get_build_nr();
 
   //  Settings.IP_Octet				 = DEFAULT_IP_OCTET;
   Settings.Delay                   = DEFAULT_DELAY;

--- a/src/src/Helpers/ESPEasy_Storage.cpp
+++ b/src/src/Helpers/ESPEasy_Storage.cpp
@@ -2,6 +2,7 @@
 
 #include "../../ESPEasy_common.h"
 
+#include "../CustomBuild/CompiletimeDefines.h"
 #include "../CustomBuild/StorageLayout.h"
 
 #include "../DataStructs/TimingStats.h"
@@ -320,7 +321,7 @@ String BuildFixes()
   #endif
 
 
-  Settings.Build = BUILD;
+  Settings.Build = get_build_nr();
   return SaveSettings();
 }
 

--- a/src/src/Helpers/ESPEasy_Storage.cpp
+++ b/src/src/Helpers/ESPEasy_Storage.cpp
@@ -320,6 +320,10 @@ String BuildFixes()
   }
   #endif
 
+  // Starting 2022/08/18
+  // Use get_build_nr() value for settings transitions.
+  // This value will also be shown when building using PlatformIO, when showing the  Compile time defines 
+
 
   Settings.Build = get_build_nr();
   return SaveSettings();

--- a/src/src/Helpers/ESPEasy_time.cpp
+++ b/src/src/Helpers/ESPEasy_time.cpp
@@ -51,40 +51,6 @@ struct tm ESPEasy_time::addSeconds(const struct tm& ts, int seconds, bool toLoca
   return result;
 }
 
-void ESPEasy_time::breakTime(unsigned long timeInput, struct tm& tm) {
-  uint32_t time = (uint32_t)timeInput;
-  tm.tm_sec  = time % 60;
-  time      /= 60;                   // now it is minutes
-  tm.tm_min  = time % 60;
-  time      /= 60;                   // now it is hours
-  tm.tm_hour = time % 24;
-  time      /= 24;                   // now it is days
-  tm.tm_wday = ((time + 4) % 7) + 1; // Sunday is day 1
-
-  int      year = 1970;
-  unsigned long days = 0;
-  while ((unsigned)(days += (isLeapYear(year) ? 366 : 365)) <= time) {
-    year++;
-  }
-  tm.tm_year = year - 1900; // tm_year starts at 1900
-
-  days -= isLeapYear(year) ? 366 : 365;
-  time -= days;      // now it is days in this year, starting at 0
-
-  uint8_t month = 0;
-  for (month = 0; month < 12; month++) {
-    const uint8_t monthLength = getMonthDays(year, month);
-    if (time >= monthLength) {
-      time -= monthLength;
-    } else {
-      break;
-    }
-  }
-  tm.tm_mon  = month;     // Jan is month 0
-  tm.tm_mday = time + 1;  // day of month start at 1
-}
-
-
 void ESPEasy_time::restoreFromRTC()
 {
   static bool firstCall = true;
@@ -482,82 +448,30 @@ bool ESPEasy_time::getNtpTime(double& unixTime_d)
  \*********************************************************************************************/
 String ESPEasy_time::getDateString(char delimiter) const
 {
-  return getDateString(tm, delimiter);
+  return formatDateString(tm, delimiter);
 }
 
-String ESPEasy_time::getDateString(const struct tm& ts, char delimiter) {
-  // time format example with ':' delimiter: 23:59:59 (HH:MM:SS)
-  char DateString[20]; // 19 digits plus the null char
-  const int year = 1900 + ts.tm_year;
-
-  sprintf_P(DateString, PSTR("%4d%c%02d%c%02d"), year, delimiter, ts.tm_mon + 1, delimiter, ts.tm_mday);
-  return DateString;
-}
 
 String ESPEasy_time::getTimeString(char delimiter, bool show_seconds /*=true*/, char hour_prefix /*='\0'*/) const
 {
-  return getTimeString(tm, delimiter, false, show_seconds, hour_prefix);
+  return formatTimeString(tm, delimiter, false, show_seconds, hour_prefix);
 }
 
 String ESPEasy_time::getTimeString_ampm(char delimiter, bool show_seconds /*=true*/, char hour_prefix /*='\0'*/) const
 {
-  return getTimeString(tm, delimiter, true, show_seconds, hour_prefix);
+  return formatTimeString(tm, delimiter, true, show_seconds, hour_prefix);
 }
 
-// returns the current Time separated by the given delimiter
-// time format example with ':' delimiter: 23:59:59 (HH:MM:SS)
-String ESPEasy_time::getTimeString(const struct tm& ts, char delimiter, bool am_pm, bool show_seconds, char hour_prefix /*='\0'*/)
-{
-  char TimeString[20]; // 19 digits plus the null char
-  char hour_prefix_s[2] = { 0 };
 
-  if (am_pm) {
-    uint8_t hour(ts.tm_hour % 12);
-
-    if (hour == 0) { hour = 12; }
-    const char a_or_p = ts.tm_hour < 12 ? 'A' : 'P';
-    if (hour < 10) { hour_prefix_s[0] = hour_prefix; }
-
-    if (show_seconds) {
-      sprintf_P(TimeString, PSTR("%s%d%c%02d%c%02d %cM"),
-                hour_prefix_s, hour, delimiter, ts.tm_min, delimiter, ts.tm_sec, a_or_p);
-    } else {
-      sprintf_P(TimeString, PSTR("%s%d%c%02d %cM"),
-                hour_prefix_s, hour, delimiter, ts.tm_min, a_or_p);
-    }
-  } else {
-    if (show_seconds) {
-      sprintf_P(TimeString, PSTR("%02d%c%02d%c%02d"),
-                ts.tm_hour, delimiter, ts.tm_min, delimiter, ts.tm_sec);
-    } else {
-      if (ts.tm_hour < 10) { hour_prefix_s[0] = hour_prefix; }
-      sprintf_P(TimeString, PSTR("%s%d%c%02d"),
-                hour_prefix_s, ts.tm_hour, delimiter, ts.tm_min);
-    }
-  }
-  return TimeString;
-}
 
 String ESPEasy_time::getDateTimeString(char dateDelimiter, char timeDelimiter,  char dateTimeDelimiter) const {
-  return getDateTimeString(tm, dateDelimiter, timeDelimiter, dateTimeDelimiter, false);
+  return formatDateTimeString(tm, dateDelimiter, timeDelimiter, dateTimeDelimiter, false);
 }
 
 String ESPEasy_time::getDateTimeString_ampm(char dateDelimiter, char timeDelimiter,  char dateTimeDelimiter) const {
-  return getDateTimeString(tm, dateDelimiter, timeDelimiter, dateTimeDelimiter, true);
+  return formatDateTimeString(tm, dateDelimiter, timeDelimiter, dateTimeDelimiter, true);
 }
 
-String ESPEasy_time::getDateTimeString(const struct tm& ts, char dateDelimiter, char timeDelimiter,  char dateTimeDelimiter, bool am_pm)
-{
-  // if called like this: getDateTimeString('\0', '\0', '\0');
-  // it will give back this: 20161231235959  (YYYYMMDDHHMMSS)
-  String ret = getDateString(ts, dateDelimiter);
-
-  if (dateTimeDelimiter != '\0') {
-    ret += dateTimeDelimiter;
-  }
-  ret += getTimeString(ts, timeDelimiter, am_pm, true);
-  return ret;
-}
 
 /********************************************************************************************\
    Get current time/date
@@ -624,25 +538,25 @@ int ESPEasy_time::getSecOffset(const String& format) {
 }
 
 String ESPEasy_time::getSunriseTimeString(char delimiter) const {
-  return getTimeString(sunRise, delimiter, false, false);
+  return formatTimeString(sunRise, delimiter, false, false);
 }
 
 String ESPEasy_time::getSunsetTimeString(char delimiter) const {
-  return getTimeString(sunSet, delimiter, false, false);
+  return formatTimeString(sunSet, delimiter, false, false);
 }
 
 String ESPEasy_time::getSunriseTimeString(char delimiter, int secOffset) const {
   if (secOffset == 0) {
     return getSunriseTimeString(delimiter);
   }
-  return getTimeString(getSunRise(secOffset), delimiter, false, false);
+  return formatTimeString(getSunRise(secOffset), delimiter, false, false);
 }
 
 String ESPEasy_time::getSunsetTimeString(char delimiter, int secOffset) const {
   if (secOffset == 0) {
     return getSunsetTimeString(delimiter);
   }
-  return getTimeString(getSunSet(secOffset), delimiter, false, false);
+  return formatTimeString(getSunSet(secOffset), delimiter, false, false);
 }
 
 float ESPEasy_time::sunDeclination(int doy) {

--- a/src/src/Helpers/ESPEasy_time.h
+++ b/src/src/Helpers/ESPEasy_time.h
@@ -18,8 +18,6 @@ public:
   struct tm   addSeconds(const struct tm& ts,
                          int              seconds,
                          bool             toLocalTime) const;
-  static void breakTime(unsigned long timeInput,
-                        struct tm   & tm);
 
   // Restore the last known system time
   // This may be useful to get some idea of what time it is.
@@ -63,30 +61,17 @@ public:
 // Default date format example: 20161231 (YYYYMMDD)
 String getDateString(char delimiter = '\0') const;
 
-// Format given Date separated by the given delimiter
-// date format example with '-' delimiter: 2016-12-31 (YYYY-MM-DD)
-static String getDateString(const struct tm& ts, char delimiter);
-
 // Formats the current Time
 // Default time format example: 235959 (HHMMSS)
 String getTimeString(char delimiter = '\0', bool show_seconds = true, char hour_prefix = '\0') const;
 
 String getTimeString_ampm(char delimiter = '\0', bool show_seconds = true, char hour_prefix = '\0') const;
 
-// returns the current Time separated by the given delimiter
-// time format example with ':' delimiter: 23:59:59 (HH:MM:SS)
-static String getTimeString(const struct tm& ts, char delimiter, bool am_pm, bool show_seconds, char hour_prefix = '\0');
-
-
 
 
 String getDateTimeString(char dateDelimiter = '-', char timeDelimiter = ':',  char dateTimeDelimiter = ' ') const;
 String getDateTimeString_ampm(char dateDelimiter = '-', char timeDelimiter = ':',  char dateTimeDelimiter = ' ') const;
 
-// returns the current Date and Time separated by the given delimiter
-// if called like this: getDateTimeString('\0', '\0', '\0');
-// it will give back this: 20161231235959  (YYYYMMDDHHMMSS)
-static String getDateTimeString(const struct tm& ts, char dateDelimiter = '-', char timeDelimiter = ':',  char dateTimeDelimiter = ' ', bool am_pm = false);
 
 
 /********************************************************************************************\

--- a/src/src/Helpers/ESPEasy_time_calc.h
+++ b/src/src/Helpers/ESPEasy_time_calc.h
@@ -69,6 +69,26 @@ uint8_t getMonthDays(int year, uint8_t month);
 
 uint32_t makeTime(const struct tm& tm);
 
+void breakTime(unsigned long timeInput, struct tm& tm);
+
+/********************************************************************************************\
+   Unix Time formatting
+ \*********************************************************************************************/
+
+// Format given Date separated by the given delimiter
+// date format example with '-' delimiter: 2016-12-31 (YYYY-MM-DD)
+String formatDateString(const struct tm& ts, char delimiter);
+
+// returns the current Time separated by the given delimiter
+// time format example with ':' delimiter: 23:59:59 (HH:MM:SS)
+String formatTimeString(const struct tm& ts, char delimiter, bool am_pm, bool show_seconds, char hour_prefix = '\0');
+
+// returns the current Date and Time separated by the given delimiter
+// if called like this: getDateTimeString('\0', '\0', '\0');
+// it will give back this: 20161231235959  (YYYYMMDDHHMMSS)
+String formatDateTimeString(const struct tm& ts, char dateDelimiter = '-', char timeDelimiter = ':',  char dateTimeDelimiter = ' ', bool am_pm = false);
+
+
 /********************************************************************************************\
    Time computations for rules.
  \*********************************************************************************************/

--- a/src/src/Helpers/ESPEasy_time_zone.cpp
+++ b/src/src/Helpers/ESPEasy_time_zone.cpp
@@ -62,8 +62,8 @@ void ESPEasy_time_zone::logTimeZoneInfo() {
 
     if (m_dstLoc != 0) {
       struct tm tmp;
-      ESPEasy_time::breakTime(m_dstLoc, tmp);
-      log += ESPEasy_time::getDateTimeString(tmp, '-', ':', ' ', false);
+      breakTime(m_dstLoc, tmp);
+      log += formatDateTimeString(tmp, '-', ':', ' ', false);
     }
     log += F(" offset: ");
     log += m_dst.offset;
@@ -75,8 +75,8 @@ void ESPEasy_time_zone::logTimeZoneInfo() {
 
   if (m_stdLoc != 0) {
     struct tm tmp;
-    ESPEasy_time::breakTime(m_stdLoc, tmp);
-    log += ESPEasy_time::getDateTimeString(tmp, '-', ':', ' ', false);
+    breakTime(m_stdLoc, tmp);
+    log += formatDateTimeString(tmp, '-', ':', ' ', false);
   }
   log += F(" offset: ");
   log += m_std.offset;

--- a/src/src/Helpers/Networking.cpp
+++ b/src/src/Helpers/Networking.cpp
@@ -1223,7 +1223,7 @@ String get_user_agent_string() {
 
   userAgent.reserve(agent_size);
   userAgent += F("ESP Easy/");
-  userAgent += BUILD;
+  userAgent += get_build_nr();
   userAgent += '/';
   userAgent += get_build_date();
   userAgent += ' ';

--- a/src/src/Helpers/StringGenerator_System.cpp
+++ b/src/src/Helpers/StringGenerator_System.cpp
@@ -5,6 +5,7 @@
    ESPEasy specific strings
 \*********************************************************************************************/
 
+#include "../CustomBuild/CompiletimeDefines.h"
 
 #if FEATURE_MQTT
 
@@ -158,12 +159,21 @@ String getResetReasonString() {
 }
 
 String getSystemBuildString() {
-  String result;
+  return formatSystemBuildNr(get_build_nr());
+}
 
-  result += BUILD;
-  result += ' ';
-  result += F(BUILD_NOTES);
-  return result;
+String formatSystemBuildNr(uint16_t buildNr) {
+  if (buildNr < 20200) return String(buildNr);
+
+  // Build NR is used as a "revision" nr for settings
+  // As of 2022-08-18, it is the nr of days since 2022-08-18 + 20200
+  const uint32_t seconds_since_start = (buildNr - 20200) * 86400;
+  const uint32_t unix_time_start = 1660780800; // Thu Aug 18 2022 00:00:00 GMT+0000
+  struct tm build_time;
+  breakTime(unix_time_start + seconds_since_start, build_time);
+
+  String res = formatDateString(build_time, '\0');
+  return res;
 }
 
 String getPluginDescriptionString() {

--- a/src/src/Helpers/StringGenerator_System.h
+++ b/src/src/Helpers/StringGenerator_System.h
@@ -29,6 +29,8 @@ String  getResetReasonString();
 
 String  getSystemBuildString();
 
+String  formatSystemBuildNr(uint16_t buildNr);
+
 String  getPluginDescriptionString();
 
 String  getSystemLibraryString();

--- a/src/src/Helpers/StringProvider.cpp
+++ b/src/src/Helpers/StringProvider.cpp
@@ -361,7 +361,7 @@ String getValue(LabelType::Enum label) {
     case LabelType::PERIODICAL_GRAT_ARP:    return jsonBool(Settings.gratuitousARP());
     case LabelType::CONNECTION_FAIL_THRESH: return String(Settings.ConnectionFailuresThreshold);
 
-    case LabelType::BUILD_DESC:             return String(BUILD);
+    case LabelType::BUILD_DESC:             return getSystemBuildString();
     case LabelType::GIT_BUILD:              
       { 
         const String res(F(BUILD_GIT));

--- a/src/src/PluginStructs/P081_data_struct.cpp
+++ b/src/src/PluginStructs/P081_data_struct.cpp
@@ -175,7 +175,7 @@ String P081_formatExecTime(taskIndex_t taskIndex, uint8_t varNr) {
   time_t exec_time = P081_getCronExecTime(taskIndex, varNr);
 
   if (exec_time != CRON_INVALID_INSTANT) {
-    return ESPEasy_time::getDateTimeString(*gmtime(&exec_time));
+    return formatDateTimeString(*gmtime(&exec_time));
   }
   return F("-");
 }

--- a/src/src/WebServer/DownloadPage.cpp
+++ b/src/src/WebServer/DownloadPage.cpp
@@ -2,10 +2,11 @@
 
 #ifdef WEBSERVER_DOWNLOAD
 
-#include "../WebServer/ESPEasy_WebServer.h"
+//#include "../WebServer/ESPEasy_WebServer.h"
 #include "../Globals/ESPEasy_time.h"
 #include "../Globals/Settings.h"
 #include "../Helpers/ESPEasy_Storage.h"
+#include "../Helpers/StringGenerator_System.h"
 
 
 // ********************************************************************************
@@ -35,7 +36,7 @@ void handle_download()
   str += F("_U");
   str += Settings.Unit;
   str += F("_Build");
-  str += BUILD;
+  str += getSystemBuildString();
   str += '_';
 
   if (node_time.systemTimePresent())

--- a/src/src/WebServer/ESPEasy_WebServer.h
+++ b/src/src/WebServer/ESPEasy_WebServer.h
@@ -1,5 +1,5 @@
-#ifndef WEBSERVER_WEBSERVER_H
-#define WEBSERVER_WEBSERVER_H
+#ifndef WEBSERVER_ESPEASY_WEBSERVER_H
+#define WEBSERVER_ESPEASY_WEBSERVER_H
 
 #include "../WebServer/common.h"
 
@@ -211,4 +211,4 @@ String webArg(const String& arg);
 String webArg(int i);
 #endif 
 
-#endif // ifndef WEBSERVER_WEBSERVER_H
+#endif // ifndef WEBSERVER_ESPEASY_WEBSERVER_H

--- a/src/src/WebServer/JSON.cpp
+++ b/src/src/WebServer/JSON.cpp
@@ -4,6 +4,8 @@
 #include "../WebServer/JSON.h"
 #include "../WebServer/Markup_Forms.h"
 
+#include "../CustomBuild/CompiletimeDefines.h"
+
 #include "../Globals/Cache.h"
 #include "../Globals/Nodes.h"
 #include "../Globals/Device.h"
@@ -16,6 +18,7 @@
 #include "../Helpers/Numerical.h"
 #include "../Helpers/StringConverter.h"
 #include "../Helpers/StringProvider.h"
+#include "../Helpers/StringGenerator_System.h"
 
 #include "../../_Plugin_Helper.h"
 #include "../../ESPEasy-Globals.h"
@@ -312,7 +315,7 @@ void handle_json()
                                         (it->first != Settings.Unit) ? it->second.nodeName : Settings.Name);
 
           if (it->second.build) {
-            stream_next_json_object_value(F("build"), it->second.build);
+            stream_next_json_object_value(F("build"), formatSystemBuildNr(it->second.build));
           }
 
           if (it->second.nodeType) {
@@ -521,7 +524,7 @@ void handle_nodes_list_json() {
       json_number(F("first"), String(it->first));
       json_prop(F("name"), isThisUnit ? Settings.Name : it->second.nodeName);
 
-      if (it->second.build) { json_prop(F("build"), String(it->second.build)); }
+      if (it->second.build) { json_prop(F("build"), formatSystemBuildNr(it->second.build)); }
       json_prop(F("type"), getNodeTypeDisplayString(it->second.nodeType));
       json_prop(F("ip"),   it->second.ip.toString());
       json_number(F("age"), String(it->second.age));

--- a/src/src/WebServer/RootPage.cpp
+++ b/src/src/WebServer/RootPage.cpp
@@ -8,6 +8,7 @@
 #include "../WebServer/LoadFromFS.h"
 #include "../WebServer/Markup.h"
 #include "../WebServer/Markup_Buttons.h"
+#include "../WebServer/Markup_Forms.h"
 
 #include "../Commands/InternalCommands.h"
 #include "../ESPEasyCore/ESPEasyNetwork.h"
@@ -21,6 +22,7 @@
 #include "../Helpers/ESPEasy_Storage.h"
 #include "../Helpers/Memory.h"
 #include "../Helpers/Misc.h"
+#include "../Helpers/StringGenerator_System.h"
 #include "../Helpers/WebServer_commandHelper.h"
 
 
@@ -298,7 +300,7 @@ void handle_root() {
 
           if (MAIN_PAGE_SHOW_NODE_LIST_BUILD) {
             if (it->second.build) {
-              addHtmlInt(it->second.build);
+              addHtml(formatSystemBuildNr(it->second.build));
             }
             html_TD();
           }

--- a/src/src/WebServer/SysInfoPage.cpp
+++ b/src/src/WebServer/SysInfoPage.cpp
@@ -148,7 +148,7 @@ void handle_sysinfo_json() {
 # endif // if FEATURE_ETHERNET
 
   json_open(false, F("firmware"));
-  json_prop(F("build"),       String(BUILD));
+  json_prop(F("build"),       getSystemBuildString());
   json_prop(F("notes"),       F(BUILD_NOTES));
   json_prop(F("libraries"),   getSystemLibraryString());
   json_prop(F("git_version"), getValue(LabelType::GIT_BUILD));

--- a/src/src/WebServer/TimingStats.cpp
+++ b/src/src/WebServer/TimingStats.cpp
@@ -44,7 +44,7 @@ void handle_timingstats() {
   addFormHeader(F("Statistics"));
   addRowLabel(F("Start Period"));
   struct tm startPeriod = node_time.addSeconds(node_time.tm, -1.0f * timespan, false);
-  addHtml(ESPEasy_time::getDateTimeString(startPeriod, '-', ':', ' ', false));
+  addHtml(formatDateTimeString(startPeriod, '-', ':', ' ', false));
   addRowLabelValue(LabelType::LOCAL_TIME);
   addRowLabel(F("Time span"));
   addHtmlFloat(timespan);

--- a/tools/pio/generate-compiletime-defines.py
+++ b/tools/pio/generate-compiletime-defines.py
@@ -22,7 +22,7 @@ def get_git_description():
         from pygit2 import Repository
         try:
             repo = Repository('.')
-            return "'{0}_{1}'".format(repo.head.shorthand, repo.revparse_single('HEAD').short_id)
+            return "{0}_{1}".format(repo.head.shorthand, repo.revparse_single('HEAD').short_id)
         except:
             return 'No_.git_dir'
     except ImportError:
@@ -56,10 +56,10 @@ def gen_compiletime_defines(node):
     return env.Object(
         node,
         CPPDEFINES=env["CPPDEFINES"]
-        + [("SET_BUILD_BINARY_FILENAME", create_binary_filename())]
-        + [("SET_BOARD_NAME", get_board_name())]
-        + [("SET_BUILD_PLATFORM", platform.platform())]
-        + [("SET_BUILD_GIT_HEAD", get_git_description())],
+        + [("SET_BUILD_BINARY_FILENAME", '\\"%s\\"' % create_binary_filename())]
+        + [("SET_BOARD_NAME", '\\"%s\\"' % get_board_name())]
+        + [("SET_BUILD_PLATFORM", '\\"%s\\"' % platform.platform())]
+        + [("SET_BUILD_GIT_HEAD", '\\"%s\\"' % get_git_description())],
         CCFLAGS=env["CCFLAGS"]
     )
 

--- a/tools/pio/generate-compiletime-defines.py
+++ b/tools/pio/generate-compiletime-defines.py
@@ -7,6 +7,13 @@ from datetime import date
 import json
 
 
+def compute_version_date():
+    d0 = date(2022, 8, 18)
+    today = date.today()
+    delta = today - d0
+    return 20200 + delta.days
+
+
 def create_binary_filename():
     today = date.today()
     d1 = today.strftime("%Y%m%d")
@@ -59,7 +66,8 @@ def gen_compiletime_defines(node):
         + [("SET_BUILD_BINARY_FILENAME", '\\"%s\\"' % create_binary_filename())]
         + [("SET_BOARD_NAME", '\\"%s\\"' % get_board_name())]
         + [("SET_BUILD_PLATFORM", '\\"%s\\"' % platform.platform())]
-        + [("SET_BUILD_GIT_HEAD", '\\"%s\\"' % get_git_description())],
+        + [("SET_BUILD_GIT_HEAD", '\\"%s\\"' % get_git_description())]
+        + [("SET_BUILD_VERSION", compute_version_date())],
         CCFLAGS=env["CCFLAGS"]
     )
 
@@ -72,6 +80,7 @@ print("\u001b[33m PROGNAME:       \u001b[0m  {}".format(env['PROGNAME']))
 print("\u001b[33m BOARD_NAME:     \u001b[0m  {}".format(get_board_name()))
 print("\u001b[33m BUILD_PLATFORM: \u001b[0m  {}".format(platform.platform()))
 print("\u001b[33m GIT_HEAD:       \u001b[0m  {}".format(get_git_description()))
+print("\u001b[33m BUILD_VERSION:  \u001b[0m  {}".format(compute_version_date()))
 
 print("\u001b[32m ------------------------------- \u001b[0m")
 print("\u001b[32m Flash configuration \u001b[0m")


### PR DESCRIPTION
The build version shown on the sysinfo page and in the list of ESPEasy p2p nodes was rather confusing to many.
It was more like a file revision nr, but lots of users reported issues based on this nr. which was confusing to say the least.

Now the `BUILD` value is being replaced by a compile time generated value.
It is the nr of days since 2022-08-18 + 20200.
The last used value for `BUILD` was `20116`.

Example of how it is now appearing in the list of p2p nodes: 
![image](https://user-images.githubusercontent.com/3751318/185787579-b005cf40-346b-416f-9d08-25e55dfa7732.png)
