### PR TITLE
[Sysinfo] Add functions to compute runtime ABP and flash frequency

### DIFF
--- a/src/Custom-sample.h
+++ b/src/Custom-sample.h
@@ -263,7 +263,7 @@
 
 //#define WEBPAGE_TEMPLATE_HIDE_HELP_BUTTON
 
-#define SHOW_SYSINFO_JSON   //Enables the sysinfo_json page (by default is enabled when WEBSERVER_NEW_UI is enabled too)
+#define SHOW_SYSINFO_JSON 1  //Enables the sysinfo_json page (by default is enabled when WEBSERVER_NEW_UI is enabled too)
 
 /*
  #######################################################################################################

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -1563,6 +1563,9 @@ To create/register a plugin, you have to :
   #ifndef FEATURE_SD
     #define FEATURE_SD 1
   #endif
+  #ifndef SHOW_SYSINFO_JSON
+    #define SHOW_SYSINFO_JSON 1
+  #endif
 
   // Plugins
   #ifndef USES_P016
@@ -2036,7 +2039,7 @@ To create/register a plugin, you have to :
 
 // By default we enable the SHOW_SYSINFO_JSON when we enable the WEBSERVER_NEW_UI
 #ifdef WEBSERVER_NEW_UI
-  #define SHOW_SYSINFO_JSON
+  #define SHOW_SYSINFO_JSON 1
 #endif
 
 #endif // CUSTOMBUILD_DEFINE_PLUGIN_SETS_H

--- a/src/src/Helpers/Hardware.cpp
+++ b/src/src/Helpers/Hardware.cpp
@@ -621,35 +621,9 @@ uint32_t getFlashRealSizeInBytes() {
 }
 
 #ifdef ESP32
-uint32_t getAbpFrequency() {
-  # if CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32S3
-  return APB_CLK_FREQ;
-  # else // if CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32S3
-  rtc_cpu_freq_config_t conf;
-
-  // Get current CPU clock configuration
-  rtc_clk_cpu_freq_get_config(&conf);
-
-  /*
-     // Debug code
-     String log = F("getAbpFrequency: source = ");
-     log += conf.source;
-     log += F(" source_freq_mhz = ");
-     log += conf.source_freq_mhz;
-     log += F(" div = ");
-     log += conf.div;
-     log += F(" freq_mhz = ");
-     log += conf.freq_mhz;
-     addLog(LOG_LEVEL_INFO, log);
-   */
-
-  if (conf.freq_mhz >= 80) {
-    return 80 * 1000000;
-  }
-  return (conf.source_freq_mhz * 1000000) / conf.div;
-  # endif // if CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32S3
+uint32_t getXtalFrequencyMHz() {
+  return rtc_clk_xtal_freq_get();
 }
-
 #endif // ifdef ESP32
 
 
@@ -659,10 +633,9 @@ uint32_t getFlashChipSpeed() {
   #else // ifdef ESP8266
   const uint32_t spi_clock = REG_READ(SPI_CLOCK_REG(0));
 
-
   if (spi_clock & BIT(31)) {
     // spi_clk is equal to system clock
-    return getAbpFrequency();
+    return getApbFrequency();
   }
 
   /* SPI_CLKCNT_N : R/W ;bitpos:[17:12] ;default: 6'h3 ; */
@@ -672,25 +645,7 @@ uint32_t getFlashChipSpeed() {
   const uint32_t spi_clkdiv_pre = (spi_clock >> 18) & 0x1FFF;
   const uint32_t spi_clkcnt_n   = (spi_clock >> 12) & 0x3F;
 
-  /*
-     // Debug code
-     const uint32_t spi_clkcnt_h = (spi_clock >> 6) & 0x3F;
-     const uint32_t spi_clkcnt_l = (spi_clock) & 0x3F;
-
-     String log = F("Flash freq: APB_CLK_FREQ = ");
-     log += getAbpFrequency();
-     log += F(" spi_clkdiv_pre = ");
-     log += spi_clkdiv_pre;
-     log += F(" spi_clkcnt_n = ");
-     log += spi_clkcnt_n;
-     log += F(" spi_clkcnt_h = ");
-     log += spi_clkcnt_h;
-     log += F(" spi_clkcnt_l = ");
-     log += spi_clkcnt_l;
-     addLog(LOG_LEVEL_INFO, log);
-   */
-
-  return (getAbpFrequency() / (spi_clkdiv_pre + 1)) / (spi_clkcnt_n + 1);
+  return (getApbFrequency() / (spi_clkdiv_pre + 1)) / (spi_clkcnt_n + 1);
   #endif // ifdef ESP8266
 }
 

--- a/src/src/Helpers/Hardware.cpp
+++ b/src/src/Helpers/Hardware.cpp
@@ -638,7 +638,7 @@ uint32_t getFlashChipSpeed() {
   #ifdef ESP8266
   return ESP.getFlashChipSpeed();
   #else // ifdef ESP8266
-  const uint32_t spi_clock = REG_READ(SPI_CLOCK_REG(1));
+  const uint32_t spi_clock = REG_READ(SPI_CLOCK_REG(FSPI));
 
   if (spi_clock & BIT(31)) {
     // spi_clk is equal to system clock

--- a/src/src/Helpers/Hardware.h
+++ b/src/src/Helpers/Hardware.h
@@ -100,7 +100,7 @@ uint32_t                   getFlashRealSizeInBytes();
 uint32_t                   getFlashChipSpeed();
 
 #ifdef ESP32
-uint32_t                   getAbpFrequency();
+uint32_t                   getXtalFrequencyMHz();
 #endif // ifdef ESP32
 
 const __FlashStringHelper* getFlashChipMode();

--- a/src/src/Helpers/Hardware.h
+++ b/src/src/Helpers/Hardware.h
@@ -19,18 +19,18 @@
 // Needed to get ADC Vref
 # include <esp_adc_cal.h>
 # include <driver/adc.h>
-#endif
+#endif // ifdef ESP32
 
-# ifdef ESP32
-#  if CONFIG_IDF_TARGET_ESP32
-  #define MAX_ADC_VALUE 4095
-#  else // if CONFIG_IDF_TARGET_ESP32
-  #define MAX_ADC_VALUE ((1 << SOC_ADC_MAX_BITWIDTH) - 1)
-#  endif // if CONFIG_IDF_TARGET_ESP32
-# endif // ifdef ESP32
-# ifdef ESP8266
-  #define MAX_ADC_VALUE 1023
-# endif // ifdef ESP8266
+#ifdef ESP32
+# if CONFIG_IDF_TARGET_ESP32
+  #  define MAX_ADC_VALUE 4095
+# else // if CONFIG_IDF_TARGET_ESP32
+  #  define MAX_ADC_VALUE ((1 << SOC_ADC_MAX_BITWIDTH) - 1)
+# endif  // if CONFIG_IDF_TARGET_ESP32
+#endif  // ifdef ESP32
+#ifdef ESP8266
+  # define MAX_ADC_VALUE 1023
+#endif // ifdef ESP8266
 
 
 /********************************************************************************************\
@@ -75,7 +75,7 @@ int espeasy_analogRead(int pin);
 #endif // ifdef ESP8266
 
 #ifdef ESP32
-void initADC();
+void                       initADC();
 
 bool                       hasADC_factory_calibration();
 const __FlashStringHelper* getADC_factory_calibration_type();
@@ -98,6 +98,12 @@ uint32_t                   getFlashChipId();
 uint32_t                   getFlashRealSizeInBytes();
 
 uint32_t                   getFlashChipSpeed();
+
+#ifdef ESP32
+uint32_t                   getAbpFrequency();
+#endif // ifdef ESP32
+
+const __FlashStringHelper* getFlashChipMode();
 
 bool                       puyaSupport();
 

--- a/src/src/Helpers/StringProvider.cpp
+++ b/src/src/Helpers/StringProvider.cpp
@@ -170,7 +170,8 @@ const __FlashStringHelper * getLabel(LabelType::Enum label) {
     case LabelType::ESP_CHIP_ID:            return F("ESP Chip ID");
     case LabelType::ESP_CHIP_FREQ:          return F("ESP Chip Frequency");
 #ifdef ESP32
-    case LabelType::ESP_CHIP_ABP_FREQ:      return F("ESP ABP Frequency");
+    case LabelType::ESP_CHIP_XTAL_FREQ:     return F("ESP Crystal Frequency");
+    case LabelType::ESP_CHIP_APB_FREQ:      return F("ESP APB Frequency");
 #endif
     case LabelType::ESP_CHIP_MODEL:         return F("ESP Chip Model");
     case LabelType::ESP_CHIP_REVISION:      return F("ESP Chip Revision");
@@ -390,7 +391,8 @@ String getValue(LabelType::Enum label) {
     case LabelType::ESP_CHIP_ID:            return formatToHex(getChipId(), 6);
     case LabelType::ESP_CHIP_FREQ:          return String(ESP.getCpuFreqMHz());
 #ifdef ESP32
-    case LabelType::ESP_CHIP_ABP_FREQ:      return String(getApbFrequency() / 1000000);
+    case LabelType::ESP_CHIP_XTAL_FREQ:     return String(getXtalFrequencyMHz());
+    case LabelType::ESP_CHIP_APB_FREQ:      return String(getApbFrequency() / 1000000);
 #endif
     case LabelType::ESP_CHIP_MODEL:         return getChipModel();
     case LabelType::ESP_CHIP_REVISION:      return String(getChipRevision());

--- a/src/src/Helpers/StringProvider.cpp
+++ b/src/src/Helpers/StringProvider.cpp
@@ -169,6 +169,9 @@ const __FlashStringHelper * getLabel(LabelType::Enum label) {
 
     case LabelType::ESP_CHIP_ID:            return F("ESP Chip ID");
     case LabelType::ESP_CHIP_FREQ:          return F("ESP Chip Frequency");
+#ifdef ESP32
+    case LabelType::ESP_CHIP_ABP_FREQ:      return F("ESP ABP Frequency");
+#endif
     case LabelType::ESP_CHIP_MODEL:         return F("ESP Chip Model");
     case LabelType::ESP_CHIP_REVISION:      return F("ESP Chip Revision");
     case LabelType::ESP_CHIP_CORES:         return F("ESP Chip Cores");
@@ -386,6 +389,9 @@ String getValue(LabelType::Enum label) {
 
     case LabelType::ESP_CHIP_ID:            return formatToHex(getChipId(), 6);
     case LabelType::ESP_CHIP_FREQ:          return String(ESP.getCpuFreqMHz());
+#ifdef ESP32
+    case LabelType::ESP_CHIP_ABP_FREQ:      return String(getApbFrequency() / 1000000);
+#endif
     case LabelType::ESP_CHIP_MODEL:         return getChipModel();
     case LabelType::ESP_CHIP_REVISION:      return String(getChipRevision());
     case LabelType::ESP_CHIP_CORES:         return String(getChipCores());
@@ -402,7 +408,7 @@ String getValue(LabelType::Enum label) {
     case LabelType::FLASH_CHIP_SPEED:       return String(getFlashChipSpeed() / 1000000);
     case LabelType::FLASH_IDE_SIZE:         break;
     case LabelType::FLASH_IDE_SPEED:        break;
-    case LabelType::FLASH_IDE_MODE:         break;
+    case LabelType::FLASH_IDE_MODE:         return getFlashChipMode();
     case LabelType::FLASH_WRITE_COUNT:      break;
     case LabelType::SKETCH_SIZE:            break;
     case LabelType::SKETCH_FREE:            break;

--- a/src/src/Helpers/StringProvider.cpp
+++ b/src/src/Helpers/StringProvider.cpp
@@ -398,7 +398,7 @@ String getValue(LabelType::Enum label) {
     case LabelType::ESP_CHIP_REVISION:      return String(getChipRevision());
     case LabelType::ESP_CHIP_CORES:         return String(getChipCores());
     case LabelType::ESP_BOARD_NAME:         return get_board_name();
-    case LabelType::FLASH_CHIP_ID:          return String(getFlashChipId());
+    case LabelType::FLASH_CHIP_ID:          return formatToHex(getFlashChipId(), 6);
     case LabelType::FLASH_CHIP_VENDOR:      return formatToHex(getFlashChipId() & 0xFF, 2);
     case LabelType::FLASH_CHIP_MODEL:
     {

--- a/src/src/Helpers/StringProvider.h
+++ b/src/src/Helpers/StringProvider.h
@@ -130,6 +130,9 @@ struct LabelType {
 
     ESP_CHIP_ID,
     ESP_CHIP_FREQ,
+#ifdef ESP32
+    ESP_CHIP_ABP_FREQ,
+#endif
     ESP_CHIP_MODEL,
     ESP_CHIP_REVISION,
     ESP_CHIP_CORES,

--- a/src/src/Helpers/StringProvider.h
+++ b/src/src/Helpers/StringProvider.h
@@ -131,7 +131,8 @@ struct LabelType {
     ESP_CHIP_ID,
     ESP_CHIP_FREQ,
 #ifdef ESP32
-    ESP_CHIP_ABP_FREQ,
+    ESP_CHIP_XTAL_FREQ,
+    ESP_CHIP_APB_FREQ,
 #endif
     ESP_CHIP_MODEL,
     ESP_CHIP_REVISION,

--- a/src/src/WebServer/ESPEasy_WebServer.cpp
+++ b/src/src/WebServer/ESPEasy_WebServer.cpp
@@ -305,7 +305,7 @@ void WebServerInit()
   web_server.on(F("/upload_json"),       HTTP_POST, handle_upload_json, handleFileUpload);
   web_server.on(F("/wifiscanner_json"),  handle_wifiscanner_json);
 #endif // WEBSERVER_NEW_UI
-#ifdef SHOW_SYSINFO_JSON
+#if SHOW_SYSINFO_JSON
     web_server.on(F("/sysinfo_json"),      handle_sysinfo_json);
 #endif//SHOW_SYSINFO_JSON
 

--- a/src/src/WebServer/SysInfoPage.cpp
+++ b/src/src/WebServer/SysInfoPage.cpp
@@ -173,11 +173,9 @@ void handle_sysinfo_json() {
 
   json_open(false, F("storage"));
 
-  uint32_t flashChipId = getFlashChipId();
-
   // Set to HEX may be something like 0x1640E0.
   // Where manufacturer is 0xE0 and device is 0x4016.
-  json_number(F("chip_id"), String(flashChipId));
+  json_number(F("chip_id"), getValue(LabelType::FLASH_CHIP_ID));
   if (flashChipVendorPuya()) {
     if (puyaSupport()) {
       json_prop(F("vendor"), F("puya, supported"));

--- a/src/src/WebServer/SysInfoPage.cpp
+++ b/src/src/WebServer/SysInfoPage.cpp
@@ -192,16 +192,7 @@ void handle_sysinfo_json() {
   // Please check what is supported for the ESP32
   json_number(F("flash_speed"), getValue(LabelType::FLASH_CHIP_SPEED));
 
-  FlashMode_t ideMode = ESP.getFlashChipMode();
-
-  switch (ideMode) {
-    case FM_QIO:   json_prop(F("mode"), F("QIO"));  break;
-    case FM_QOUT:  json_prop(F("mode"), F("QOUT")); break;
-    case FM_DIO:   json_prop(F("mode"), F("DIO"));  break;
-    case FM_DOUT:  json_prop(F("mode"), F("DOUT")); break;
-    default:
-      json_prop(F("mode"), F("Unknown")); break;
-  }
+  json_prop(F("mode"), getFlashChipMode());
 
   json_number(F("writes"),        String(RTC.flashDayCounter));
   json_number(F("flash_counter"), String(RTC.flashCounter));
@@ -565,9 +556,12 @@ void handle_sysinfo_ESP_Board() {
     addHtml(')');
   }
 
-  addRowLabel(LabelType::ESP_CHIP_FREQ);
-  addHtmlInt(ESP.getCpuFreqMHz());
+  addRowLabelValue(LabelType::ESP_CHIP_FREQ);
   addHtml(F(" MHz"));
+#ifdef ESP32
+  addRowLabelValue(LabelType::ESP_CHIP_ABP_FREQ);
+  addHtml(F(" MHz"));
+#endif
 
   addRowLabelValue(LabelType::ESP_CHIP_MODEL);
 
@@ -628,18 +622,7 @@ void handle_sysinfo_Storage() {
   addHtmlInt(ESP.getFlashChipSpeed() / 1000000);
   addHtml(F(" MHz"));
 
-  FlashMode_t ideMode = ESP.getFlashChipMode();
-  addRowLabel(LabelType::FLASH_IDE_MODE);
-  {
-    switch (ideMode) {
-      case FM_QIO:   addHtml(F("QIO"));  break;
-      case FM_QOUT:  addHtml(F("QOUT")); break;
-      case FM_DIO:   addHtml(F("DIO"));  break;
-      case FM_DOUT:  addHtml(F("DOUT")); break;
-      default:
-        addHtml(F("Unknown")); break;
-    }
-  }
+  addRowLabelValue(LabelType::FLASH_IDE_MODE);
 
   addRowLabel(LabelType::FLASH_WRITE_COUNT);
   {

--- a/src/src/WebServer/SysInfoPage.cpp
+++ b/src/src/WebServer/SysInfoPage.cpp
@@ -1,6 +1,6 @@
 #include "../WebServer/SysInfoPage.h"
 
-#if defined(WEBSERVER_SYSINFO) || defined(SHOW_SYSINFO_JSON)
+#if defined(WEBSERVER_SYSINFO) || SHOW_SYSINFO_JSON
 
 #include "../WebServer/ESPEasy_WebServer.h"
 #include "../WebServer/HTML_wrappers.h"
@@ -52,7 +52,7 @@
 
 
 
-#ifdef SHOW_SYSINFO_JSON
+#if SHOW_SYSINFO_JSON
 // ********************************************************************************
 // Web Interface sysinfo page
 // ********************************************************************************
@@ -108,14 +108,14 @@ void handle_sysinfo_json() {
   json_close();
 
   json_open(false, F("boot"));
-  json_prop(F("last_cause"), getLastBootCauseString());
-  json_number(F("counter"), String(RTC.bootCounter));
-  json_prop(F("reset_reason"), getResetReasonString());
+  json_prop(F("last_cause"),    getLastBootCauseString());
+  json_number(F("counter"),     String(RTC.bootCounter));
+  json_prop(F("reset_reason"),  getResetReasonString());
   json_close();
 
   json_open(false, F("wifi"));
-  json_prop(F("type"), toString(getConnectionProtocol()));
-  json_number(F("rssi"), String(WiFi.RSSI()));
+  json_prop(F("type"),          toString(getConnectionProtocol()));
+  json_number(F("rssi"),        String(WiFi.RSSI()));
   json_prop(F("dhcp"),          useStaticIP() ? getLabel(LabelType::IP_CONFIG_STATIC) : getLabel(LabelType::IP_CONFIG_DYNAMIC));
   json_prop(F("ip"),            getValue(LabelType::IP_ADDRESS));
   json_prop(F("subnet"),        getValue(LabelType::IP_SUBNET));
@@ -148,13 +148,13 @@ void handle_sysinfo_json() {
 # endif // if FEATURE_ETHERNET
 
   json_open(false, F("firmware"));
-  json_prop(F("build"),       getSystemBuildString());
-  json_prop(F("notes"),       F(BUILD_NOTES));
-  json_prop(F("libraries"),   getSystemLibraryString());
-  json_prop(F("git_version"), getValue(LabelType::GIT_BUILD));
-  json_prop(F("plugins"),     getPluginDescriptionString());
-  json_prop(F("md5"),         String(CRCValues.compileTimeMD5[0], HEX));
-  json_number(F("md5_check"), String(CRCValues.checkPassed()));
+  json_prop(F("build"),          getSystemBuildString());
+  json_prop(F("notes"),          F(BUILD_NOTES));
+  json_prop(F("libraries"),      getSystemLibraryString());
+  json_prop(F("git_version"),    getValue(LabelType::GIT_BUILD));
+  json_prop(F("plugins"),        getPluginDescriptionString());
+  json_prop(F("md5"),            String(CRCValues.compileTimeMD5[0], HEX));
+  json_number(F("md5_check"),    String(CRCValues.checkPassed()));
   json_prop(F("build_time"),     get_build_time());
   json_prop(F("filename"),       getValue(LabelType::BINARY_FILENAME));
   json_prop(F("build_platform"), getValue(LabelType::BUILD_PLATFORM));
@@ -162,37 +162,39 @@ void handle_sysinfo_json() {
   json_close();
 
   json_open(false, F("esp"));
-  json_prop(F("chip_id"), getValue(LabelType::ESP_CHIP_ID));
-  json_number(F("cpu"), getValue(LabelType::ESP_CHIP_FREQ));
-  json_prop(F("board"), get_board_name());
+  json_prop(F("chip_id"),        getValue(LabelType::ESP_CHIP_ID));
+  json_number(F("cpu"),          getValue(LabelType::ESP_CHIP_FREQ));
+#ifdef ESP32
+  json_number(F("xtal_freq"),    getValue(LabelType::ESP_CHIP_XTAL_FREQ));
+  json_number(F("abp_freq"),     getValue(LabelType::ESP_CHIP_APB_FREQ));
+#endif
+  json_prop(F("board"),          getValue(LabelType::ESP_BOARD_NAME));
   json_close();
+
   json_open(false, F("storage"));
 
-  # if defined(ESP8266)
   uint32_t flashChipId = getFlashChipId();
 
   // Set to HEX may be something like 0x1640E0.
   // Where manufacturer is 0xE0 and device is 0x4016.
   json_number(F("chip_id"), String(flashChipId));
-
-  if (flashChipVendorPuya())
-  {
+  if (flashChipVendorPuya()) {
     if (puyaSupport()) {
       json_prop(F("vendor"), F("puya, supported"));
     } else {
       json_prop(F("vendor"), F("puya, error"));
     }
+  } else {
+    json_prop(F("vendor"),        getValue(LabelType::FLASH_CHIP_VENDOR));
   }
-  uint32_t flashDevice = (flashChipId & 0xFF00) | ((flashChipId >> 16) & 0xFF);
-  json_number(F("device"),    String(flashDevice));
-  # endif // if defined(ESP8266)
-  json_number(F("real_size"), String(getFlashRealSizeInBytes() / 1024));
-  json_number(F("ide_size"),  String(ESP.getFlashChipSize() / 1024));
+  json_number(F("device"),        getValue(LabelType::FLASH_CHIP_MODEL));
+  json_number(F("real_size"),     String(getFlashRealSizeInBytes() / 1024));
+  json_number(F("ide_size"),      String(ESP.getFlashChipSize() / 1024));
 
   // Please check what is supported for the ESP32
-  json_number(F("flash_speed"), getValue(LabelType::FLASH_CHIP_SPEED));
+  json_number(F("flash_speed"),   getValue(LabelType::FLASH_CHIP_SPEED));
 
-  json_prop(F("mode"), getFlashChipMode());
+  json_prop(F("mode"),            getFlashChipMode());
 
   json_number(F("writes"),        String(RTC.flashDayCounter));
   json_number(F("flash_counter"), String(RTC.flashCounter));
@@ -559,7 +561,9 @@ void handle_sysinfo_ESP_Board() {
   addRowLabelValue(LabelType::ESP_CHIP_FREQ);
   addHtml(F(" MHz"));
 #ifdef ESP32
-  addRowLabelValue(LabelType::ESP_CHIP_ABP_FREQ);
+  addRowLabelValue(LabelType::ESP_CHIP_XTAL_FREQ);
+  addHtml(F(" MHz"));
+  addRowLabelValue(LabelType::ESP_CHIP_APB_FREQ);
   addHtml(F(" MHz"));
 #endif
 

--- a/src/src/WebServer/SysInfoPage.h
+++ b/src/src/WebServer/SysInfoPage.h
@@ -4,7 +4,7 @@
 #include "../WebServer/common.h"
 
 
-#ifdef SHOW_SYSINFO_JSON
+#if SHOW_SYSINFO_JSON
 
 // ********************************************************************************
 // Web Interface sysinfo page


### PR DESCRIPTION
ABP frequency may change when CPU frequency changes.
SPI frequency depends on ABP frequency, as do lots of other timers.
Thus it is useful to determine the actual runtime ABP frequency.