### PR TITLE
[String] Use .equals for flash strings instead of ==

### DIFF
--- a/boards/esp32-cam.json
+++ b/boards/esp32-cam.json
@@ -2,13 +2,13 @@
   "build": {
     "arduino":{
       "ldscript": "esp32_out.ld",
-      "memory_type": "dout_qspi"
+      "memory_type": "dio_qspi"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_ESP32_DEV -DBOARD_HAS_PSRAM -DHAS_PSRAM_FIX -mfix-esp32-psram-cache-issue -mfix-esp32-psram-cache-strategy=memw -DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_4M",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
-    "flash_mode": "dout",
+    "flash_mode": "dio",
     "mcu": "esp32",
     "variant": "esp32",
     "partitions": "esp32_partition_app1810k_spiffs316k.csv"

--- a/boards/esp32-m5core2.json
+++ b/boards/esp32-m5core2.json
@@ -2,13 +2,13 @@
   "build": {
     "arduino":{
       "ldscript": "esp32_out.ld",
-      "memory_type": "dout_qspi"
+      "memory_type": "dio_qspi"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_M5STACK_Core2 -DBOARD_HAS_PSRAM -DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_16M",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
-    "flash_mode": "dout",
+    "flash_mode": "dio",
     "mcu": "esp32",
     "variant": "m5stack_core2",
     "partitions": "esp32_partition_app4096k_spiffs8124k.csv"

--- a/boards/esp32-odroid.json
+++ b/boards/esp32-odroid.json
@@ -2,13 +2,13 @@
   "build": {
     "arduino":{
       "ldscript": "esp32_out.ld",
-      "memory_type": "dout_qspi"
+      "memory_type": "dio_qspi"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_ODROID_ESP32 -DBOARD_HAS_PSRAM -DHAS_PSRAM_FIX -mfix-esp32-psram-cache-issue -mfix-esp32-psram-cache-strategy=memw -DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_16M",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
-    "flash_mode": "dout",
+    "flash_mode": "dio",
     "mcu": "esp32",
     "variant": "odroid_esp32",
     "partitions": "esp32_partition_app4096k_spiffs8124k.csv"

--- a/boards/esp32_16M1M.json
+++ b/boards/esp32_16M1M.json
@@ -2,13 +2,13 @@
   "build": {
     "arduino":{
       "ldscript": "esp32_out.ld",
-      "memory_type": "dout_qspi"
+      "memory_type": "dio_qspi"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_ESP32_DEV -DBOARD_HAS_PSRAM -DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_16M",
     "f_cpu": "240000000L",
     "f_flash": "40000000L",
-    "flash_mode": "dout",
+    "flash_mode": "dio",
     "mcu": "esp32",
     "variant": "esp32",
     "partitions": "esp32_partition_app4096k_spiffs1024k.csv"

--- a/boards/esp32_16M8M.json
+++ b/boards/esp32_16M8M.json
@@ -2,13 +2,13 @@
   "build": {
     "arduino":{
       "ldscript": "esp32_out.ld",
-      "memory_type": "dout_qspi"
+      "memory_type": "dio_qspi"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_ESP32_DEV -DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_16M",
     "f_cpu": "240000000L",
     "f_flash": "40000000L",
-    "flash_mode": "dout",
+    "flash_mode": "dio",
     "mcu": "esp32",
     "variant": "esp32",
     "partitions": "esp32_partition_app4096k_spiffs8124k.csv"

--- a/boards/esp32_4M.json
+++ b/boards/esp32_4M.json
@@ -2,13 +2,13 @@
   "build": {
     "arduino":{
       "ldscript": "esp32_out.ld",
-      "memory_type": "dout_qspi"
+      "memory_type": "dio_qspi"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_ESP32_DEV -DBOARD_HAS_PSRAM -DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_4M",
     "f_cpu": "240000000L",
     "f_flash": "40000000L",
-    "flash_mode": "dout",
+    "flash_mode": "dio",
     "mcu": "esp32",
     "variant": "esp32",
     "partitions": "esp32_partition_app1810k_spiffs316k.csv"
@@ -32,6 +32,9 @@
     "maximum_ram_size": 327680,
     "maximum_size": 1900544,
     "require_upload_port": true,
+    "resetmethod": "nodemcu",
+    "before_reset": "default_reset",
+    "after_reset": "hard_reset",
     "speed": 460800
   },
   "url": "https://en.wikipedia.org/wiki/ESP32",

--- a/boards/esp32_8M.json
+++ b/boards/esp32_8M.json
@@ -2,13 +2,13 @@
   "build": {
     "arduino":{
       "ldscript": "esp32_out.ld",
-      "memory_type": "dout_qspi"
+      "memory_type": "dio_qspi"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_ESP32_DEV -DBOARD_HAS_PSRAM -DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_8M",
     "f_cpu": "240000000L",
     "f_flash": "40000000L",
-    "flash_mode": "dout",
+    "flash_mode": "dio",
     "mcu": "esp32",
     "variant": "esp32",
     "partitions": "esp32_partition_app2944k_spiffs2M.csv"

--- a/boards/esp32_solo1_4M.json
+++ b/boards/esp32_solo1_4M.json
@@ -2,13 +2,13 @@
   "build": {
     "arduino":{
       "ldscript": "esp32_out.ld",
-      "memory_type": "dout_qspi"
+      "memory_type": "dio_qspi"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_ESP32_DEV -DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_4M -DCORE32SOLO1",
     "f_cpu": "80000000L",
     "f_flash": "40000000L",
-    "flash_mode": "dout",
+    "flash_mode": "dio",
     "mcu": "esp32",
     "variant": "esp32",
     "partitions": "esp32_partition_app1810k_spiffs316k.csv"

--- a/boards/esp32c3.json
+++ b/boards/esp32c3.json
@@ -2,19 +2,20 @@
   "build": {
     "arduino":{
       "ldscript": "esp32c3_out.ld",
-      "memory_type": "dout_qspi"
+      "memory_type": "dio_qspi"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_4M -DESP32C3",
     "f_cpu": "160000000L",
     "f_flash": "80000000L",
-    "flash_mode": "dout",
+    "flash_mode": "dio",
     "mcu": "esp32c3",
     "variant": "esp32c3",
     "partitions": "esp32_partition_app1810k_spiffs316k.csv"
   },
   "connectivity": [
-    "wifi"
+    "wifi",
+    "bluetooth"
   ],
   "debug": {
     "openocd_target": "esp32c3.cfg"

--- a/boards/esp32s2.json
+++ b/boards/esp32s2.json
@@ -2,13 +2,13 @@
   "build": {
     "arduino":{
       "ldscript": "esp32s2_out.ld",
-      "memory_type": "dout_qspi"
+      "memory_type": "dio_qspi"
     },
     "core": "esp32",
     "extra_flags": "-DBOARD_HAS_PSRAM -DESP32_4M -DESP32S2",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
-    "flash_mode": "dout",
+    "flash_mode": "dio",
     "mcu": "esp32s2",
     "variant": "esp32s2",
     "partitions": "esp32_partition_app1810k_spiffs316k.csv"
@@ -27,7 +27,7 @@
   "upload": {
     "flash_size": "4MB",
     "maximum_ram_size": 327680,
-    "maximum_size": 1900544,
+    "maximum_size": 4194304,
     "require_upload_port": true,
     "speed": 460800
   },

--- a/boards/esp8266_16M14M_board.json
+++ b/boards/esp8266_16M14M_board.json
@@ -24,7 +24,7 @@
     "maximum_ram_size": 81920,
     "maximum_size": 1040316,
     "require_upload_port": true,
-    "resetmethod": "ck",
+    "resetmethod": "nodemcu",
     "speed": 115200
   },
   "url": "http://www.esp8266.com/wiki/doku.php?id=esp8266-module-family",

--- a/boards/esp8266_16M14M_board.json
+++ b/boards/esp8266_16M14M_board.json
@@ -15,9 +15,7 @@
     "wifi"
   ],
   "frameworks": [
-    "arduino",
-    "esp8266-rtos-sdk",
-    "esp8266-nonos-sdk"
+    "arduino"
   ],
   "name": "Espressif Generic ESP8266 ESPEasy 16M Flash 14M FS",
   "upload": {

--- a/boards/esp8266_1M128k.json
+++ b/boards/esp8266_1M128k.json
@@ -24,7 +24,7 @@
     "maximum_ram_size": 81920,
     "maximum_size": 892912,
     "require_upload_port": true,
-    "resetmethod": "ck",
+    "resetmethod": "nodemcu",
     "speed": 115200
   },
   "url": "http://www.esp8266.com/wiki/doku.php?id=esp8266-module-family",

--- a/boards/esp8266_1M128k.json
+++ b/boards/esp8266_1M128k.json
@@ -15,9 +15,7 @@
     "wifi"
   ],
   "frameworks": [
-    "arduino",
-    "esp8266-rtos-sdk",
-    "esp8266-nonos-sdk"
+    "arduino"
   ],
   "name": "Espressif Generic ESP8266 ESPEasy 1M Flash 128k FS",
   "upload": {

--- a/boards/esp8266_1M128k_OTA.json
+++ b/boards/esp8266_1M128k_OTA.json
@@ -24,7 +24,7 @@
     "maximum_ram_size": 81920,
     "maximum_size": 616448,
     "require_upload_port": true,
-    "resetmethod": "ck",
+    "resetmethod": "nodemcu",
     "speed": 115200
   },
   "url": "http://www.esp8266.com/wiki/doku.php?id=esp8266-module-family",

--- a/boards/esp8266_1M128k_OTA.json
+++ b/boards/esp8266_1M128k_OTA.json
@@ -15,9 +15,7 @@
     "wifi"
   ],
   "frameworks": [
-    "arduino",
-    "esp8266-rtos-sdk",
-    "esp8266-nonos-sdk"
+    "arduino"
   ],
   "name": "Espressif Generic ESP8266 ESPEasy 1M Flash 128k FS",
   "upload": {

--- a/boards/esp8266_2M1M.json
+++ b/boards/esp8266_2M1M.json
@@ -24,7 +24,7 @@
     "maximum_ram_size": 81920,
     "maximum_size": 1040316,
     "require_upload_port": true,
-    "resetmethod": "ck",
+    "resetmethod": "nodemcu",
     "speed": 115200
   },
   "url": "http://www.esp8266.com/wiki/doku.php?id=esp8266-module-family",

--- a/boards/esp8266_2M1M.json
+++ b/boards/esp8266_2M1M.json
@@ -15,9 +15,7 @@
     "wifi"
   ],
   "frameworks": [
-    "arduino",
-    "esp8266-rtos-sdk",
-    "esp8266-nonos-sdk"
+    "arduino"
   ],
   "name": "Espressif Generic ESP8266 ESPEasy 1M sketch 1M FS",
   "upload": {

--- a/boards/esp8266_2M256.json
+++ b/boards/esp8266_2M256.json
@@ -24,7 +24,7 @@
     "maximum_ram_size": 81920,
     "maximum_size": 1040316,
     "require_upload_port": true,
-    "resetmethod": "ck",
+    "resetmethod": "nodemcu",
     "speed": 115200
   },
   "url": "http://www.esp8266.com/wiki/doku.php?id=esp8266-module-family",

--- a/boards/esp8266_2M256.json
+++ b/boards/esp8266_2M256.json
@@ -15,9 +15,7 @@
     "wifi"
   ],
   "frameworks": [
-    "arduino",
-    "esp8266-rtos-sdk",
-    "esp8266-nonos-sdk"
+    "arduino"
   ],
   "name": "Espressif Generic ESP8266 ESPEasy 2M Flash 256k FS",
   "upload": {

--- a/boards/esp8266_4M1M_board.json
+++ b/boards/esp8266_4M1M_board.json
@@ -15,9 +15,7 @@
     "wifi"
   ],
   "frameworks": [
-    "arduino",
-    "esp8266-rtos-sdk",
-    "esp8266-nonos-sdk"
+    "arduino"
   ],
   "name": "Espressif Generic ESP8266 ESPEasy 4M Flash 1M FS",
   "upload": {

--- a/boards/esp8266_4M1M_board.json
+++ b/boards/esp8266_4M1M_board.json
@@ -24,7 +24,7 @@
     "maximum_ram_size": 81920,
     "maximum_size": 1040316,
     "require_upload_port": true,
-    "resetmethod": "ck",
+    "resetmethod": "nodemcu",
     "speed": 115200
   },
   "url": "http://www.esp8266.com/wiki/doku.php?id=esp8266-module-family",

--- a/boards/esp8266_4M2M_board.json
+++ b/boards/esp8266_4M2M_board.json
@@ -24,7 +24,7 @@
     "maximum_ram_size": 81920,
     "maximum_size": 1040316,
     "require_upload_port": true,
-    "resetmethod": "ck",
+    "resetmethod": "nodemcu",
     "speed": 115200
   },
   "url": "http://www.esp8266.com/wiki/doku.php?id=esp8266-module-family",

--- a/boards/esp8266_4M2M_board.json
+++ b/boards/esp8266_4M2M_board.json
@@ -15,9 +15,7 @@
     "wifi"
   ],
   "frameworks": [
-    "arduino",
-    "esp8266-rtos-sdk",
-    "esp8266-nonos-sdk"
+    "arduino"
   ],
   "name": "Espressif Generic ESP8266 ESPEasy 4M Flash 2M FS",
   "upload": {

--- a/boards/esp8266_4M3M.json
+++ b/boards/esp8266_4M3M.json
@@ -24,7 +24,7 @@
     "maximum_ram_size": 81920,
     "maximum_size": 1040316,
     "require_upload_port": true,
-    "resetmethod": "ck",
+    "resetmethod": "nodemcu",
     "speed": 115200
   },
   "url": "http://www.esp8266.com/wiki/doku.php?id=esp8266-module-family",

--- a/boards/esp8266_4M3M.json
+++ b/boards/esp8266_4M3M.json
@@ -15,9 +15,7 @@
     "wifi"
   ],
   "frameworks": [
-    "arduino",
-    "esp8266-rtos-sdk",
-    "esp8266-nonos-sdk"
+    "arduino"
   ],
   "name": "Espressif Generic ESP8266 ESPEasy 4M Flash 3M FS",
   "upload": {

--- a/boards/esp8266_zbbridge.json
+++ b/boards/esp8266_zbbridge.json
@@ -24,7 +24,7 @@
     "maximum_ram_size": 81920,
     "maximum_size": 1040316,
     "require_upload_port": true,
-    "resetmethod": "ck",
+    "resetmethod": "nodemcu",
     "speed": 115200
   },
   "url": "https://templates.blakadder.com/sonoff_ZBBridge.html",

--- a/boards/esp8266_zbbridge.json
+++ b/boards/esp8266_zbbridge.json
@@ -15,9 +15,7 @@
     "wifi"
   ],
   "frameworks": [
-    "arduino",
-    "esp8266-rtos-sdk",
-    "esp8266-nonos-sdk"
+    "arduino"
   ],
   "name": "Sonoff ZbBridge ESPEasy 2M Flash 256k FS",
   "upload": {

--- a/boards/esp8285_1M128k.json
+++ b/boards/esp8285_1M128k.json
@@ -15,9 +15,7 @@
     "wifi"
   ],
   "frameworks": [
-    "arduino",
-    "esp8266-rtos-sdk",
-    "esp8266-nonos-sdk"
+    "arduino"
   ],
   "name": "Espressif Generic ESP8285 ESPEasy 1M Flash 128k FS",
   "upload": {

--- a/boards/esp8285_1M128k.json
+++ b/boards/esp8285_1M128k.json
@@ -24,7 +24,7 @@
     "maximum_ram_size": 81920,
     "maximum_size": 892912,
     "require_upload_port": true,
-    "resetmethod": "ck",
+    "resetmethod": "nodemcu",
     "speed": 115200
   },
   "url": "http://www.esp8266.com/wiki/doku.php?id=esp8266-module-family",

--- a/boards/esp8285_1M128k_OTA.json
+++ b/boards/esp8285_1M128k_OTA.json
@@ -15,9 +15,7 @@
     "wifi"
   ],
   "frameworks": [
-    "arduino",
-    "esp8266-rtos-sdk",
-    "esp8266-nonos-sdk"
+    "arduino"
   ],
   "name": "Espressif Generic ESP8285 ESPEasy 1M Flash 128k FS",
   "upload": {

--- a/boards/esp8285_1M128k_OTA.json
+++ b/boards/esp8285_1M128k_OTA.json
@@ -24,7 +24,7 @@
     "maximum_ram_size": 81920,
     "maximum_size": 616448,
     "require_upload_port": true,
-    "resetmethod": "ck",
+    "resetmethod": "nodemcu",
     "speed": 115200
   },
   "url": "http://www.esp8266.com/wiki/doku.php?id=esp8266-module-family",

--- a/lib/Adafruit_BME680/bme680_defs.h
+++ b/lib/Adafruit_BME680/bme680_defs.h
@@ -82,9 +82,9 @@
 /** C standard macros **/
 #ifndef NULL
 #ifdef __cplusplus
-#define NULL   0
+#define NULL   nullptr
 #else
-#define NULL   ((void *) 0)
+#define NULL   nullptr
 #endif
 #endif
 

--- a/platformio_core_defs.ini
+++ b/platformio_core_defs.ini
@@ -205,13 +205,12 @@ platform_packages =
 [core_stage]
 extends                   = esp82xx_3_0_x
 platform                  = https://github.com/platformio/platform-espressif8266.git
-build_flags               = ${esp82xx_3_0_x.build_flags}
-                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK3
-                            -DPHASE_LOCKED_WAVEFORM
 platform_packages = 
     platformio/framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
     mcspr/toolchain-xtensa @ ~5.100300.211127
-
+build_flags               = ${esp82xx_3_0_x.build_flags}
+                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK3
+                            -DPHASE_LOCKED_WAVEFORM
 
 
 

--- a/platformio_esp32_envs.ini
+++ b/platformio_esp32_envs.ini
@@ -18,6 +18,9 @@ lib_ignore                = ESP8266Ping
 
 [esp32_base]
 extends                   = common, core_esp32_IDF4_4__2_0_4
+upload_speed              = 460800
+upload_before_reset       = default_reset
+upload_after_reset        = hard_reset
 lib_deps                  = 
                             Adafruit ILI9341 ESPEasy
                             Adafruit_ST77xx

--- a/platformio_esp82xx_base.ini
+++ b/platformio_esp82xx_base.ini
@@ -17,10 +17,10 @@ lib_ignore                = ${core_2_7_4_alt_wifi.lib_ignore}
 
 
 [core302_platform]
-build_flags               = ${core_4_0_1.build_flags}
-platform                  = ${core_4_0_1.platform}
-platform_packages         = ${core_4_0_1.platform_packages}
-lib_ignore                = ${core_4_0_1.lib_ignore}
+build_flags               = ${core_stage.build_flags}
+platform                  = ${core_stage.platform}
+platform_packages         = ${core_stage.platform_packages}
+lib_ignore                = ${core_stage.lib_ignore}
 
 
 [beta_platform_2ndheap]

--- a/src/_C014.cpp
+++ b/src/_C014.cpp
@@ -705,7 +705,7 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
         int lastindex = event->String1.lastIndexOf('/');
         errorCounter = 0;
 
-        if (event->String1.substring(lastindex + 1) == F("set"))
+        if (event->String1.substring(lastindex + 1).equals(F("set")))
         {
           pubname   = event->String1.substring(0, lastindex);
           lastindex = pubname.lastIndexOf('/');
@@ -723,7 +723,7 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
             log += valueName;
           }
 
-          if (nodeName == F(CPLUGIN_014_SYSTEM_DEVICE))                                              // msg to a system device
+          if (nodeName.equals(F(CPLUGIN_014_SYSTEM_DEVICE)))                                              // msg to a system device
           {
             if (valueName.startsWith(F(CPLUGIN_014_GPIO_VALUE))) // msg to to set gpio values
             {
@@ -732,10 +732,10 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
               cmd  = F("GPIO,");
               cmd += valueName.substring(gpio_value_tag_length).toInt();                    // get the GPIO
 
-              if ((event->String2 == F("true")) || (event->String2 == F("1"))) { cmd += F(",1"); }
+              if ((event->String2.equals(F("true"))) || (event->String2.equals(F("1")))) { cmd += F(",1"); }
               else { cmd += F(",0"); }
               validTopic = true;
-            } else if (valueName == F(CPLUGIN_014_CMD_VALUE)) // msg to send a command
+            } else if (valueName.equals(F(CPLUGIN_014_CMD_VALUE))) // msg to send a command
             {
               cmd        = event->String2;
               validTopic = true;
@@ -825,7 +825,7 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
           // in case of event, store to buffer and return...
           String command = parseString(cmd, 1);
 
-          if ((command == F("event")) || (command == F("asyncevent")))
+          if ((command.equals(F("event"))) || (command.equals(F("asyncevent"))))
           {
             if (Settings.UseRules) {
               String newEvent = parseStringToEnd(cmd, 2);
@@ -965,7 +965,7 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
       if (!string.isEmpty()) {
         String commandName = parseString(string, 1); // could not find a way to get the command out of the event structure.
 
-        if (commandName == F("gpio"))                // !ToDo : As gpio is like any other plugin commands should be integrated below!
+        if (commandName.equals(F("gpio")))                // !ToDo : As gpio is like any other plugin commands should be integrated below!
         {
           int port         = event->Par1;            // parseString(string, 2).toInt();
           int valueInt     = event->Par2;            // parseString(string, 3).toInt();
@@ -1020,7 +1020,7 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
             String valueStr;
             int    valueInt = 0;
 
-            if ((commandName == F("taskvalueset")) || (commandName == F("dummyvalueset"))) // should work for both
+            if ((commandName.equals(F("taskvalueset"))) || (commandName.equals(F("dummyvalueset")))) // should work for both
             {
               valueStr = formatUserVarNoCheck(event, taskVarIndex);                        // parseString(string, 4);
               success  = MQTTpublish(CPLUGIN_ID_014, INVALID_TASK_INDEX, topic.c_str(), valueStr.c_str(), false);
@@ -1050,7 +1050,7 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
                 log += F(" ERROR!");
                 addLogMove(LOG_LEVEL_ERROR, log);
               }
-            } else if (parseString(commandName, 1) == F("homievalueset")) { // acknolages value form P086 Homie Receiver
+            } else if (parseString(commandName, 1).equals(F("homievalueset"))) { // acknolages value form P086 Homie Receiver
               switch (Settings.TaskDevicePluginConfig[deviceIndex - 1][taskVarIndex]) {
                 case 0:                                                     // PLUGIN_085_VALUE_INTEGER
                   valueInt = static_cast<int>(UserVar[userVarIndex]);

--- a/src/_C018.cpp
+++ b/src/_C018.cpp
@@ -360,7 +360,7 @@ private:
       {
         cacheDevAddr = myLora->sendRawCommand(F("mac get devaddr"));
 
-        if (cacheDevAddr == F("00000000")) {
+        if (cacheDevAddr.equals(F("00000000"))) {
           cacheDevAddr = String();
         }
       }

--- a/src/_P001_Switch.ino
+++ b/src/_P001_Switch.ino
@@ -684,7 +684,7 @@ boolean Plugin_001(uint8_t function, struct EventStruct *event, String& string)
       // WARNING: don't read "globalMapPortStatus[key]" here, as it will create a new entry if key does not exist
 
 
-      if (command == F("inputswitchstate")) {
+      if (command.equals(F("inputswitchstate"))) {
         success = true;
 
         // @giig1967g deprecated since 2019-11-26

--- a/src/_P003_Pulse.ino
+++ b/src/_P003_Pulse.ino
@@ -248,8 +248,8 @@ boolean Plugin_003(uint8_t function, struct EventStruct *event, String& string)
         const String command      = parseString(string, 1);
         bool   mustCallPluginRead = false;
 
-        const bool cmd_resetpulsecounter    = command == F("resetpulsecounter");
-        const bool cmd_setpulsecountertotal = command == F("setpulsecountertotal");
+        const bool cmd_resetpulsecounter    = command.equals(F("resetpulsecounter"));
+        const bool cmd_setpulsecountertotal = command.equals(F("setpulsecountertotal"));
 
         if (cmd_resetpulsecounter || cmd_setpulsecountertotal)
         {
@@ -290,7 +290,7 @@ boolean Plugin_003(uint8_t function, struct EventStruct *event, String& string)
 
           success = true;
         }
-        else if (command == F("logpulsestatistic"))
+        else if (command.equals(F("logpulsestatistic")))
         {
           # ifdef PULSE_STATISTIC
 
@@ -303,8 +303,8 @@ boolean Plugin_003(uint8_t function, struct EventStruct *event, String& string)
           //       i = increase the log level for regular statstic logs to "info"
 
           const String subcommand = parseString(string, 2);
-          const bool sub_i = subcommand == F("i");
-          const bool sub_r = subcommand == F("r");
+          const bool sub_i = subcommand.equals(F("i"));
+          const bool sub_r = subcommand.equals(F("r"));
 
           if ((sub_i) || (sub_r) || (subcommand.isEmpty())) {
             P003_data->pulseHelper.doStatisticLogging(P003_PULSE_STATS_ADHOC_LOG_LEVEL);

--- a/src/_P011_PME.ino
+++ b/src/_P011_PME.ino
@@ -93,7 +93,7 @@ boolean Plugin_011(uint8_t function, struct EventStruct *event, String& string)
       String log;
       String command = parseString(string, 1);
 
-      if (command == F("extgpio"))
+      if (command.equals(F("extgpio")))
       {
         success = true;
         portStatusStruct tempStatus;
@@ -121,7 +121,7 @@ boolean Plugin_011(uint8_t function, struct EventStruct *event, String& string)
         SendStatusOnlyIfNeeded(event, SEARCH_PIN_STATE, key, log, 0);
       }
 
-      if (command == F("extpwm"))
+      if (command.equals(F("extpwm")))
       {
         success = true;
         uint8_t address = PLUGIN_011_I2C_ADDRESS;
@@ -154,7 +154,7 @@ boolean Plugin_011(uint8_t function, struct EventStruct *event, String& string)
         SendStatusOnlyIfNeeded(event, SEARCH_PIN_STATE, key, log, 0);
       }
 
-      if (command == F("extpulse"))
+      if (command.equals(F("extpulse")))
       {
         success = true;
 
@@ -188,7 +188,7 @@ boolean Plugin_011(uint8_t function, struct EventStruct *event, String& string)
         }
       }
 
-      if (command == F("extlongpulse"))
+      if (command.equals(F("extlongpulse")))
       {
         success = true;
 
@@ -221,8 +221,8 @@ boolean Plugin_011(uint8_t function, struct EventStruct *event, String& string)
         }
       }
 
-      if (command == F("status")) {
-        if (parseString(string, 2) == F("ext"))
+      if (command.equals(F("status"))) {
+        if (parseString(string, 2).equals(F("ext")))
         {
           success = true;
           const uint32_t key = createKey(PLUGIN_ID_011, event->Par2); // WARNING: 'status' uses Par2 instead of Par1

--- a/src/_P020_Ser2Net.ino
+++ b/src/_P020_Ser2Net.ino
@@ -315,13 +315,13 @@ boolean Plugin_020(uint8_t function, struct EventStruct *event, String& string)
         break;
       }
 
-      if (command == F("serialsend")) {
+      if (command.equals(F("serialsend"))) {
         task->ser2netSerial->write(string.substring(11).c_str());
         task->ser2netSerial->flush();
         success = true;
       }
 
-      if ((command == F("ser2netclientsend")) && (task->hasClientConnected())) {
+      if ((command.equals(F("ser2netclientsend"))) && (task->hasClientConnected())) {
         task->ser2netClient.print(string.substring(18));
         task->ser2netClient.flush();
         success = true;

--- a/src/_P021_Level.ino
+++ b/src/_P021_Level.ino
@@ -106,7 +106,7 @@ boolean Plugin_021(uint8_t function, struct EventStruct *event, String& string)
     {
       String command = parseString(string, 1);
 
-      if (command == F("setlevel")) {
+      if (command.equals(F("setlevel"))) {
         String value  = parseString(string, 2);
         double result = 0.0;
 
@@ -128,7 +128,7 @@ boolean Plugin_021(uint8_t function, struct EventStruct *event, String& string)
     {
       String command = parseString(string, 1);
 
-      if (command == F("getlevel")) {
+      if (command.equals(F("getlevel"))) {
         string  = PCONFIG_FLOAT(0);
         success = true;
       }

--- a/src/_P022_PCA9685.ino
+++ b/src/_P022_PCA9685.ino
@@ -211,7 +211,7 @@ boolean Plugin_022(uint8_t function, struct EventStruct *event, String& string)
         }
       }
 
-      if ((command == F("pcapwm")) || (instanceCommand && (command == F("pwm"))))
+      if ((command.equals(F("pcapwm"))) || (instanceCommand && (command.equals(F("pwm")))))
       {
         success = true;
 
@@ -297,7 +297,7 @@ boolean Plugin_022(uint8_t function, struct EventStruct *event, String& string)
         }
       }
 
-      if ((command == F("pcafrq")) || (instanceCommand && (command == F("frq"))))
+      if ((command.equals(F("pcafrq"))) || (instanceCommand && (command.equals(F("frq")))))
       {
         success = true;
 
@@ -336,7 +336,7 @@ boolean Plugin_022(uint8_t function, struct EventStruct *event, String& string)
         }
       }
 
-      if (instanceCommand && (command == F("mode2")))
+      if (instanceCommand && (command.equals(F("mode2"))))
       {
         success = true;
 
@@ -360,9 +360,9 @@ boolean Plugin_022(uint8_t function, struct EventStruct *event, String& string)
         }
       }
 
-      if (command == F("status"))
+      if (command.equals(F("status")))
       {
-        if (parseString(string, 2) == F("pca"))
+        if (parseString(string, 2).equals(F("pca")))
         {
           if (!P022_data->p022_is_init(address))
           {
@@ -378,12 +378,12 @@ boolean Plugin_022(uint8_t function, struct EventStruct *event, String& string)
         }
       }
 
-      if (instanceCommand && (command == F("gpio")))
+      if (instanceCommand && (command.equals(F("gpio"))))
       {
         success = true;
         log     = formatToHex(address, F("PCA 0x"), 2);
         log    += F(": GPIO ");
-        const bool allPins = parseString(string, 2) == F("all");
+        const bool allPins = parseString(string, 2).equals(F("all"));
 
         if (((event->Par1 >= 0) && (event->Par1 <= PCA9685_MAX_PINS)) ||
             allPins)
@@ -437,7 +437,7 @@ boolean Plugin_022(uint8_t function, struct EventStruct *event, String& string)
         }
       }
 
-      if (instanceCommand && (command == F("pulse")))
+      if (instanceCommand && (command.equals(F("pulse"))))
       {
         success = true;
         log     = formatToHex(address, F("PCA 0x"), 2);
@@ -470,7 +470,7 @@ boolean Plugin_022(uint8_t function, struct EventStruct *event, String& string)
 
           if (event->Par3 > 0)
           {
-            if (parseString(string, 5) == F("auto"))
+            if (parseString(string, 5).equals(F("auto")))
             {
               autoreset = -1;
               log      += F(" with autoreset infinity");

--- a/src/_P033_Dummy.ino
+++ b/src/_P033_Dummy.ino
@@ -90,7 +90,7 @@ boolean Plugin_033(uint8_t function, struct EventStruct *event, String& string)
     {
       String command = parseString(string, 1);
 
-      if (command == F("dummyvalueset"))
+      if (command.equals(F("dummyvalueset")))
       {
         if (event->Par1 == event->TaskIndex + 1) // make sure that this instance is the target
         {

--- a/src/_P036_FrameOLED.ino
+++ b/src/_P036_FrameOLED.ino
@@ -846,12 +846,12 @@ boolean Plugin_036(uint8_t function, struct EventStruct *event, String& string)
       bool sendEvents = bitRead(P036_FLAGS_0, P036_FLAG_SEND_EVENTS); // Bit 28 Send Events
       # endif // ifdef P036_SEND_EVENTS
 
-      if ((command == F("oledframedcmd")) && P036_data->isInitialized()) {
-        if (subcommand == F("display")) {
+      if ((command.equals(F("oledframedcmd"))) && P036_data->isInitialized()) {
+        if (subcommand.equals(F("display"))) {
           // display functions
           String para1 = parseString(string, 3);
 
-          if (para1 == F("on")) {
+          if (para1.equals(F("on"))) {
             success                 = true;
             P036_data->displayTimer = P036_TIMER;
             P036_data->display->displayOn();
@@ -864,7 +864,7 @@ boolean Plugin_036(uint8_t function, struct EventStruct *event, String& string)
             # endif // ifdef P036_SEND_EVENTS
           }
 
-          if (para1 == F("off")) {
+          if (para1.equals(F("off"))) {
             success                 = true;
             P036_data->displayTimer = 0;
             P036_data->display->displayOff();
@@ -877,7 +877,7 @@ boolean Plugin_036(uint8_t function, struct EventStruct *event, String& string)
             # endif // ifdef P036_SEND_EVENTS
           }
 
-          if (para1 == F("low")) {
+          if (para1.equals(F("low"))) {
             success = true;
             P036_data->setContrast(P36_CONTRAST_LOW);
             # ifdef P036_SEND_EVENTS
@@ -893,7 +893,7 @@ boolean Plugin_036(uint8_t function, struct EventStruct *event, String& string)
             UserVar[event->BaseVarIndex] = 1; //  Save the fact that the display is now ON
           }
 
-          if (para1 == F("med")) {
+          if (para1.equals(F("med"))) {
             success = true;
             P036_data->setContrast(P36_CONTRAST_MED);
             # ifdef P036_SEND_EVENTS
@@ -909,7 +909,7 @@ boolean Plugin_036(uint8_t function, struct EventStruct *event, String& string)
             UserVar[event->BaseVarIndex] = 1; //  Save the fact that the display is now ON
           }
 
-          if (para1 == F("high")) {
+          if (para1.equals(F("high"))) {
             success = true;
             P036_data->setContrast(P36_CONTRAST_HIGH);
             # ifdef P036_SEND_EVENTS
@@ -924,7 +924,7 @@ boolean Plugin_036(uint8_t function, struct EventStruct *event, String& string)
             # endif // ifdef P036_SEND_EVENTS
             UserVar[event->BaseVarIndex] = 1; //  Save the fact that the display is now ON
           }
-        } else if ((subcommand == F("frame")) &&
+        } else if ((subcommand.equals(F("frame"))) &&
                    (event->Par2 >= 0) &&
                    (event->Par2 <= P036_data->MaxFramesToDisplay + 1)) {
           success = true;
@@ -951,7 +951,7 @@ boolean Plugin_036(uint8_t function, struct EventStruct *event, String& string)
           # endif // ifdef P036_SEND_EVENTS
         }
         # ifdef P036_ENABLE_LINECOUNT
-        else if ((subcommand == F("linecount")) &&
+        else if ((subcommand.equals(F("linecount"))) &&
                  (event->Par2 >= 1) &&
                  (event->Par2 <= 4)) {
           success = true;
@@ -969,7 +969,7 @@ boolean Plugin_036(uint8_t function, struct EventStruct *event, String& string)
         }
         # endif // P036_ENABLE_LINECOUNT
         # ifdef P036_ENABLE_LEFT_ALIGN
-        else if ((subcommand == F("leftalign")) &&
+        else if ((subcommand.equals(F("leftalign"))) &&
                  ((event->Par2 == 0) ||
                   (event->Par2 == 1))) {
           success = true;

--- a/src/_P037_MQTTImport.ino
+++ b/src/_P037_MQTTImport.ino
@@ -816,7 +816,7 @@ bool MQTTCheckSubscription_037(const String& Topic, const String& Subscription) 
   // Test for multi-level wildcard (#) see: http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718107 (for MQTT 3 and
   // MQTT 5)
 
-  if (tmpSub == F("#")) { return true; // If the subscription is for '#' then all topics are accepted
+  if (tmpSub.equals(F("#"))) { return true; // If the subscription is for '#' then all topics are accepted
   }
 
   if (tmpSub.endsWith(F("/#"))) {      // A valid MQTT multi-level wildcard is a # at the end of the topic that's preceded by a /
@@ -877,7 +877,7 @@ bool MQTTCheckSubscription_037(const String& Topic, const String& Subscription) 
     //  If the subtopics match then OK - otherwise fail
     if (pSub == "#") { return true; }
 
-    if ((pTopic != pSub) && (pSub != F("+"))) { return false; }
+    if ((pTopic != pSub) && (!pSub.equals(F("+")))) { return false; }
 
     count = count + 1;
   }

--- a/src/_P053_PMSx003.ino
+++ b/src/_P053_PMSx003.ino
@@ -374,12 +374,12 @@ boolean Plugin_053(uint8_t function, struct EventStruct *event, String& string)
         String command    = parseString(string, 1);
         String subcommand = parseString(string, 2);
 
-        if (command == F("pmsx003")) {
-          if (subcommand == F("wake")) {
+        if (command.equals(F("pmsx003"))) {
+          if (subcommand.equals(F("wake"))) {
             success = P053_data->wakeSensor();
-          } else if (subcommand == F("sleep")) {
+          } else if (subcommand.equals(F("sleep"))) {
             success = P053_data->sleepSensor();
-          } else if (subcommand == F("reset")) {
+          } else if (subcommand.equals(F("reset"))) {
             success = P053_data->resetSensor();
           }
         }

--- a/src/_P054_DMX512.ino
+++ b/src/_P054_DMX512.ino
@@ -150,7 +150,7 @@ boolean Plugin_054(uint8_t function, struct EventStruct *event, String& string)
         lowerString.toLowerCase();
         String command = parseString(lowerString, 1);
 
-        if (command == F("dmx"))
+        if (command.equals(F("dmx")))
         {
           String param;
           String paramKey;
@@ -172,7 +172,7 @@ boolean Plugin_054(uint8_t function, struct EventStruct *event, String& string)
               addLog(LOG_LEVEL_DEBUG_MORE, param);
               #endif
 
-              if (param == F("log"))
+              if (param.equals(F("log")))
               {
                 if (loglevelActiveFor(LOG_LEVEL_INFO)) {
                   String log = F("DMX  : ");
@@ -186,7 +186,7 @@ boolean Plugin_054(uint8_t function, struct EventStruct *event, String& string)
                 success = true;
               }
 
-              else if (param == F("test"))
+              else if (param.equals(F("test")))
               {
                 for (int16_t i = 0; i < Plugin_054_DMXSize; i++)
                   //Plugin_054_DMXBuffer[i] = i+1;
@@ -194,13 +194,13 @@ boolean Plugin_054(uint8_t function, struct EventStruct *event, String& string)
                 success = true;
               }
 
-              else if (param == F("on"))
+              else if (param.equals(F("on")))
               {
                 memset(Plugin_054_DMXBuffer, 255, Plugin_054_DMXSize);
                 success = true;
               }
 
-              else if (param == F("off"))
+              else if (param.equals(F("off")))
               {
                 memset(Plugin_054_DMXBuffer, 0, Plugin_054_DMXSize);
                 success = true;

--- a/src/_P055_Chiming.ino
+++ b/src/_P055_Chiming.ino
@@ -219,7 +219,7 @@ boolean Plugin_055(uint8_t function, struct EventStruct *event, String& string)
 
         String command = parseString(string, 1);
 
-        if (command == F("chime"))
+        if (command.equals(F("chime")))
         {
           String param = parseStringToEndKeepCase(string, 2);
           if (param.length() > 0) {
@@ -227,7 +227,7 @@ boolean Plugin_055(uint8_t function, struct EventStruct *event, String& string)
           }
           success = true;
         }
-        if (command == F("chimeplay"))
+        if (command.equals(F("chimeplay")))
         {
           String name = parseString(string, 2);
           if (name.length() > 0) {
@@ -237,7 +237,7 @@ boolean Plugin_055(uint8_t function, struct EventStruct *event, String& string)
           }
           success = true;
         }
-        if (command == F("chimesave"))
+        if (command.equals(F("chimesave")))
         {
           String name = parseString(string, 2);
           String param = parseStringToEndKeepCase(string, 3);

--- a/src/_P057_HT16K33_LED.ino
+++ b/src/_P057_HT16K33_LED.ino
@@ -178,7 +178,7 @@ boolean Plugin_057(uint8_t function, struct EventStruct *event, String& string)
 
       String command = parseString(string, 1);
 
-      if (command == F("mprint"))
+      if (command.equals(F("mprint")))
       {
         String text = parseStringToEnd(string, 2);
 
@@ -202,7 +202,7 @@ boolean Plugin_057(uint8_t function, struct EventStruct *event, String& string)
           success = true;
         }
       }
-      else if (command == F("mbr")) {
+      else if (command.equals(F("mbr"))) {
         String param = parseString(string, 2);
         int    brightness;
 
@@ -213,7 +213,7 @@ boolean Plugin_057(uint8_t function, struct EventStruct *event, String& string)
         }
         success = true;
       }
-      else if ((command == F("m")) || (command == F("mx")) || (command == F("mnum")))
+      else if ((command.equals(F("m"))) || (command.equals(F("mx"))) || (command.equals(F("mnum"))))
       {
         String   param;
         String   paramKey;
@@ -238,7 +238,7 @@ boolean Plugin_057(uint8_t function, struct EventStruct *event, String& string)
             addLog(LOG_LEVEL_DEBUG_MORE, param);
             #endif
 
-            if (param == F("log"))
+            if (param.equals(F("log")))
             {
               if (loglevelActiveFor(LOG_LEVEL_INFO)) {
                 String log = F("MX   : ");
@@ -253,7 +253,7 @@ boolean Plugin_057(uint8_t function, struct EventStruct *event, String& string)
               success = true;
             }
 
-            else if (param == F("test"))
+            else if (param.equals(F("test")))
             {
               for (uint8_t i = 0; i < 8; i++) {
                 P057_data->ledMatrix.SetRow(i, 1 << i);
@@ -261,7 +261,7 @@ boolean Plugin_057(uint8_t function, struct EventStruct *event, String& string)
               success = true;
             }
 
-            else if (param == F("clear"))
+            else if (param.equals(F("clear")))
             {
               P057_data->ledMatrix.ClearRowBuffer();
               success = true;
@@ -282,7 +282,7 @@ boolean Plugin_057(uint8_t function, struct EventStruct *event, String& string)
                 paramVal = param;
               }
 
-              if (command == F("mnum"))
+              if (command.equals(F("mnum")))
               {
                 value = paramVal.toInt();
 
@@ -293,7 +293,7 @@ boolean Plugin_057(uint8_t function, struct EventStruct *event, String& string)
                   P057_data->ledMatrix.SetRow(seg, value);
                 }
               }
-              else if (command == F("mx"))
+              else if (command.equals(F("mx")))
               {
                 char *ep;
                 value = strtol(paramVal.c_str(), &ep, 16);

--- a/src/_P059_Encoder.ino
+++ b/src/_P059_Encoder.ino
@@ -184,7 +184,7 @@ boolean Plugin_059(uint8_t function, struct EventStruct *event, String& string)
         if (P_059_sensordefs.count(event->TaskIndex) != 0)
         {
             String command = parseString(string, 1);
-            if (command == F("encwrite"))
+            if (command.equals(F("encwrite")))
             {
               if (event->Par1 >= 0)
               {

--- a/src/_P065_DRF0299_MP3.ino
+++ b/src/_P065_DRF0299_MP3.ino
@@ -141,19 +141,19 @@ boolean Plugin_065(uint8_t function, struct EventStruct *event, String& string)
       int    value;
       bool   valueValid = validIntFromString(param, value);
 
-      if (valueValid && (command == F("play")))
+      if (valueValid && (command.equals(F("play"))))
       {
         Plugin_065_Play(value);
         success = true;
       }
 
-      if (command == F("stop"))
+      if (command.equals(F("stop")))
       {
         Plugin_065_SendCmd(0x0E, 0);
         success = true;
       }
 
-      if (valueValid && (command == F("vol")))
+      if (valueValid && (command.equals(F("vol"))))
       {
         if (value == 0) { value = 30; }
         PCONFIG(0) = value;
@@ -161,19 +161,19 @@ boolean Plugin_065(uint8_t function, struct EventStruct *event, String& string)
         success = true;
       }
 
-      if (valueValid && (command == F("eq")))
+      if (valueValid && (command.equals(F("eq"))))
       {
         Plugin_065_SetEQ(value);
         success = true;
       }
 
-      if (valueValid && (command == F("mode")))
+      if (valueValid && (command.equals(F("mode"))))
       {
         Plugin_065_SetMode(value);
         success = true;
       }
 
-      if (valueValid && (command == F("repeat")))
+      if (valueValid && (command.equals(F("repeat"))))
       {
         Plugin_065_SetRepeat(value);
         success = true;
@@ -185,7 +185,7 @@ boolean Plugin_065(uint8_t function, struct EventStruct *event, String& string)
         log  = F("MP3  : ");
         log += command;
 
-        if (command != F("stop")) {
+        if (!command.equals(F("stop"))) {
           log += '=';
           log += value;
         }

--- a/src/_P070_NeoPixel_Clock.ino
+++ b/src/_P070_NeoPixel_Clock.ino
@@ -145,7 +145,7 @@ boolean Plugin_070(uint8_t function, struct EventStruct *event, String& string)
 
       P070_data_struct *P070_data = static_cast<P070_data_struct *>(getPluginTaskData(event->TaskIndex));
 
-      if ((nullptr != P070_data) && (command == F("clock"))) {
+      if ((nullptr != P070_data) && (command.equals(F("clock")))) {
         int val_Mode;
 
         if (validIntFromString(param1, val_Mode)) {

--- a/src/_P073_7DGT.ino
+++ b/src/_P073_7DGT.ino
@@ -361,41 +361,41 @@ bool p073_plugin_write(struct EventStruct *event,
 
   const String text = parseStringToEndKeepCase(string, 2);
 
-  if (cmd.equals("7dn")) {
+  if (cmd.equals(F("7dn"))) {
     return p073_plugin_write_7dn(event, text);
-  } else if (cmd.equals("7dt")) {
+  } else if (cmd.equals(F("7dt"))) {
     return p073_plugin_write_7dt(event, text);
   # ifdef P073_7DDT_COMMAND
-  } else if (cmd.equals("7ddt")) {
+  } else if (cmd.equals(F("7ddt"))) {
     return p073_plugin_write_7ddt(event, text);
   # endif // ifdef P073_7DDT_COMMAND
-  } else if (cmd.equals("7dst")) {
+  } else if (cmd.equals(F("7dst"))) {
     return p073_plugin_write_7dst(event);
-  } else if (cmd.equals("7dsd")) {
+  } else if (cmd.equals(F("7dsd"))) {
     return p073_plugin_write_7dsd(event);
-  } else if (cmd.equals("7dtext")) {
+  } else if (cmd.equals(F("7dtext"))) {
     return p073_plugin_write_7dtext(event, text);
   # ifdef P073_EXTRA_FONTS
-  } else if (cmd.equals("7dfont")) {
+  } else if (cmd.equals(F("7dfont"))) {
     return p073_plugin_write_7dfont(event, text);
   # endif // P073_EXTRA_FONTS
   # ifdef P073_7DBIN_COMMAND
-  } else if (cmd.equals("7dbin")) {
+  } else if (cmd.equals(F("7dbin"))) {
     return p073_plugin_write_7dbin(event, text);
   # endif // P073_7DBIN_COMMAND
   } else {
     bool p073_validcmd  = false;
     bool p073_displayon = false;
 
-    if (cmd.equals("7don")) {
+    if (cmd.equals(F("7don"))) {
       addLog(LOG_LEVEL_INFO, F("7DGT : Display ON"));
       p073_displayon = true;
       p073_validcmd  = true;
-    } else if (cmd.equals("7doff")) {
+    } else if (cmd.equals(F("7doff"))) {
       addLog(LOG_LEVEL_INFO, F("7DGT : Display OFF"));
       p073_displayon = false;
       p073_validcmd  = true;
-    } else if (cmd.equals("7db")) {
+    } else if (cmd.equals(F("7db"))) {
       if ((event->Par1 >= 0) && (event->Par1 < 16)) {
         if (loglevelActiveFor(LOG_LEVEL_INFO)) {
           String log = F("7DGT : Brightness=");
@@ -820,13 +820,13 @@ bool p073_plugin_write_7dfont(struct EventStruct *event,
     String fontArg = parseString(text, 1);
     int    fontNr  = -1;
 
-    if ((fontArg == F("default")) || (fontArg == F("7dgt"))) {
+    if ((fontArg.equals(F("default"))) || (fontArg.equals(F("7dgt")))) {
       fontNr = 0;
-    } else if (fontArg == F("siekoo")) {
+    } else if (fontArg.equals(F("siekoo"))) {
       fontNr = 1;
-    } else if (fontArg == F("siekoo_upper")) {
+    } else if (fontArg.equals(F("siekoo_upper"))) {
       fontNr = 2;
-    } else if (fontArg == F("dseg7")) {
+    } else if (fontArg.equals(F("dseg7"))) {
       fontNr = 3;
     } else if (!validIntFromString(text, fontNr)) {
       fontNr = -1; // reset if invalid

--- a/src/_P075_Nextion.ino
+++ b/src/_P075_Nextion.ino
@@ -473,9 +473,9 @@ boolean Plugin_075(uint8_t function, struct EventStruct *event, String& string)
 
                   if (argIndex) { Nvalue = tmpString.substring(argIndex + 2, argEnd); }
 
-                  if (Nvalue == F("On")) { Svalue = '1'; }
+                  if (Nvalue.equals(F("On"))) { Svalue = '1'; }
 
-                  if (Nvalue == F("Off")) { Svalue = '0'; }
+                  if (Nvalue.equals(F("Off"))) { Svalue = '0'; }
                   break;
               }
 

--- a/src/_P079_Wemos_Motorshield.ino
+++ b/src/_P079_Wemos_Motorshield.ino
@@ -273,7 +273,7 @@ boolean Plugin_079(uint8_t function, struct EventStruct *event, String& string)
           return true;                                             // Exit now. Info Log shows Lolin Info.
         }
         else {
-          if ((paramMotor == F("0")) || (paramMotor == F("1"))) {
+          if ((paramMotor.equals(F("0"))) || (paramMotor.equals(F("1")))) {
             motor_number = paramMotor.toInt();
           }
           else {

--- a/src/_P086_Homie.ino
+++ b/src/_P086_Homie.ino
@@ -180,7 +180,7 @@ boolean Plugin_086(uint8_t function, struct EventStruct *event, String& string)
     case PLUGIN_WRITE:
       {
         String command = parseString(string, 1);
-        if (command == F("homievalueset"))
+        if (command.equals(F("homievalueset")))
         {
           const taskVarIndex_t taskVarIndex = event->Par2 - 1;
           const userVarIndex_t userVarIndex = event->BaseVarIndex + taskVarIndex;

--- a/src/_P089_Ping.ino
+++ b/src/_P089_Ping.ino
@@ -109,7 +109,7 @@ boolean Plugin_089(uint8_t function, struct EventStruct *event, String& string)
     {
       String command = parseString(string, 1);
 
-      if (command == F("pingset"))
+      if (command.equals(F("pingset")))
       {
         String taskName       = parseString(string, 2);
         taskIndex_t taskIndex = findTaskIndexByName(taskName);

--- a/src/_P091_SerSwitch.ino
+++ b/src/_P091_SerSwitch.ino
@@ -583,7 +583,7 @@ boolean Plugin_091(uint8_t function, struct EventStruct *event, String& string)
 
         if (Plugin_091_init)
         {
-          if ( command == F("relay") ) // deal with relay change command
+          if ( command.equals(F("relay"))) // deal with relay change command
           {
             success = true;
 
@@ -633,7 +633,7 @@ boolean Plugin_091(uint8_t function, struct EventStruct *event, String& string)
             }
           }
 
-          if ( command == F("relaypulse") )
+          if ( command.equals(F("relaypulse")))
           {
             success = true;
 
@@ -685,7 +685,7 @@ boolean Plugin_091(uint8_t function, struct EventStruct *event, String& string)
             }
           }
 
-          if ( command == F("relaylongpulse") )
+          if ( command.equals(F("relaylongpulse")))
           {
             success = true;
 
@@ -737,7 +737,7 @@ boolean Plugin_091(uint8_t function, struct EventStruct *event, String& string)
               addLogMove(LOG_LEVEL_INFO, log);
             }
           }
-          if ( command == F("ydim") ) // deal with dimmer command
+          if ( command.equals(F("ydim")) ) // deal with dimmer command
           {
             if (( (Plugin_091_globalpar0 == SER_SWITCH_YEWE) && (Plugin_091_numrelay > 1)) || (Plugin_091_globalpar0 == SER_SWITCH_WIFIDIMMER)) { // only on tuya dimmer
               success = true;

--- a/src/_P098_PWM_motor.ino
+++ b/src/_P098_PWM_motor.ino
@@ -388,28 +388,28 @@ boolean Plugin_098(uint8_t function, struct EventStruct *event, String& string)
         const String command = parseString(string, 1);
 
         if (command.startsWith(F("pwmmotor"))) {
-          if (command == F("pwmmotorhome")) {
+          if (command.equals(F("pwmmotorhome"))) {
             // Run the motor in reverse till limit A switch is reached
             P098_data->findHome();
             success = true;
-          } else if (command == F("pwmmotorend")) {
+          } else if (command.equals(F("pwmmotorend"))) {
             // Run the motor forward till limit B switch is reached
             P098_data->moveForward(-1);
             success = true;
-          } else if (command == F("pwmmotorforward")) {
+          } else if (command.equals(F("pwmmotorforward"))) {
             // Run the motor N steps forward
             // N <= 0: Move till limit B switch is reached
             P098_data->moveForward(event->Par1);
             success = true;
-          } else if (command == F("pwmmotorreverse")) {
+          } else if (command.equals(F("pwmmotorreverse"))) {
             // Run the motor N steps in reverse
             P098_data->moveReverse(event->Par1);
             success = true;
-          } else if (command == F("pwmmotorstop")) {
+          } else if (command.equals(F("pwmmotorstop"))) {
             // Run the motor N steps in reverse
             P098_data->stop();
             success = true;
-          } else if (command == F("pwmmotormovetopos")) {
+          } else if (command.equals(F("pwmmotormovetopos"))) {
             // Run the motor in the required direction to position N
             // What to do when position is unknown?
             if (!P098_data->moveToPos(event->Par1)) {

--- a/src/_P101_WakeOnLan.ino
+++ b/src/_P101_WakeOnLan.ino
@@ -427,10 +427,10 @@ uint8_t safeName(taskIndex_t index) {
     safeCode = NAME_MISSING;
   }
 
-  if (devName == F("reboot")) {
+  if (devName.equals(F("reboot"))) {
     safeCode = NAME_UNSAFE;
   }
-  else if (devName == F("reset")) {
+  else if (devName.equals(F("reset"))) {
     safeCode = NAME_UNSAFE;
   }
 

--- a/src/_P102_PZEM004Tv3.ino
+++ b/src/_P102_PZEM004Tv3.ino
@@ -347,7 +347,7 @@ boolean Plugin_102(uint8_t function, struct EventStruct *event, String& string)
       {
         String command = parseString(string, 1);
 
-        if ((command == F("resetenergy")) && (P102_PZEM_FIRST == event->TaskIndex))
+        if ((command.equals(F("resetenergy"))) && (P102_PZEM_FIRST == event->TaskIndex))
         {
           if ((event->Par1 >= 0) && (event->Par1 <= 247))
           {

--- a/src/_P103_Atlas_EZO_pH_ORP_EC_DO.ino
+++ b/src/_P103_Atlas_EZO_pH_ORP_EC_DO.ino
@@ -99,19 +99,19 @@ boolean Plugin_103(uint8_t function, struct EventStruct *event, String &string)
       String version = boardInfo.substring(boardInfo.lastIndexOf(',') + 1);
       addHtml(board);
 
-      if (board == F("pH"))
+      if (board.equals(F("pH")))
       {
         board_type = PH;
       }
-      else if (board == F("ORP"))
+      else if (board.equals(F("ORP")))
       {
         board_type = ORP;
       }
-      else if (board == F("EC"))
+      else if (board.equals(F("EC")))
       {
         board_type = EC;
       }
-      else if (board == F("D.O."))
+      else if (board.equals(F("D.O.")))
       {
         board_type = DO;
       }

--- a/src/_P109_ThermOLED.ino
+++ b/src/_P109_ThermOLED.ino
@@ -570,41 +570,41 @@ boolean Plugin_109(byte function, struct EventStruct *event, String& string)
       String logstr;
 
       if (Plugin_109_init) {
-        if (command == F("oledframedcmd"))
+        if (command.equals(F("oledframedcmd")))
         {
           success = true;
 
-          if (subcommand == F("off")) {
+          if (subcommand.equals(F("off"))) {
             P109_setContrast(P109_CONTRAST_OFF);
           }
-          else if (subcommand == F("on")) {
+          else if (subcommand.equals(F("on"))) {
             P109_display->displayOn();
           }
-          else if (subcommand == F("low")) {
+          else if (subcommand.equals(F("low"))) {
             P109_setContrast(P109_CONTRAST_LOW);
           }
-          else if (subcommand == F("med")) {
+          else if (subcommand.equals(F("med"))) {
             P109_setContrast(P109_CONTRAST_MED);
           }
-          else if (subcommand == F("high")) {
+          else if (subcommand.equals(F("high"))) {
             P109_setContrast(P109_CONTRAST_HIGH);
           }
           logstr = F("\nOk");
           SendStatus(event, logstr);
         }
 
-        if (command == F("thermo"))
+        if (command.equals(F("thermo")))
         {
           success = true;
           String par1 = parseString(string, 3);
 
-          if (subcommand == F("setpoint")) {
+          if (subcommand.equals(F("setpoint"))) {
             P109_setSetpoint(par1);
           }
-          else if (subcommand == F("heating")) {
+          else if (subcommand.equals(F("heating"))) {
             P109_setHeater(par1); Plugin_109_changed = 1;
           }
-          else if (subcommand == F("mode")) {
+          else if (subcommand.equals(F("mode"))) {
             P109_setMode(par1, parseString(string, 4));
           }
           logstr = F("\nOk");
@@ -910,10 +910,10 @@ void P109_setHeatRelay(byte state) {
 }
 
 void P109_setHeater(String heater) {
-  if ((heater == F("1")) || (heater == F("on"))) {
+  if ((heater.equals(F("1"))) || (heater.equals(F("on")))) {
     UserVar[Plugin_109_varindex + 1] = 1;
     P109_setHeatRelay(HIGH);
-  } else if ((heater == F("0")) || (heater == F("off"))) {
+  } else if ((heater.equals(F("0"))) || (heater.equals(F("off")))) {
     UserVar[Plugin_109_varindex + 1] = 0;
     P109_setHeatRelay(LOW);
   } else if (UserVar[Plugin_109_varindex + 1] == 0) {
@@ -927,16 +927,16 @@ void P109_setHeater(String heater) {
 }
 
 void P109_setMode(String amode, String atimeout) {
-  if ((amode == F("0")) || (amode == F("x"))) {
+  if ((amode.equals(F("0"))) || (amode.equals(F("x")))) {
     UserVar[Plugin_109_varindex + 2] = 0;
     P109_setHeater(F("0"));
     P109_display->setColor(BLACK);
     P109_display->fillRect(86, 35, 41, 21);
     Plugin_109_prev_setpoint = 0;
-  } else if ((amode == F("1")) || (amode == F("a"))) {
+  } else if ((amode.equals(F("1"))) || (amode.equals(F("a")))) {
     UserVar[Plugin_109_varindex + 2] = 1;
     P109_display_setpoint_temp(1);
-  } else if ((amode == F("2")) || (amode == F("m"))) {
+  } else if ((amode.equals(F("2"))) || (amode.equals(F("m")))) {
     UserVar[Plugin_109_varindex + 2] = 2;
     UserVar[Plugin_109_varindex + 3] = (atimeout.toFloat() * 60);
     Plugin_109_prev_timeout          = 32768;

--- a/src/_P115_MAX1704x_v2.ino
+++ b/src/_P115_MAX1704x_v2.ino
@@ -171,7 +171,7 @@ boolean Plugin_115(uint8_t function, struct EventStruct *event, String& string)
       if ((nullptr != P115_data) && P115_data->initialized) {
         const String command = parseString(string, 1);
 
-        if ((command == F("max1704xclearalert")))
+        if ((command.equals(F("max1704xclearalert"))))
         {
           P115_data->clearAlert();
           success = true;

--- a/src/src/Commands/Blynk.cpp
+++ b/src/src/Commands/Blynk.cpp
@@ -133,7 +133,7 @@ bool Blynk_get(const String& command, controllerIndex_t controllerIndex, float *
       #endif
 
       // success ?
-      if (line.substring(0, 15) == F("HTTP/1.1 200 OK")) {
+      if (line.substring(0, 15).equals(F("HTTP/1.1 200 OK"))) {
         #ifndef BUILD_NO_DEBUG
         strcpy_P(log, PSTR("HTTP : Success"));
         #endif
@@ -141,10 +141,10 @@ bool Blynk_get(const String& command, controllerIndex_t controllerIndex, float *
         if (!data) { success = true; }
       }
       #ifndef BUILD_NO_DEBUG
-      else if (line.substring(0, 24) == F("HTTP/1.1 400 Bad Request")) {
+      else if (line.substring(0, 24).equals(F("HTTP/1.1 400 Bad Request"))) {
         strcpy_P(log, PSTR("HTTP : Unauthorized"));
       }
-      else if (line.substring(0, 25) == F("HTTP/1.1 401 Unauthorized")) {
+      else if (line.substring(0, 25).equals(F("HTTP/1.1 401 Unauthorized"))) {
         strcpy_P(log, PSTR("HTTP : Unauthorized"));
       }
       addLog(LOG_LEVEL_DEBUG, log);

--- a/src/src/DataStructs/PluginStats.cpp
+++ b/src/src/DataStructs/PluginStats.cpp
@@ -76,14 +76,14 @@ bool PluginStats::plugin_get_config_value_base(struct EventStruct *event, String
 
   float value;
 
-  if (command == F("min")) {        // [taskname#valuename.min] Lowest value seen since value reset
+  if (command.equals(F("min"))) {        // [taskname#valuename.min] Lowest value seen since value reset
     value   = getPeakLow();
     success = true;
-  } else if (command == F("max")) { // [taskname#valuename.max] Highest value seen since value reset
+  } else if (command.equals(F("max"))) { // [taskname#valuename.max] Highest value seen since value reset
     value   = getPeakHigh();
     success = true;
   } else if (command.startsWith(F("avg"))) {
-    if (command == F("avg")) { // [taskname#valuename.avg] Average value of the last N kept samples
+    if (command.equals(F("avg"))) { // [taskname#valuename.avg] Average value of the last N kept samples
       value   = getSampleAvg();
       success = true;
     } else {

--- a/src/src/ESPEasyCore/ESPEasyRules.cpp
+++ b/src/src/ESPEasyCore/ESPEasyRules.cpp
@@ -840,7 +840,7 @@ void processMatchedRule(String& action, const String& event,
     }
   }
 
-  if ((lcAction == F("else")) && !fakeIfBlock) // in case of an "else" block of
+  if ((lcAction.equals(F("else"))) && !fakeIfBlock) // in case of an "else" block of
                                                // actions, set ifBranche to
                                                // false
   {
@@ -858,7 +858,7 @@ void processMatchedRule(String& action, const String& event,
 #endif // ifndef BUILD_NO_DEBUG
   }
 
-  if (lcAction == F("endif")) // conditional block ends here
+  if (lcAction.equals(F("endif"))) // conditional block ends here
   {
     if (fakeIfBlock) {
       fakeIfBlock--;

--- a/src/src/Helpers/AdafruitGFX_helper.cpp
+++ b/src/src/Helpers/AdafruitGFX_helper.cpp
@@ -1730,12 +1730,12 @@ bool AdafruitGFX_helper::pluginGetConfigValue(String& string) {
   bool   success = false;
   String command = parseString(string, 1);
 
-  if (command == F("win")) {          // win: get current window id
+  if (command.equals(F("win"))) {          // win: get current window id
     #  if ADAGFX_ENABLE_FRAMED_WINDOW // if feature enabled
     string  = getWindow();
     success = true;
     #  endif // if ADAGFX_ENABLE_FRAMED_WINDOW
-  } else if (command == F("iswin")) { // iswin: check if windows exists
+  } else if (command.equals(F("iswin"))) { // iswin: check if windows exists
     #  if ADAGFX_ENABLE_FRAMED_WINDOW // if feature enabled
     command = parseString(string, 2);
     int win = 0;
@@ -1747,39 +1747,39 @@ bool AdafruitGFX_helper::pluginGetConfigValue(String& string) {
     }
     success = true;                     // Always correct, just return 'false' if wrong
     #  endif // if ADAGFX_ENABLE_FRAMED_WINDOW
-  } else if ((command == F("width")) || // width/height: get window width or height
-             (command == F("height"))) {
+  } else if ((command.equals(F("width"))) || // width/height: get window width or height
+             (command.equals(F("height")))) {
     #  if ADAGFX_ENABLE_FRAMED_WINDOW   // if feature enabled
     uint16_t w = 0, h = 0;
     getWindowLimits(w, h);
 
-    if (command == F("width")) {
+    if (command.equals(F("width"))) {
       string = w;
     } else {
       string = h;
     }
     success = true;
     #  endif // if ADAGFX_ENABLE_FRAMED_WINDOW
-  } else if ((command == F("length")) || // length/textheight: get text length or height
-             (command == F("textheight"))) {
+  } else if ((command.equals(F("length"))) || // length/textheight: get text length or height
+             (command.equals(F("textheight")))) {
     int16_t  x1, y1;
     uint16_t w1, h1;
     String   newString = AdaGFXparseTemplate(parseStringToEndKeepCase(string, 2), 0);
     _display->getTextBounds(newString, 0, 0, &x1, &y1, &w1, &h1); // Count length and height
 
-    if (command == F("length")) {
+    if (command.equals(F("length"))) {
       string = w1;
     } else {
       string = h1;
     }
     success = true;
-  } else if (command == F("rot")) { // rot: get current rotation setting
+  } else if (command.equals(F("rot"))) { // rot: get current rotation setting
     string  = _rotation;
     success = true;
-  } else if (command == F("txs")) { // txs: get current text scaling setting
+  } else if (command.equals(F("txs"))) { // txs: get current text scaling setting
     string  = _fontscaling;
     success = true;
-  } else if (command == F("tpm")) { // tpm: get current text print mode setting
+  } else if (command.equals(F("tpm"))) { // tpm: get current text print mode setting
     string  = static_cast<int>(_textPrintMode);
     success = true;
   }

--- a/src/src/Helpers/ESPEasy_Storage.cpp
+++ b/src/src/Helpers/ESPEasy_Storage.cpp
@@ -146,7 +146,7 @@ fs::File tryOpenFile(const String& fname, const String& mode) {
   bool exists = fileExists(fname);
 
   if (!exists) {
-    if (mode == F("r")) {
+    if (mode.equals(F("r"))) {
       return f;
     }
     Cache.fileExistsMap.clear();

--- a/src/src/Helpers/Misc.cpp
+++ b/src/src/Helpers/Misc.cpp
@@ -28,10 +28,10 @@ bool remoteConfig(struct EventStruct *event, const String& string)
   bool   success = false;
   String command = parseString(string, 1);
 
-  if (command == F("config"))
+  if (command.equals(F("config")))
   {
     // Command: "config,task,<taskname>,<actual Set Config command>"
-    if (parseString(string, 2) == F("task"))
+    if (parseString(string, 2).equals(F("task")))
     {
       String configTaskName = parseStringKeepCase(string, 3);
 

--- a/src/src/Helpers/Numerical.cpp
+++ b/src/src/Helpers/Numerical.cpp
@@ -242,7 +242,7 @@ String getNumerical(const String& tBuf, NumericalType requestedType, NumericalTy
         decPt        = true;
         detectedType = NumericalType::FloatingPoint;
       } else {
-        if (result == F("-")) {
+        if (result.equals(F("-"))) {
           detectedType = NumericalType::Not_a_number;
           return emptyString;
         }
@@ -306,7 +306,7 @@ String getNumerical(const String& tBuf, NumericalType requestedType, NumericalTy
     }
   }
 
-  if (result == F("-")) {
+  if (result.equals(F("-"))) {
     detectedType = NumericalType::Not_a_number;
     return emptyString;
   }

--- a/src/src/Helpers/StringParser.cpp
+++ b/src/src/Helpers/StringParser.cpp
@@ -285,7 +285,7 @@ void transformValue(
               maskChar = tempValueFormat[1];
             }
 
-            if (value == F("0")) {
+            if (value.equals(F("0"))) {
               value = String();
             } else {
               const int valueLength = value.length();

--- a/src/src/Helpers/WebServer_commandHelper.cpp
+++ b/src/src/Helpers/WebServer_commandHelper.cpp
@@ -29,7 +29,7 @@ HandledWebCommand_result handle_command_from_web(EventValueSource::Enum source, 
   // in case of event, store to buffer and return...
   String command = parseString(webrequest, 1);
 
-  if ((command == F("event")) || (command == F("asyncevent")))
+  if ((command.equals(F("event"))) || (command.equals(F("asyncevent"))))
   {
     eventQueue.addMove(parseStringToEndKeepCase(webrequest, 2));
     handledCmd = true;

--- a/src/src/PluginStructs/P049_data_struct.cpp
+++ b/src/src/PluginStructs/P049_data_struct.cpp
@@ -101,25 +101,25 @@ bool P049_data_struct::plugin_write(struct EventStruct *event, const String& str
 {
   String command = parseString(string, 1);
 
-  if (command == F("mhzcalibratezero"))
+  if (command.equals(F("mhzcalibratezero")))
   {
     send_mhzCmd(mhzCmdCalibrateZero);
     addLog(LOG_LEVEL_INFO, F("MHZ19: Calibrated zero point!"));
     return true;
   }
-  else if (command == F("mhzreset"))
+  else if (command.equals(F("mhzreset")))
   {
     send_mhzCmd(mhzCmdReset);
     addLog(LOG_LEVEL_INFO, F("MHZ19: Sent sensor reset!"));
     return true;
   }
-  else if (command == F("mhzabcenable"))
+  else if (command.equals(F("mhzabcenable")))
   {
     send_mhzCmd(mhzCmdABCEnable);
     addLog(LOG_LEVEL_INFO, F("MHZ19: Sent sensor ABC Enable!"));
     return true;
   }
-  else if (command == F("mhzabcdisable"))
+  else if (command.equals(F("mhzabcdisable")))
   {
     send_mhzCmd(mhzCmdABCDisable);
     addLog(LOG_LEVEL_INFO, F("MHZ19: Sent sensor ABC Disable!"));
@@ -128,25 +128,25 @@ bool P049_data_struct::plugin_write(struct EventStruct *event, const String& str
 
 # ifdef ENABLE_DETECTION_RANGE_COMMANDS
   else if (command.startsWith(F("mhzmeasurementrange"))) {
-    if (command == F("mhzmeasurementrange1000"))
+    if (command.equals(F("mhzmeasurementrange1000")))
     {
       send_mhzCmd(mhzCmdMeasurementRange1000);
       addLog(LOG_LEVEL_INFO, F("MHZ19: Sent measurement range 0-1000PPM!"));
       return true;
     }
-    else if (command == F("mhzmeasurementrange2000"))
+    else if (command.equals(F("mhzmeasurementrange2000")))
     {
       send_mhzCmd(mhzCmdMeasurementRange2000);
       addLog(LOG_LEVEL_INFO, F("MHZ19: Sent measurement range 0-2000PPM!"));
       return true;
     }
-    else if (command == F("mhzmeasurementrange3000"))
+    else if (command.equals(F("mhzmeasurementrange3000")))
     {
       send_mhzCmd(mhzCmdMeasurementRange3000);
       addLog(LOG_LEVEL_INFO, F("MHZ19: Sent measurement range 0-3000PPM!"));
       return true;
     }
-    else if (command == F("mhzmeasurementrange5000"))
+    else if (command.equals(F("mhzmeasurementrange5000")))
     {
       send_mhzCmd(mhzCmdMeasurementRange5000);
       addLog(LOG_LEVEL_INFO, F("MHZ19: Sent measurement range 0-5000PPM!"));

--- a/src/src/PluginStructs/P093_data_struct.cpp
+++ b/src/src/PluginStructs/P093_data_struct.cpp
@@ -89,22 +89,22 @@ bool P093_data_struct::read(String& result) const {
 void P093_data_struct::write(const String& command, const String& value) {
     # define lookup(x, list, placeholder) findByMapping(x, list, sizeof(list) / sizeof(Tuple), placeholder)
 
-  if (command == F("temperature")) {
+  if (command.equals(F("temperature"))) {
     float temperature = 0;
 
     if (string2float(value, temperature) && (temperature >= 16) && (temperature <= 31)) {
       _wantedSettings.temperature = temperature;
       _writeStatus.set(Temperature);
     }
-  } else if ((command == F("power")) && lookup(value, _mappings.power, _wantedSettings.power)) {
+  } else if ((command.equals(F("power"))) && lookup(value, _mappings.power, _wantedSettings.power)) {
     _writeStatus.set(Power);
-  } else if ((command == F("mode")) && lookup(value, _mappings.mode, _wantedSettings.mode)) {
+  } else if ((command.equals(F("mode"))) && lookup(value, _mappings.mode, _wantedSettings.mode)) {
     _writeStatus.set(Mode);
-  } else if ((command == F("fan")) && lookup(value, _mappings.fan, _wantedSettings.fan)) {
+  } else if ((command.equals(F("fan"))) && lookup(value, _mappings.fan, _wantedSettings.fan)) {
     _writeStatus.set(Fan);
-  } else if ((command == F("vane")) && lookup(value, _mappings.vane, _wantedSettings.vane)) {
+  } else if ((command.equals(F("vane"))) && lookup(value, _mappings.vane, _wantedSettings.vane)) {
     _writeStatus.set(Vane);
-  } else if ((command == F("widevane")) && lookup(value, _mappings.wideVane, _wantedSettings.wideVane)) {
+  } else if ((command.equals(F("widevane"))) && lookup(value, _mappings.wideVane, _wantedSettings.wideVane)) {
     _writeStatus.set(WideVane);
   }
 

--- a/src/src/PluginStructs/P099_data_struct.cpp
+++ b/src/src/PluginStructs/P099_data_struct.cpp
@@ -174,7 +174,7 @@ bool P099_data_struct::isValidAndTouchedTouchObject(uint16_t x, uint16_t y, Stri
   for (uint8_t objectNr = 0; objectNr < checkObjectCount; objectNr++) {
     String objectName = String(StoredSettings.TouchObjects[objectNr].objectname);
     if ( objectName.length() > 0
-      && objectName.substring(0,1 ) != F("_")         // Ignore if name starts with an underscore
+      && !objectName.substring(0,1 ).equals(F("_"))         // Ignore if name starts with an underscore
       && StoredSettings.TouchObjects[objectNr].bottom_right.x > 0
       && StoredSettings.TouchObjects[objectNr].bottom_right.y > 0) { // Not initial could be valid
 
@@ -228,7 +228,7 @@ bool P099_data_struct::isValidAndTouchedTouchObject(uint16_t x, uint16_t y, Stri
  * Checks if the name doesn't exceed the max. length.
  */
 bool P099_data_struct::setTouchObjectState(const String& touchObject, bool state, uint8_t checkObjectCount) {
-  if (touchObject.isEmpty() || touchObject.substring(0, 1) == F("_")) return false;
+  if (touchObject.isEmpty() || touchObject.substring(0, 1).equals(F("_"))) return false;
   String findObject = (state ? F("_") : F("")); // When enabling, try to find a disabled object
   findObject += touchObject;
   String thisObject;

--- a/src/src/PluginStructs/P104_data_struct.cpp
+++ b/src/src/PluginStructs/P104_data_struct.cpp
@@ -333,7 +333,7 @@ void P104_data_struct::loadSettings() {
     while (zoneIndex < expectedZones) {
       zones.push_back(P104_zone_struct(zoneIndex + 1));
 
-      if (zones[zoneIndex].text == F("\"\"")) { // Special case
+      if (zones[zoneIndex].text.equals(F("\"\""))) { // Special case
         zones[zoneIndex].text.clear();
       }
 

--- a/src/src/PluginStructs/P128_data_struct.cpp
+++ b/src/src/PluginStructs/P128_data_struct.cpp
@@ -66,7 +66,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
 
   const String command = parseString(string, 1);
 
-  if ((command == F("neopixelfx")) || (command == F("nfx"))) {
+  if ((command.equals(F("neopixelfx"))) || (command.equals(F("nfx")))) {
     const String subCommand = parseString(string, 2);
 
     const String  str3  = parseString(string, 3);
@@ -80,33 +80,33 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
     const String  str7  = parseString(string, 7);
     const int32_t str7i = str7.toInt();
 
-    if (subCommand == F("fadetime")) {
+    if (subCommand.equals(F("fadetime"))) {
       success  = true;
       fadetime = str3i;
     }
 
-    else if (subCommand == F("fadedelay")) {
+    else if (subCommand.equals(F("fadedelay"))) {
       success   = true;
       fadedelay = str3i;
     }
 
-    else if (subCommand == F("speed")) {
+    else if (subCommand.equals(F("speed"))) {
       success      = true;
       defaultspeed = str3i;
       speed        = defaultspeed;
     }
 
-    else if (subCommand == F("bgcolor")) {
+    else if (subCommand.equals(F("bgcolor"))) {
       success = true;
       hex2rrggbb(str3);
     }
 
-    else if (subCommand == F("count")) {
+    else if (subCommand.equals(F("count"))) {
       success = true;
       count   = str3i;
     }
 
-    else if ((subCommand == F("on")) || (subCommand == F("off"))) {
+    else if ((subCommand.equals(F("on"))) || (subCommand.equals(F("off")))) {
       success   = true;
       fadetime  = 1000;
       fadedelay = 0;
@@ -125,18 +125,18 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
 
         starttime[r_pixel] = counter20ms + (pixel * abs(fadedelay) / 20);
 
-        if ((subCommand == F("on")) && (mode == P128_modetype::Off)) { // switch on
+        if ((subCommand.equals(F("on"))) && (mode == P128_modetype::Off)) { // switch on
           rgb_target[pixel] = rgb_old[pixel];
           rgb_old[pixel]    = Plugin_128_pixels->GetPixelColor(pixel);
-        } else if (subCommand == F("off")) {                           // switch off
+        } else if (subCommand.equals(F("off"))) {                           // switch off
           rgb_old[pixel]    = Plugin_128_pixels->GetPixelColor(pixel);
           rgb_target[pixel] = RgbColor(0);
         }
       }
 
-      if ((subCommand == F("on")) && (mode == P128_modetype::Off)) { // switch on
+      if ((subCommand.equals(F("on"))) && (mode == P128_modetype::Off)) { // switch on
         mode = (savemode == P128_modetype::On) ? P128_modetype::Fade : savemode;
-      } else if (subCommand == F("off")) {                           // switch off
+      } else if (subCommand.equals(F("off"))) {                           // switch off
         savemode = mode;
         mode     = P128_modetype::Fade;
       }
@@ -144,14 +144,14 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
       maxtime = starttime[r_pixel] + (fadetime / 20);
     }
 
-    else if (subCommand == F("dim")) {
+    else if (subCommand.equals(F("dim"))) {
       if ((str3i >= 0) && (str3i <= maxBright)) { // Safety check
         success = true;
         Plugin_128_pixels->SetBrightness(str3i);
       }
     }
 
-    else if (subCommand == F("line")) {
+    else if (subCommand.equals(F("line"))) {
       success = true;
       mode    = P128_modetype::On;
 
@@ -162,7 +162,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
       }
     }
 
-    else if (subCommand == F("tick")) {
+    else if (subCommand.equals(F("tick"))) {
       success = true;
       mode    = P128_modetype::On;
 
@@ -174,7 +174,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
       }
     }
 
-    else if (subCommand == F("one")) {
+    else if (subCommand.equals(F("one"))) {
       success = true;
       mode    = P128_modetype::On;
 
@@ -184,11 +184,11 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
       Plugin_128_pixels->SetPixelColor(pixnum, rgb);
     }
 
-    else if ((subCommand == F("fade")) || (subCommand == F("all")) || (subCommand == F("rgb"))) {
+    else if ((subCommand.equals(F("fade"))) || (subCommand.equals(F("all"))) || (subCommand.equals(F("rgb")))) {
       success = true;
       mode    = P128_modetype::Fade;
 
-      if ((subCommand == F("all")) || (subCommand == F("rgb"))) {
+      if ((subCommand.equals(F("all"))) || (subCommand.equals(F("rgb")))) {
         fadedelay = 0;
       }
 
@@ -214,7 +214,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
       maxtime = starttime[r_pixel] + (fadetime / 20);
     }
 
-    else if (subCommand == F("hsv")) {
+    else if (subCommand.equals(F("hsv"))) {
       success   = true;
       mode      = P128_modetype::Fade;
       fadedelay = 0;
@@ -245,7 +245,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
       maxtime = starttime[r_pixel] + (fadetime / 20);
     }
 
-    else if (subCommand == F("hsvone")) {
+    else if (subCommand.equals(F("hsvone"))) {
       success = true;
       mode    = P128_modetype::On;
       rgb     =
@@ -259,7 +259,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
       Plugin_128_pixels->SetPixelColor(pixnum, rgb);
     }
 
-    else if (subCommand == F("hsvline")) {
+    else if (subCommand.equals(F("hsvline"))) {
       success = true;
       mode    = P128_modetype::On;
 
@@ -276,7 +276,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
       }
     }
 
-    else if (subCommand == F("rainbow")) {
+    else if (subCommand.equals(F("rainbow"))) {
       success     = true;
       fadeIn      = (mode == P128_modetype::Off) ? true : false;
       mode        = P128_modetype::Rainbow;
@@ -291,7 +291,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
           : str4i;
     }
 
-    else if (subCommand == F("colorfade")) {
+    else if (subCommand.equals(F("colorfade"))) {
       success = true;
       mode    = P128_modetype::ColorFade;
 
@@ -307,7 +307,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
           : str6i - 1;
     }
 
-    else if (subCommand == F("kitt")) {
+    else if (subCommand.equals(F("kitt"))) {
       success = true;
       mode    = P128_modetype::Kitt;
 
@@ -320,7 +320,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
           : str4i;
     }
 
-    else if (subCommand == F("comet")) {
+    else if (subCommand.equals(F("comet"))) {
       success = true;
       mode    = P128_modetype::Comet;
 
@@ -333,7 +333,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
           : str4i;
     }
 
-    else if (subCommand == F("theatre")) {
+    else if (subCommand.equals(F("theatre"))) {
       success = true;
       mode    = P128_modetype::Theatre;
 
@@ -358,7 +358,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
       }
     }
 
-    else if (subCommand == F("scan")) {
+    else if (subCommand.equals(F("scan"))) {
       success = true;
       mode    = P128_modetype::Scan;
 
@@ -373,7 +373,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
           : str5i;
     }
 
-    else if (subCommand == F("dualscan")) {
+    else if (subCommand.equals(F("dualscan"))) {
       success = true;
       mode    = P128_modetype::Dualscan;
 
@@ -388,7 +388,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
           : str5i;
     }
 
-    else if (subCommand == F("twinkle")) {
+    else if (subCommand.equals(F("twinkle"))) {
       success = true;
       mode    = P128_modetype::Twinkle;
 
@@ -403,7 +403,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
           : str5i;
     }
 
-    else if (subCommand == F("twinklefade")) {
+    else if (subCommand.equals(F("twinklefade"))) {
       success = true;
       mode    = P128_modetype::TwinkleFade;
 
@@ -418,7 +418,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
           : str5i;
     }
 
-    else if (subCommand == F("sparkle")) {
+    else if (subCommand.equals(F("sparkle"))) {
       success = true;
       mode    = P128_modetype::Sparkle;
 
@@ -432,7 +432,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
           : str5i;
     }
 
-    else if (subCommand == F("wipe")) {
+    else if (subCommand.equals(F("wipe"))) {
       success = true;
       mode    = P128_modetype::Wipe;
 
@@ -451,7 +451,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
           : str5i;
     }
 
-    else if (subCommand == F("dualwipe")) {
+    else if (subCommand.equals(F("dualwipe"))) {
       success = true;
       mode    = P128_modetype::Dualwipe;
 
@@ -471,7 +471,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
     }
 
     # if P128_ENABLE_FAKETV
-    else if (subCommand == F("faketv")) {
+    else if (subCommand.equals(F("faketv"))) {
       success            = true;
       mode               = P128_modetype::FakeTV;
       _counter_mode_step = 0;
@@ -488,7 +488,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
     }
     # endif // if P128_ENABLE_FAKETV
 
-    else if (subCommand == F("fire")) {
+    else if (subCommand.equals(F("fire"))) {
       success = true;
       mode    = P128_modetype::Fire;
 
@@ -509,7 +509,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
           : str6.toFloat();
     }
 
-    else if (subCommand == F("fireflicker")) {
+    else if (subCommand.equals(F("fireflicker"))) {
       success = true;
       mode    = P128_modetype::FireFlicker;
 
@@ -522,7 +522,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
           : str4i;
     }
 
-    else if (subCommand == F("simpleclock")) {
+    else if (subCommand.equals(F("simpleclock"))) {
       success = true;
       mode    = P128_modetype::SimpleClock;
 
@@ -585,7 +585,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
       }
 
       if (!str7.isEmpty()) {
-        if (str7 == F("off")) {
+        if (str7.equals(F("off"))) {
           rgb_s_off = true;
         } else if (str7.length() <= 6) {
           const uint32_t hcolorui = rgbStr2Num(str7);
@@ -625,7 +625,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
       }
 
       if (!str7.isEmpty()) {
-        if (str7 == F("off")) {
+        if (str7.equals(F("off"))) {
           rgb_s_off = true;
         } else {
           const uint32_t hcolorui = rgbStr2Num(str7);
@@ -642,12 +642,12 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
       }
     }
 
-    else if (subCommand == F("stop")) {
+    else if (subCommand.equals(F("stop"))) {
       success = true;
       mode    = P128_modetype::On;
     }
 
-    else if (subCommand == F("statusrequest")) {
+    else if (subCommand.equals(F("statusrequest"))) {
       success = true;
     }
 

--- a/src/src/WebServer/ESPEasy_WebServer.cpp
+++ b/src/src/WebServer/ESPEasy_WebServer.cpp
@@ -373,7 +373,7 @@ void getWebPageTemplateDefault(const String& tmplName, WebTemplateParser& parser
   const bool addJS   = true;
   const bool addMeta = true;
 
-  if (tmplName == F("TmplAP"))
+  if (tmplName.equals(F("TmplAP")))
   {
 
     getWebPageTemplateDefaultHead(parser, !addMeta, !addJS);
@@ -391,7 +391,7 @@ void getWebPageTemplateDefault(const String& tmplName, WebTemplateParser& parser
     getWebPageTemplateDefaultContentSection(parser);
     getWebPageTemplateDefaultFooter(parser);
   }
-  else if (tmplName == F("TmplMsg"))
+  else if (tmplName.equals(F("TmplMsg")))
   {
     getWebPageTemplateDefaultHead(parser, !addMeta, !addJS);
     if (!parser.isTail()) {
@@ -401,7 +401,7 @@ void getWebPageTemplateDefault(const String& tmplName, WebTemplateParser& parser
     getWebPageTemplateDefaultContentSection(parser);
     getWebPageTemplateDefaultFooter(parser);
   }
-  else if (tmplName == F("TmplDsh"))
+  else if (tmplName.equals(F("TmplDsh")))
   {
     getWebPageTemplateDefaultHead(parser, !addMeta, addJS);
     parser.process(F(

--- a/src/src/WebServer/FileList.cpp
+++ b/src/src/WebServer/FileList.cpp
@@ -330,17 +330,17 @@ void handle_SDfilelist() {
   String parent_dir;
 
   for (uint8_t i = 0; i < web_server.args(); i++) {
-    if (web_server.argName(i) == F("delete"))
+    if (web_server.argName(i).equals(F("delete")))
     {
       fdelete = webArg(i);
     }
 
-    if (web_server.argName(i) == F("deletedir"))
+    if (web_server.argName(i).equals(F("deletedir")))
     {
       ddelete = webArg(i);
     }
 
-    if (web_server.argName(i) == F("chgto"))
+    if (web_server.argName(i).equals(F("chgto")))
     {
       change_to_dir = webArg(i);
     }

--- a/src/src/WebServer/JSON.cpp
+++ b/src/src/WebServer/JSON.cpp
@@ -121,7 +121,7 @@ void handle_json()
   {
     const String view = webArg(F("view"));
 
-    if (view == F("sensorupdate")) {
+    if (view.equals(F("sensorupdate"))) {
       showSystem = false;
       showWifi   = false;
       #if FEATURE_ETHERNET

--- a/src/src/WebServer/Log.cpp
+++ b/src/src/WebServer/Log.cpp
@@ -52,7 +52,7 @@ void handle_log_JSON() {
   String webrequest = webArg(F("view"));
   addHtml(F("{\"Log\": {"));
 
-  if (webrequest == F("legend")) {
+  if (webrequest.equals(F("legend"))) {
     addHtml(F("\"Legend\": ["));
 
     for (uint8_t i = 0; i < LOG_LEVEL_NRELEMENTS; ++i) {

--- a/src/src/WebServer/Markup_Forms.cpp
+++ b/src/src/WebServer/Markup_Forms.cpp
@@ -766,7 +766,7 @@ bool isFormItemChecked(const __FlashStringHelper * id)
 
 bool isFormItemChecked(const String& id)
 {
-  return webArg(id) == F("on");
+  return webArg(id).equals(F("on"));
 }
 
 bool isFormItemChecked(const LabelType::Enum& id)

--- a/src/src/WebServer/Rules.cpp
+++ b/src/src/WebServer/Rules.cpp
@@ -441,7 +441,7 @@ bool handle_rules_edit(String originalUri, bool isAddNew) {
     if (web_server.args() > 0)
     {
       const String& rules = webArg(F("rules"));
-      isNew = webArg(F("IsNew")) == F("yes");
+      isNew = webArg(F("IsNew")).equals(F("yes"));
 
       // Overwrite verification
       if (isEdit && isNew) {

--- a/src/src/WebServer/WebTemplateParser.cpp
+++ b/src/src/WebServer/WebTemplateParser.cpp
@@ -212,10 +212,10 @@ void WebTemplateParser::processVarName()
   if (!varName.length()) { return; }
   varName.toLowerCase();
 
-  if (varName == F("error")) {
+  if (varName.equals(F("error"))) {
     getErrorNotifications();
   }
-  else if (varName == F("meta")) {
+  else if (varName.equals(F("meta"))) {
     if (Rebooting) {
       addHtml(F("<meta http-equiv='refresh' content='10 url=/'>"));
     }
@@ -253,17 +253,17 @@ void WebTemplateParser::getWebPageTemplateVar(const String& varName)
   // (varValue.length()) ;serialPrint("after:  ");
   // varValue = "";
 
-  if (varName == F("name"))
+  if (varName.equals(F("name")))
   {
     addHtml(Settings.Name);
   }
 
-  else if (varName == F("unit"))
+  else if (varName.equals(F("unit")))
   {
     addHtmlInt(Settings.Unit);
   }
   
-  else if (varName == F("build"))
+  else if (varName.equals(F("build")))
   {
     #if BUILD_IN_WEBFOOTER
     // In the footer, show full build binary name, will be 'firmware.bin' when compiled using Arduino IDE.
@@ -271,7 +271,7 @@ void WebTemplateParser::getWebPageTemplateVar(const String& varName)
     #endif
   }
 
-  else if (varName == F("date"))
+  else if (varName.equals(F("date")))
   {
     #if BUILD_IN_WEBFOOTER
     // Add the compile-date
@@ -279,7 +279,7 @@ void WebTemplateParser::getWebPageTemplateVar(const String& varName)
     #endif
   }
 
-  else if (varName == F("menu"))
+  else if (varName.equals(F("menu")))
   {
     addHtml(F("<div class='menubar'>"));
 
@@ -314,7 +314,7 @@ void WebTemplateParser::getWebPageTemplateVar(const String& varName)
     addHtml(F("</div>"));
   }
 
-  else if (varName == F("logo"))
+  else if (varName.equals(F("logo")))
   {
     if (fileExists(F("esp.png")))
     {
@@ -322,14 +322,14 @@ void WebTemplateParser::getWebPageTemplateVar(const String& varName)
     }
   }
 
-  else if (varName == F("css"))
+  else if (varName.equals(F("css")))
   {
     serve_favicon();
     serve_CSS();
   }
 
 
-  else if (varName == F("js"))
+  else if (varName.equals(F("js")))
   {
     html_add_JQuery_script();
     #if FEATURE_CHART_JS
@@ -339,12 +339,12 @@ void WebTemplateParser::getWebPageTemplateVar(const String& varName)
     serve_JS(JSfiles_e::Toasting);
   }
 
-  else if (varName == F("error"))
+  else if (varName.equals(F("error")))
   {
     // print last error - not implemented yet
   }
 
-  else if (varName == F("debug"))
+  else if (varName.equals(F("debug")))
   {
     // print debug messages - not implemented yet
   }

--- a/tools/pio/post_esp32.py
+++ b/tools/pio/post_esp32.py
@@ -40,7 +40,7 @@ def esp32_create_combined_bin(source, target, env):
     flash_size = env.BoardConfig().get("upload.flash_size")
     flash_freq = env.BoardConfig().get("build.f_flash", '40m')
     flash_freq = flash_freq.replace('000000L', 'm')
-    flash_mode = env.BoardConfig().get("build.flash_mode", "dout")
+    flash_mode = env.BoardConfig().get("build.flash_mode", "dio")
     if flash_mode == "qio":
         flash_mode = "dio"
     elif flash_mode == "qout":


### PR DESCRIPTION
Extending the `operator ==` in esp8266/Arduino WString for flash strings does reduce bin size.
However this change was already removed before.
See: https://github.com/esp8266/Arduino/pull/8663#issuecomment-1227865270

Therefore it is best to replace `== F("...")` with `.equals(F("..."))` in our code.

N.B. this may only reduce bin size on SDK 3.0.x builds as there was no .equals for flash strings in SDK 2.7.4