### PR TITLE
[Bugfix] DevicesPage: ExtraTaskSettings are not always saved

### DIFF
--- a/src/src/WebServer/DevicesPage.cpp
+++ b/src/src/WebServer/DevicesPage.cpp
@@ -379,8 +379,8 @@ void handle_devices_CopySubmittedSettings(taskIndex_t taskIndex, pluginID_t task
   {
     String dummy;
 
+    SaveTaskSettings(taskIndex);
     if (Device[DeviceIndex].ExitTaskBeforeSave) {
-      SaveTaskSettings(taskIndex);
       PluginCall(PLUGIN_EXIT, &TempEvent, dummy);
     }
 


### PR DESCRIPTION
Some plugins refused to save a 'Name' or changed 'Values' names, because of attributes set for that that plugin (`ExitTaskBeforeSave = false;`)
This is corrected by this change.