### PR TITLE
[Build] Remove all debug logs when BUILD_NO_DEBUG is set

### DIFF
--- a/src/_C003.cpp
+++ b/src/_C003.cpp
@@ -110,12 +110,15 @@ bool do_process_c003_delay_queue(int controller_number, const C003_queue_element
     if (line.startsWith(F("Enter your password:")))
     {
       success = true;
+      #ifndef BUILD_NO_DEBUG
       addLog(LOG_LEVEL_DEBUG, F("TELNT: Password request ok"));
+      #endif
     }
     delay(1);
   }
-
+  #ifndef BUILD_NO_DEBUG
   addLog(LOG_LEVEL_DEBUG, F("TELNT: Sending pw"));
+  #endif
   client.println(getControllerPass(element.controller_idx, ControllerSettings));
   delay(100);
 
@@ -123,7 +126,9 @@ bool do_process_c003_delay_queue(int controller_number, const C003_queue_element
     client.read();
   }
 
+  #ifndef BUILD_NO_DEBUG
   addLog(LOG_LEVEL_DEBUG, F("TELNT: Sending cmd"));
+  #endif
   client.print(element.txt);
   delay(10);
 
@@ -131,7 +136,9 @@ bool do_process_c003_delay_queue(int controller_number, const C003_queue_element
     client.read();
   }
 
+  #ifndef BUILD_NO_DEBUG
   addLog(LOG_LEVEL_DEBUG, F("TELNT: closing connection"));
+  #endif
 
   client.stop();
   return success;

--- a/src/_C007.cpp
+++ b/src/_C007.cpp
@@ -101,9 +101,11 @@ bool do_process_c007_delay_queue(int controller_number, const C007_queue_element
   url += F("&apikey=");
   url += getControllerPass(element.controller_idx, ControllerSettings); // "0UDNN17RW6XAS2E5" // api key
 
+#ifndef BUILD_NO_DEBUG
   if (Settings.SerialLogLevel >= LOG_LEVEL_DEBUG_MORE) {
     serialPrintln(url);
   }
+#endif
 
   int httpCode = -1;
   send_via_http(

--- a/src/_N001_Email.cpp
+++ b/src/_N001_Email.cpp
@@ -127,9 +127,11 @@ bool NPlugin_001_send(const NotificationSettingsStruct& notificationsettings, co
 
   String aHost = notificationsettings.Server;
 
+#ifndef BUILD_NO_DEBUG
   if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
     addLog(LOG_LEVEL_DEBUG, String(F("EMAIL: Connecting to ")) + aHost + notificationsettings.Port);
   }
+#endif
 
   if (!connectClient(client, aHost.c_str(), notificationsettings.Port, CONTROLLER_CLIENTTIMEOUT_DFLT)) {
     if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
@@ -252,9 +254,11 @@ bool NPlugin_001_Auth(WiFiClient& client, const String& user, const String& pass
 
 bool NPlugin_001_MTA(WiFiClient& client, const String& aStr, const String& aWaitForPattern)
 {
+#ifndef BUILD_NO_DEBUG
   if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
     addLog(LOG_LEVEL_DEBUG, aStr);
   }
+#endif
 
   if (aStr.length()) { client.println(aStr); }
 
@@ -281,12 +285,12 @@ bool NPlugin_001_MTA(WiFiClient& client, const String& aStr, const String& aWait
 
     const bool patternFound = line.indexOf(aWaitForPattern) >= 0;
 
-                # ifndef BUILD_NO_DEBUG
+# ifndef BUILD_NO_DEBUG
 
     if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
       addLogMove(LOG_LEVEL_DEBUG, line);
     }
-                # endif // ifndef BUILD_NO_DEBUG
+# endif // ifndef BUILD_NO_DEBUG
 
     if (patternFound) {
       return true;

--- a/src/_P003_Pulse.ino
+++ b/src/_P003_Pulse.ino
@@ -17,7 +17,9 @@
 
 # include "src/Helpers/ESPEasy_time_calc.h"
 
+#ifndef BUILD_NO_DEBUG
 # define P003_PULSE_STATS_DEFAULT_LOG_LEVEL  LOG_LEVEL_DEBUG
+#endif
 # define P003_PULSE_STATS_ADHOC_LOG_LEVEL    LOG_LEVEL_INFO
 
 # define PLUGIN_003
@@ -149,7 +151,9 @@ boolean Plugin_003(uint8_t function, struct EventStruct *event, String& string)
 
       if (nullptr != P003_data) {
         #ifdef PULSE_STATISTIC
+        #ifndef BUILD_NO_DEBUG
         P003_data->pulseHelper.setStatsLogLevel(P003_PULSE_STATS_DEFAULT_LOG_LEVEL);
+        #endif
         #endif
 
         // Restore the total counter from the unused 4th UserVar value.

--- a/src/_P009_MCP.ino
+++ b/src/_P009_MCP.ino
@@ -258,7 +258,9 @@ boolean Plugin_009(uint8_t function, struct EventStruct *event, String& string)
         // CASE 1: using SafeButton, so wait 1 more 100ms cycle to acknowledge the status change
         if (round(P009_SAFE_BTN) && (state != currentStatus.state) && (PCONFIG_LONG(3) == 0))
         {
+          #ifndef BUILD_NO_DEBUG
           addLog(LOG_LEVEL_DEBUG, F("MCP :SafeButton 1st click."));
+          #endif
           PCONFIG_LONG(3) = 1;
         }
 

--- a/src/_P019_PCF8574.ino
+++ b/src/_P019_PCF8574.ino
@@ -313,7 +313,9 @@ boolean Plugin_019(uint8_t function, struct EventStruct *event, String& string)
         // QUESTION: MAYBE IT'S BETTER TO WAIT 2 CYCLES??
         if (round(P019_SAFE_BTN) && (state != currentStatus.state) && (PCONFIG_LONG(3) == 0))
         {
+          # ifndef BUILD_NO_DEBUG
           addLog(LOG_LEVEL_DEBUG, F("PCF :SafeButton 1st click."));
+          #endif
           PCONFIG_LONG(3) = 1;
         }
 

--- a/src/_P037_MQTTImport.ino
+++ b/src/_P037_MQTTImport.ino
@@ -82,7 +82,7 @@ bool P037_addEventToQueue(struct EventStruct *event, String& newEvent) {
   } else {
     result = false;
   }
-
+# ifndef BUILD_NO_DEBUG
   if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
     String log = F("MQTT: Event added: ");
 
@@ -93,6 +93,7 @@ bool P037_addEventToQueue(struct EventStruct *event, String& newEvent) {
     }
     addLog(LOG_LEVEL_DEBUG, log);
   }
+#endif
   return result;
 }
 
@@ -440,13 +441,14 @@ boolean Plugin_037(uint8_t function, struct EventStruct *event, String& string)
         #   endif // P037_FILTER_PER_TOPIC
         #  endif  // if P037_JSON_SUPPORT
       }
-
+# ifndef BUILD_NO_DEBUG
       if (matchedTopic && P037_data->hasFilters() && // Single log statement
           loglevelActiveFor(LOG_LEVEL_DEBUG)) {      // Reduce standard logging
         String log = F("IMPT : MQTT filter result: ");
         log += processData ? F("true") : F("false");
         addLogMove(LOG_LEVEL_DEBUG, log);
       }
+#endif
       # endif // if P037_FILTER_SUPPORT
 
       if (!processData) { // Nothing to do? then clean up

--- a/src/_P050_TCS34725.ino
+++ b/src/_P050_TCS34725.ino
@@ -269,7 +269,9 @@ boolean Plugin_050(uint8_t function, struct EventStruct *event, String& string)
       }
 
       if (P050_data->tcs.begin()) {
+# ifndef BUILD_NO_DEBUG
         addLog(LOG_LEVEL_DEBUG, F("Found TCS34725 sensor"));
+#endif
 
         uint16_t r, g, b, c;
         float value4 = 0.0f;
@@ -475,7 +477,9 @@ boolean Plugin_050(uint8_t function, struct EventStruct *event, String& string)
 
         success = true;
       } else {
+# ifndef BUILD_NO_DEBUG
         addLog(LOG_LEVEL_DEBUG, F("No TCS34725 found"));
+#endif
         success = false;
       }
 

--- a/src/_P055_Chiming.ino
+++ b/src/_P055_Chiming.ino
@@ -316,11 +316,14 @@ boolean Plugin_055(uint8_t function, struct EventStruct *event, String& string)
           if (! Plugin_055_IsEmptyFIFO())
           {
             char c = Plugin_055_ReadFIFO();
-
-            String log = F("Chime: Process '");
-            log += c;
-            log += '\'';
-            addLogMove(LOG_LEVEL_DEBUG, log);
+            # ifndef BUILD_NO_DEBUG
+            if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+              String log = F("Chime: Process '");
+              log += c;
+              log += '\'';
+              addLogMove(LOG_LEVEL_DEBUG, log);
+            }
+            #endif
 
             switch (c)
             {

--- a/src/_P075_Nextion.ino
+++ b/src/_P075_Nextion.ino
@@ -313,7 +313,9 @@ boolean Plugin_075(uint8_t function, struct EventStruct *event, String& string)
           log.reserve(24 + nextionArguments.length()); // Prevent re-allocation
           log  = F("NEXTION075 : WRITE = ");
           log += nextionArguments;
+          # ifndef BUILD_NO_DEBUG
           addLog(LOG_LEVEL_DEBUG, log);
+          #endif
           SendStatus(event, log); // Reply (echo) to sender. This will print message on browser.
         }
 

--- a/src/_P082_GPS.ino
+++ b/src/_P082_GPS.ino
@@ -368,7 +368,9 @@ boolean Plugin_082(uint8_t function, struct EventStruct *event, String& string) 
         if (P082_data->_lastSentence.substring(0,10).indexOf(F("TXT")) != -1) {
           addLog(LOG_LEVEL_INFO, P082_data->_lastSentence);
         } else {
+          # ifndef BUILD_NO_DEBUG
           addLog(LOG_LEVEL_DEBUG, P082_data->_lastSentence);
+          #endif
         }
 # endif // ifdef P082_SEND_GPS_TO_LOG
         Scheduler.schedule_task_device_timer(event->TaskIndex, millis());

--- a/src/_P088_HeatpumpIR.ino
+++ b/src/_P088_HeatpumpIR.ino
@@ -178,7 +178,9 @@ boolean Plugin_088(uint8_t function, struct EventStruct *event, String& string)
 
             addLog(LOG_LEVEL_INFO, F("P088: Heatpump IR code transmitted"));
 #ifdef IR_DEBUG_PACKET
+# ifndef BUILD_NO_DEBUG
             addLog(LOG_LEVEL_DEBUG, IRPacket);
+#endif
 #endif
             if (printToWeb)
             {

--- a/src/_P103_Atlas_EZO_pH_ORP_EC_DO.ino
+++ b/src/_P103_Atlas_EZO_pH_ORP_EC_DO.ino
@@ -557,16 +557,16 @@ bool _P103_send_I2C_command(uint8_t I2Caddress, const String &cmd, char *sensord
     }
     sensordata[sensor_bytes_received] = '\0';
 
-    if (loglevelActiveFor(LOG_LEVEL_DEBUG))
+    switch (i2c_response_code)
     {
-      switch (i2c_response_code)
-      {
       case 1:
       {
         #ifndef BUILD_NO_DEBUG
-        String log = F("< success, answer = ");
-        log += sensordata;
-        addLogMove(LOG_LEVEL_DEBUG, log);
+        if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+          String log = F("< success, answer = ");
+          log += sensordata;
+          addLogMove(LOG_LEVEL_DEBUG, log);
+        }
         #endif
         break;
       }
@@ -588,7 +588,6 @@ bool _P103_send_I2C_command(uint8_t I2Caddress, const String &cmd, char *sensord
         addLog(LOG_LEVEL_DEBUG, F("< no data"));
         #endif
         return false;
-      }
     }
   }
 

--- a/src/_P118_Itho.ino
+++ b/src/_P118_Itho.ino
@@ -67,6 +67,10 @@
 #include "IthoCC1101.h"
 #include "IthoPacket.h"
 
+#ifndef BUILD_NO_DEBUG
+#define P118_DEBUG_LOG
+#endif
+
 // This extra settings struct is needed because the default settingsstruct doesn't support strings
 struct PLUGIN__ExtraSettingsStruct
 {       char ID1[9];
@@ -460,10 +464,12 @@ void PLUGIN_118_ITHOcheck()
 
     // int index = PLUGIN_118_RFRemoteIndex(Id);
     // IF id is know index should be >0
+#ifdef P118_DEBUG_LOG
     String log2;
-
+#endif
     if (index > 0)
     {
+#ifdef P118_DEBUG_LOG
       if (PLUGIN_118_Log) {
         log2 += F("Command received from remote-ID: ");
         log2 += Id;
@@ -471,83 +477,96 @@ void PLUGIN_118_ITHOcheck()
 
         // addLog(LOG_LEVEL_DEBUG, log);
       }
-
+#endif
       switch (cmd)
       {
         case IthoUnknown:
-
+#ifdef P118_DEBUG_LOG
           if (PLUGIN_118_Log) { log2 += F("unknown"); }
+#endif
           break;
         case IthoStandby:
         case DucoStandby:
-
+#ifdef P118_DEBUG_LOG
           if (PLUGIN_118_Log) { log2 += F("standby"); }
+#endif
           PLUGIN_118_State       = 0;
           PLUGIN_118_Timer       = 0;
           PLUGIN_118_LastIDindex = index;
           break;
         case IthoLow:
         case DucoLow:
-
+#ifdef P118_DEBUG_LOG
           if (PLUGIN_118_Log) { log2 += F("low"); }
+#endif
           PLUGIN_118_State       = 1;
           PLUGIN_118_Timer       = 0;
           PLUGIN_118_LastIDindex = index;
           break;
         case IthoMedium:
         case DucoMedium:
-
+#ifdef P118_DEBUG_LOG
           if (PLUGIN_118_Log) { log2 += F("medium"); }
+#endif
           PLUGIN_118_State       = 2;
           PLUGIN_118_Timer       = 0;
           PLUGIN_118_LastIDindex = index;
           break;
         case IthoHigh:
         case DucoHigh:
-
+#ifdef P118_DEBUG_LOG
           if (PLUGIN_118_Log) { log2 += F("high"); }
+#endif
           PLUGIN_118_State       = 3;
           PLUGIN_118_Timer       = 0;
           PLUGIN_118_LastIDindex = index;
           break;
         case IthoFull:
-
+#ifdef P118_DEBUG_LOG
           if (PLUGIN_118_Log) { log2 += F("full"); }
+#endif
           PLUGIN_118_State       = 4;
           PLUGIN_118_Timer       = 0;
           PLUGIN_118_LastIDindex = index;
           break;
         case IthoTimer1:
-
+#ifdef P118_DEBUG_LOG
           if (PLUGIN_118_Log) { log2 += +F("timer1"); }
+#endif
           PLUGIN_118_State       = 13;
           PLUGIN_118_Timer       = PLUGIN_118_Time1;
           PLUGIN_118_LastIDindex = index;
           break;
         case IthoTimer2:
-
+#ifdef P118_DEBUG_LOG
           if (PLUGIN_118_Log) { log2 += F("timer2"); }
+#endif
           PLUGIN_118_State       = 23;
           PLUGIN_118_Timer       = PLUGIN_118_Time2;
           PLUGIN_118_LastIDindex = index;
           break;
         case IthoTimer3:
-
+#ifdef P118_DEBUG_LOG
           if (PLUGIN_118_Log) { log2 += F("timer3"); }
+#endif
           PLUGIN_118_State       = 33;
           PLUGIN_118_Timer       = PLUGIN_118_Time3;
           PLUGIN_118_LastIDindex = index;
           break;
         case IthoJoin:
-
+#ifdef P118_DEBUG_LOG
           if (PLUGIN_118_Log) { log2 += F("join"); }
+#endif
           break;
         case IthoLeave:
 
+#ifdef P118_DEBUG_LOG
           if (PLUGIN_118_Log) { log2 += F("leave"); }
+#endif
           break;
       }
     }
+#ifdef P118_DEBUG_LOG    
     else {
       if (PLUGIN_118_Log) {
         log2 += F("Device-ID: ");
@@ -559,6 +578,7 @@ void PLUGIN_118_ITHOcheck()
     if (PLUGIN_118_Log) { 
       addLogMove(LOG_LEVEL_DEBUG, log2);
     }
+#endif
   }
 }
 

--- a/src/src/Commands/Diagnostic.cpp
+++ b/src/src/Commands/Diagnostic.cpp
@@ -153,7 +153,13 @@ const __FlashStringHelper * Command_logentry(struct EventStruct *event, const ch
 {
   uint8_t level = LOG_LEVEL_INFO;
   // An extra optional parameter to set log level.
-  if (event->Par2 > LOG_LEVEL_NONE && event->Par2 <= LOG_LEVEL_DEBUG_MORE) { level = event->Par2; }
+  if (event->Par2 > LOG_LEVEL_NONE && event->Par2 <= 
+  # ifndef BUILD_NO_DEBUG
+    LOG_LEVEL_DEBUG_MORE
+  #else
+    LOG_LEVEL_INFO
+  #endif
+    ) { level = event->Par2; }
   addLog(level, tolerantParseStringKeepCase(Line, 2));
   return return_command_success();
 }

--- a/src/src/Commands/GPIO.cpp
+++ b/src/src/Commands/GPIO.cpp
@@ -539,12 +539,13 @@ void logErrorGpioOffline(const String& prefix, int port)
 void logErrorGpioOutOfRange(const String& prefix, int port, const char *Line)
 {
   logErrorGpio(prefix, port, F(" is out of range"));
-
+  # ifndef BUILD_NO_DEBUG
   if (port >= 0) {
     if (Line != nullptr) {
       addLog(LOG_LEVEL_DEBUG, Line);
     }
   }
+  #endif
 }
 
 void logErrorGpioNotOutput(const String& prefix, int port)

--- a/src/src/Commands/InternalCommands.cpp
+++ b/src/src/Commands/InternalCommands.cpp
@@ -598,13 +598,13 @@ bool ExecuteCommand(taskIndex_t            taskIndex,
   // Maybe ExecuteCommand can be scheduled?
   delay(0);
 
+#ifndef BUILD_NO_DEBUG
   if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
     {
       String log = F("Command: ");
       log += cmd;
       addLogMove(LOG_LEVEL_DEBUG, log);
     }
-#ifndef BUILD_NO_DEBUG
     addLog(LOG_LEVEL_DEBUG, Line); // for debug purposes add the whole line.
     {
       String parameters;
@@ -621,8 +621,8 @@ bool ExecuteCommand(taskIndex_t            taskIndex,
       parameters += TempEvent.Par5;
       addLogMove(LOG_LEVEL_DEBUG, parameters);
     }
-#endif // ifndef BUILD_NO_DEBUG
   }
+#endif // ifndef BUILD_NO_DEBUG
 
 
   if (tryInternal) {

--- a/src/src/Commands/MQTT.cpp
+++ b/src/src/Commands/MQTT.cpp
@@ -31,9 +31,11 @@ const __FlashStringHelper * Command_MQTT_Publish(struct EventStruct *event, cons
   }
 
   // Command structure:  Publish,<topic>,<value>
-  String topic = parseStringKeepCase(Line, 2);
-  String value = tolerantParseStringKeepCase(Line, 3);
+  const String topic = parseStringKeepCase(Line, 2);
+  const String value = tolerantParseStringKeepCase(Line, 3);
+  # ifndef BUILD_NO_DEBUG
   addLog(LOG_LEVEL_DEBUG, String(F("Publish: ")) + topic + value);
+  #endif
 
   if ((topic.length() > 0) && (value.length() > 0)) {
 

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -266,6 +266,13 @@ To create/register a plugin, you have to :
   #define CONTROLLER_SET_COLLECTION
   #define NOTIFIER_SET_COLLECTION
   #define PLUGIN_BUILD_NORMAL     // add stable
+
+  #ifdef EMBED_ESPEASY_AUTO_MIN_CSS
+    #undef EMBED_ESPEASY_AUTO_MIN_CSS
+    #ifndef EMBED_ESPEASY_DEFAULT_MIN_CSS
+      #define EMBED_ESPEASY_DEFAULT_MIN_CSS
+    #endif
+  #endif
 #endif
 
 #ifdef PLUGIN_BUILD_COLLECTION_B
@@ -1215,6 +1222,11 @@ To create/register a plugin, you have to :
     #endif
     #ifndef NOTIFIER_SET_NONE
       #define NOTIFIER_SET_NONE
+    #endif
+    
+    // Do not include large blobs but fetch them from CDN
+    #ifndef WEBSERVER_USE_CDN_JS_CSS
+      #define WEBSERVER_USE_CDN_JS_CSS
     #endif
   #endif
 #endif

--- a/src/src/DataStructs/WiFiEventData.cpp
+++ b/src/src/DataStructs/WiFiEventData.cpp
@@ -130,7 +130,9 @@ void WiFiEventData_t::setWiFiConnected() {
 
 void WiFiEventData_t::setWiFiServicesInitialized() {
   if (!unprocessedWifiEvents() && WiFiConnected() && WiFiGotIP()) {
+    # ifndef BUILD_NO_DEBUG
     addLog(LOG_LEVEL_DEBUG, F("WiFi : WiFi services initialized"));
+    #endif
     bitSet(wifiStatus, ESPEASY_WIFI_SERVICES_INITIALIZED);
     wifiConnectInProgress = false;
   }

--- a/src/src/ESPEasyCore/ESPEasy_Log.cpp
+++ b/src/src/ESPEasyCore/ESPEasy_Log.cpp
@@ -37,9 +37,11 @@ const __FlashStringHelper * getLogLevelDisplayString(int logLevel) {
     case LOG_LEVEL_NONE:       return F("None");
     case LOG_LEVEL_ERROR:      return F("Error");
     case LOG_LEVEL_INFO:       return F("Info");
+# ifndef BUILD_NO_DEBUG
     case LOG_LEVEL_DEBUG:      return F("Debug");
     case LOG_LEVEL_DEBUG_MORE: return F("Debug More");
     case LOG_LEVEL_DEBUG_DEV:  return F("Debug dev");
+#endif
 
     default:
     break;
@@ -51,9 +53,11 @@ const __FlashStringHelper * getLogLevelDisplayStringFromIndex(uint8_t index, int
   switch (index) {
     case 0: logLevel = LOG_LEVEL_ERROR;      break;
     case 1: logLevel = LOG_LEVEL_INFO;       break;
+# ifndef BUILD_NO_DEBUG
     case 2: logLevel = LOG_LEVEL_DEBUG;      break;
     case 3: logLevel = LOG_LEVEL_DEBUG_MORE; break;
     case 4: logLevel = LOG_LEVEL_DEBUG_DEV;  break;
+#endif
 
     default: logLevel = -1; return F("");
   }

--- a/src/src/ESPEasyCore/ESPEasy_Log.h
+++ b/src/src/ESPEasyCore/ESPEasy_Log.h
@@ -13,7 +13,7 @@
 #define LOG_LEVEL_DEBUG_DEV                 9 // use for testing/debugging only, not for regular use
 #define LOG_LEVEL_NRELEMENTS                5 // Update this and getLogLevelDisplayString() when new log levels are added
 #else
-#define LOG_LEVEL_NRELEMENTS                3 // Update this and getLogLevelDisplayString() when new log levels are added
+#define LOG_LEVEL_NRELEMENTS                2 // Update this and getLogLevelDisplayString() when new log levels are added
 #endif
 
 #define LOG_TO_SERIAL         1

--- a/src/src/ESPEasyCore/ESPEasy_Log.h
+++ b/src/src/ESPEasyCore/ESPEasy_Log.h
@@ -7,10 +7,14 @@
 #define LOG_LEVEL_NONE                      0
 #define LOG_LEVEL_ERROR                     1
 #define LOG_LEVEL_INFO                      2
+# ifndef BUILD_NO_DEBUG
 #define LOG_LEVEL_DEBUG                     3
 #define LOG_LEVEL_DEBUG_MORE                4
 #define LOG_LEVEL_DEBUG_DEV                 9 // use for testing/debugging only, not for regular use
 #define LOG_LEVEL_NRELEMENTS                5 // Update this and getLogLevelDisplayString() when new log levels are added
+#else
+#define LOG_LEVEL_NRELEMENTS                3 // Update this and getLogLevelDisplayString() when new log levels are added
+#endif
 
 #define LOG_TO_SERIAL         1
 #define LOG_TO_SYSLOG         2

--- a/src/src/ESPEasyCore/ESPEasy_setup.cpp
+++ b/src/src/ESPEasyCore/ESPEasy_setup.cpp
@@ -374,10 +374,11 @@ void ESPEasy_setup()
     addLogMove(LOG_LEVEL_INFO, log);
   }
 
+# ifndef BUILD_NO_DEBUG
   if (Settings.UseSerial && (Settings.SerialLogLevel >= LOG_LEVEL_DEBUG_MORE)) {
     Serial.setDebugOutput(true);
   }
-
+#endif
 
   timermqtt_interval      = 250; // Interval for checking MQTT
   timerAwakeFromDeepSleep = millis();

--- a/src/src/Helpers/Misc.cpp
+++ b/src/src/Helpers/Misc.cpp
@@ -290,7 +290,11 @@ void SendValueLogger(taskIndex_t TaskIndex)
   featureSD = true;
   # endif // if FEATURE_SD
 
-  if (featureSD || loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+  if (featureSD 
+      # ifndef BUILD_NO_DEBUG
+      || loglevelActiveFor(LOG_LEVEL_DEBUG)
+      #endif
+  ) {
     const deviceIndex_t DeviceIndex = getDeviceIndex_from_TaskIndex(TaskIndex);
 
     if (validDeviceIndex(DeviceIndex)) {
@@ -311,7 +315,9 @@ void SendValueLogger(taskIndex_t TaskIndex)
         logger += formatUserVarNoCheck(TaskIndex, varNr);
         logger += F("\r\n");
       }
+      # ifndef BUILD_NO_DEBUG
       addLog(LOG_LEVEL_DEBUG, logger);
+      #endif
     }
   }
 #endif // if !defined(BUILD_NO_DEBUG) || FEATURE_SD

--- a/src/src/Helpers/Networking.cpp
+++ b/src/src/Helpers/Networking.cpp
@@ -286,7 +286,9 @@ void checkUDP()
           if (static_cast<uint8_t>(packetBuffer[0]) != 255)
           {
             packetBuffer[len] = 0;
+            # ifndef BUILD_NO_DEBUG
             addLog(LOG_LEVEL_DEBUG, &packetBuffer[0]);
+            #endif
             ExecuteCommand_all(EventValueSource::Enum::VALUE_SOURCE_SYSTEM, &packetBuffer[0]);
           }
           else

--- a/src/src/Helpers/PeriodicalActions.cpp
+++ b/src/src/Helpers/PeriodicalActions.cpp
@@ -393,7 +393,11 @@ controllerIndex_t firstEnabledMQTT_ControllerIndex() {
 
 
 void logTimerStatistics() {
-  uint8_t loglevel = LOG_LEVEL_DEBUG;
+# ifndef BUILD_NO_DEBUG
+  const uint8_t loglevel = LOG_LEVEL_DEBUG;
+#else
+  const uint8_t loglevel = LOG_LEVEL_NONE;
+#endif
   updateLoopStats_30sec(loglevel);
 #ifndef BUILD_NO_DEBUG
 //  logStatistics(loglevel, true);

--- a/src/src/Helpers/StringGenerator_System.cpp
+++ b/src/src/Helpers/StringGenerator_System.cpp
@@ -1,6 +1,7 @@
 #include "../Helpers/StringGenerator_System.h"
-#include "../Helpers/ESPEasy_time_calc.h"
 
+#include "../Helpers/ESPEasy_time_calc.h"
+#include "../Helpers/StringConverter.h"
 
 /*********************************************************************************************\
    ESPEasy specific strings
@@ -178,27 +179,27 @@ String formatSystemBuildNr(uint16_t buildNr) {
 }
 
 String getPluginDescriptionString() {
-  String result;
-
+  return F(
+    ""
   #ifdef PLUGIN_BUILD_NORMAL
-  result += F(" [Normal]");
+  "[Normal]"
   #endif // ifdef PLUGIN_BUILD_NORMAL
   #ifdef PLUGIN_BUILD_COLLECTION
-  result += F(" [Collection]");
+  "[Collection]"
   #endif // ifdef PLUGIN_BUILD_COLLECTION
   #ifdef PLUGIN_BUILD_DEV
-  result += F(" [Development]");
+  "[Development]"
   #endif // ifdef PLUGIN_BUILD_DEV
   #ifdef PLUGIN_DESCR
-  result += F(" [");
-  result += F(PLUGIN_DESCR);
-  result += ']';
+  "[" PLUGIN_DESCR "]"
   #endif // ifdef PLUGIN_DESCR
+  #ifdef BUILD_NO_DEBUG
+  "[No Debug Log]"
+  #endif
   #if FEATURE_NON_STANDARD_24_TASKS && defined(ESP8266)
-  result += F(" 24tasks");
+  "[24tasks]"
   #endif // if FEATURE_NON_STANDARD_24_TASKS && defined(ESP8266)
-  result.trim();
-  return result;
+  );
 }
 
 String getSystemLibraryString() {

--- a/src/src/Helpers/_Plugin_Helper_serial.cpp
+++ b/src/src/Helpers/_Plugin_Helper_serial.cpp
@@ -20,11 +20,13 @@ String serialHelper_getSerialTypeLabel(ESPEasySerialPort serType) {
 }
 
 void serialHelper_log_GpioDescription(ESPEasySerialPort typeHint, int config_pin1, int config_pin2) {
+  # ifndef BUILD_NO_DEBUG
   if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
     String log = F("Serial : ");
     log += serialHelper_getGpioDescription(typeHint, config_pin1, config_pin2, " ");
     addLogMove(LOG_LEVEL_DEBUG, log);
   }
+  #endif
 }
 
 String serialHelper_getGpioDescription(ESPEasySerialPort typeHint, int config_pin1, int config_pin2, const String& newline) {

--- a/src/src/PluginStructs/P044_data_struct.cpp
+++ b/src/src/PluginStructs/P044_data_struct.cpp
@@ -237,7 +237,9 @@ void P044_Task::serialBegin(const ESPEasySerialPort port, int16_t rxPin, int16_t
 #elif defined(ESP32)
       P1EasySerial->begin(baud, config);
 #endif // if defined(ESP8266)
+# ifndef BUILD_NO_DEBUG
       addLog(LOG_LEVEL_DEBUG, F("P1   : Serial opened"));
+#endif
     }
   }
   state = ParserState::WAITING;
@@ -247,7 +249,9 @@ void P044_Task::serialEnd() {
   if (nullptr != P1EasySerial) {
     delete P1EasySerial;
     P1EasySerial = nullptr;
+# ifndef BUILD_NO_DEBUG
     addLog(LOG_LEVEL_DEBUG, F("P1   : Serial closed"));
+#endif
   }
 }
 
@@ -275,8 +279,9 @@ void P044_Task::handleSerialIn(struct EventStruct *event) {
   if (done) {
     P1GatewayClient.print(serial_buffer);
     P1GatewayClient.flush();
-
+# ifndef BUILD_NO_DEBUG
     addLog(LOG_LEVEL_DEBUG, F("P1   : data send!"));
+#endif
     blinkLED();
 
     if (Settings.UseRules)
@@ -291,7 +296,9 @@ void P044_Task::handleSerialIn(struct EventStruct *event) {
 
 bool P044_Task::handleChar(char ch) {
   if (serial_buffer.length() >= P044_DATAGRAM_MAX_SIZE - 2) { // room for cr/lf
+# ifndef BUILD_NO_DEBUG
     addLog(LOG_LEVEL_DEBUG, F("P1   : Error: Buffer overflow, discarded input."));
+#endif
     state = ParserState::WAITING;                             // reset
   }
 
@@ -321,7 +328,9 @@ bool P044_Task::handleChar(char ch) {
           done = true;
         }
       } else if (ch == P044_DATAGRAM_START_CHAR) {
+# ifndef BUILD_NO_DEBUG
         addLog(LOG_LEVEL_DEBUG, F("P1   : Error: Start detected, discarded input."));
+#endif
         state = ParserState::WAITING; // reset
         return handleChar(ch);
       } else {
@@ -345,7 +354,9 @@ bool P044_Task::handleChar(char ch) {
 
   if (invalid) {
     // input is not a datagram char
+# ifndef BUILD_NO_DEBUG
     addLog(LOG_LEVEL_DEBUG, F("P1   : Error: DATA corrupt, discarded input."));
+#endif
 
     #ifdef PLUGIN_044_DEBUG
       serialPrint(F("faulty char>"));
@@ -364,9 +375,13 @@ bool P044_Task::handleChar(char ch) {
       addChar('\r');
       addChar('\n');
     } else if (CRCcheck) {
+# ifndef BUILD_NO_DEBUG
       addLog(LOG_LEVEL_DEBUG, F("P1   : Error: Invalid CRC, dropped data"));
+#endif
     } else {
+# ifndef BUILD_NO_DEBUG
       addLog(LOG_LEVEL_DEBUG, F("P1   : Error: Invalid datagram, dropped data"));
+#endif
     }
     state = ParserState::WAITING; // prepare for next one
   }

--- a/src/src/PluginStructs/P082_data_struct.h
+++ b/src/src/PluginStructs/P082_data_struct.h
@@ -7,7 +7,7 @@
 # include <TinyGPS++.h>
 # include <ESPeasySerial.h>
 
-#ifndef LIMIT_BUILD_SIZE
+# ifndef BUILD_NO_DEBUG
 # define P082_SEND_GPS_TO_LOG
 //# define P082_USE_U_BLOX_SPECIFIC // TD-er: Disabled for now, as it is not working reliable/predictable
 #endif

--- a/src/src/PluginStructs/P087_data_struct.cpp
+++ b/src/src/PluginStructs/P087_data_struct.cpp
@@ -47,7 +47,9 @@ void P087_data_struct::post_init() {
     capture_index_used[i] = false;
   }
   regex_empty = _lines[P087_REGEX_POS].isEmpty();
+  # ifndef BUILD_NO_DEBUG
   String log = F("P087_post_init:");
+  #endif
 
   for (uint8_t i = 0; i < P087_NR_FILTERS; ++i) {
     // Create some quick lookup table to see if we have a filter for the specific index
@@ -56,15 +58,19 @@ void P087_data_struct::post_init() {
 
     // Index is negative when not used.
     if ((index >= 0) && (index < P87_MAX_CAPTURE_INDEX) && (_lines[i * 3 + P087_FIRST_FILTER_POS + 2].length() > 0)) {
+      # ifndef BUILD_NO_DEBUG
       log                      += ' ';
       log                      += String(i);
       log                      += ':';
       log                      += String(index);
+      #endif
       capture_index[i]          = index;
       capture_index_used[index] = true;
     }
   }
+  # ifndef BUILD_NO_DEBUG
   addLogMove(LOG_LEVEL_DEBUG, log);
+  #endif
 }
 
 bool P087_data_struct::isInitialized() const {

--- a/src/src/PluginStructs/P093_data_struct.cpp
+++ b/src/src/PluginStructs/P093_data_struct.cpp
@@ -2,9 +2,6 @@
 
 #ifdef USES_P093
 
-
-# define PLUGIN_093_DEBUG
-
 /*
  *
  * Bi-directional communication with the heat pump.
@@ -263,7 +260,9 @@ void P093_data_struct::responseReceived() {
 }
 
 void P093_data_struct::updateStatus() {
+  # ifdef PLUGIN_093_DEBUG
   addLog(LOG_LEVEL_DEBUG, String(F("M-AC: US: ")) + _infoModeIndex);
+  #endif
 
   uint8_t packet[PACKET_LEN] = { 0xfc, 0x42, 0x01, 0x30, 0x10 };
 
@@ -320,7 +319,9 @@ void P093_data_struct::applySettings() {
 }
 
 void P093_data_struct::connect() {
+  # ifdef PLUGIN_093_DEBUG
   addLog(LOG_LEVEL_DEBUG, String(F("M-AC: Connect ")) + getBaudRate());
+  #endif
 
   _serial.begin(getBaudRate(), SERIAL_8E1);
   const uint8_t buffer[] = { 0xfc, 0x5a, 0x01, 0x30, 0x02, 0xca, 0x01, 0xa8 };
@@ -346,7 +347,9 @@ void P093_data_struct::addByteToReadBuffer(uint8_t value) {
     _readBuffer[_readPos] = value;
     ++_readPos;
   } else {
+    # ifdef PLUGIN_093_DEBUG
     addLog(LOG_LEVEL_DEBUG, F("M-AC: ABTRB(0)"));
+    #endif
     _readPos = 0;
   }
 }
@@ -369,7 +372,9 @@ bool P093_data_struct::readIncommingBytes() {
       if (value == 0xfc) {
         addByteToReadBuffer(value);
       } else {
+        # ifdef PLUGIN_093_DEBUG
         addLog(LOG_LEVEL_DEBUG, String(F("M-AC: RIB(0) ")) + formatToHex(value));
+        #endif
       }
     } else if ((_readPos <= DATA_LEN_INDEX) || (_readPos <= DATA_LEN_INDEX + _readBuffer[DATA_LEN_INDEX])) {
       // Read header + data part - data length is at index 4.
@@ -410,7 +415,9 @@ bool P093_data_struct::processIncomingPacket(const uint8_t *packet, uint8_t leng
 
 bool P093_data_struct::parseValues(const uint8_t *data, size_t length) {
   if (length == 0) {
+    # ifdef PLUGIN_093_DEBUG
     addLog(LOG_LEVEL_DEBUG, F("M-AC: PV(0)"));
+    #endif
     return false;
   }
 
@@ -459,8 +466,9 @@ bool P093_data_struct::parseValues(const uint8_t *data, size_t length) {
       }
       break;
   }
-
+  # ifdef PLUGIN_093_DEBUG
   addLog(LOG_LEVEL_DEBUG, F("M-AC: PV(1)"));
+  #endif
   return false;
 }
 
@@ -470,14 +478,18 @@ P093_data_struct::State P093_data_struct::checkIncomingPacket(const uint8_t *pac
 # endif // ifdef PLUGIN_093_DEBUG
 
   if ((packet[2] != 0x01) || (packet[3] != 0x30)) {
+    # ifdef PLUGIN_093_DEBUG
     addLog(LOG_LEVEL_DEBUG, F("M-AC: CIP(0)"));
+    #endif
     return Invalid;
   }
 
   uint8_t calculatedChecksum = checkSum(packet, length);
 
   if (calculatedChecksum != checksum) {
+    # ifdef PLUGIN_093_DEBUG
     addLog(LOG_LEVEL_DEBUG, String(F("M-AC: CIP(1) ")) + calculatedChecksum);
+    #endif
     return Invalid;
   }
 
@@ -517,7 +529,7 @@ bool P093_data_struct::findByMapping(const String& mapping, const Tuple list[], 
   for (size_t index = 0; index < count; ++index) {
     const Tuple& tuple = list[index];
 
-    if (mapping == tuple.mapping) {
+    if (mapping.equals(tuple.mapping)) {
       value = tuple.value;
       return true;
     }

--- a/src/src/PluginStructs/P093_data_struct.h
+++ b/src/src/PluginStructs/P093_data_struct.h
@@ -5,7 +5,10 @@
 #ifdef USES_P093
 
 
+#ifndef BUILD_NO_DEBUG
 # define PLUGIN_093_DEBUG
+#endif
+
 
 /*
  *

--- a/src/src/PluginStructs/P110_data_struct.h
+++ b/src/src/PluginStructs/P110_data_struct.h
@@ -7,7 +7,7 @@
 #define P110_DEBUG        // Enable debugging output (INFO loglevel)
 #define P110_DEBUG_DEBUG  // Enable extended debugging output (DEBUG loglevel)
 
-#ifdef LIMIT_BUILD_SIZE
+#ifdef BUILD_NO_DEBUG
   #ifdef P110_DEBUG_DEBUG
   #undef P110_DEBUG_DEBUG
   #endif

--- a/src/src/PluginStructs/P113_data_struct.h
+++ b/src/src/PluginStructs/P113_data_struct.h
@@ -5,7 +5,9 @@
 #ifdef USES_P113
 
 # define P113_DEBUG       // Enable debugging output (INFO loglevel)
+# ifndef BUILD_NO_DEBUG
 # define P113_DEBUG_DEBUG // Enable extended debugging output (DEBUG loglevel)
+#endif
 
 # ifdef LIMIT_BUILD_SIZE
   #  ifdef P113_DEBUG_DEBUG

--- a/src/src/PluginStructs/P126_data_struct.h
+++ b/src/src/PluginStructs/P126_data_struct.h
@@ -6,9 +6,9 @@
 
 # include <ShiftRegister74HC595_NonTemplate.h>
 
-# ifndef LIMIT_BUILD_SIZE
+# ifndef BUILD_NO_DEBUG
 #  define P126_DEBUG_LOG // Enable for some (extra) logging
-# endif // ifndef LIMIT_BUILD_SIZE
+# endif
 
 # define P126_CONFIG_CHIP_COUNT       PCONFIG(0)
 # define P126_CONFIG_SHOW_OFFSET      PCONFIG(1)

--- a/src/src/PluginStructs/P129_data_struct.h
+++ b/src/src/PluginStructs/P129_data_struct.h
@@ -4,9 +4,9 @@
 #include "../../_Plugin_Helper.h"
 #ifdef USES_P129
 
-# ifndef LIMIT_BUILD_SIZE
+# ifndef BUILD_NO_DEBUG
 #  define P129_DEBUG_LOG // Enable for some (extra) logging
-# endif // ifndef LIMIT_BUILD_SIZE
+# endif
 
 # define P129_CONFIG_CHIP_COUNT       PCONFIG(0)
 # define P129_CONFIG_DATA_PIN         PIN(0)

--- a/src/src/PluginStructs/P131_data_struct.h
+++ b/src/src/PluginStructs/P131_data_struct.h
@@ -10,7 +10,9 @@
 
 # include <vector>
 
+# ifndef BUILD_NO_DEBUG
 # define P131_DEBUG_LOG  // Enable for some (extra) logging
+#endif
 
 # define P131_Nlines  16 // The number of different lines which can be displayed
 # define P131_Nchars  50

--- a/src/src/WebServer/AdvancedConfigPage.cpp
+++ b/src/src/WebServer/AdvancedConfigPage.cpp
@@ -384,6 +384,10 @@ void addFormExtTimeSourceSelect(const __FlashStringHelper * label, const __Flash
 
 void addFormLogLevelSelect(LabelType::Enum label, int choice)
 {
+  #ifdef BUILD_NO_DEBUG
+  if (choice > LOG_LEVEL_INFO) choice = LOG_LEVEL_INFO;
+  #endif
+
   addRowLabel(getLabel(label));
   const __FlashStringHelper * options[LOG_LEVEL_NRELEMENTS + 1];
   int    optionValues[LOG_LEVEL_NRELEMENTS + 1] = { 0 };


### PR DESCRIPTION
Actually undefining LOG_LEVEL_DEBUG and the more verbose versions when BUILD_NO_DEBUG is defined.