### PR TITLE
partial fix for #4234

### DIFF
--- a/src/_P016_IR.ino
+++ b/src/_P016_IR.ino
@@ -382,10 +382,9 @@ boolean Plugin_016(uint8_t function, struct EventStruct *event, String& string)
           }
 
           const String P016_HEX_INPUT_PATTERN = F("(0x)?[0-9a-fA-F]{0,16}"); // 16 nibbles = 64 bit, 0x prefix is allowed but not added by
-                                                                             // default
-          addRowLabel(F("Code - command map"));
+                                                                             // defaul
 
-          html_table(EMPTY_STRING);
+          html_table("normal");
           html_table_header(F("&nbsp;#&nbsp;"));
           html_table_header(F("Decode type"));
           html_table_header(F("Repeat"));


### PR DESCRIPTION
I made a normal table out of it.. it is simple and works.
The first colum was unnecessary because it was redundant to the subheader..

<img width="883" alt="Bildschirmfoto 2022-08-31 um 01 28 27" src="https://user-images.githubusercontent.com/33860956/187561248-1d93f191-ddce-4eee-93f3-96b13a15ce08.png">
