### PR TITLE
[PZEM004T] Fix nullptr dereference (#4251)

### DIFF
--- a/src/_P102_PZEM004Tv3.ino
+++ b/src/_P102_PZEM004Tv3.ino
@@ -219,6 +219,8 @@ boolean Plugin_102(uint8_t function, struct EventStruct *event, String& string)
 
     case PLUGIN_INIT:
     {
+
+      // FIXME TD-er: This will fail if the set to be first taskindex is no longer enabled
       if (P102_PZEM_FIRST == event->TaskIndex) // If first PZEM, serial config available
       {
         int rxPin                    = CONFIG_PIN1;
@@ -235,25 +237,27 @@ boolean Plugin_102(uint8_t function, struct EventStruct *event, String& string)
         P102_PZEM_sensor = new (std::nothrow) PZEM004Tv30(port, rxPin, txPin);
 
         // Sequence for changing PZEM address
-        if (P102_PZEM_ADDR_SET == 1) // if address programming confirmed
+        if (P102_PZEM_ADDR_SET == 1 && P102_PZEM_sensor != nullptr) // if address programming confirmed
         {
           P102_PZEM_sensor->setAddress(P102_PZEM_ADDR);
           P102_PZEM_mode     = 0;    // Back to read mode
           P102_PZEM_ADDR_SET = 3;    // Address programmed
         }
       }
-      P102_PZEM_sensor->init(P102_PZEM_ADDR);
+      if (P102_PZEM_sensor != nullptr) {
+        P102_PZEM_sensor->init(P102_PZEM_ADDR);
 
-      // Sequence for reseting PZEM energy
-      if (P102_PZEM_mode == 1)
-      {
-        P102_PZEM_sensor->resetEnergy();
-        P102_PZEM_mode     = 0; // Back to read mode
-        P102_PZEM_ADDR_SET = 4; // Energy reset done
+        // Sequence for reseting PZEM energy
+        if (P102_PZEM_mode == 1)
+        {
+          P102_PZEM_sensor->resetEnergy();
+          P102_PZEM_mode     = 0; // Back to read mode
+          P102_PZEM_ADDR_SET = 4; // Energy reset done
+        }
+
+        Plugin_102_init = true;
+        success         = true;
       }
-
-      Plugin_102_init = true;
-      success         = true;
       break;
     }
 


### PR DESCRIPTION
To Do:
- [x] Fix nullptr dereference
- [ ] Make selecting "first" PZEM instance automatic.

Fixes: #4251