### PR TITLE
[P037] Enable all features for NORMAL builds not using LIMIT_BUILD_SIZE (2M/4M/16M)

### DIFF
--- a/docs/source/Plugin/P037.rst
+++ b/docs/source/Plugin/P037.rst
@@ -31,7 +31,7 @@ Only numbers can be stored in variables (Plugin Generic - Dummy Device), so eith
 Device configuration
 --------------------
 
-NB: To save space it is possible that not all features are available in all builds. The screenshots are taken including all options.
+NB: To save space it is possible that not all features are available in all builds. All features are available in ``normal`` builds with 2MB or more flash size, ``max`` builds, and when self-building in a ``Custom`` build. The screenshots are taken including all options.
 
 The options that can be included or excluded are:
 
@@ -41,7 +41,7 @@ The options that can be included or excluded are:
 
 * Apply mappings
 
-* To replace by comma in event
+* Character to replace by comma in event
 
 Initial setup after adding the plugin:
 
@@ -75,7 +75,7 @@ The event for such attribute looks like ``<topic>#<attribute>=<attribute_value>`
 
 In addition, for each accepted JSON attribute also an event is generated, like ``<devicename>#<valuename>=<value>``, for example ``MQTT_Import#Value1=on``. If Mappings are used, again the value after mapping is provided.
 
-NB: When receiving non-numeric values, like above, you must explicitly name the event **and** value to trigger on, (this is an ESPEasy limitation), for example:
+NB: When receiving non-numeric values, like above, you can use wild-card matching ``on <topic>* do`` or explicitly name the event **and** value to trigger on, for example:
 
 .. code-block:: none
 

--- a/src/src/PluginStructs/P037_data_struct.h
+++ b/src/src/PluginStructs/P037_data_struct.h
@@ -16,7 +16,7 @@
 // # define PLUGIN_037_DEBUG     // Additional debugging information
 
 # if defined(PLUGIN_BUILD_CUSTOM) || defined(PLUGIN_BUILD_MAX_ESP32) \
-  || (defined(PLUGIN_SET_STABLE) && !defined(PLUGIN_SET_COLLECTION))
+  || (defined(PLUGIN_SET_STABLE) && !(defined(PLUGIN_SET_COLLECTION) || defined(PLUGIN_ENERGY_COLLECTION)))
 #  ifndef P037_MAPPING_SUPPORT
 #   define P037_MAPPING_SUPPORT 1           // Enable Value mapping support
 #  endif // ifndef P037_MAPPING_SUPPORT
@@ -30,7 +30,7 @@
 #   define P037_REPLACE_BY_COMMA_SUPPORT  1 // Enable Replace by comnma support
 #  endif // ifndef P037_REPLACE_BY_COMMA_SUPPORT
 # endif // if defined(PLUGIN_BUILD_CUSTOM) || defined(PLUGIN_BUILD_MAX_ESP32)
-// || (defined(PLUGIN_SET_STABLE) && !defined(PLUGIN_SET_COLLECTION))
+// || (defined(PLUGIN_SET_STABLE) && !(defined(PLUGIN_SET_COLLECTION) || defined(PLUGIN_ENERGY_COLLECTION)))
 
 // # define P037_OVERRIDE        // When defined, do not limit features because of LIMIT_BUILD_SIZE
 // # define P037_LIMIT_BUILD_SIZE // Only limit build size for this plugin (to be defined in Custom.h etc.)

--- a/src/src/PluginStructs/P037_data_struct.h
+++ b/src/src/PluginStructs/P037_data_struct.h
@@ -15,7 +15,8 @@
 
 // # define PLUGIN_037_DEBUG     // Additional debugging information
 
-# if defined(PLUGIN_BUILD_CUSTOM) || defined(PLUGIN_BUILD_MAX_ESP32)
+# if defined(PLUGIN_BUILD_CUSTOM) || defined(PLUGIN_BUILD_MAX_ESP32) \
+  || (defined(PLUGIN_SET_STABLE) && !defined(PLUGIN_SET_COLLECTION))
 #  ifndef P037_MAPPING_SUPPORT
 #   define P037_MAPPING_SUPPORT 1           // Enable Value mapping support
 #  endif // ifndef P037_MAPPING_SUPPORT
@@ -29,6 +30,7 @@
 #   define P037_REPLACE_BY_COMMA_SUPPORT  1 // Enable Replace by comnma support
 #  endif // ifndef P037_REPLACE_BY_COMMA_SUPPORT
 # endif // if defined(PLUGIN_BUILD_CUSTOM) || defined(PLUGIN_BUILD_MAX_ESP32)
+// || (defined(PLUGIN_SET_STABLE) && !defined(PLUGIN_SET_COLLECTION))
 
 // # define P037_OVERRIDE        // When defined, do not limit features because of LIMIT_BUILD_SIZE
 // # define P037_LIMIT_BUILD_SIZE // Only limit build size for this plugin (to be defined in Custom.h etc.)


### PR DESCRIPTION
From a [Forum request](https://www.letscontrolit.com/forum/viewtopic.php?t=9246)

Features:
- Enable all MQTT Import features for NORMAL builds, not using the LIMIT_BUILD_SIZE option (2M/4M/16M):
  - Parse JSON messages
  - Apply filters
  - Apply mappings
  - Character replacement by a comma in events

Had to (also) exclude `ENERGY` builds here, as it won't fit in the ESP8266 build.