### PR TITLE
[P131] Fix lines display to start on next tile

### DIFF
--- a/src/_P131_NeoPixelMatrix.ino
+++ b/src/_P131_NeoPixelMatrix.ino
@@ -114,34 +114,34 @@ boolean Plugin_131(uint8_t function, struct EventStruct *event, String& string)
 
         addFormSubHeader(F("Matrix"));
 
-        addFormNumericBox(F("Matrix width"),  F("matrixwidth"),
+        addFormNumericBox(F("Matrix width"),  F("mxwidth"),
                           P131_CONFIG_MATRIX_WIDTH, 1, 100);
-        addFormNumericBox(F("Matrix height"), F("matrixheight"),
+        addFormNumericBox(F("Matrix height"), F("mxheight"),
                           P131_CONFIG_MATRIX_HEIGHT, 1, 100);
 
-        addFormSelector(F("Matrix start-pixel"), F("matrixstart"), 4, optionsTop, optionValuesTop,
+        addFormSelector(F("Matrix start-pixel"), F("mxstart"), 4, optionsTop, optionValuesTop,
                         get2BitFromUL(P131_CONFIG_FLAGS, P131_FLAGS_MATRIX_TYPE_TOP));
 
-        addFormSelector(F("Matrix Rows/Columns mode"), F("matrixrowcol"), 2, optionsRowCol, optionValuesZeroOne,
+        addFormSelector(F("Matrix Rows/Columns mode"), F("mxrowcol"), 2, optionsRowCol, optionValuesZeroOne,
                         bitRead(P131_CONFIG_FLAGS, P131_FLAGS_MATRIX_TYPE_RC));
 
-        addFormSelector(F("Matrix flow direction"), F("matrixprozig"), 2, optionsProZig, optionValuesZeroOne,
+        addFormSelector(F("Matrix flow direction"), F("mxprozig"), 2, optionsProZig, optionValuesZeroOne,
                         bitRead(P131_CONFIG_FLAGS, P131_FLAGS_MATRIX_TYPE_PZ));
 
         addFormSubHeader(F("Multiple matrices: Tiles"));
 
-        addFormNumericBox(F("Tile matrix width"),  F("tilewidth"),
+        addFormNumericBox(F("Tile matrix width"),  F("tlwidth"),
                           P131_CONFIG_TILE_WIDTH, 1, 32);
-        addFormNumericBox(F("Tile matrix height"), F("tileheight"),
+        addFormNumericBox(F("Tile matrix height"), F("tlheight"),
                           P131_CONFIG_TILE_HEIGHT, 1, P131_Nlines);
 
-        addFormSelector(F("Tile start-matrix"), F("tilestart"), 4, optionsTop, optionValuesTop,
+        addFormSelector(F("Tile start-matrix"), F("tlstart"), 4, optionsTop, optionValuesTop,
                         get2BitFromUL(P131_CONFIG_FLAGS, P131_FLAGS_TILE_TYPE_TOP));
 
-        addFormSelector(F("Tile Rows/Columns mode"), F("tilerowcol"), 2, optionsRowCol, optionValuesZeroOne,
+        addFormSelector(F("Tile Rows/Columns mode"), F("tlrowcol"), 2, optionsRowCol, optionValuesZeroOne,
                         bitRead(P131_CONFIG_FLAGS, P131_FLAGS_TILE_TYPE_RC));
 
-        addFormSelector(F("Tile flow direction"), F("tileprozig"), 2, optionsProZig, optionValuesZeroOne,
+        addFormSelector(F("Tile flow direction"), F("tlprozig"), 2, optionsProZig, optionValuesZeroOne,
                         bitRead(P131_CONFIG_FLAGS, P131_FLAGS_TILE_TYPE_PZ));
       }
 
@@ -174,7 +174,7 @@ boolean Plugin_131(uint8_t function, struct EventStruct *event, String& string)
           static_cast<int>(P131_CommandTrigger::neo)
         };
         addFormSelector(F("Write Command trigger"),
-                        F("commandtrigger"),
+                        F("cmdtrigger"),
                         static_cast<int>(P131_CommandTrigger::MAX),
                         commandTriggers,
                         commandTriggerOptions,
@@ -267,12 +267,8 @@ boolean Plugin_131(uint8_t function, struct EventStruct *event, String& string)
           remain -= (strings[varNr].length() + 1);
 
           if ((P131_CONFIG_TILE_HEIGHT > 1) && (varNr == P131_CONFIG_TILE_HEIGHT - 1)) {
-            String remainStr;
-            remainStr.reserve(15);
-            remainStr  = F("Remaining: ");
-            remainStr += remain;
             html_TD();
-            addUnit(remainStr);
+            addUnit(concat(F("Remaining: "), remain));
           }
         }
         html_end_table();
@@ -285,27 +281,27 @@ boolean Plugin_131(uint8_t function, struct EventStruct *event, String& string)
     case PLUGIN_WEBFORM_SAVE:
     {
       const uint8_t prevLines = P131_CONFIG_TILE_HEIGHT;
-      P131_CONFIG_MATRIX_WIDTH  = getFormItemInt(F("matrixwidth"));
-      P131_CONFIG_MATRIX_HEIGHT = getFormItemInt(F("matrixheight"));
-      P131_CONFIG_TILE_WIDTH    = getFormItemInt(F("tilewidth"));
-      P131_CONFIG_TILE_HEIGHT   = getFormItemInt(F("tileheight"));
+      P131_CONFIG_MATRIX_WIDTH  = getFormItemInt(F("mxwidth"));
+      P131_CONFIG_MATRIX_HEIGHT = getFormItemInt(F("mxheight"));
+      P131_CONFIG_TILE_WIDTH    = getFormItemInt(F("tlwidth"));
+      P131_CONFIG_TILE_HEIGHT   = getFormItemInt(F("tlheight"));
 
       // Bits are already in the correct order/configuration to be passed on to the constructor
       // Matrix bits
-      set2BitToUL(P131_CONFIG_FLAGS, P131_FLAGS_MATRIX_TYPE_TOP, getFormItemInt(F("matrixstart")) & 0x03);
-      bitWrite(P131_CONFIG_FLAGS, P131_FLAGS_MATRIX_TYPE_RC, getFormItemInt(F("matrixrowcol")));
-      bitWrite(P131_CONFIG_FLAGS, P131_FLAGS_MATRIX_TYPE_PZ, getFormItemInt(F("matrixprozig")));
+      set2BitToUL(P131_CONFIG_FLAGS, P131_FLAGS_MATRIX_TYPE_TOP, getFormItemInt(F("mxstart")) & 0x03);
+      bitWrite(P131_CONFIG_FLAGS, P131_FLAGS_MATRIX_TYPE_RC, getFormItemInt(F("mxrowcol")));
+      bitWrite(P131_CONFIG_FLAGS, P131_FLAGS_MATRIX_TYPE_PZ, getFormItemInt(F("mxprozig")));
 
       // Tile bits
-      set2BitToUL(P131_CONFIG_FLAGS, P131_FLAGS_TILE_TYPE_TOP, getFormItemInt(F("tilestart")) & 0x03);
-      bitWrite(P131_CONFIG_FLAGS, P131_FLAGS_TILE_TYPE_RC, getFormItemInt(F("tilerowcol")));
-      bitWrite(P131_CONFIG_FLAGS, P131_FLAGS_TILE_TYPE_PZ, getFormItemInt(F("tileprozig")));
+      set2BitToUL(P131_CONFIG_FLAGS, P131_FLAGS_TILE_TYPE_TOP, getFormItemInt(F("tlstart")) & 0x03);
+      bitWrite(P131_CONFIG_FLAGS, P131_FLAGS_TILE_TYPE_RC, getFormItemInt(F("tlrowcol")));
+      bitWrite(P131_CONFIG_FLAGS, P131_FLAGS_TILE_TYPE_PZ, getFormItemInt(F("tlprozig")));
 
       // Other settings
       set4BitToUL(P131_CONFIG_FLAGS, P131_CONFIG_FLAG_MODE,        getFormItemInt(F("tpmode")));
       set4BitToUL(P131_CONFIG_FLAGS, P131_CONFIG_FLAG_ROTATION,    getFormItemInt(F("rotate")));
       set4BitToUL(P131_CONFIG_FLAGS, P131_CONFIG_FLAG_FONTSCALE,   getFormItemInt(F("fontscale")));
-      set4BitToUL(P131_CONFIG_FLAGS, P131_CONFIG_FLAG_CMD_TRIGGER, getFormItemInt(F("commandtrigger")));
+      set4BitToUL(P131_CONFIG_FLAGS, P131_CONFIG_FLAG_CMD_TRIGGER, getFormItemInt(F("cmdtrigger")));
 
       bitWrite(P131_CONFIG_FLAGS, P131_CONFIG_FLAG_CLEAR_ON_EXIT, isFormItemChecked(F("clearOnExit")));
       bitWrite(P131_CONFIG_FLAGS, P131_CONFIG_FLAG_STRIP_TYPE,    getFormItemInt(F("striptype")) == 1);

--- a/src/src/PluginStructs/P131_data_struct.cpp
+++ b/src/src/PluginStructs/P131_data_struct.cpp
@@ -353,7 +353,7 @@ void P131_data_struct::display_content(struct EventStruct *event,
         }
       }
       delay(0);
-      yPos += (_fontheight * _fontscaling);
+      yPos += P131_CONFIG_MATRIX_HEIGHT;
     }
     gfxHelper->setValidation(useVal);
     matrix->show();


### PR DESCRIPTION
As reported [here](https://github.com/letscontrolit/ESPEasy/issues/3958#issuecomment-1240715694) the display of lines doesn't start on the next tile as it should. That's fixed now.