### PR TITLE
[GPIO] Fix bug in GPIO command parsing (#4271)

### DIFF
--- a/platformio_esp82xx_envs.ini
+++ b/platformio_esp82xx_envs.ini
@@ -733,6 +733,7 @@ platform_packages         = ${regular_platform.platform_packages}
 build_flags               = ${regular_platform.build_flags}
                             ${esp8266_4M1M.build_flags}
                             -D PLUGIN_ENERGY_COLLECTION
+                            -D WEBSERVER_USE_CDN_JS_CSS
 
 ; display : 4096k version ----------------------------
 [env:display_ESP8266_4M1M]
@@ -742,6 +743,7 @@ platform_packages         = ${regular_platform.platform_packages}
 build_flags               = ${regular_platform.build_flags}
                             ${esp8266_4M1M.build_flags}
                             -D PLUGIN_DISPLAY_COLLECTION
+                            -D WEBSERVER_USE_CDN_JS_CSS
 
 ; neopixel : 4096k version ----------------------------
 [env:neopixel_ESP8266_4M1M]

--- a/src/src/Commands/GPIO.cpp
+++ b/src/src/Commands/GPIO.cpp
@@ -175,7 +175,7 @@ const __FlashStringHelper * Command_GPIO_LongPulse_Ms(struct EventStruct *event,
   bool success = false;
 
   // Line[0]='l':longpulse; ='p':pcflongpulse; ='m':mcplongpulse
-  const __FlashStringHelper * logPrefix = getPluginIDAndPrefix(parseString(Line, 2).charAt(0), pluginID, success);
+  const __FlashStringHelper * logPrefix = getPluginIDAndPrefix(Line[0], pluginID, success);
 
   if (success && checkValidPortRange(pluginID, event->Par1))
   {
@@ -388,7 +388,7 @@ const __FlashStringHelper * Command_GPIO_Toggle(struct EventStruct *event, const
   bool success = false;
 
   // Line[0]='g':gpiotoggle; ='p':pcfgpiotoggle; ='m':mcpgpiotoggle
-  const __FlashStringHelper * logPrefix = getPluginIDAndPrefix(parseString(Line, 2).charAt(0), pluginID, success);
+  const __FlashStringHelper * logPrefix = getPluginIDAndPrefix(Line[0], pluginID, success);
 
   if (success && checkValidPortRange(pluginID, event->Par1))
   {
@@ -446,7 +446,7 @@ const __FlashStringHelper * Command_GPIO(struct EventStruct *event, const char *
   bool success = false;
 
   // Line[0]='g':gpio; ='p':pcfgpio; ='m':mcpgpio
-  const __FlashStringHelper * logPrefix = getPluginIDAndPrefix(parseString(Line, 2).charAt(0), pluginID, success);
+  const __FlashStringHelper * logPrefix = getPluginIDAndPrefix(Line[0], pluginID, success);
 
   if (success && checkValidPortRange(pluginID, event->Par1))
   {
@@ -1015,7 +1015,7 @@ bool gpio_mode_range_helper(uint8_t pin, uint8_t pinMode, struct EventStruct *ev
   bool success = false;
 
   // Line[0]='g':gpio; ='p':pcfgpio; ='m':mcpgpio
-  const __FlashStringHelper * logPrefix = getPluginIDAndPrefix(parseString(Line, 2).charAt(0), pluginID, success);
+  const __FlashStringHelper * logPrefix = getPluginIDAndPrefix(Line[0], pluginID, success);
   const __FlashStringHelper * logPostfix = F(""); // = new char;
 
   if (success && checkValidPortRange(pluginID, pin))

--- a/src/src/ESPEasyCore/ESPEasyWifi.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi.cpp
@@ -1138,7 +1138,7 @@ void setWifiMode(WiFiMode_t wifimode) {
     delay(100);
   }
 
-  addLog(LOG_LEVEL_INFO, String(F("WIFI : Set WiFi to ")) + getWifiModeString(wifimode));
+  addLog(LOG_LEVEL_INFO, concat(F("WIFI : Set WiFi to "), getWifiModeString(wifimode)));
 
   int retry = 2;
   while (!WiFi.mode(wifimode) && retry > 0) {

--- a/src/src/PluginStructs/P044_data_struct.cpp
+++ b/src/src/PluginStructs/P044_data_struct.cpp
@@ -43,10 +43,9 @@ void P044_Task::startServer(uint16_t portnumber) {
     P1GatewayServer->begin();
 
     if (serverActive(P1GatewayServer)) {
-      addLog(LOG_LEVEL_INFO, String(F("P1   : WiFi server started at port ")) + portnumber);
+      addLog(LOG_LEVEL_INFO, concat(F("P1   : WiFi server started at port "), portnumber));
     } else {
-      addLog(LOG_LEVEL_ERROR, String(F("P1   : WiFi server start failed at port ")) +
-             portnumber + String(F(", retrying...")));
+      addLog(LOG_LEVEL_ERROR, concat(F("P1   : WiFi server start failed at port "), portnumber) + F(", retrying..."));
     }
   }
 }
@@ -202,26 +201,19 @@ unsigned int P044_Task::CRC16(const String& buf, int len)
        Returns false on a datagram start ('/'), end ('!') or invalid character
  */
 bool P044_Task::validP1char(char ch) {
-  if (isAlphaNumeric(ch))
-  {
-    return true;
-  }
-
-  switch (ch) {
-    case '.':
-    case ' ':
-    case '\\': // Single backslash, but escaped in C++
-    case '\r':
-    case '\n':
-    case '(':
-    case ')':
-    case '-':
-    case '*':
-    case ':':
-    case '_':
-      return true;
-  }
-  return false;
+  return
+    isAlphaNumeric(ch) ||
+    ch == '.' ||
+    ch == ' ' ||
+    ch == '\\'|| // Single backslash, but escaped in C++
+    ch == '\r'||
+    ch == '\n'||
+    ch == '(' ||
+    ch == ')' ||
+    ch == '-' ||
+    ch == '*' ||
+    ch == ':' ||
+    ch == '_';
 }
 
 void P044_Task::serialBegin(const ESPEasySerialPort port, int16_t rxPin, int16_t txPin,


### PR DESCRIPTION
Fixes: #4271

Bug introduced here: https://github.com/letscontrolit/ESPEasy/pull/4266/files#diff-86bd0e7e90a431e07faa6b14a48383724441cb39143494643b98c27b76fdccda Just a very stupid cut-'n-paste error.