### PR TITLE
[Build] Restore Notifiers and other features in normal_ESP8266_4M1M_VCC

### DIFF
--- a/platformio_esp82xx_envs.ini
+++ b/platformio_esp82xx_envs.ini
@@ -311,6 +311,7 @@ platform_packages         = ${regular_platform.platform_packages}
 build_flags               = ${regular_platform.build_flags}
                             ${esp8266_4M1M.build_flags}
                             -D FEATURE_ADC_VCC=1
+                            -D LIMIT_BUILD_SIZE=0
 
 [env:normal_alt_wifi_ESP8266_4M1M]
 extends                   = esp8266_4M1M

--- a/platformio_esp82xx_envs.ini
+++ b/platformio_esp82xx_envs.ini
@@ -311,7 +311,7 @@ platform_packages         = ${regular_platform.platform_packages}
 build_flags               = ${regular_platform.build_flags}
                             ${esp8266_4M1M.build_flags}
                             -D FEATURE_ADC_VCC=1
-                            -D LIMIT_BUILD_SIZE=0
+                            -D NO_LIMIT_BUILD_SIZE
 
 [env:normal_alt_wifi_ESP8266_4M1M]
 extends                   = esp8266_4M1M

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -1892,7 +1892,7 @@ To create/register a plugin, you have to :
 
 // VCC builds need a bit more, disable timing stats to make it fit.
 #ifndef PLUGIN_BUILD_CUSTOM
-  #if FEATURE_ADC_VCC && !(defined(PLUGIN_SET_MAX) || (defined(LIMIT_BUILD_SIZE) && (LIMIT_BUILD_SIZE == 0)))
+  #if FEATURE_ADC_VCC && !(defined(PLUGIN_SET_MAX) || defined(NO_LIMIT_BUILD_SIZE))
     #ifndef LIMIT_BUILD_SIZE
       #define LIMIT_BUILD_SIZE
     #endif
@@ -1926,14 +1926,10 @@ To create/register a plugin, you have to :
   #define FEATURE_EXT_RTC 0
 #endif
 
-#ifdef PLUGIN_BUILD_MAX_ESP32
+#if defined(PLUGIN_BUILD_MAX_ESP32) || defined(NO_LIMIT_BUILD_SIZE)
   #ifdef LIMIT_BUILD_SIZE
     #undef LIMIT_BUILD_SIZE
   #endif
-#endif
-
-#if defined(LIMIT_BUILD_SIZE) && (LIMIT_BUILD_SIZE == 0) // Set to 0 with the intent to undef
-  #undef LIMIT_BUILD_SIZE
 #endif
 
 // Disable some diagnostic parts to make builds fit.

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -1892,7 +1892,7 @@ To create/register a plugin, you have to :
 
 // VCC builds need a bit more, disable timing stats to make it fit.
 #ifndef PLUGIN_BUILD_CUSTOM
-  #if FEATURE_ADC_VCC && !defined(PLUGIN_SET_MAX)
+  #if FEATURE_ADC_VCC && !(defined(PLUGIN_SET_MAX) || (defined(LIMIT_BUILD_SIZE) && LIMIT_BUILD_SIZE == 0))
     #ifndef LIMIT_BUILD_SIZE
       #define LIMIT_BUILD_SIZE
     #endif
@@ -1930,6 +1930,10 @@ To create/register a plugin, you have to :
   #ifdef LIMIT_BUILD_SIZE
     #undef LIMIT_BUILD_SIZE
   #endif
+#endif
+
+#if defined(LIMIT_BUILD_SIZE) && LIMIT_BUILD_SIZE == 0 // Set to 0 with the intent to undef
+  #undef LIMIT_BUILD_SIZE
 #endif
 
 // Disable some diagnostic parts to make builds fit.

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -1892,7 +1892,7 @@ To create/register a plugin, you have to :
 
 // VCC builds need a bit more, disable timing stats to make it fit.
 #ifndef PLUGIN_BUILD_CUSTOM
-  #if FEATURE_ADC_VCC && !(defined(PLUGIN_SET_MAX) || (defined(LIMIT_BUILD_SIZE) && LIMIT_BUILD_SIZE == 0))
+  #if FEATURE_ADC_VCC && !(defined(PLUGIN_SET_MAX) || (defined(LIMIT_BUILD_SIZE) && (LIMIT_BUILD_SIZE == 0)))
     #ifndef LIMIT_BUILD_SIZE
       #define LIMIT_BUILD_SIZE
     #endif
@@ -1932,7 +1932,7 @@ To create/register a plugin, you have to :
   #endif
 #endif
 
-#if defined(LIMIT_BUILD_SIZE) && LIMIT_BUILD_SIZE == 0 // Set to 0 with the intent to undef
+#if defined(LIMIT_BUILD_SIZE) && (LIMIT_BUILD_SIZE == 0) // Set to 0 with the intent to undef
   #undef LIMIT_BUILD_SIZE
 #endif
 


### PR DESCRIPTION
The only difference between the `normal_ESP8266_4M1M` and `normal_ESP8266_4M1M_VCC` _should_ be the VCC feature, but many other features where also disabled (to keep the Collection VCC builds within their size limits). This bugfix corrects that.