### PR TITLE
Fix CPLIGIN-WRITE to allow controller commands

### DIFF
--- a/src/src/Globals/CPlugins.cpp
+++ b/src/src/Globals/CPlugins.cpp
@@ -106,8 +106,9 @@ bool CPluginCall(CPlugin::Function Function, struct EventStruct *event, String& 
         if ((Settings.Protocol[x] != 0) && Settings.ControllerEnabled[x]) {
           protocolIndex_t ProtocolIndex = getProtocolIndex_from_ControllerIndex(x);
           event->ControllerIndex = x;
-          String dummy;
-          const bool success = CPluginCall(ProtocolIndex, Function, event, dummy);
+          String command;
+          if (Function == CPlugin::Function::CPLUGIN_WRITE) command = str;
+          const bool success = CPluginCall(ProtocolIndex, Function, event, command);
           if (success && Function == CPlugin::Function::CPLUGIN_WRITE) {
             return success;
           }


### PR DESCRIPTION
For some unknown reason a dummy blank command was sent also to WRITE function (?) this will prevent ANY controller plugin from getting commands.
my PR limiting the command to be trasferred only in case of WRITE function (assuming there was a good reason for the original "dummy"  )