### PR TITLE
[Formatting] Formatting values doesn't work as intended

### DIFF
--- a/src/src/Helpers/StringParser.cpp
+++ b/src/src/Helpers/StringParser.cpp
@@ -255,9 +255,9 @@ bool isTransformString(char c, bool logicVal, String& strValue)
       return false;
   }
   if (value_ch != '\0') {
-    strValue = value;
-  } else {
     strValue = value_ch;
+  } else {
+    strValue = value;
   }
   return true;
 }


### PR DESCRIPTION
Partial fix for #4295 

Formatting of variables wasn't working as intended because of a reversed logical expression.