### PR TITLE
[Longpulse] Add repeat option + improve accuracy

### DIFF
--- a/docs/source/Plugin/P001_commands_GPIO.repl
+++ b/docs/source/Plugin/P001_commands_GPIO.repl
@@ -38,33 +38,60 @@ Supported hardware: |P000_usedby_GPIO|
   "
   ``LongPulse,<GPIO>,<state>,<duration>``
 
-  GPIO: 0 ... 16
+  ``LongPulse,<GPIO>,<state>,<duration high>,<duration low>``
+
+  ``LongPulse,<GPIO>,<state>,<duration high>,<duration low>,<nr of repeats>``
+
+  GPIO: All GPIO pins with output capabilities
 
   State: 1/0
 
-  Duration: 1 ... 999 S
+  Duration low/high: 1 ... 999 S
+
+  Nr of Repeats: ``-1`` = continous repeat, ``0`` = only single pulse
   ","
   **To send a *long* pulse to a certain pin.**.
   A long pulse is basically the same as the plain pulse.  Duration is defined in seconds, which makes it more suitable for longer duration.
   This command is not blocking, but will send 2 events to start and stop the pulse. This may have some variation depending on the system load of the module.
   Variation is typically up-to 10 msec, but may be up-to a second, depending on active plugins and controllers performing blocking operations.
+
+  Changed: 2022/10/15
+
+  - Added ``<duration low>`` and repeat functionality
+  - On ESP8266 it now uses the way more accurate ``startWaveform`` function for high/low durations upto 15 seconds.
+
+  Example: ``longpulse,2,1,1,1,-1`` Continuous blinking of the onboard LED at 0.5 Hz. (50% duty cycle)
   "
   "
   ``LongPulse_mS,<GPIO>,<state>,<duration>``
 
-  GPIO: 0 ... 16
+  ``LongPulse_mS,<GPIO>,<state>,<duration high>,<duration low>``
+
+  ``LongPulse_mS,<GPIO>,<state>,<duration high>,<duration low>,<nr of repeats>``
+
+  GPIO: All GPIO pins with output capabilities
 
   State: 1/0
 
-  Duration: 10 ... 15000 msec
+  Duration low/high: 1 ... 15000 msec
+
+  Nr of Repeats: ``-1`` = continous repeat, ``0`` = only single pulse
   ","
-  **To send a *long* pulse to a certain pin.**
+  **To send a (non blocking) *long* pulse to a certain pin.**
+
   A ``LongPulse_mS`` is the same as the regular ``LongPulse``. The only difference is the time base in milliseconds rather than in seconds.
+
+  Changed: 2022/10/15
+
+  - Added ``<duration low>`` and repeat functionality
+  - On ESP8266 it now uses the way more accurate ``startWaveform`` function for high/low durations upto 15 seconds.
+
+  Example: ``longpulse_ms,2,1,500,500,-1`` Continuous blinking of the onboard LED at 1 Hz. (50% duty cycle)
   "
   "
   ``Pulse,<GPIO>,<state>,<duration>``
 
-  GPIO: 0 ... 16
+  GPIO: All GPIO pins with output capabilities
 
   State: 1/0
 
@@ -81,7 +108,9 @@ Supported hardware: |P000_usedby_GPIO|
 
   ``PWM,<GPIO>,<duty>,<duration>,<frequency>``
 
-  GPIO: 0 ... **15**
+  ESP8266 GPIO: 0 ... **15**
+
+  ESP32 GPIO: All GPIO pins with output capabilities
 
   Duty: 0 ... 1023
 
@@ -97,32 +126,6 @@ Supported hardware: |P000_usedby_GPIO|
 
   Frequency (in Hz) will be set to 1000 Hz when not given.
   Frequencies above 30 kHz are not stable and will likely crash the ESP.
-  "
-  "
-  ``Wave_mS,<GPIO>,<msec low>,<msec high>,<duration in msec>``
-
-  ``Wave_uS,<GPIO>,<usec low>,<usec high>,<duration in usec>``
-
-  GPIO: 0 ... 16
-
-  High: The duration of the 'high' state in either msec or usec.
-
-  Low: The duration of the 'low' state in either msec or usec.
-
-  Duration: 0 or total duration of repeating the wave form.
-  ","
-  **To send a non-blocking (repeating) pulse to a pin.**
-  ``Wave_mS`` is the same as ``Wave_uS``. The only difference is the time base in milliseconds or micro seconds.
-
-  Duration of 0 means continous repeating the wave form.
-
-  For duration > 0, the total duration is rounded up to the period defined by the high and low times.
-
-  Example: ``wave_ms,2,1000,1000`` will blink the on board LED at 0.5 Hz.
-
-  Added: 2022/10/15
-
-  N.B. Currently only implemented for ESP8266, not yet for ESP32
   "
   "
   ``Servo,<servo ID>,<GPIO>,<position>``

--- a/docs/source/Plugin/P001_commands_GPIO.repl
+++ b/docs/source/Plugin/P001_commands_GPIO.repl
@@ -99,6 +99,32 @@ Supported hardware: |P000_usedby_GPIO|
   Frequencies above 30 kHz are not stable and will likely crash the ESP.
   "
   "
+  ``Wave_mS,<GPIO>,<msec low>,<msec high>,<duration in msec>``
+
+  ``Wave_uS,<GPIO>,<usec low>,<usec high>,<duration in usec>``
+
+  GPIO: 0 ... 16
+
+  High: The duration of the 'high' state in either msec or usec.
+
+  Low: The duration of the 'low' state in either msec or usec.
+
+  Duration: 0 or total duration of repeating the wave form.
+  ","
+  **To send a non-blocking (repeating) pulse to a pin.**
+  ``Wave_mS`` is the same as ``Wave_uS``. The only difference is the time base in milliseconds or micro seconds.
+
+  Duration of 0 means continous repeating the wave form.
+
+  For duration > 0, the total duration is rounded up to the period defined by the high and low times.
+
+  Example: ``wave_ms,2,1000,1000`` will blink the on board LED at 0.5 Hz.
+
+  Added: 2022/10/15
+
+  N.B. Currently only implemented for ESP8266, not yet for ESP32
+  "
+  "
   ``Servo,<servo ID>,<GPIO>,<position>``
 
   GPIO: 0 ... **15**

--- a/src/_P009_MCP.ino
+++ b/src/_P009_MCP.ino
@@ -512,6 +512,7 @@ boolean Plugin_009(uint8_t function, struct EventStruct *event, String& string)
     case PLUGIN_TASKTIMER_IN:
     case PLUGIN_DEVICETIMER_IN:
     {
+      Scheduler.clearGPIOTimer(PLUGIN_MCP, event->Par1);
       GPIO_MCP_Write(event->Par1, event->Par2);
 
       // setPinState(PLUGIN_ID_009, event->Par1, PIN_MODE_OUTPUT, event->Par2);

--- a/src/_P019_PCF8574.ino
+++ b/src/_P019_PCF8574.ino
@@ -592,6 +592,7 @@ boolean Plugin_019(uint8_t function, struct EventStruct *event, String& string)
         tempStatus.forceMonitor = (tempStatus.monitor) ?  1 :  0; // added to send event for longpulse command  
       }
       savePortStatus(key, tempStatus);
+      Scheduler.clearGPIOTimer(PLUGIN_PCF, event->Par1);
       if (function == PLUGIN_TASKTIMER_IN) {
         GPIO_PCF_Write(event->Par1, event->Par2);
       } else {

--- a/src/src/Commands/GPIO.cpp
+++ b/src/src/Commands/GPIO.cpp
@@ -18,7 +18,9 @@
 #include "../Helpers/PortStatus.h"
 #include "../Helpers/Numerical.h"
 
-#include <core_esp8266_waveform.h>
+#ifdef ESP8266
+# include <core_esp8266_waveform.h>
+#endif 
 
 // Forward declarations of functions used in this module
 // Normally those would be declared in the .h file as private members

--- a/src/src/Commands/GPIO.cpp
+++ b/src/src/Commands/GPIO.cpp
@@ -204,18 +204,18 @@ const __FlashStringHelper * Command_GPIO_LongPulse_Ms(struct EventStruct *event,
       // Max time high or low is roughly 53 sec @ 80 MHz or half @160 MHz.
       // This is not available on ESP32.
 
-     const uint8_t pin = event->Par1;
-     uint32_t timeHighUS = event->Par3 * 1000;
-     uint32_t timeLowUS  = event->Par4 * 1000;
+      const uint8_t pin = event->Par1;
+      uint32_t timeHighUS = event->Par3 * 1000;
+      uint32_t timeLowUS  = event->Par4 * 1000;
 
-     if (event->Par2 == 0) {
-       std::swap(timeHighUS, timeLowUS);
-     }
-     uint32_t runTimeUS = 0;
-     if (event->Par5 > 0) {
-       // Must set slightly lower than expected duration as it will be rounded up.
-       runTimeUS = event->Par5 * (timeHighUS + timeLowUS) - ((timeHighUS + timeLowUS) / 2);
-     }
+      if (event->Par2 == 0) {
+        std::swap(timeHighUS, timeLowUS);
+      }
+      uint32_t runTimeUS = 0;
+      if (event->Par5 > 0) {
+        // Must set slightly lower than expected duration as it will be rounded up.
+        runTimeUS = event->Par5 * (timeHighUS + timeLowUS) - ((timeHighUS + timeLowUS) / 2);
+      }
 
       pinMode(event->Par1, OUTPUT);
       usingWaveForm = startWaveform(
@@ -278,53 +278,6 @@ const __FlashStringHelper * Command_GPIO_LongPulse_Ms(struct EventStruct *event,
     return return_command_failed();
   }
 }
-
-#ifdef ESP8266
-const __FlashStringHelper * Command_GPIO_Wave_Ms(struct EventStruct *event, const char* Line)
-{
-  event->Par2 *= 1000;
-  event->Par3 *= 1000;
-  event->Par4 *= 1000;
-  return Command_GPIO_Wave_usec(event, Line);
-}
-
-const __FlashStringHelper * Command_GPIO_Wave_usec(struct EventStruct *event, const char* Line)
-{
-  pluginID_t pluginID = INVALID_PLUGIN_ID;
-  bool success = false;
-
-  // Line[0]='l':longpulse; ='p':pcflongpulse; ='m':mcplongpulse
-  const __FlashStringHelper * logPrefix = getPluginIDAndPrefix('g', pluginID, success);
-
-  if (success && checkValidPortRange(pluginID, event->Par1))
-  {
-    const uint32_t key = createKey(pluginID, event->Par1);
-    createAndSetPortStatus_Mode_State(key, PIN_MODE_OUTPUT, event->Par2);
-    pinMode(event->Par1, OUTPUT);
-
-
-    // FIXME TD-er: Find analog way to start a waveform on ESP32
-    success = startWaveform(event->Par1, event->Par2, event->Par3, event->Par4);
-
-    String log = logPrefix;
-    log += F(" : port ");
-    log += event->Par1;
-    log += F(". Wave H:");
-    log += event->Par2 / 1000;
-    log += F(" L:");
-    log += event->Par3/1000;
-    log += F(" Dur: ");
-    log += event->Par4 / 1000;
-    log += F(" ms");
-    addLog(LOG_LEVEL_INFO, log);
-    SendStatusOnlyIfNeeded(event, SEARCH_PIN_STATE, key, log, 0);
-
-    if (success) return return_command_success();
-  }
-  logErrorGpioOutOfRange(logPrefix, event->Par1, Line);
-  return return_command_failed();
-}
-#endif
 
 const __FlashStringHelper * Command_GPIO_Status(struct EventStruct *event, const char *Line)
 {

--- a/src/src/Commands/GPIO.h
+++ b/src/src/Commands/GPIO.h
@@ -17,6 +17,10 @@ const __FlashStringHelper * Command_GPIO_RTTTL(struct EventStruct *event, const 
 const __FlashStringHelper * Command_GPIO_Pulse(struct EventStruct *event, const char* Line);
 const __FlashStringHelper * Command_GPIO_LongPulse(struct EventStruct *event, const char* Line);
 const __FlashStringHelper * Command_GPIO_LongPulse_Ms(struct EventStruct *event, const char* Line);
+#ifdef ESP8266
+const __FlashStringHelper * Command_GPIO_Wave_Ms(struct EventStruct *event, const char* Line);
+const __FlashStringHelper * Command_GPIO_Wave_usec(struct EventStruct *event, const char* Line);
+#endif
 const __FlashStringHelper * Command_GPIO_Monitor(struct EventStruct *event, const char* Line);
 const __FlashStringHelper * Command_GPIO_UnMonitor(struct EventStruct *event, const char* Line);
 const __FlashStringHelper * Command_GPIO_Status(struct EventStruct *event, const char* Line);

--- a/src/src/Commands/GPIO.h
+++ b/src/src/Commands/GPIO.h
@@ -17,10 +17,6 @@ const __FlashStringHelper * Command_GPIO_RTTTL(struct EventStruct *event, const 
 const __FlashStringHelper * Command_GPIO_Pulse(struct EventStruct *event, const char* Line);
 const __FlashStringHelper * Command_GPIO_LongPulse(struct EventStruct *event, const char* Line);
 const __FlashStringHelper * Command_GPIO_LongPulse_Ms(struct EventStruct *event, const char* Line);
-#ifdef ESP8266
-const __FlashStringHelper * Command_GPIO_Wave_Ms(struct EventStruct *event, const char* Line);
-const __FlashStringHelper * Command_GPIO_Wave_usec(struct EventStruct *event, const char* Line);
-#endif
 const __FlashStringHelper * Command_GPIO_Monitor(struct EventStruct *event, const char* Line);
 const __FlashStringHelper * Command_GPIO_UnMonitor(struct EventStruct *event, const char* Line);
 const __FlashStringHelper * Command_GPIO_Status(struct EventStruct *event, const char* Line);

--- a/src/src/Commands/InternalCommands.cpp
+++ b/src/src/Commands/InternalCommands.cpp
@@ -482,11 +482,6 @@ bool executeInternalCommand(command_case_data & data)
       break;
     }
     case 'w': {
-#ifdef ESP8266
-      COMMAND_CASE_A(   "wave_ms", Command_GPIO_Wave_Ms, 4);    // GPIO.h
-      COMMAND_CASE_A(   "wave_us", Command_GPIO_Wave_usec, 4);    // GPIO.h
-#endif
-
       #ifndef LIMIT_BUILD_SIZE
       COMMAND_CASE_R("wdconfig", Command_WD_Config, 3);               // WD.h
       COMMAND_CASE_R(  "wdread", Command_WD_Read,   2);               // WD.h

--- a/src/src/Commands/InternalCommands.cpp
+++ b/src/src/Commands/InternalCommands.cpp
@@ -333,8 +333,8 @@ bool executeInternalCommand(command_case_data & data)
       COMMAND_CASE_A(       "logentry", Command_logentry,         -1); // Diagnostic.h
       COMMAND_CASE_A(   "looptimerset", Command_Loop_Timer_Set,    3); // Timers.h
       COMMAND_CASE_A("looptimerset_ms", Command_Loop_Timer_Set_ms, 3); // Timers.h
-      COMMAND_CASE_A(      "longpulse", Command_GPIO_LongPulse,    3);    // GPIO.h
-      COMMAND_CASE_A(   "longpulse_ms", Command_GPIO_LongPulse_Ms, 3);    // GPIO.h
+      COMMAND_CASE_A(      "longpulse", Command_GPIO_LongPulse,    5);    // GPIO.h
+      COMMAND_CASE_A(   "longpulse_ms", Command_GPIO_LongPulse_Ms, 5);    // GPIO.h
     #ifndef BUILD_NO_DIAGNOSTIC_COMMANDS
       COMMAND_CASE_A(  "logportstatus", Command_logPortStatus,     0); // Diagnostic.h
       COMMAND_CASE_A(         "lowmem", Command_Lowmem,            0); // Diagnostic.h
@@ -482,6 +482,11 @@ bool executeInternalCommand(command_case_data & data)
       break;
     }
     case 'w': {
+#ifdef ESP8266
+      COMMAND_CASE_A(   "wave_ms", Command_GPIO_Wave_Ms, 4);    // GPIO.h
+      COMMAND_CASE_A(   "wave_us", Command_GPIO_Wave_usec, 4);    // GPIO.h
+#endif
+
       #ifndef LIMIT_BUILD_SIZE
       COMMAND_CASE_R("wdconfig", Command_WD_Config, 3);               // WD.h
       COMMAND_CASE_R(  "wdread", Command_WD_Read,   2);               // WD.h

--- a/src/src/ESPEasyCore/ESPEasyGPIO.cpp
+++ b/src/src/ESPEasyCore/ESPEasyGPIO.cpp
@@ -541,6 +541,9 @@ bool GPIO_Write(pluginID_t pluginID, int port, uint8_t value, uint8_t pinMode)
     default:
       success=false;
   }
+  if (success) {
+    Scheduler.clearGPIOTimer(pluginID, port);
+  }
   return success;
 }
 

--- a/src/src/Helpers/Scheduler.cpp
+++ b/src/src/Helpers/Scheduler.cpp
@@ -971,8 +971,6 @@ void ESPEasy_Scheduler::process_gpio_timer(unsigned long id, unsigned long lastt
     setNextTimeInterval(newTimer, it->second.getInterval());
     setNewTimerAt(mixedTimerId, newTimer);
     it->second.markNextRecurring();
-  } else {
-    systemTimers.erase(mixedTimerId);
   }
 
   uint8_t GPIOType      = static_cast<uint8_t>((id) & 0xFF);
@@ -1004,6 +1002,9 @@ void ESPEasy_Scheduler::process_gpio_timer(unsigned long id, unsigned long lastt
   }
 
 
+  if (!it->second.isRecurring()) {
+    Scheduler.clearGPIOTimer(pluginID, pinNumber);
+  }
 
   const uint32_t key = createKey(pluginID, pinNumber);
 

--- a/src/src/Helpers/Scheduler.cpp
+++ b/src/src/Helpers/Scheduler.cpp
@@ -297,7 +297,7 @@ void ESPEasy_Scheduler::handle_schedule() {
       process_task_device_timer(id, timer);
       break;
     case SchedulerTimerType_e::GPIO_timer:
-      process_gpio_timer(id);
+      process_gpio_timer(id, timer);
       break;
 
     case SchedulerTimerType_e::SystemEventQueue:
@@ -887,7 +887,13 @@ unsigned long ESPEasy_Scheduler::createGPIOTimerId(uint8_t GPIOType, uint8_t pin
   return mixed & mask;
 }
 
-void ESPEasy_Scheduler::setGPIOTimer(unsigned long msecFromNow, pluginID_t pluginID, int Par1, int Par2, int Par3, int Par4, int Par5)
+void ESPEasy_Scheduler::setGPIOTimer(
+  unsigned long msecFromNow, 
+  pluginID_t pluginID, 
+  int        pinnr,
+  int        state,
+  int        repeatInterval,
+  int        recurringCount)
 {
   uint8_t GPIOType = GPIO_TYPE_INVALID;
 
@@ -905,12 +911,70 @@ void ESPEasy_Scheduler::setGPIOTimer(unsigned long msecFromNow, pluginID_t plugi
 
   if (GPIOType != GPIO_TYPE_INVALID) {
     // Par1 & Par2 & GPIOType form a unique key
-    const unsigned long mixedTimerId = getMixedId(SchedulerTimerType_e::GPIO_timer, createGPIOTimerId(GPIOType, Par1, Par2));
+    const unsigned long mixedTimerId = getMixedId(
+      SchedulerTimerType_e::GPIO_timer, 
+      createGPIOTimerId(GPIOType, pinnr, state));
+
+    const systemTimerStruct timer_data(
+      recurringCount, 
+      repeatInterval, 
+      state);
+    systemTimers[mixedTimerId] = timer_data;
     setNewTimerAt(mixedTimerId, millis() + msecFromNow);
   }
 }
 
-void ESPEasy_Scheduler::process_gpio_timer(unsigned long id) {
+void ESPEasy_Scheduler::clearGPIOTimer(pluginID_t pluginID, int pinnr)
+{
+  uint8_t GPIOType = GPIO_TYPE_INVALID;
+
+  switch (pluginID) {
+    case PLUGIN_GPIO:
+      GPIOType = GPIO_TYPE_INTERNAL;
+      break;
+    case PLUGIN_PCF:
+      GPIOType = GPIO_TYPE_PCF;
+      break;
+    case PLUGIN_MCP:
+      GPIOType = GPIO_TYPE_MCP;
+      break;
+  }
+
+  if (GPIOType != GPIO_TYPE_INVALID) {
+    // Par1 & Par2 & GPIOType form a unique key
+    for (int state = 0; state <= 1; ++state) {
+      const unsigned long mixedTimerId = getMixedId(
+        SchedulerTimerType_e::GPIO_timer, 
+        createGPIOTimerId(GPIOType, pinnr, state));
+      auto it = systemTimers.find(mixedTimerId);
+      if (it != systemTimers.end()) {
+        systemTimers.erase(it);
+      }
+      msecTimerHandler.remove(mixedTimerId);
+    }
+  }
+}
+
+void ESPEasy_Scheduler::process_gpio_timer(unsigned long id, unsigned long lasttimer) {
+ const unsigned long mixedTimerId = getMixedId(
+    SchedulerTimerType_e::GPIO_timer, id);
+
+  auto it = systemTimers.find(mixedTimerId);
+  if (it == systemTimers.end()) {
+    return;
+  }
+
+  // Reschedule before sending the event, as it may get rescheduled in handling the timer event.
+  if (it->second.isRecurring()) {
+    // Recurring timer
+    unsigned long newTimer = lasttimer;
+    setNextTimeInterval(newTimer, it->second.getInterval());
+    setNewTimerAt(mixedTimerId, newTimer);
+    it->second.markNextRecurring();
+  } else {
+    systemTimers.erase(mixedTimerId);
+  }
+
   uint8_t GPIOType      = static_cast<uint8_t>((id) & 0xFF);
   uint8_t pinNumber     = static_cast<uint8_t>((id >> 8) & 0xFF);
   uint8_t pinStateValue = static_cast<uint8_t>((id >> 16) & 0xFF);
@@ -938,6 +1002,8 @@ void ESPEasy_Scheduler::process_gpio_timer(unsigned long id) {
     default:
       return;
   }
+
+
 
   const uint32_t key = createKey(pluginID, pinNumber);
 

--- a/src/src/Helpers/Scheduler.h
+++ b/src/src/Helpers/Scheduler.h
@@ -214,13 +214,14 @@ public:
 
   void setGPIOTimer(unsigned long msecFromNow,
                     pluginID_t    pluginID,
-                    int           Par1,
-                    int           Par2 = 0,
-                    int           Par3 = 0,
-                    int           Par4 = 0,
-                    int           Par5 = 0);
+                    int           pinnr,
+                    int           state = 0,
+                    int           repeatInterval = 0,
+                    int           recurringCount = 0);
 
-  void process_gpio_timer(unsigned long id);
+  void clearGPIOTimer(pluginID_t pluginID, int pinnr);
+
+  void process_gpio_timer(unsigned long id, unsigned long lasttimer);
 
   /*********************************************************************************************\
   * Task Device Timer

--- a/src/src/Helpers/msecTimerHandlerStruct.cpp
+++ b/src/src/Helpers/msecTimerHandlerStruct.cpp
@@ -23,6 +23,11 @@
     insert(item);
   }
 
+  void msecTimerHandlerStruct::remove(unsigned long id) {
+    timer_id_couple item(id, 0);
+    remove(item);
+  }
+
   // Check if timeout has been reached and also return its set timer.
   // Return 0 if no item has reached timeout moment.
   unsigned long msecTimerHandlerStruct::getNextId(unsigned long& timer) {
@@ -131,6 +136,13 @@
     // It should be a relative light operation, to insert into a sorted list.
     // Perhaps it is better to use std::set ????
     // Keep in mind: order is based on timer, uniqueness is based on id.
+  }
+
+  void msecTimerHandlerStruct::remove(const timer_id_couple& item) {
+    if (item._id == 0) { return; }
+
+    // Make sure only one is present with the same id.
+    _timer_ids.remove_if(match_id(item._id));
   }
 
   void msecTimerHandlerStruct::recordIdle() {

--- a/src/src/Helpers/msecTimerHandlerStruct.h
+++ b/src/src/Helpers/msecTimerHandlerStruct.h
@@ -16,6 +16,8 @@ struct msecTimerHandlerStruct {
   void registerAt(unsigned long id,
                   unsigned long timer);
 
+  void remove(unsigned long id);
+
   // Check if timeout has been reached and also return its set timer.
   // Return 0 if no item has reached timeout moment.
   unsigned long getNextId(unsigned long& timer);
@@ -34,6 +36,8 @@ struct msecTimerHandlerStruct {
 private:
 
   void insert(const timer_id_couple& item);
+
+  void remove(const timer_id_couple& item);
 
   void recordIdle();
 


### PR DESCRIPTION
ESP8266 does support sending a "wave form" with quite accurate timings.
It allows timings upto 15+ seconds "high" and "low" timings including some set repeat option.

These accurate timing functions are not present for ESP32.
But the ESPEasy scheduler can still achieve quite accurate timings, depending on the system load.

The `longpulse` and `longpulse_ms` commands now have optionally 2 extra parameters, to allow for low frequency PWM which was not possible with the normal PWM commands.
For example blinking a LED at 0.5 Hz is now a single command without the need for a looptimer in rules.

Emulating some power meter over S0 is now also a single command in rules.