### PR TITLE
[Various] Check Arduino OTA setting, increase max. plugin count

### DIFF
--- a/boards/esp32c3.json
+++ b/boards/esp32c3.json
@@ -5,7 +5,7 @@
       "memory_type": "dio_qspi"
     },
     "core": "esp32",
-    "extra_flags": "-DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_4M -DESP32C3",
+    "extra_flags": "-DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_4M -DESP32C3 -DCONFIG_IDF_TARGET_ESP32C3=1",
     "f_cpu": "160000000L",
     "f_flash": "80000000L",
     "flash_mode": "dio",

--- a/boards/esp32c3.json
+++ b/boards/esp32c3.json
@@ -5,7 +5,7 @@
       "memory_type": "dio_qspi"
     },
     "core": "esp32",
-    "extra_flags": "-DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_4M -DESP32C3 -DCONFIG_IDF_TARGET_ESP32C3=1",
+    "extra_flags": "-DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_4M -DESP32C3 -DESP_IDF_VERSION_MAJOR=4 -DCONFIG_IDF_TARGET_ESP32C3=1",
     "f_cpu": "160000000L",
     "f_flash": "80000000L",
     "flash_mode": "dio",

--- a/boards/esp32c3.json
+++ b/boards/esp32c3.json
@@ -5,7 +5,7 @@
       "memory_type": "dio_qspi"
     },
     "core": "esp32",
-    "extra_flags": "-DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_4M -DESP32C3 -DESP_IDF_VERSION_MAJOR=4 -DCONFIG_IDF_TARGET_ESP32C3=1",
+    "extra_flags": "-DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_4M -DESP32C3 -DCONFIG_IDF_TARGET_ESP32C3=1",
     "f_cpu": "160000000L",
     "f_flash": "80000000L",
     "flash_mode": "dio",

--- a/boards/esp32s2.json
+++ b/boards/esp32s2.json
@@ -5,7 +5,7 @@
       "memory_type": "dio_qspi"
     },
     "core": "esp32",
-    "extra_flags": "-DBOARD_HAS_PSRAM -DESP32_4M -DESP32S2 -DESP_IDF_VERSION_MAJOR=4 -DCONFIG_IDF_TARGET_ESP32S2=1",
+    "extra_flags": "-DBOARD_HAS_PSRAM -DESP32_4M -DESP32S2 -DCONFIG_IDF_TARGET_ESP32S2=1",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
     "flash_mode": "dio",

--- a/boards/esp32s2.json
+++ b/boards/esp32s2.json
@@ -5,7 +5,7 @@
       "memory_type": "dio_qspi"
     },
     "core": "esp32",
-    "extra_flags": "-DBOARD_HAS_PSRAM -DESP32_4M -DESP32S2",
+    "extra_flags": "-DBOARD_HAS_PSRAM -DESP32_4M -DESP32S2 -DCONFIG_IDF_TARGET_ESP32S2=1",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
     "flash_mode": "dio",

--- a/boards/esp32s2.json
+++ b/boards/esp32s2.json
@@ -5,7 +5,7 @@
       "memory_type": "dio_qspi"
     },
     "core": "esp32",
-    "extra_flags": "-DBOARD_HAS_PSRAM -DESP32_4M -DESP32S2 -DCONFIG_IDF_TARGET_ESP32S2=1",
+    "extra_flags": "-DBOARD_HAS_PSRAM -DESP32_4M -DESP32S2 -DESP_IDF_VERSION_MAJOR=4 -DCONFIG_IDF_TARGET_ESP32S2=1",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
     "flash_mode": "dio",

--- a/platformio_core_defs.ini
+++ b/platformio_core_defs.ini
@@ -234,6 +234,7 @@ platform                    = https://github.com/Jason2866/platform-espressif32.
 platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/938/framework-arduinoespressif32-443_esp421-10ab11e815.tar.gz
 
 build_flags                 = -DESP32_STAGE
+                              -DESP_IDF_VERSION_MAJOR=4
                               -DMUSTFIX_CLIENT_TIMEOUT_IN_SECONDS
                               -DLIBRARIES_NO_LOG=1
                               -I$PROJECT_DIR/src/include
@@ -244,6 +245,7 @@ build_flags                 = -DESP32_STAGE
 platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.4.1/platform-espressif32-2.0.4.1.zip
 platform_packages           = 
 build_flags                 = -DESP32_STAGE
+                              -DESP_IDF_VERSION_MAJOR=4
                               -DMUSTFIX_CLIENT_TIMEOUT_IN_SECONDS
                               -DLIBRARIES_NO_LOG=1
                               -I$PROJECT_DIR/src/include

--- a/platformio_core_defs.ini
+++ b/platformio_core_defs.ini
@@ -221,7 +221,7 @@ build_flags               = ${esp82xx_3_0_x.build_flags}
 ; IDF 4.4 = platform-espressif32 3.4.x = espressif/arduino-esp32 tag 2.0.4
 ; Just for those who lost track of the extremely confusing numbering schema.
 ; For MUSTFIX_CLIENT_TIMEOUT_IN_SECONDS See: https://github.com/espressif/arduino-esp32/pull/6676
-[core_esp32_IDF4_4__2_0_4]
+[core_esp32_IDF4_4__2_0_5]
 ;platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.4.1/platform-espressif32-2.0.4.1.zip
 
 ; debug boot log enabled
@@ -230,8 +230,11 @@ build_flags               = ${esp82xx_3_0_x.build_flags}
 ;platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/936/framework-arduinoespressif32-443_esp421-9ce849ce72.tar.gz
 
 ; debug boot log disabled
-platform                    = https://github.com/Jason2866/platform-espressif32.git
-platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/938/framework-arduinoespressif32-443_esp421-10ab11e815.tar.gz
+;platform                    = https://github.com/Jason2866/platform-espressif32.git
+;platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/938/framework-arduinoespressif32-443_esp421-10ab11e815.tar.gz
+
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.5.1/platform-espressif32-2.0.5.1.zip
+platform_packages           =
 
 build_flags                 = -DESP32_STAGE
                               -DESP_IDF_VERSION_MAJOR=4

--- a/platformio_esp32_envs.ini
+++ b/platformio_esp32_envs.ini
@@ -17,7 +17,7 @@ lib_ignore                = ESP8266Ping
 
 
 [esp32_base]
-extends                   = common, core_esp32_IDF4_4__2_0_4
+extends                   = common, core_esp32_IDF4_4__2_0_5
 upload_speed              = 460800
 upload_before_reset       = default_reset
 upload_after_reset        = hard_reset
@@ -53,7 +53,7 @@ lib_deps                  =
 extra_scripts             = post:tools/pio/post_esp32.py
                             ${extra_scripts_default.extra_scripts}
 build_unflags             = -Wall
-build_flags               = ${core_esp32_IDF4_4__2_0_4.build_flags}
+build_flags               = ${core_esp32_IDF4_4__2_0_5.build_flags}
                             ${mqtt_flags.build_flags}
                             -DCONFIG_FREERTOS_ASSERT_DISABLE
                             -DCONFIG_LWIP_ESP_GRATUITOUS_ARP

--- a/src/src/CustomBuild/ESPEasyLimits.h
+++ b/src/src/CustomBuild/ESPEasyLimits.h
@@ -84,7 +84,7 @@
 #ifndef DEVICES_MAX
   // TODO TD-er: This should be set automatically by counting the number of included plugins.
   # ifdef ESP32
-    # define DEVICES_MAX                      130
+    # define DEVICES_MAX                      140
   #else
     #if defined(PLUGIN_BUILD_COLLECTION) || defined(PLUGIN_BUILD_DEV)
       #  define DEVICES_MAX                      95

--- a/src/src/CustomBuild/ESPEasyLimits.h
+++ b/src/src/CustomBuild/ESPEasyLimits.h
@@ -35,12 +35,12 @@
 
   #ifndef MAX_GPIO
     #if ESP_IDF_VERSION_MAJOR > 3       // IDF 4+
-      #if CONFIG_IDF_TARGET_ESP32       // ESP32/PICO-D4
-        #define MAX_GPIO  39
-      #elif CONFIG_IDF_TARGET_ESP32S2   // ESP32-S2
+      #if CONFIG_IDF_TARGET_ESP32S2     // ESP32-S2
         #define MAX_GPIO  46
       #elif CONFIG_IDF_TARGET_ESP32C3   // ESP32-C3
         // FIXME TD-er: Implement ESP32C3 support
+      #elif CONFIG_IDF_TARGET_ESP32     // ESP32/PICO-D4
+        #define MAX_GPIO  39
       #else
         #error Target CONFIG_IDF_TARGET is not supported
       #endif

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -1768,6 +1768,9 @@ To create/register a plugin, you have to :
   #ifndef SHOW_SYSINFO_JSON
     #define SHOW_SYSINFO_JSON 1
   #endif
+  #ifndef FEATURE_I2C_DEVICE_SCAN
+    #define FEATURE_I2C_DEVICE_SCAN   1
+  #endif
 
   // Plugins
   #ifndef USES_P016

--- a/src/src/ESPEasyCore/ESPEasy_setup.cpp
+++ b/src/src/ESPEasyCore/ESPEasy_setup.cpp
@@ -117,7 +117,7 @@ void ESPEasy_setup()
   psramInit();
 #endif
 
-#ifdef CONFIG_IDF_TARGET_ESP32
+#if CONFIG_IDF_TARGET_ESP32
   // restore GPIO16/17 if no PSRAM is found
   if (!FoundPSRAM()) {
     // test if the CPU is not pico
@@ -128,7 +128,7 @@ void ESPEasy_setup()
       gpio_reset_pin(GPIO_NUM_17);
     }
   }
-#endif  // CONFIG_IDF_TARGET_ESP32
+#endif  // if CONFIG_IDF_TARGET_ESP32
   initADC();
 #endif  // ESP32
 #ifndef BUILD_NO_RAM_TRACKER

--- a/src/src/ESPEasyCore/ESPEasy_setup.cpp
+++ b/src/src/ESPEasyCore/ESPEasy_setup.cpp
@@ -400,8 +400,9 @@ void ESPEasy_setup()
   logMemUsageAfter(F("PluginInit()"));
   #endif
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-    String log  = F("INFO : Plugins: ");
-    log += deviceCount + 1;
+    String log;
+    log.reserve(80);
+    log += concat(F("INFO : Plugins: "), deviceCount + 1);
     log += ' ';
     log += getPluginDescriptionString();
     log += F(" (");
@@ -411,7 +412,7 @@ void ESPEasy_setup()
   }
 
   if (deviceCount + 1 >= PLUGIN_MAX) {
-    addLog(LOG_LEVEL_ERROR, String(F("Programming error! - Increase PLUGIN_MAX (")) + deviceCount + ')');
+    addLog(LOG_LEVEL_ERROR, concat(F("Programming error! - Increase PLUGIN_MAX ("), deviceCount) + ')');
   }
 
   clearAllCaches();

--- a/src/src/Helpers/Hardware.cpp
+++ b/src/src/Helpers/Hardware.cpp
@@ -821,7 +821,7 @@ const __FlashStringHelper* getChipModel() {
   bool single_core = (1 == chip_info.cores);
 
   if (chip_model < 2) { // ESP32
-# ifdef CONFIG_IDF_TARGET_ESP32
+# if CONFIG_IDF_TARGET_ESP32
 
     /* esptool:
         def get_pkg_version(self):
@@ -864,7 +864,7 @@ const __FlashStringHelper* getChipModel() {
         return F("ESP32-PICO-V3-02");                    // Max 240MHz, Dual core, LGA 7*7, 8MB embedded flash, 2MB embedded PSRAM,
                                                          // ESP32-PICO-MINI-02, ESP32-PICO-DevKitM-2
     }
-# endif // CONFIG_IDF_TARGET_ESP32
+# endif // if CONFIG_IDF_TARGET_ESP32
     return F("ESP32");
   }
   else if (2 == chip_model) { // ESP32-S2
@@ -1070,7 +1070,7 @@ bool CanUsePSRAM() {
 # ifdef HAS_PSRAM_FIX
   return true;
 # endif // ifdef HAS_PSRAM_FIX
-# ifdef CONFIG_IDF_TARGET_ESP32
+# if CONFIG_IDF_TARGET_ESP32
   esp_chip_info_t chip_info;
   esp_chip_info(&chip_info);
 
@@ -1086,7 +1086,7 @@ bool CanUsePSRAM() {
   }
 #  endif // ESP_IDF_VERSION_MAJOR < 4
 
-# endif // CONFIG_IDF_TARGET_ESP32
+# endif // if CONFIG_IDF_TARGET_ESP32
   return true;
 }
 

--- a/src/src/Helpers/Hardware.cpp
+++ b/src/src/Helpers/Hardware.cpp
@@ -35,18 +35,18 @@
   # include <soc/rtc.h>
 
   # if ESP_IDF_VERSION_MAJOR > 3      // IDF 4+
-    #  if CONFIG_IDF_TARGET_ESP32     // ESP32/PICO-D4
-      #   include <esp32/rom/spi_flash.h>
-      #   include <esp32/spiram.h>
-    #  elif CONFIG_IDF_TARGET_ESP32S2 // ESP32-S2
+    #  if CONFIG_IDF_TARGET_ESP32S2   // ESP32-S2
       #   include <esp32s2/rom/spi_flash.h>
       #   include <esp32s2/spiram.h>
     #  elif CONFIG_IDF_TARGET_ESP32C3 // ESP32-C3
       #   include <esp32c3/rom/spi_flash.h>
       #   include <esp32c3/spiram.h>
-    #  else // if CONFIG_IDF_TARGET_ESP32
+    #  elif CONFIG_IDF_TARGET_ESP32   // ESP32/PICO-D4
+      #   include <esp32/rom/spi_flash.h>
+      #   include <esp32/spiram.h>
+    #  else // if CONFIG_IDF_TARGET_ESP32S2
       #   error Target CONFIG_IDF_TARGET is not supported
-    #  endif // if CONFIG_IDF_TARGET_ESP32
+    #  endif // if CONFIG_IDF_TARGET_ESP32S2
   # else // ESP32 Before IDF 4.0
     #  include <rom/spi_flash.h>
   # endif    // if ESP_IDF_VERSION_MAJOR > 3
@@ -666,20 +666,7 @@ const __FlashStringHelper* getFlashChipMode() {
   const uint32_t spi_ctrl = REG_READ(PERIPHS_SPI_FLASH_CTRL);
 
   # if ESP_IDF_VERSION_MAJOR > 3      // IDF 4+
-    #  if CONFIG_IDF_TARGET_ESP32     // ESP32/PICO-D4
-      if (spi_ctrl & SPI_FREAD_QIO) {  
-        return F("QIO");
-      } else if (spi_ctrl & SPI_FREAD_QUAD) { 
-        return F("QOUT");
-      } else if (spi_ctrl & SPI_FREAD_DIO) {
-        return F("DIO");
-      } else if (spi_ctrl & SPI_FREAD_DUAL) {
-        return F("DOUT");
-      } else if (spi_ctrl & SPI_FASTRD_MODE) {
-        return F("Fast");
-      }
-      return F("Slow");
-    #  elif CONFIG_IDF_TARGET_ESP32S2 // ESP32-S2
+    #  if CONFIG_IDF_TARGET_ESP32S2   // ESP32-S2
       if (spi_ctrl & SPI_FREAD_OCT) {  
         return F("OCT");
       } else if (spi_ctrl & SPI_FREAD_QUAD) { 
@@ -695,7 +682,20 @@ const __FlashStringHelper* getFlashChipMode() {
         return F("DIO");
       }
       return F("DOUT");
-    #  endif // if CONFIG_IDF_TARGET_ESP32
+    #  elif CONFIG_IDF_TARGET_ESP32   // ESP32/PICO-D4
+      if (spi_ctrl & SPI_FREAD_QIO) {  
+        return F("QIO");
+      } else if (spi_ctrl & SPI_FREAD_QUAD) { 
+        return F("QOUT");
+      } else if (spi_ctrl & SPI_FREAD_DIO) {
+        return F("DIO");
+      } else if (spi_ctrl & SPI_FREAD_DUAL) {
+        return F("DOUT");
+      } else if (spi_ctrl & SPI_FASTRD_MODE) {
+        return F("Fast");
+      }
+      return F("Slow");
+    #  endif // if CONFIG_IDF_TARGET_ESP32S2
   # else // ESP32 Before IDF 4.0
     if (spi_ctrl & (BIT(24))) {  
       return F("QIO");

--- a/src/src/Helpers/OTA.cpp
+++ b/src/src/Helpers/OTA.cpp
@@ -55,62 +55,64 @@ bool OTA_possible(uint32_t& maxSketchSize, bool& use2step) {
  \*********************************************************************************************/
 void ArduinoOTAInit()
 {
-  # ifndef BUILD_NO_RAM_TRACKER
-  checkRAM(F("ArduinoOTAInit"));
-  # endif // ifndef BUILD_NO_RAM_TRACKER
+  if (Settings.ArduinoOTAEnable) {
+    # ifndef BUILD_NO_RAM_TRACKER
+    checkRAM(F("ArduinoOTAInit"));
+    # endif // ifndef BUILD_NO_RAM_TRACKER
 
-  ArduinoOTA.setPort(ARDUINO_OTA_PORT);
-  ArduinoOTA.setHostname(Settings.getHostname().c_str());
+    ArduinoOTA.setPort(ARDUINO_OTA_PORT);
+    ArduinoOTA.setHostname(Settings.getHostname().c_str());
 
-  if (SecuritySettings.Password[0] != 0) {
-    ArduinoOTA.setPassword(SecuritySettings.Password);
-  }
-
-  ArduinoOTA.onStart([]() {
-    serialPrintln(F("OTA  : Start upload"));
-    ArduinoOTAtriggered = true;
-    ESPEASY_FS.end(); // important, otherwise it fails
-  });
-
-  ArduinoOTA.onEnd([]() {
-    serialPrintln(F("\nOTA  : End"));
-
-    // "dangerous": if you reset during flash you have to reflash via serial
-    // so dont touch device until restart is complete
-    serialPrintln(F("\nOTA  : DO NOT RESET OR POWER OFF UNTIL BOOT+FLASH IS COMPLETE."));
-
-    // delay(100);
-    // reboot(); //Not needed, node reboots automaticall after calling onEnd and succesfully flashing
-  });
-  ArduinoOTA.onProgress([](unsigned int progress, unsigned int total) {
-    if (Settings.UseSerial) {
-      Serial.printf("OTA  : Progress %u%%\r", (progress / (total / 100)));
+    if (SecuritySettings.Password[0] != 0) {
+      ArduinoOTA.setPassword(SecuritySettings.Password);
     }
-  });
 
-  ArduinoOTA.onError([](ota_error_t error) {
-    serialPrint(F("\nOTA  : Error (will reboot): "));
+    ArduinoOTA.onStart([]() {
+      serialPrintln(F("OTA  : Start upload"));
+      ArduinoOTAtriggered = true;
+      ESPEASY_FS.end(); // important, otherwise it fails
+    });
 
-    if (error == OTA_AUTH_ERROR) { serialPrintln(F("Auth Failed")); }
-    else if (error == OTA_BEGIN_ERROR) { serialPrintln(F("Begin Failed")); }
-    else if (error == OTA_CONNECT_ERROR) { serialPrintln(F("Connect Failed")); }
-    else if (error == OTA_RECEIVE_ERROR) { serialPrintln(F("Receive Failed")); }
-    else if (error == OTA_END_ERROR) { serialPrintln(F("End Failed")); }
+    ArduinoOTA.onEnd([]() {
+      serialPrintln(F("\nOTA  : End"));
 
-    delay(100);
-    reboot(ESPEasy_Scheduler::IntendedRebootReason_e::OTA_error);
-  });
+      // "dangerous": if you reset during flash you have to reflash via serial
+      // so dont touch device until restart is complete
+      serialPrintln(F("\nOTA  : DO NOT RESET OR POWER OFF UNTIL BOOT+FLASH IS COMPLETE."));
 
-  #if defined(ESP8266) && FEATURE_MDNS
-  ArduinoOTA.begin(true);
-  #else
-  ArduinoOTA.begin();
-  #endif
+      // delay(100);
+      // reboot(); //Not needed, node reboots automaticall after calling onEnd and succesfully flashing
+    });
+    ArduinoOTA.onProgress([](unsigned int progress, unsigned int total) {
+      if (Settings.UseSerial) {
+        Serial.printf("OTA  : Progress %u%%\r", (progress / (total / 100)));
+      }
+    });
 
-  if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-    String log = F("OTA  : Arduino OTA enabled on port ");
-    log += ARDUINO_OTA_PORT;
-    addLogMove(LOG_LEVEL_INFO, log);
+    ArduinoOTA.onError([](ota_error_t error) {
+      serialPrint(F("\nOTA  : Error (will reboot): "));
+
+      if (error == OTA_AUTH_ERROR) { serialPrintln(F("Auth Failed")); }
+      else if (error == OTA_BEGIN_ERROR) { serialPrintln(F("Begin Failed")); }
+      else if (error == OTA_CONNECT_ERROR) { serialPrintln(F("Connect Failed")); }
+      else if (error == OTA_RECEIVE_ERROR) { serialPrintln(F("Receive Failed")); }
+      else if (error == OTA_END_ERROR) { serialPrintln(F("End Failed")); }
+
+      delay(100);
+      reboot(ESPEasy_Scheduler::IntendedRebootReason_e::OTA_error);
+    });
+
+    #if defined(ESP8266) && FEATURE_MDNS
+    ArduinoOTA.begin(true);
+    #else
+    ArduinoOTA.begin();
+    #endif
+
+    if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+      String log = F("OTA  : Arduino OTA enabled on port ");
+      log += ARDUINO_OTA_PORT;
+      addLogMove(LOG_LEVEL_INFO, log);
+    }
   }
 }
 

--- a/src/src/Helpers/StringGenerator_GPIO.cpp
+++ b/src/src/Helpers/StringGenerator_GPIO.cpp
@@ -159,6 +159,7 @@ const __FlashStringHelper* getConflictingUse(int gpio, PinSelectPurpose purpose)
       includeI2C = false;
       break;
     case PinSelectPurpose::SPI:
+    case PinSelectPurpose::SPI_MISO:
       includeSPI = false;
       break;
     case PinSelectPurpose::Ethernet:

--- a/src/src/Helpers/StringGenerator_GPIO.h
+++ b/src/src/Helpers/StringGenerator_GPIO.h
@@ -24,6 +24,7 @@ enum class PinSelectPurpose {
   Generic_bidir,
   I2C,
   SPI,
+  SPI_MISO,
   Ethernet
 
 };

--- a/src/src/Helpers/StringGenerator_System.cpp
+++ b/src/src/Helpers/StringGenerator_System.cpp
@@ -125,16 +125,16 @@ String getResetReasonString(uint8_t icore) {
 
 /*
   switch (reason) {
-  #if CONFIG_IDF_TARGET_ESP32
-    case POWERON_RESET:
-    case SW_CPU_RESET:
-    case DEEPSLEEP_RESET:
-    case SW_RESET:
-  #elif CONFIG_IDF_TARGET_ESP32S2
+  #if CONFIG_IDF_TARGET_ESP32S2
     case POWERON_RESET:
     case RTC_SW_CPU_RESET:
     case DEEPSLEEP_RESET:
     case RTC_SW_SYS_RESET:
+  #elif CONFIG_IDF_TARGET_ESP32
+    case POWERON_RESET:
+    case SW_CPU_RESET:
+    case DEEPSLEEP_RESET:
+    case SW_RESET:
   #endif
   }
 */

--- a/src/src/WebServer/DevicesPage.cpp
+++ b/src/src/WebServer/DevicesPage.cpp
@@ -1073,7 +1073,14 @@ void devicePage_show_pin_config(taskIndex_t taskIndex, deviceIndex_t DeviceIndex
     }
 
     if (Device[DeviceIndex].usesTaskDevicePin(3)) {
-      addFormPinSelect(PinSelectPurpose::Generic, TempEvent.String3, F("taskdevicepin3"), Settings.TaskDevicePin3[taskIndex]);
+      PinSelectPurpose purpose = PinSelectPurpose::Generic;
+
+      if (Device[DeviceIndex].isSPI())
+      {
+        // SPI only needs output pins
+        purpose = PinSelectPurpose::Generic_output;
+      }
+      addFormPinSelect(purpose, TempEvent.String3, F("taskdevicepin3"), Settings.TaskDevicePin3[taskIndex]);
     }
   }
 }

--- a/src/src/WebServer/HardwarePage.cpp
+++ b/src/src/WebServer/HardwarePage.cpp
@@ -185,7 +185,7 @@ void handle_hardware() {
     addFormSelector_script(F("Init SPI"), F("initspi"), 4, spi_options, spi_index, nullptr, Settings.InitSPI, F("spiOptionChanged(this)"));
     // User-defined pins
     addFormPinSelect(PinSelectPurpose::SPI, formatGpioName_output(F("CLK")),  F("spipinsclk"), Settings.SPI_SCLK_pin);
-    addFormPinSelect(PinSelectPurpose::SPI, formatGpioName_input(F("MISO")),  F("spipinmiso"), Settings.SPI_MISO_pin);
+    addFormPinSelect(PinSelectPurpose::SPI_MISO, formatGpioName_input(F("MISO")),  F("spipinmiso"), Settings.SPI_MISO_pin);
     addFormPinSelect(PinSelectPurpose::SPI, formatGpioName_output(F("MOSI")), F("spipinmosi"), Settings.SPI_MOSI_pin);
     html_add_script(F("document.getElementById('initspi').onchange();"), false); // Initial trigger onchange script
     addFormNote(F("Changing SPI settings requires to press the hardware-reset button or power off-on!"));

--- a/src/src/WebServer/I2C_Scanner.cpp
+++ b/src/src/WebServer/I2C_Scanner.cpp
@@ -219,20 +219,20 @@ String getKnownI2Cdevice(uint8_t address) {
       result +=  F("MAX1704x");
       break;
     case 0x38:
-      result +=  F("PCF8574A,AHT10/20/21");
+      result +=  F("LCD,PCF8574A,AHT10/20/21,VEML6070");
       break;
     case 0x3A:
     case 0x3B:
     case 0x3E:
     case 0x3F:
-      result +=  F("PCF8574A");
+      result +=  F("LCD,PCF8574A");
       break;
     case 0x39:
-      result +=  F("PCF8574A,TSL2561,APDS9960,AHT10");
+      result +=  F("LCD,PCF8574A,TSL2561,APDS9960,AHT10");
       break;
     case 0x3C:
     case 0x3D:
-      result +=  F("PCF8574A,OLED");
+      result +=  F("LCD,PCF8574A,OLED");
       break;
     case 0x40:
       result +=  F("SI7021,HTU21D,INA219,PCA9685,HDC1080");
@@ -299,7 +299,7 @@ String getKnownI2Cdevice(uint8_t address) {
       result += F("Atlas EZO EC");
       break;
     case 0x68:
-      result +=  F("DS1307,DS3231,PCF8523,ITG3205,CDM7160");
+      result +=  F("MPU6050,DS1307,DS3231,PCF8523,ITG3205,CDM7160");
       break;
     case 0x69:
       result +=  F("ITG3205,CDM7160");

--- a/src/src/WebServer/Markup.cpp
+++ b/src/src/WebServer/Markup.cpp
@@ -280,7 +280,11 @@ void addPinSelector_Item(PinSelectPurpose purpose, const String& gpio_label, int
 
       switch (purpose) {
         case PinSelectPurpose::SPI:
+        case PinSelectPurpose::SPI_MISO:
           includeSPI = false;
+          if (purpose == PinSelectPurpose::SPI && !output) {
+            return;
+          }
           break;
         case PinSelectPurpose::Ethernet:
           #if FEATURE_ETHERNET


### PR DESCRIPTION
Features/improvements:
- Initialize Arduino OTA only when enabled in Advanced settings page
- Increase max. number of plugins to allow all in MAX builds (140)
- Logging improvements
- Enable I2C Device scan for MAX builds
- Updated I2C scanner with some missing devices
- [P039] Allow GPIO-0 (D3 on NodeMCU/Wemos boards) to be used for CS (Bugfix)
- [Boards] Additional IDF flag for ESP32s2 and, currently unsupported ESP32c3, boards to get correct hardware configuration
- [SPI] 3rd SPI GPIO pin should be output only (and not Generic = Input/Output)
- [SPI] User-defined pin selection allows correct input/output pins only (Hardware page)
- [ESP32] Use patched 2.0.5.1 framework-arduinoespressif32

Resolves: #4312 

TODO:
- [x] Check if Arduino OTA should be enabled by default -> No.
- [x] More small improvements and bugfixes