### PR TITLE
[Docs] Add rules example for a b-tree search on a list of Tags

### DIFF
--- a/docs/source/Rules/Rules.rst
+++ b/docs/source/Rules/Rules.rst
@@ -2056,5 +2056,132 @@ Therefore the ``asyncevent`` is used to append the events to a queue.
 This can be made much more dynamic as you may trigger a ``taskrun``, which will send an event when new values are read.
 Like this it is possible to automate a complex sequence of steps as not only GPIO pins can be stored, but also task indices.
 
+Validate a RFID tag against a sorted list
+-----------------------------------------
+
+For validating the Tag value, scanned using a RFID reader, it is quite time-consuming to check all, possibly hundreds, values.
+
+To speed up the search process, a b-tree search is much more efficient to find a match.
+
+The pre-requisites are:
+
+* A sorted list of accepted tag numbers
+* Enough memory to store the list
+* Configure "Serial Log Level" to ``Error`` (Tools/Advanced page) (logging is quite time-consuming, the script will log minimally on Error level)
+
+Storing a larger number of variables requires quite some memory so the use of an ESP32 is advised for larger tag-lists, 300 tags will need over 5 kB of RAM, and that could be problematic on an ESP8266, up to 100 tags should be achievable on an ESP8266 though.
+
+The list can be initialized calling the ``loadData`` event from ``On System#Boot Do``. This ``loadData`` event should be placed separately in the ``Rules Set 2`` file (or Rules Set 3 or Rules Set 4 if the other file is already used).
+
+.. code-block:: text
+
+  On loadData Do // Sorted by value
+    Let,1000,12345678
+    Let,1001,12345679
+    ....
+    Let,1300,34567890
+
+    Let,999,1300 // The last index used for storing a key (the upper limit for searching)
+  Endon
+
+This will initialize the list. A script can best be used to generate this list, as the values **must** be in sorted order from lowest to highest. Variables numbering is started at 1000, to leave lower numbers available for other script parts. Variable 999 is set to the highest variable number used, and variables 997 and 998 are used internally.
+
+NB: Despite a possible complaint that the filesize exceeds the web editor limit, this will work without problems, assuming a stable WiFi connection.
+
+The next script should be placed at the top of ``Rules Set 1`` as they are called quite often, rules processing starts from Rules Set 1, and stops when the first instance of a rule is handled.
+
+.. code-block:: text
+
+  On checkID Do
+    // %eventvalue1% = key
+    // %eventvalue2% = lower limit index
+    // %eventvalue3% = upper limit index
+    Let,997,(%eventvalue2%+%eventvalue3%)/2 // Compute "middle" index
+    Let,998,[int#997]+1
+    // [int#%v997%] is the key in the middle of our search range
+    
+    If %eventvalue1% = [int#%v997%] or %eventvalue1% = [int#%v998%] 
+      // Found it
+      Event,OkTag=%eventvalue1%
+    Else
+      If %eventvalue2%=%eventvalue3%
+        // Upper and lower limit are the same
+        // So we have not found the key
+        // No need to continue searching
+      Else
+        // When refering to an index, make sure to use the [int#<n>] notation, not the floating point version.
+        If %eventvalue1% > [int#%v997%]
+          // Check upper half
+          Asyncevent,checkID=%eventvalue1%,[int#997],%eventvalue3%
+        Else
+          // Check lower half
+          Asyncevent,checkID=%eventvalue1%,%eventvalue2%,[int#997]
+        Endif
+      Endif
+    Endif
+  Endon
+
+  On Turnstile_out#Tag Do // Out-going reader
+    If [Turnstile_out#Tag]>0
+      Event,readet=[Turnstile_out#Tag]
+    Endif
+  Endon
+
+  On Turnstile_in#Tag Do // Incoming reader
+    If [Turnstile_in#Tag]>0
+      Event,readet=[Turnstile_in#Tag]
+    Endif
+  Endon
+
+  On readet Do // Valid tag value, now check if accepted
+    // %eventvalue1% = key
+    // 1000  = Lower limit
+    // [int#999] = upper limit
+    Asyncevent,checkID=%eventvalue1%,1000,[int#999]
+  Endon
+
+  On OkTag Do // Matching tag found
+    LogEntry,'Tag %eventvalue1% OK',1 // ERROR log
+    LongPulse,25,0,2 // Activate door-opener on GPIO-25, active low, for 2 seconds
+  Endon
+
+  On System#Boot Do
+    Asyncevent,loadData // Load the sorted tag data
+  Endon
+
+Processing a single tag takes ca. 300 to 500 msec on an ESP32 on a list of ca. 256 tags. For for every *duplication* of the number of tags, an extra 20 to 25 msec is needed for processing.
+
+To find a match, on a list of ca. 256 tags, at most 10 asyncevent calls to checkID will be needed, max. 11 calls when having 512 tags, 12 calls for 1024 tags, etc. But then, the used amount of memory could become somewhat problematic...
+
+To process a list of tags into an ``On loadData Do`` event rule, this small python script can be used.
+
+It will read from file ``tags.txt`` and write to file ``loaddata.txt``:
+
+.. code-block:: python
+
+  # Process file tags.txt to an ESPEasy On loadData Do event
+
+  t = open('tags.txt','r')
+  tags = t.readlines()
+  tags.sort()
+
+  let = 1000
+
+  with open('loaddata.txt','w') as r:
+    r.write('On loadData Do // Sorted by value. Should be loaded from System#Boot event or reloaded manually using command: Asyncevent,loadData\n')
+
+    for rtag in tags:
+      tag = rtag.strip()
+      if tag.isnumeric() and int(tag) > 0: # Ignore non-numeric values, f.e. comments
+        r.write('  Let,')
+        r.write(str(let))
+        r.write(',')
+        r.write(tag)
+        r.write('\n')
+        let = let + 1
+    r.write('\n  Let,999,')
+    r.write(str(let - 1))
+    r.write(' // Last index used\n')
+    r.write('Endon\n')
 
 


### PR DESCRIPTION
After a [request on the forum](https://www.letscontrolit.com/forum/viewtopic.php?t=9314#p60461), TD-er created a nice rules-script for matching a RFID tag on a (sorted) list of tags, using a B-tree search.
This is now turned into a documentation example, for others to use too.

Features:
- Documentation update