### PR TITLE
[GPS] Fix set system time via GPS

### DIFF
--- a/lib/TinyGPSPlus-1.0.2/src/TinyGPS++.cpp
+++ b/lib/TinyGPSPlus-1.0.2/src/TinyGPS++.cpp
@@ -537,18 +537,14 @@ void TinyGPSDate::commit()
 
 void TinyGPSTime::commit()
 {
+   const uint32_t oldtime = time;
    time = newTime;
+   if (second() > 60 || minute() > 59 || hour() > 23) {
+     valid = false;
+     time = oldtime;
+     return;
+   }
    lastCommitTime = millis();
-   valid = false;
-   if (second() > 60) {
-     return;
-   }
-   if (minute() > 59) {
-     return;
-   }
-   if (hour() > 23) {
-     return;
-   }
    updated = true;
    valid = true;
 }

--- a/src/src/PluginStructs/P082_data_struct.cpp
+++ b/src/src/PluginStructs/P082_data_struct.cpp
@@ -185,6 +185,22 @@ bool P082_data_struct::loop() {
           if (available == 0) {
             available = easySerial->available();
           }
+          if (c == '$') {
+            _start_prev_sentence = _start_sentence;
+            _start_sentence = millis();
+            const unsigned long baudrate = easySerial->getBaudRate();
+            if (baudrate != 0) {
+              // Subtract the time (msec) taken to send the nr of bytes present in the serial buffer
+              // Assume 10 bits per byte. (8N1)
+              _start_sentence -= (available * 10000) / baudrate;
+            }
+            const int32_t max_sentence_duration = (160 * 10000) / baudrate;
+            if (timeDiff(_start_prev_sentence, _start_sentence) > max_sentence_duration) {
+              _start_sequence = _start_sentence;
+              // Debug accuracy of computing the time stability
+//              addLog(LOG_LEVEL_INFO, concat(F("GPS  : Start Sequence: "), _start_sequence));
+            }
+          }
         }
       }
     }
@@ -226,8 +242,17 @@ double P082_data_struct::distanceSinceLast(unsigned int maxAge_msec) {
 // Return the GPS time stamp, which is in UTC.
 // @param age is the time in msec since the last update of the time +
 // additional centiseconds given by the GPS.
-bool P082_data_struct::getDateTime(struct tm& dateTime, uint32_t& age, bool& pps_sync) {
+bool P082_data_struct::getDateTime(
+    struct tm& dateTime, 
+    uint32_t& age, 
+    bool& updated,
+    bool& pps_sync) {
+  updated = false;
   if (!isInitialized()) {
+    return false;
+  }
+
+  if (!gps->time.isUpdated() || !gps->date.isUpdated()) {
     return false;
   }
 
@@ -236,7 +261,7 @@ bool P082_data_struct::getDateTime(struct tm& dateTime, uint32_t& age, bool& pps
     _pps_time = 0;
     pps_sync = true;
 
-    if ((age > 1000) || (gps->time.age() > age)) {
+    if ((age > P082_TIMESTAMP_AGE) || (gps->time.age() > age)) {
       return false;
     }
   } else {
@@ -248,11 +273,20 @@ bool P082_data_struct::getDateTime(struct tm& dateTime, uint32_t& age, bool& pps
     return false;
   }
 
+  if (!gps->time.isUpdated() || !gps->date.isUpdated()) {
+    return false;
+  }
+
   if (gps->date.age() > P082_TIMESTAMP_AGE) {
     return false;
   }
 
-  if (!gps->date.isValid() || !gps->time.isValid()) {
+  if (!gps->time.isValid()) {
+    gps->time.value(); // Clear the 'updated' state
+    return false;
+  }
+  if (!gps->date.isValid()) {
+    gps->date.value(); // Clear the 'updated' state
     return false;
   }
   dateTime.tm_year = gps->date.year() - 1900;
@@ -263,10 +297,22 @@ bool P082_data_struct::getDateTime(struct tm& dateTime, uint32_t& age, bool& pps
   dateTime.tm_min  = gps->time.minute();
   dateTime.tm_sec  = gps->time.second();
 
+  const uint32_t reported_time = gps->time.value();
+  const uint32_t reported_date = gps->date.value();
+  updated = reported_time != _last_time;
+
+  _last_time = reported_time;
+  _last_date = reported_date;
   // FIXME TD-er: Must the offset in centisecond be added when pps_sync active?
   if (!pps_sync) {
+    // Don't use the "commit" time when the sentence was read, but use the timestamp when the first sentence of a NMEA sequence was received.
+    const long time_since_start_seq = timePassedSince(_start_sequence);
+    if (time_since_start_seq < P082_TIMESTAMP_AGE) {
+      age = time_since_start_seq;
+    }
     age += (gps->time.centisecond() * 10);
   }
+
   return true;
 }
 

--- a/src/src/PluginStructs/P082_data_struct.h
+++ b/src/src/PluginStructs/P082_data_struct.h
@@ -12,7 +12,7 @@
 //# define P082_USE_U_BLOX_SPECIFIC // TD-er: Disabled for now, as it is not working reliable/predictable
 #endif
 
-# define P082_TIMESTAMP_AGE       1500
+# define P082_TIMESTAMP_AGE       1000
 # define P082_DEFAULT_FIX_TIMEOUT 2500 // TTL of fix status in ms since last update
 
 
@@ -93,6 +93,7 @@ struct P082_data_struct : public PluginTaskData_base {
   // additional centiseconds given by the GPS.
   bool getDateTime(struct tm& dateTime,
                    uint32_t & age,
+                   bool     & updated,
                    bool     & pps_sync);
 
   // Send command to GPS to put it in PMREQ backup mode (UBLOX only)
@@ -136,6 +137,12 @@ public:
 
   unsigned long _pps_time         = 0;
   unsigned long _last_measurement = 0;
+  uint32_t _last_time = 0;
+  uint32_t _last_date = 0;
+  uint32_t _last_setSystemTime = 0;
+  uint32_t _start_sentence = 0;
+  uint32_t _start_prev_sentence = 0;
+  uint32_t _start_sequence = 0;
 # ifdef P082_SEND_GPS_TO_LOG
   String _lastSentence;
   String _currentSentence;


### PR DESCRIPTION
The GPS was setting the system time every second.
Also it was not checking to see if the time was changed, thus letting the system time "hop" around sometimes.

A typical GPS receiver does send several NMEA sentences containing the time/date in a sequence.
However these will probably contain the same timestamp, when set to 1 GPS sample/sec (some GPS modules can be configured to output position more often)
Thus the "second fraction" in the timestamp is then always the same (or 0) and you must rely on the time the first NMEA sentence was started.

A standard U-blox GPS module does send out all the sentences in a burst, thus only sending data for roughly 60% of the second cycle as can be seen from this logic analyzer output:
![image](https://user-images.githubusercontent.com/3751318/197900577-a97e803b-37e2-4ef0-a258-544aa8ee4f8d.png)

This allows us to trace back when the sentence was started, but more importantly when the "second" or "sequence of sentences" was started.
This start point of a "second" is important as it is actually the start of a new second.

By taking this into account, we can now get a way more [accurate and precise](https://danielmiessler.com/blog/difference-precision-accuracy/) time sync.
The best time sync is of course when using a GPS with PPS pin, but only relying on the serial transmission, this is about the best we can achieve.
