### PR TITLE
[PMSx003] Support I2C UART bridge on ESP32

### DIFF
--- a/lib/SC16IS752/SC16IS752.cpp
+++ b/lib/SC16IS752/SC16IS752.cpp
@@ -28,7 +28,7 @@
 
 #ifdef __AVR__
  # define WIRE Wire
-#elif ESP8266 // ESP8266
+#elif defined(ESP8266) || defined(ESP32) // ESP8266/ESP32
  # define WIRE Wire
 #else // Arduino Due
  # define WIRE Wire1

--- a/lib/SC16IS752/library.json
+++ b/lib/SC16IS752/library.json
@@ -1,6 +1,6 @@
 {
     "name": "SC16IS752",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "keywords": [
       "serial", "io", "sc16is752", "i2c", "uart"
     ],

--- a/platformio_esp32_envs.ini
+++ b/platformio_esp32_envs.ini
@@ -43,6 +43,7 @@ lib_deps                  =
                             ccronexpr
                             rlogiacco/CircularBuffer
                             td-er/ESPeasySerial @ 2.0.15
+                            td-er/SC16IS752 @ ^1.0.2
                             sparkfun/SparkFun MAX1704x Fuel Gauge Arduino Library @ ^1.0.3
                             ShiftRegister74HC595_NonTemplate
                             VL53L0X @ 1.3.0

--- a/platformio_esp82xx_base.ini
+++ b/platformio_esp82xx_base.ini
@@ -90,6 +90,7 @@ lib_deps                  =
                             bblanchon/ArduinoJson @ ^6.17.2
                             rlogiacco/CircularBuffer
                             td-er/ESPeasySerial @ 2.0.15
+                            td-er/SC16IS752 @ ^1.0.2
                             td-er/RABurton ESP8266 Mutex @ ^1.0.2
                             sparkfun/SparkFun MAX1704x Fuel Gauge Arduino Library @ ^1.0.3
                             VL53L0X @ 1.3.0

--- a/src/_P053_PMSx003.ino
+++ b/src/_P053_PMSx003.ino
@@ -350,6 +350,7 @@ boolean Plugin_053(uint8_t function, struct EventStruct *event, String& string)
           addLog(LOG_LEVEL_DEBUG_MORE, F("PMSx003 : Packet available"));
           # endif // ifndef BUILD_NO_DEBUG
           success = P053_data->processData(event);
+          P053_data->clearPacket();
         }
       }
       break;

--- a/src/src/PluginStructs/P053_data_struct.cpp
+++ b/src/src/PluginStructs/P053_data_struct.cpp
@@ -114,11 +114,12 @@ bool P053_data_struct::initialized() const
 // Read 2 bytes from serial and make an uint16 of it. Additionally calculate
 // checksum for PMSx003. Assumption is that there is data available, otherwise
 // this function is blocking.
-void P053_data_struct::SerialRead16(uint16_t& value, uint16_t *checksum)
+void P053_data_struct::PacketRead16(uint16_t& value, uint16_t *checksum)
 {
   if (!initialized()) { return; }
-  const uint8_t data_high = _easySerial->read();
-  const uint8_t data_low  = _easySerial->read();
+  if (_packetPos > (PMSx003_PACKET_BUFFER_SIZE - 2)) return;
+  const uint8_t data_high = _packet[_packetPos++];
+  const uint8_t data_low  = _packet[_packetPos++];
 
   value  = data_low;
   value |= (data_high << 8);
@@ -165,23 +166,37 @@ uint8_t P053_data_struct::packetSize() const {
 
 bool P053_data_struct::packetAvailable()
 {
+  const uint8_t expectedSize = packetSize();
+  if (expectedSize == 0) return false;
   if (_easySerial != nullptr)
   {
-    // When there is enough data in the buffer, search through the buffer to
-    // find header (buffer may be out of sync)
-    if (!_easySerial->available()) { return false; }
-
-    while ((_easySerial->peek() != PMSx003_SIG1) && _easySerial->available()) {
-      _easySerial->read(); // Read until the buffer starts with the
-      // first uint8_t of a message, or buffer
-      // empty.
-    }
-
-    if (_easySerial->available() < packetSize()) {
-      return false; // Not enough yet for a complete packet
+    if (_packetPos < expectedSize) {
+      // When there is enough data in the buffer, search through the buffer to
+      // find header (buffer may be out of sync)
+      if (!_easySerial->available()) { return false; }
+      
+      if (_packetPos == 0) {
+        while ((_easySerial->peek() != PMSx003_SIG1) && _easySerial->available()) {
+          _easySerial->read(); // Read until the buffer starts with the
+          // first uint8_t of a message, or buffer
+          // empty.
+        }
+        if (_easySerial->peek() == PMSx003_SIG1) {
+          _packet[_packetPos++] = _easySerial->read();
+        }
+      }
+      if (_packetPos > 0) {
+        while (_packetPos < expectedSize) {
+          if (_easySerial->available() == 0) {
+            return false;
+          } else {
+            _packet[_packetPos++] = _easySerial->read();
+          }
+        }
+      }
     }
   }
-  return true;
+  return _packetPos >= expectedSize;
 }
 
 # ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
@@ -229,15 +244,16 @@ bool P053_data_struct::processData(struct EventStruct *event) {
   uint16_t checksum = 0, checksum2 = 0;
   uint16_t framelength   = 0;
   uint16_t packet_header = 0;
+  _packetPos = 0;
 
-  SerialRead16(packet_header, &checksum); // read PMSx003_SIG1 + PMSx003_SIG2
+  PacketRead16(packet_header, &checksum); // read PMSx003_SIG1 + PMSx003_SIG2
 
   if (packet_header != ((PMSx003_SIG1 << 8) | PMSx003_SIG2)) {
     // Not the start of the packet, stop reading.
     return false;
   }
 
-  SerialRead16(framelength, &checksum);
+  PacketRead16(framelength, &checksum);
 
   if ((framelength + 4) != packetSize()) {
     if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
@@ -259,7 +275,7 @@ bool P053_data_struct::processData(struct EventStruct *event) {
   uint16_t data[PMS_RECEIVE_BUFFER_SIZE] = { 0 }; // uint8_t data_low, data_high;
 
   for (uint8_t i = 0; i < frameData && i < PMS_RECEIVE_BUFFER_SIZE; i++) {
-    SerialRead16(data[i], &checksum);
+    PacketRead16(data[i], &checksum);
   }
 
   # ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
@@ -339,7 +355,7 @@ bool P053_data_struct::processData(struct EventStruct *event) {
   # endif      // ifndef BUILD_NO_DEBUG
 
   // Compare checksums
-  SerialRead16(checksum2, nullptr);
+  PacketRead16(checksum2, nullptr);
   SerialFlush(); // Make sure no data is lost due to full buffer.
 
   if (checksum != checksum2) {
@@ -664,6 +680,11 @@ void P053_data_struct::clearReceivedData() {
   }
   # endif // ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
   _values_received = 0;
+}
+
+void P053_data_struct::clearPacket() {
+  _packetPos = 0;
+  ZERO_FILL(_packet);
 }
 
 const __FlashStringHelper * P053_data_struct::getEventString(uint8_t index) {

--- a/src/src/PluginStructs/P053_data_struct.h
+++ b/src/src/PluginStructs/P053_data_struct.h
@@ -87,6 +87,9 @@ const __FlashStringHelper* toString(PMSx003_event_datatype selection);
 # define PMS5003_ST_SIZE        40
 # define PMS2003_3003_SIZE      24
 
+// Use the largest possible packet size as buffer size
+# define PMSx003_PACKET_BUFFER_SIZE  PMS5003_ST_SIZE
+
 
 // Active mode transport protocol description
 // "factory" relates to "CF=1" in the datasheet. (CF: Calibration Factory)
@@ -111,7 +114,7 @@ const __FlashStringHelper* toString(PMSx003_event_datatype selection);
 # define PMS_T_Hum_pct             11
 # define PMS_Reserved              15
 # define PMS_FW_rev_error          16
-# define PMS_RECEIVE_BUFFER_SIZE   ((PMS5003_ST_SIZE / 2) - 3)
+# define PMS_RECEIVE_BUFFER_SIZE   ((PMSx003_PACKET_BUFFER_SIZE / 2) - 3)
 
 
 struct P053_data_struct : public PluginTaskData_base {
@@ -142,7 +145,7 @@ public:
 
 private:
 
-  void    SerialRead16(uint16_t& value,
+  void    PacketRead16(uint16_t& value,
                        uint16_t *checksum);
 
   void    SerialFlush();
@@ -195,6 +198,8 @@ private:
 
 public:
 
+  void clearPacket();
+
   static const __FlashStringHelper* getEventString(uint8_t index);
 
   static void                       setTaskValueNames(ExtraTaskSettingsStruct& settings,
@@ -207,7 +212,10 @@ public:
 
 private:
 
+
   ESPeasySerial     *_easySerial = nullptr;
+  uint8_t            _packet[PMSx003_PACKET_BUFFER_SIZE] = { 0 };
+  uint8_t            _packetPos = 0;
   const taskIndex_t  _taskIndex  = INVALID_TASK_INDEX;
   const PMSx003_type _sensortype;
   # ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS


### PR DESCRIPTION
The `SC16IS752` library was referring to `Wire1` when used on ESP32.
Also since the `SC16IS752` only has 64 bytes of FIFO, it must be read as soon as possible or else it may get lost on 'chatty' devices like the PMSx003.
