### PR TITLE
[Build] Add PSRAM environments for 16M8M

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,14 +101,15 @@ Flash size | Description                 |
 
 
 *[opt-build-features]* can be any of:
-Build features  | Description                                                              |
-----------------|--------------------------------------------------------------------------|
-LittleFS        | Use LittleFS instead of SPIFFS filesystem (SPIFFS is unstable \> 2 MB)    |
-VCC             | Analog input configured to measure VCC voltage                           |
-OTA             | Arduino OTA (Over The Air) update feature enabled                        |
-Domoticz        | Only Domoticz controllers (HTTP+MQTT) and plugins included               |
-FHEM_HA         | Only FHEM/OpenHAB/Home Assistant (MQTT) controllers and plugins included |
-ETH             | Ethernet interface enabled (ESP32 only)                                  |
+Build features  | Description                                                                                                   |
+----------------|---------------------------------------------------------------------------------------------------------------|
+PSRAM           | Enable PSRAM feature (*only* differentiated for 16M8M builds, other ESP32 builds have PSRAM enabled by default) |
+LittleFS        | Use LittleFS instead of SPIFFS filesystem (SPIFFS is unstable \> 2 MB)                                        |
+VCC             | Analog input configured to measure VCC voltage (ESP8266 only)                                                 |
+OTA             | Arduino OTA (Over The Air) update feature enabled                                                             |
+Domoticz        | Only Domoticz controllers (HTTP+MQTT) and plugins included                                                    |
+FHEM_HA         | Only FHEM/OpenHAB/Home Assistant (MQTT) controllers and plugins included                                      |
+ETH             | Ethernet interface enabled (ESP32 only)                                                                       |
 
 Some example firmware names:
 Firmware name                                       | Hardware                       | Included plugins                 |

--- a/boards/esp32_16M8M_psram.json
+++ b/boards/esp32_16M8M_psram.json
@@ -1,0 +1,39 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32_out.ld",
+      "memory_type": "dio_qspi"
+    },
+    "core": "esp32",
+    "extra_flags": "-DARDUINO_ESP32_DEV -DBOARD_HAS_PSRAM -DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_16M",
+    "f_cpu": "240000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "dio",
+    "mcu": "esp32",
+    "variant": "esp32",
+    "partitions": "esp32_partition_app4096k_spiffs8124k.csv"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet",
+    "can"
+  ],
+  "debug": {
+    "openocd_target": "esp32.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Espressif Generic ESP32 16M Flash PSRAM ESPEasy 4M Code/OTA 8M FS",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 16777216,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://en.wikipedia.org/wiki/ESP32",
+  "vendor": "Espressif"
+}

--- a/platformio_core_defs.ini
+++ b/platformio_core_defs.ini
@@ -233,7 +233,7 @@ build_flags               = ${esp82xx_3_0_x.build_flags}
 ;platform                    = https://github.com/Jason2866/platform-espressif32.git
 ;platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/938/framework-arduinoespressif32-443_esp421-10ab11e815.tar.gz
 
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.5.1/platform-espressif32-2.0.5.1.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.5.2/platform-espressif32-2.0.5.2.zip
 platform_packages           =
 
 build_flags                 = -DESP32_STAGE

--- a/platformio_esp32_envs.ini
+++ b/platformio_esp32_envs.ini
@@ -139,6 +139,10 @@ extends                   = esp32_custom_base_LittleFS
 board                     = esp32_16M8M
 board_upload.flash_size   = 16MB
 
+[env:custom_ESP32_16M8M_PSRAM_LittleFS]
+extends                   = env:custom_ESP32_16M8M_LittleFS
+board                     = esp32_16M8M_psram
+
 [env:custom_IR_ESP32_4M316k]
 extends                   = esp32_base
 board                     = esp32_4M
@@ -362,12 +366,20 @@ lib_deps                  = ${esp32_base.lib_deps}
                             LittleFS
 board_build.filesystem    = littlefs
 
+[env:max_ESP32_16M8M_PSRAM_LittleFS]
+extends                   = env:max_ESP32_16M8M_LittleFS
+board                     = esp32_16M8M_psram
+
 ; If you have a board with Ethernet integrated and 16MB Flash, then this configuration could be enabled, it's based on the max_ESP32_16M8M_LittleFS definition
 [env:max_ESP32_16M8M_LittleFS_ETH]
 extends                   = env:max_ESP32_16M8M_LittleFS
+board                     = ${env:max_ESP32_16M8M_LittleFS.board}
 build_flags               = ${env:max_ESP32_16M8M_LittleFS.build_flags}
                             -DFEATURE_ETHERNET=1
 
+[env:max_ESP32_16M8M_PSRAM_LittleFS_ETH]
+extends                   = env:max_ESP32_16M8M_LittleFS_ETH
+board                     = esp32_16M8M_psram
 
 
 


### PR DESCRIPTION
- Add builds for 16M8M environments with PSRAM support enabled, as required for boards which have PSRAM installed.
Using the non-PSRAM builds frees GPIO-16 and GPIO-17 for generic use.
NB: Other ESP32 builds *have* PSRAM enabled by default.

- Updated README.md, documenting this option.