### PR TITLE
[Setup] Fix CSS on setup page + WiFi/Eth event handling

### DIFF
--- a/platformio_esp32_envs.ini
+++ b/platformio_esp32_envs.ini
@@ -327,6 +327,25 @@ build_flags               = ${env:collection_E_ESP32_4M316k.build_flags}
                             -DFEATURE_ETHERNET=1
                             -DCOLLECTION_USE_RTTTL
 
+[env:energy_ESP32_4M316k_ETH]
+extends                   = env:energy_ESP32_4M316k
+build_flags               = ${env:energy_ESP32_4M316k.build_flags}
+                            -DFEATURE_ETHERNET=1
+
+[env:display_ESP32_4M316k_ETH]
+extends                   = env:display_ESP32_4M316k
+build_flags               = ${env:display_ESP32_4M316k.build_flags}
+                            -DFEATURE_ETHERNET=1
+
+[env:climate_ESP32_4M316k_ETH]
+extends                   = env:climate_ESP32_4M316k
+build_flags               = ${env:climate_ESP32_4M316k.build_flags}
+                            -DFEATURE_ETHERNET=1
+
+[env:neopixel_ESP32_4M316k_ETH]
+extends                   = env:neopixel_ESP32_4M316k
+build_flags               = ${env:neopixel_ESP32_4M316k.build_flags}
+                            -DFEATURE_ETHERNET=1
 
 
 ; ESP32 MAX builds 16M flash ------------------------------

--- a/src/src/CustomBuild/ESPEasyDefaults.h
+++ b/src/src/CustomBuild/ESPEasyDefaults.h
@@ -83,7 +83,7 @@
 #endif
 
 #ifndef DEFAULT_WIFI_CONNECTION_TIMEOUT
-#define DEFAULT_WIFI_CONNECTION_TIMEOUT  10000  // minimum timeout in ms for WiFi to be connected.
+#define DEFAULT_WIFI_CONNECTION_TIMEOUT  20000  // minimum timeout in ms for WiFi to be connected.
 #endif
 #ifndef DEFAULT_WIFI_FORCE_BG_MODE
 #define DEFAULT_WIFI_FORCE_BG_MODE       false  // when set, only allow to connect in 802.11B or G mode (not N)

--- a/src/src/DataStructs/EthernetEventData.cpp
+++ b/src/src/DataStructs/EthernetEventData.cpp
@@ -119,6 +119,7 @@ void EthernetEventData_t::markLostIP() {
   bitClear(ethStatus, ESPEASY_ETH_GOT_IP);
   bitClear(ethStatus, ESPEASY_ETH_SERVICES_INITIALIZED);
   lastGetIPmoment.clear();
+  processedGotIP = false;
 }
 
 void EthernetEventData_t::markDisconnect() {

--- a/src/src/DataStructs/EthernetEventData.cpp
+++ b/src/src/DataStructs/EthernetEventData.cpp
@@ -91,7 +91,7 @@ void EthernetEventData_t::setEthConnected() {
   setEthServicesInitialized();
 }
 
-void EthernetEventData_t::setEthServicesInitialized() {
+bool EthernetEventData_t::setEthServicesInitialized() {
   if (!unprocessedEthEvents() && !EthServicesInitialized()) {
     if (EthGotIP() && EthConnected()) {
       #ifndef BUILD_NO_DEBUG
@@ -99,8 +99,10 @@ void EthernetEventData_t::setEthServicesInitialized() {
       #endif
       bitSet(ethStatus, ESPEASY_ETH_SERVICES_INITIALIZED);
       ethConnectInProgress = false;
+      return true;
     }
   }
+  return false;
 }
 
 void EthernetEventData_t::markGotIP() {

--- a/src/src/DataStructs/EthernetEventData.h
+++ b/src/src/DataStructs/EthernetEventData.h
@@ -38,7 +38,7 @@ struct EthernetEventData_t {
   void setEthDisconnected();
   void setEthGotIP();
   void setEthConnected();
-  void setEthServicesInitialized();
+  bool setEthServicesInitialized();
 
 
   void markGotIP();

--- a/src/src/DataStructs/EthernetEventData.h
+++ b/src/src/DataStructs/EthernetEventData.h
@@ -77,6 +77,11 @@ struct EthernetEventData_t {
 
   bool ethInitSuccess            = false;
   unsigned long connectionFailures = 0;
+
+#ifdef ESP32
+  WiFiEventId_t wm_event_id = 0;
+#endif // ifdef ESP32
+
 };
 
 #endif

--- a/src/src/DataStructs/ExtendedControllerCredentialsStruct.cpp
+++ b/src/src/DataStructs/ExtendedControllerCredentialsStruct.cpp
@@ -2,27 +2,65 @@
 
 #include "../Helpers/ESPEasy_Storage.h"
 
+#ifdef ESP32
+# include <MD5Builder.h>
+#endif // ifdef ESP32
+
 #define EXT_CONTR_CRED_USER_OFFSET 0
 #define EXT_CONTR_CRED_PASS_OFFSET 1
+
+
+uint8_t last_ExtendedControllerCredentialsStruct_md5[16] = { 0 };
 
 
 ExtendedControllerCredentialsStruct::ExtendedControllerCredentialsStruct() {}
 
 
+bool ExtendedControllerCredentialsStruct::computeChecksum(uint8_t checksum[16]) const
+{
+  MD5Builder md5;
+
+  md5.begin();
+
+  for (size_t i = 0; i < CONTROLLER_MAX * 2; ++i) {
+    md5.add(_strings[i].c_str());
+  }
+
+  md5.calculate();
+  uint8_t tmp_md5[16] = { 0 };
+
+  md5.getBytes(tmp_md5);
+
+  if (memcmp(tmp_md5, checksum, 16) != 0) {
+    // Data has changed, copy computed checksum
+    memcpy(checksum, tmp_md5, 16);
+    return false;
+  }
+  return true;
+}
+
 String ExtendedControllerCredentialsStruct::load()
 {
-  return LoadStringArray(SettingsType::Enum::ExtdControllerCredentials_Type,
-                           0,
-                           _strings, CONTROLLER_MAX * 2, 0);
+  const String res =
+    LoadStringArray(SettingsType::Enum::ExtdControllerCredentials_Type,
+                    0,
+                    _strings, CONTROLLER_MAX * 2, 0);
+
+  // Update the checksum after loading.
+  computeChecksum(last_ExtendedControllerCredentialsStruct_md5);
+
+  return res;
 }
 
 String ExtendedControllerCredentialsStruct::save() const
 {
+  if (computeChecksum(last_ExtendedControllerCredentialsStruct_md5)) {
+    return EMPTY_STRING;
+  }
   return SaveStringArray(SettingsType::Enum::ExtdControllerCredentials_Type,
-                           0,
-                           _strings, CONTROLLER_MAX * 2, 0);
+                         0,
+                         _strings, CONTROLLER_MAX * 2, 0);
 }
-
 
 String ExtendedControllerCredentialsStruct::getControllerUser(controllerIndex_t controller_idx) const
 {

--- a/src/src/DataStructs/ExtendedControllerCredentialsStruct.h
+++ b/src/src/DataStructs/ExtendedControllerCredentialsStruct.h
@@ -13,6 +13,11 @@ struct ExtendedControllerCredentialsStruct
 {
   ExtendedControllerCredentialsStruct();
 
+  // Compute checksum of the data.
+  // @param checksum The expected checksum. Will contain checksum after call finished.
+  // @retval true when checksum matches
+  bool computeChecksum(uint8_t checksum[16]) const;
+
   String load();
   String save() const;
 
@@ -22,10 +27,9 @@ struct ExtendedControllerCredentialsStruct
   void setControllerUser(controllerIndex_t controller_idx, const String& user);
   void setControllerPass(controllerIndex_t controller_idx, const String& pass);
 
-  private:
+private:
 
   String _strings[CONTROLLER_MAX * 2];
-
 
   // TODO TD-er: Add extra WiFi credentials
 };

--- a/src/src/DataStructs/NTP_candidate.cpp
+++ b/src/src/DataStructs/NTP_candidate.cpp
@@ -20,7 +20,7 @@ bool NTP_candidate_struct::set(const NodeStruct& node)
 
   // Only allow time from p2p nodes who only got it via p2p themselves as "last resource"
   const unsigned long p2p_source_penalty =
-    isExternalTimeSource(timeSource)  ? 0 : 2000;
+    isExternalTimeSource(timeSource)  ? 0 : 10000;
   const unsigned long time_wander_other =
     p2p_source_penalty + computeExpectedWander(timeSource, node.lastUpdated);
 

--- a/src/src/DataStructs/SettingsStruct.h
+++ b/src/src/DataStructs/SettingsStruct.h
@@ -324,11 +324,6 @@ class SettingsStruct_tmpl
   uint16_t      WebserverPort = 80;
   uint16_t      SyslogPort = 0;
 
-  // FIXME @TD-er: As discussed in #1292, the CRC for the settings is now disabled.
-  // make sure crc is the last value in the struct
-  // Try to extend settings to make the checksum 4-uint8_t aligned.
-//  uint8_t       ProgmemMd5[16]; // crc of the binary that last saved the struct to file.
-//  uint8_t       md5[16];
   int8_t          ETH_Phy_Addr = -1;
   int8_t          ETH_Pin_mdc = -1;
   int8_t          ETH_Pin_mdio = -1;
@@ -357,6 +352,15 @@ class SettingsStruct_tmpl
   int8_t        SPI_MISO_pin = -1;
   int8_t        SPI_MOSI_pin = -1;
   int8_t        alignmentFiller0 = 0;  // Should be reused, just added to keep up with alignment
+
+  // Do not rename or move this checksum.
+  // Checksum calculation will work "around" this
+  uint8_t       md5[16]; // Store checksum of the settings.
+  
+//  uint8_t       ProgmemMd5[16]; // crc of the binary that last saved the struct to file.
+
+
+  // Try to extend settings to make the checksum 4-uint8_t aligned.
 };
 
 /*

--- a/src/src/DataStructs/WiFiEventData.cpp
+++ b/src/src/DataStructs/WiFiEventData.cpp
@@ -14,7 +14,7 @@
 #define ESPEASY_WIFI_GOT_IP                  1
 #define ESPEASY_WIFI_SERVICES_INITIALIZED    2
 
-#define WIFI_RECONNECT_WAIT                  20000  // in milliSeconds
+#define WIFI_RECONNECT_WAIT                  30000  // in milliSeconds
 
 #define CONNECT_TIMEOUT_MAX                  4000   // in milliSeconds
 

--- a/src/src/DataStructs/WiFiEventData.h
+++ b/src/src/DataStructs/WiFiEventData.h
@@ -122,6 +122,10 @@ struct WiFiEventData_t {
 
   std::map<int, uint32_t> connectDurations;
 
+#ifdef ESP32
+  WiFiEventId_t wm_event_id = 0;
+#endif // ifdef ESP32
+
 
 };
 

--- a/src/src/DataTypes/ESPEasyTimeSource.cpp
+++ b/src/src/DataTypes/ESPEasyTimeSource.cpp
@@ -62,6 +62,7 @@ unsigned long computeExpectedWander(timeSource_t  timeSource,
     }
     case timeSource_t::NTP_time_source:
     {
+      // Typical time needed to perform a NTP request to an online NTP server
       expectedWander_ms += 30;
       break;
     }
@@ -70,15 +71,22 @@ unsigned long computeExpectedWander(timeSource_t  timeSource,
     case timeSource_t::ESPEASY_p2p_UDP:
     {
       // expected wander is 144 per hour.
-      // Using a 'penalty' of 300 makes it only preferrable over NTP after +/- 2 hour.
-      expectedWander_ms += 300;
+      // Using a 'penalty' of 1000 makes it only preferrable over NTP after +/- 7 hour.
+      expectedWander_ms += 1000;
       break;
     }
 
     case timeSource_t::External_RTC_time_source:
+    {
+      // Will be off by +/- 500 msec
+      expectedWander_ms += 500;
+      break;
+    }
     case timeSource_t::Restore_RTC_time_source:
     {
-      expectedWander_ms += 2000;
+      // May be off by the time needed to reboot + some time since the last update of the RTC
+      // If a reboot was due to a watchdog reset, then it will be an additional 2 - 6 seconds.
+      expectedWander_ms += 5000;
       break;
     }
     case timeSource_t::Manual_set:

--- a/src/src/ESPEasyCore/ESPEasyEth.cpp
+++ b/src/src/ESPEasyCore/ESPEasyEth.cpp
@@ -7,7 +7,7 @@
 #include "../ESPEasyCore/ESPEasyWifi.h"
 #include "../ESPEasyCore/ESPEasy_Log.h"
 #include "../ESPEasyCore/ESPEasyGPIO.h"
-#include "../ESPEasyCore/ESPEasyWiFiEvent.h"
+#include "../ESPEasyCore/ESPEasyEthEvent.h"
 #include "../Globals/ESPEasyWiFiEvent.h"
 #include "../Globals/NetworkState.h"
 #include "../Globals/Settings.h"
@@ -147,7 +147,7 @@ void registerEthEventHandler()
   if (EthEventData.wm_event_id != 0) {
     removeEthEventHandler();
   }
-  EthEventData.wm_event_id = WiFi.onEvent(WiFiEvent);
+  EthEventData.wm_event_id = WiFi.onEvent(EthEvent);
 }
 
 

--- a/src/src/ESPEasyCore/ESPEasyEth.cpp
+++ b/src/src/ESPEasyCore/ESPEasyEth.cpp
@@ -26,8 +26,8 @@ bool ethUseStaticIP() {
 }
 
 void ethSetupStaticIPconfig() {
+  const IPAddress IP_zero(0, 0, 0, 0); 
   if (!ethUseStaticIP()) { 
-    const IPAddress IP_zero(0, 0, 0, 0); 
     if (!ETH.config(IP_zero, IP_zero, IP_zero, IP_zero)) {
       addLog(LOG_LEVEL_ERROR, F("ETH  : Cannot set IP config"));
     }
@@ -39,6 +39,7 @@ void ethSetupStaticIPconfig() {
   const IPAddress dns    = Settings.ETH_DNS;
 
   EthEventData.dns0_cache = dns;
+  EthEventData.dns1_cache = IP_zero;
 
 
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
@@ -53,6 +54,7 @@ void ethSetupStaticIPconfig() {
     addLogMove(LOG_LEVEL_INFO, log);
   }
   ETH.config(ip, gw, subnet, dns);
+  ethSetDNS(EthEventData.dns0_cache, EthEventData.dns1_cache);
 }
 
 void ethSetDNS(const IPAddress& dns0, const IPAddress& dns1) 

--- a/src/src/ESPEasyCore/ESPEasyEth.cpp
+++ b/src/src/ESPEasyCore/ESPEasyEth.cpp
@@ -38,6 +38,9 @@ void ethSetupStaticIPconfig() {
   const IPAddress subnet = Settings.ETH_Subnet;
   const IPAddress dns    = Settings.ETH_DNS;
 
+  EthEventData.dns0_cache = dns;
+
+
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
     String log = F("ETH IP   : Static IP : ");
     log += formatIP(ip);

--- a/src/src/ESPEasyCore/ESPEasyEth.cpp
+++ b/src/src/ESPEasyCore/ESPEasyEth.cpp
@@ -8,7 +8,7 @@
 #include "../ESPEasyCore/ESPEasy_Log.h"
 #include "../ESPEasyCore/ESPEasyGPIO.h"
 #include "../ESPEasyCore/ESPEasyEthEvent.h"
-#include "../Globals/ESPEasyWiFiEvent.h"
+#include "../Globals/ESPEasyEthEvent.h"
 #include "../Globals/NetworkState.h"
 #include "../Globals/Settings.h"
 #include "../Helpers/StringConverter.h"

--- a/src/src/ESPEasyCore/ESPEasyEth.cpp
+++ b/src/src/ESPEasyCore/ESPEasyEth.cpp
@@ -7,6 +7,7 @@
 #include "../ESPEasyCore/ESPEasyWifi.h"
 #include "../ESPEasyCore/ESPEasy_Log.h"
 #include "../ESPEasyCore/ESPEasyGPIO.h"
+#include "../ESPEasyCore/ESPEasyWiFiEvent.h"
 #include "../Globals/ESPEasyWiFiEvent.h"
 #include "../Globals/NetworkState.h"
 #include "../Globals/Settings.h"
@@ -135,6 +136,21 @@ MAC_address ETHMacAddress() {
   return mac;
 }
 
+void removeEthEventHandler()
+{
+  WiFi.removeEvent(EthEventData.wm_event_id);
+  EthEventData.wm_event_id = 0;
+}
+
+void registerEthEventHandler()
+{
+  if (EthEventData.wm_event_id != 0) {
+    removeEthEventHandler();
+  }
+  EthEventData.wm_event_id = WiFi.onEvent(WiFiEvent);
+}
+
+
 bool ETHConnectRelaxed() {
   if (EthEventData.ethInitSuccess) {
     return EthLinkUp();
@@ -147,17 +163,13 @@ bool ETHConnectRelaxed() {
     return false;
   }
   // Re-register event listener
-  #if defined(ESP32)
-  removeWiFiEventHandler();
-  #endif
+  removeEthEventHandler();
 
   ethPower(true);
   EthEventData.markEthBegin();
 
   // Re-register event listener
-  #if defined(ESP32)
-  registerWiFiEventHandler();
-  #endif
+  registerEthEventHandler();
 
   if (!EthEventData.ethInitSuccess) {
     ethResetGPIOpins();

--- a/src/src/ESPEasyCore/ESPEasyEth.h
+++ b/src/src/ESPEasyCore/ESPEasyEth.h
@@ -21,5 +21,8 @@ void     ethPower(bool enable);
 void     ethResetGPIOpins();
 MAC_address ETHMacAddress();
 
+void removeEthEventHandler();
+void registerEthEventHandler();
+
 #endif // if FEATURE_ETHERNET
 #endif // ifndef ESPEASY_ETH_H

--- a/src/src/ESPEasyCore/ESPEasyEthEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyEthEvent.cpp
@@ -5,7 +5,7 @@
 #  include <ETH.h>
 
 #include "../ESPEasyCore/ESPEasyEth.h"
-#include "../Globals/ESPEasyWiFiEvent.h" // EthEventData
+#include "../Globals/ESPEasyEthEvent.h"
 
 
 // ********************************************************************************

--- a/src/src/ESPEasyCore/ESPEasyEthEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyEthEvent.cpp
@@ -1,0 +1,63 @@
+#include "../ESPEasyCore/ESPEasyEthEvent.h"
+
+#ifdef ESP32
+# if FEATURE_ETHERNET
+#  include <ETH.h>
+
+#include "../ESPEasyCore/ESPEasyEth.h"
+#include "../Globals/ESPEasyWiFiEvent.h" // EthEventData
+
+
+// ********************************************************************************
+// Functions called on events.
+// Make sure not to call anything in these functions that result in delay() or yield()
+// ********************************************************************************
+
+#  include <WiFi.h>
+
+
+#  if ESP_IDF_VERSION_MAJOR > 3
+void EthEvent(WiFiEvent_t event, arduino_event_info_t info) {
+  switch (event) {
+    case ARDUINO_EVENT_ETH_START:
+
+      if (ethPrepare()) {
+        addLog(LOG_LEVEL_INFO, F("ETH event: Started"));
+      } else {
+        addLog(LOG_LEVEL_ERROR, F("ETH event: Could not prepare ETH!"));
+      }
+      break;
+    case ARDUINO_EVENT_ETH_CONNECTED:
+      addLog(LOG_LEVEL_INFO, F("ETH event: Connected"));
+      EthEventData.markConnected();
+      break;
+    case ARDUINO_EVENT_ETH_GOT_IP:
+      EthEventData.markGotIP();
+      addLog(LOG_LEVEL_INFO,  F("ETH event: Got IP"));
+      break;
+    case ARDUINO_EVENT_ETH_DISCONNECTED:
+      addLog(LOG_LEVEL_ERROR, F("ETH event: Disconnected"));
+      EthEventData.markDisconnect();
+      break;
+    case ARDUINO_EVENT_ETH_STOP:
+      addLog(LOG_LEVEL_INFO, F("ETH event: Stopped"));
+      break;
+    #   if ESP_IDF_VERSION_MAJOR > 3
+    case ARDUINO_EVENT_ETH_GOT_IP6:
+    #   else // if ESP_IDF_VERSION_MAJOR > 3
+    case ARDUINO_EVENT_GOT_IP6:
+    #   endif // if ESP_IDF_VERSION_MAJOR > 3
+      addLog(LOG_LEVEL_INFO, F("ETH event: Got IP6"));
+      break;
+    default:
+    {
+      break;
+    }
+  }
+}
+
+#  endif // if ESP_IDF_VERSION_MAJOR > 3
+
+# endif // if FEATURE_ETHERNET
+
+#endif // ifdef ESP32

--- a/src/src/ESPEasyCore/ESPEasyEthEvent.h
+++ b/src/src/ESPEasyCore/ESPEasyEthEvent.h
@@ -1,0 +1,18 @@
+#ifndef ESPEASY_ETH_EVENT_H
+#define ESPEASY_ETH_EVENT_H
+
+#include "../../ESPEasy_common.h"
+
+
+// ********************************************************************************
+// Functions called on Eth events.
+// Make sure not to call anything in these functions that result in delay() or yield()
+// ********************************************************************************
+#ifdef ESP32
+ #if ESP_IDF_VERSION_MAJOR > 3
+  void EthEvent(WiFiEvent_t event, arduino_event_info_t info);
+ #endif
+#endif
+
+
+#endif // ESPEASY_ETH_EVENT_H

--- a/src/src/ESPEasyCore/ESPEasyEth_ProcessEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyEth_ProcessEvent.cpp
@@ -1,0 +1,232 @@
+#include "../ESPEasyCore/ESPEasyEth_ProcessEvent.h"
+
+#if FEATURE_ETHERNET
+
+# include "../../ESPEasy-Globals.h"
+
+# include "../ESPEasyCore/ESPEasyEth.h"
+# include "../ESPEasyCore/ESPEasyNetwork.h"
+# include "../ESPEasyCore/ESPEasyWifi.h" // LogConnectionStatus
+
+# include "../Globals/ESPEasyEthEvent.h"
+# include "../Globals/ESPEasyWiFiEvent.h"
+# include "../Globals/ESPEasy_Scheduler.h"
+# include "../Globals/ESPEasy_time.h"
+# include "../Globals/EventQueue.h"
+# include "../Globals/MQTT.h"
+# include "../Globals/NetworkState.h"
+# include "../Globals/Settings.h"
+
+# include "../Helpers/Network.h"
+# include "../Helpers/PeriodicalActions.h"
+# include "../Helpers/StringConverter.h"
+
+
+void handle_unprocessedEthEvents() {
+  if (EthEventData.unprocessedEthEvents()) {
+    // Process disconnect events before connect events.
+    if (!EthEventData.processedDisconnect) {
+      # ifndef BUILD_NO_DEBUG
+      addLog(LOG_LEVEL_DEBUG, F("Eth  : Entering processDisconnect()"));
+      # endif // ifndef BUILD_NO_DEBUG
+      processEthernetDisconnected();
+    }
+
+    // Must process the Ethernet Connected event regardless the active network medium.
+    // It may happen by plugging in the cable while WiFi was active.
+    if (!EthEventData.processedConnect) {
+      # ifndef BUILD_NO_DEBUG
+      addLog(LOG_LEVEL_DEBUG, F("Eth  : Entering processConnect()"));
+      # endif // ifndef BUILD_NO_DEBUG
+      processEthernetConnected();
+    }
+  }
+
+  if (active_network_medium == NetworkMedium_t::Ethernet) {
+    const bool EthServices_was_initialized = EthEventData.EthServicesInitialized();
+
+    if (!EthEventData.EthServicesInitialized() || EthEventData.unprocessedEthEvents())
+    {
+      if (!EthEventData.unprocessedEthEvents() && EthEventData.EthConnectAllowed()) {
+        NetworkConnectRelaxed();
+      }
+
+      if (!EthEventData.processedGotIP) {
+        # ifndef BUILD_NO_DEBUG
+        addLog(LOG_LEVEL_DEBUG, F("Eth  : Entering processGotIP()"));
+        # endif // ifndef BUILD_NO_DEBUG
+        processEthernetGotIP();
+      }
+
+      if (!EthEventData.processedDHCPTimeout) {
+        # ifndef BUILD_NO_DEBUG
+        addLog(LOG_LEVEL_DEBUG, F("Eth  : DHCP timeout, Calling disconnect()"));
+        # endif // ifndef BUILD_NO_DEBUG
+        EthEventData.processedDHCPTimeout = true;
+
+        // WifiDisconnect();
+      }
+    }
+    EthEventData.setEthServicesInitialized();
+
+    if (!EthServices_was_initialized && EthEventData.setEthServicesInitialized()) {
+      registerEthEventHandler();
+    }
+  }
+}
+
+void check_Eth_DNS_valid() {
+  // Check if DNS is still valid, as this may have been reset by the WiFi module turned off.
+  // DNS records are shared between WiFi and Ethernet IP stack.
+  // Turning off WiFi will clead DNS records for Ethernet
+  if (EthEventData.EthServicesInitialized() &&
+      (active_network_medium == NetworkMedium_t::Ethernet) &&
+      EthEventData.ethInitSuccess &&
+      !ethUseStaticIP()) {
+    const bool has_cache = !EthEventData.dns0_cache && !EthEventData.dns1_cache;
+
+    if (has_cache) {
+      const IPAddress dns0 = NetworkDnsIP(0);
+      const IPAddress dns1 = NetworkDnsIP(1);
+
+      if (!dns0 && !dns1) {
+        addLog(LOG_LEVEL_ERROR, F("ETH  : DNS server was cleared, use cached DNS IP"));
+        ethSetDNS(EthEventData.dns0_cache, EthEventData.dns1_cache);
+      }
+    }
+  }
+}
+
+void processEthernetConnected() {
+  if (EthEventData.processedConnect) { return; }
+
+  // FIXME TD-er: Must differentiate among reconnects for WiFi and Ethernet.
+  ++WiFiEventData.wifi_reconnects;
+  EthEventData.setEthConnected();
+  EthEventData.processedConnect = true;
+
+  if (Settings.UseRules)
+  {
+    eventQueue.add(F("Ethernet#LinkUp"));
+  }
+  setNetworkMedium(Settings.NetworkMedium);
+
+  if (ethUseStaticIP()) { EthEventData.processedGotIP = false; }
+}
+
+void processEthernetDisconnected() {
+  if (EthEventData.processedDisconnect) { return; }
+  EthEventData.setEthDisconnected();
+  EthEventData.processedDisconnect     = true;
+  EthEventData.ethConnectAttemptNeeded = true;
+
+  if (Settings.UseRules)
+  {
+    eventQueue.add(F("Ethernet#Disconnected"));
+  }
+}
+
+void processEthernetGotIP() {
+  if (EthEventData.processedGotIP || !EthEventData.ethInitSuccess) {
+    return;
+  }
+
+  if (ethUseStaticIP()) {
+    ethSetupStaticIPconfig();
+  }
+  const IPAddress ip = NetworkLocalIP();
+
+  if (!ip) {
+    return;
+  }
+
+  const IPAddress gw     = NetworkGatewayIP();
+  const IPAddress subnet = NetworkSubnetMask();
+
+  IPAddress dns0                              = NetworkDnsIP(0);
+  IPAddress dns1                              = NetworkDnsIP(1);
+  const LongTermTimer::Duration dhcp_duration = EthEventData.lastConnectMoment.timeDiff(EthEventData.lastGetIPmoment);
+
+  if (!dns0 && !dns1) {
+    addLog(LOG_LEVEL_ERROR, F("ETH  : No DNS server received via DHCP, use cached DNS IP"));
+    ethSetDNS(EthEventData.dns0_cache, EthEventData.dns1_cache);
+  } else {
+    EthEventData.dns0_cache = dns0;
+    EthEventData.dns1_cache = dns1;
+  }
+
+  if (loglevelActiveFor(LOG_LEVEL_INFO))
+  {
+    String log;
+
+    if (log.reserve(160)) {
+      log  = F("ETH MAC: ");
+      log += NetworkMacAddress().toString();
+      log += ' ';
+
+      if (ethUseStaticIP()) {
+        log += F("Static");
+      } else {
+        log += F("DHCP");
+      }
+      log += F(" IP: ");
+      log += ip.toString();
+      log += ' ';
+      log += wrap_braces(NetworkGetHostname());
+      log += F(" GW: ");
+      log += gw.toString();
+      log += F(" SN: ");
+      log += subnet.toString();
+      log += F(" DNS: ");
+      log += dns0.toString();
+      log += '/';
+      log += dns1.toString();
+
+      if (EthLinkUp()) {
+        if (EthFullDuplex()) {
+          log += F(" FULL_DUPLEX");
+        }
+        log += ' ';
+        log += EthLinkSpeed();
+        log += F("Mbps");
+      } else {
+        log += F(" Link Down");
+      }
+
+      if ((dhcp_duration > 0ll) && (dhcp_duration < 30000000ll)) {
+        // Just log times when they make sense.
+        log += F("   duration: ");
+        log += static_cast<int32_t>(dhcp_duration / 1000);
+        log += F(" ms");
+      }
+
+      addLogMove(LOG_LEVEL_INFO, log);
+    }
+  }
+
+  // First try to get the time, since that may be used in logs
+  if (node_time.systemTimePresent()) {
+    node_time.initTime();
+  }
+# if FEATURE_MQTT
+  mqtt_reconnect_count        = 0;
+  MQTTclient_should_reconnect = true;
+  timermqtt_interval          = 100;
+  Scheduler.setIntervalTimer(ESPEasy_Scheduler::IntervalTimer_e::TIMER_MQTT);
+  scheduleNextMQTTdelayQueue();
+# endif // if FEATURE_MQTT
+  Scheduler.sendGratuitousARP_now();
+
+  if (Settings.UseRules)
+  {
+    eventQueue.add(F("Ethernet#Connected"));
+  }
+  statusLED(true);
+  logConnectionStatus();
+
+  EthEventData.processedGotIP = true;
+  EthEventData.setEthGotIP();
+  CheckRunningServices();
+}
+
+#endif // if FEATURE_ETHERNET

--- a/src/src/ESPEasyCore/ESPEasyEth_ProcessEvent.h
+++ b/src/src/ESPEasyCore/ESPEasyEth_ProcessEvent.h
@@ -1,0 +1,16 @@
+#ifndef ESPEASYCORE_ESPEASYETH_PROCESSEVENT_H
+#define ESPEASYCORE_ESPEASYETH_PROCESSEVENT_H
+
+#include "../../ESPEasy_common.h"
+
+#if FEATURE_ETHERNET
+void handle_unprocessedEthEvents();
+
+void check_Eth_DNS_valid();
+
+void processEthernetConnected();
+void processEthernetDisconnected();
+void processEthernetGotIP();
+#endif // if FEATURE_ETHERNET
+
+#endif // ifndef ESPEASYCORE_ESPEASYETH_PROCESSEVENT_H

--- a/src/src/ESPEasyCore/ESPEasyNetwork.cpp
+++ b/src/src/ESPEasyCore/ESPEasyNetwork.cpp
@@ -12,6 +12,7 @@
 #include "../Helpers/MDNS_Helper.h"
 
 #if FEATURE_ETHERNET
+#include "../Globals/ESPEasyEthEvent.h"
 #include <ETH.h>
 #endif
 

--- a/src/src/ESPEasyCore/ESPEasyWiFiEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWiFiEvent.cpp
@@ -22,6 +22,10 @@
 #include "../Helpers/ESPEasy_time_calc.h"
 
 
+#if FEATURE_ETHERNET
+#include "../Globals/ESPEasyEthEvent.h"
+#endif
+
 
 #ifdef ESP32
 void WiFi_Access_Static_IP::set_use_static_ip(bool enabled) {

--- a/src/src/ESPEasyCore/ESPEasyWiFiEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWiFiEvent.cpp
@@ -82,16 +82,20 @@ void WiFiEvent(WiFiEvent_t event, arduino_event_info_t info) {
     case ARDUINO_EVENT_WIFI_STA_LOST_IP:
       // ESP32 station lost IP and the IP is reset to 0
       #if FEATURE_ETHERNET
+      /*
       if (active_network_medium == NetworkMedium_t::Ethernet) {
         EthEventData.markLostIP();
       }
-      else
+      */
       #endif // if FEATURE_ETHERNET
       WiFiEventData.markLostIP();
       # ifndef BUILD_NO_DEBUG
       addLog(LOG_LEVEL_INFO, 
+      /*
         active_network_medium == NetworkMedium_t::Ethernet ?
-        F("ETH : Event Lost IP") : F("WiFi : Event Lost IP"));
+        F("ETH : Event Lost IP") :
+      */
+         F("WiFi : Event Lost IP"));
       #endif
       break;
 
@@ -160,33 +164,16 @@ void WiFiEvent(WiFiEvent_t event, arduino_event_info_t info) {
       break;
 #if FEATURE_ETHERNET
     case ARDUINO_EVENT_ETH_START:
-      if (ethPrepare()) {
-        addLog(LOG_LEVEL_INFO, F("ETH event: Started"));
-      } else {
-        addLog(LOG_LEVEL_ERROR, F("ETH event: Could not prepare ETH!"));
-      }
-      break;
     case ARDUINO_EVENT_ETH_CONNECTED:
-      addLog(LOG_LEVEL_INFO, F("ETH event: Connected"));
-      EthEventData.markConnected();
-      break;
     case ARDUINO_EVENT_ETH_GOT_IP:
-      EthEventData.markGotIP();
-      addLog(LOG_LEVEL_INFO, F("ETH event: Got IP"));
-      break;
     case ARDUINO_EVENT_ETH_DISCONNECTED:
-      addLog(LOG_LEVEL_ERROR, F("ETH event: Disconnected"));
-      EthEventData.markDisconnect();
-      break;
     case ARDUINO_EVENT_ETH_STOP:
-      addLog(LOG_LEVEL_INFO, F("ETH event: Stopped"));
-      break;
     #if ESP_IDF_VERSION_MAJOR > 3
     case ARDUINO_EVENT_ETH_GOT_IP6:
     #else
     case ARDUINO_EVENT_GOT_IP6:
     #endif
-      addLog(LOG_LEVEL_INFO, F("ETH event: Got IP6"));
+      // Handled in EthEvent
       break;
 #endif //FEATURE_ETHERNET
     default:

--- a/src/src/ESPEasyCore/ESPEasyWiFiEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWiFiEvent.cpp
@@ -86,11 +86,12 @@ void WiFiEvent(WiFiEvent_t event, arduino_event_info_t info) {
     case ARDUINO_EVENT_WIFI_STA_LOST_IP:
       // ESP32 station lost IP and the IP is reset to 0
       #if FEATURE_ETHERNET
-      /*
       if (active_network_medium == NetworkMedium_t::Ethernet) {
+        // DNS records are shared among WiFi and Ethernet (very bad design!)
+        // So we must restore the DNS records for Ethernet in case we started with WiFi and then plugged in Ethernet.
+        // As soon as WiFi is turned off, the DNS entry for Ethernet is cleared.
         EthEventData.markLostIP();
       }
-      */
       #endif // if FEATURE_ETHERNET
       WiFiEventData.markLostIP();
       # ifndef BUILD_NO_DEBUG

--- a/src/src/ESPEasyCore/ESPEasyWifi.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi.cpp
@@ -1358,7 +1358,7 @@ bool WifiIsSTA(WiFiMode_t wifimode)
   #endif // if defined(ESP32)
 }
 
-bool useStaticIP() {
+bool WiFiUseStaticIP() {
   return Settings.IP[0] != 0 && Settings.IP[0] != 255;
 }
 

--- a/src/src/ESPEasyCore/ESPEasyWifi.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi.cpp
@@ -594,12 +594,16 @@ void resetWiFi() {
 #ifdef ESP32
 void removeWiFiEventHandler()
 {
-  WiFi.removeEvent(wm_event_id);
+  WiFi.removeEvent(WiFiEventData.wm_event_id);
+  WiFiEventData.wm_event_id = 0;
 }
 
 void registerWiFiEventHandler()
 {
-  wm_event_id = WiFi.onEvent(WiFiEvent);
+  if (WiFiEventData.wm_event_id != 0) {
+    removeWiFiEventHandler();
+  }
+  WiFiEventData.wm_event_id = WiFi.onEvent(WiFiEvent);
 }
 #endif
 
@@ -619,11 +623,12 @@ void initWiFi()
   // those WiFi connections will take a long time to make or sometimes will not work at all.
   WiFi.disconnect(false);
   delay(1);
+  setSTA(true);
   WifiScan(false);
   setWifiMode(WIFI_OFF);
 
 #if defined(ESP32)
-  wm_event_id = WiFi.onEvent(WiFiEvent);
+  registerWiFiEventHandler();
 #endif
 #ifdef ESP8266
   // WiFi event handlers
@@ -838,7 +843,7 @@ void WifiDisconnect()
   #ifdef ESP32
   WiFi.disconnect();
   delay(1);
-  WiFi.removeEvent(wm_event_id);
+  removeWiFiEventHandler();
   {
     const IPAddress ip;
     const IPAddress gw;
@@ -1266,6 +1271,11 @@ void setWifiMode(WiFiMode_t new_mode) {
     #endif // ifdef ESP8266
     delay(1);
   } else {
+    #ifdef ESP32
+    if (cur_mode == WIFI_OFF) {
+      registerWiFiEventHandler();
+    }
+    #endif
     // Only set power mode when AP is not enabled
     // When AP is enabled, the sleep mode is already set to WIFI_NONE_SLEEP
     if (!WifiIsAP(new_mode)) {

--- a/src/src/ESPEasyCore/ESPEasyWifi.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi.cpp
@@ -1431,9 +1431,9 @@ void setConnectionSpeed() {
 }
 
 void setupStaticIPconfig() {
-  setUseStaticIP(useStaticIP());
+  setUseStaticIP(WiFiUseStaticIP());
 
-  if (!useStaticIP()) { return; }
+  if (!WiFiUseStaticIP()) { return; }
   const IPAddress ip     = Settings.IP;
   const IPAddress gw     = Settings.Gateway;
   const IPAddress subnet = Settings.Subnet;

--- a/src/src/ESPEasyCore/ESPEasyWifi.h
+++ b/src/src/ESPEasyCore/ESPEasyWifi.h
@@ -15,7 +15,7 @@
 
 #include "../Helpers/LongTermTimer.h"
 
-#define WIFI_RECONNECT_WAIT                 20000 // in milliSeconds
+#define WIFI_RECONNECT_WAIT                 30000 // in milliSeconds
 #define WIFI_AP_OFF_TIMER_DURATION         300000 // in milliSeconds
 #define WIFI_CONNECTION_CONSIDERED_STABLE  300000 // in milliSeconds
 #define WIFI_ALLOW_AP_AFTERBOOT_PERIOD     5      // in minutes

--- a/src/src/ESPEasyCore/ESPEasyWifi.h
+++ b/src/src/ESPEasyCore/ESPEasyWifi.h
@@ -130,7 +130,7 @@ const __FlashStringHelper * getWifiModeString(WiFiMode_t wifimode);
 void setWifiMode(WiFiMode_t wifimode);
 bool WifiIsAP(WiFiMode_t wifimode);
 bool WifiIsSTA(WiFiMode_t wifimode);
-bool useStaticIP();
+bool WiFiUseStaticIP();
 bool wifiAPmodeActivelyUsed();
 void setConnectionSpeed();
 void setupStaticIPconfig();

--- a/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
@@ -31,6 +31,10 @@
 #include "../Helpers/StringConverter.h"
 #include "../Helpers/StringGenerator_WiFi.h"
 
+#if FEATURE_ETHERNET
+#include "../Globals/ESPEasyEthEvent.h"
+#endif
+
 
 // ********************************************************************************
 // Called from the loop() to make sure events are processed as soon as possible.
@@ -244,7 +248,8 @@ void handle_unprocessedNetworkEvents()
   // Check if DNS is still valid, as this may have been reset by the WiFi module turned off.
   if (EthEventData.EthServicesInitialized() && 
       active_network_medium == NetworkMedium_t::Ethernet &&
-      EthEventData.ethInitSuccess) {
+      EthEventData.ethInitSuccess &&
+      !ethUseStaticIP()) {
     const bool has_cache = !EthEventData.dns0_cache && !EthEventData.dns1_cache;
     if (has_cache) {
       const IPAddress dns0     = NetworkDnsIP(0);

--- a/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
@@ -1,14 +1,13 @@
 #include "../ESPEasyCore/ESPEasyWifi_ProcessEvent.h"
 
-// FIXME TD-er: Rename this to ESPEasyNetwork_ProcessEvent
-
 #include "../../ESPEasy-Globals.h"
 
-#include "../ESPEasyCore/ESPEasy_Log.h"
+#if FEATURE_ETHERNET
+#include "../ESPEasyCore/ESPEasyEth_ProcessEvent.h"
+#endif
 #include "../ESPEasyCore/ESPEasyNetwork.h"
-#include "../ESPEasyCore/ESPEasyEth.h"
 #include "../ESPEasyCore/ESPEasyWifi.h"
-#include "../ESPEasyCore/ESPEasyWiFiEvent.h"
+
 #include "../Globals/ESPEasyWiFiEvent.h"
 #include "../Globals/ESPEasy_Scheduler.h"
 #include "../Globals/ESPEasy_time.h"
@@ -17,23 +16,25 @@
 #include "../Globals/NetworkState.h"
 #include "../Globals/RTC.h"
 #include "../Globals/SecuritySettings.h"
-#include "../Globals/Settings.h"
 #include "../Globals/Services.h"
+#include "../Globals/Settings.h"
 #include "../Globals/WiFi_AP_Candidates.h"
+
+#include "../Helpers/Convert.h"
 #include "../Helpers/ESPEasyRTC.h"
 #include "../Helpers/ESPEasy_Storage.h"
-#include "../Helpers/ESPEasy_time_calc.h"
-#include "../Helpers/Misc.h"
 #include "../Helpers/Network.h"
 #include "../Helpers/Networking.h"
 #include "../Helpers/PeriodicalActions.h"
-#include "../Helpers/Scheduler.h"
 #include "../Helpers/StringConverter.h"
 #include "../Helpers/StringGenerator_WiFi.h"
 
-#if FEATURE_ETHERNET
-#include "../Globals/ESPEasyEthEvent.h"
-#endif
+// #include "../ESPEasyCore/ESPEasyEth.h"
+// #include "../ESPEasyCore/ESPEasyWiFiEvent.h"
+// #include "../ESPEasyCore/ESPEasy_Log.h"
+// #include "../Helpers/ESPEasy_time_calc.h"
+// #include "../Helpers/Misc.h"
+// #include "../Helpers/Scheduler.h"
 
 
 // ********************************************************************************
@@ -43,54 +44,9 @@
 void handle_unprocessedNetworkEvents()
 {
 #if FEATURE_ETHERNET
-  if (EthEventData.unprocessedEthEvents()) {
-    // Process disconnect events before connect events.
-    if (!EthEventData.processedDisconnect) {
-      #ifndef BUILD_NO_DEBUG
-      addLog(LOG_LEVEL_DEBUG, F("Eth  : Entering processDisconnect()"));
-      #endif // ifndef BUILD_NO_DEBUG
-      processEthernetDisconnected();
-    }
+  handle_unprocessedEthEvents();
+#endif
 
-    // Must process the Ethernet Connected event regardless the active network medium.
-    // It may happen by plugging in the cable while WiFi was active.
-    if (!EthEventData.processedConnect) {
-      #ifndef BUILD_NO_DEBUG
-      addLog(LOG_LEVEL_DEBUG, F("Eth  : Entering processConnect()"));
-      #endif // ifndef BUILD_NO_DEBUG
-      processEthernetConnected();
-    }
-  }
-
-  if (active_network_medium == NetworkMedium_t::Ethernet) {
-    const bool EthServices_was_initialized = EthEventData.EthServicesInitialized();
-    if (!EthEventData.EthServicesInitialized() || EthEventData.unprocessedEthEvents())
-    {
-      if (!EthEventData.unprocessedEthEvents() && EthEventData.EthConnectAllowed()) {
-        NetworkConnectRelaxed();
-      }
- 
-      if (!EthEventData.processedGotIP) {
-        #ifndef BUILD_NO_DEBUG
-        addLog(LOG_LEVEL_DEBUG, F("Eth  : Entering processGotIP()"));
-        #endif // ifndef BUILD_NO_DEBUG
-        processEthernetGotIP();
-      }
-
-      if (!EthEventData.processedDHCPTimeout) {
-        #ifndef BUILD_NO_DEBUG
-        addLog(LOG_LEVEL_DEBUG, F("Eth  : DHCP timeout, Calling disconnect()"));
-        #endif // ifndef BUILD_NO_DEBUG
-        EthEventData.processedDHCPTimeout = true;
-        //WifiDisconnect();
-      }
-    }
-    EthEventData.setEthServicesInitialized();
-    if (!EthServices_was_initialized && EthEventData.setEthServicesInitialized()) {
-      registerEthEventHandler();
-    }
-  }
-#endif // if FEATURE_ETHERNET
   if (active_network_medium == NetworkMedium_t::WIFI) {
     const bool should_be_initialized = (WiFiEventData.WiFiGotIP() && WiFiEventData.WiFiConnected()) || NetworkConnected();
     if (WiFiEventData.WiFiServicesInitialized() != should_be_initialized)
@@ -245,22 +201,7 @@ void handle_unprocessedNetworkEvents()
     }
   }
 #if FEATURE_ETHERNET
-  // Check if DNS is still valid, as this may have been reset by the WiFi module turned off.
-  if (EthEventData.EthServicesInitialized() && 
-      active_network_medium == NetworkMedium_t::Ethernet &&
-      EthEventData.ethInitSuccess &&
-      !ethUseStaticIP()) {
-    const bool has_cache = !EthEventData.dns0_cache && !EthEventData.dns1_cache;
-    if (has_cache) {
-      const IPAddress dns0     = NetworkDnsIP(0);
-      const IPAddress dns1     = NetworkDnsIP(1);
-
-      if (!dns0 && !dns1) {
-        addLog(LOG_LEVEL_ERROR, F("ETH  : DNS server was cleared, use cached DNS IP"));
-        ethSetDNS(EthEventData.dns0_cache, EthEventData.dns1_cache);
-      }
-    }
-  }
+  check_Eth_DNS_valid();
 #endif // if FEATURE_ETHERNET
 
 #if FEATURE_ESPEASY_P2P
@@ -641,130 +582,3 @@ void processScanDone() {
 
 
 
-#if FEATURE_ETHERNET
-
-void processEthernetConnected() {
-  if (EthEventData.processedConnect) return;
-  // FIXME TD-er: Must differentiate among reconnects for WiFi and Ethernet.
-  ++WiFiEventData.wifi_reconnects;
-  EthEventData.setEthConnected();
-  EthEventData.processedConnect = true;
-  if (Settings.UseRules)
-  {
-    eventQueue.add(F("Ethernet#LinkUp"));
-  }  
-  setNetworkMedium(Settings.NetworkMedium);
-}
-
-void processEthernetDisconnected() {
-  if (EthEventData.processedDisconnect) return;
-  EthEventData.setEthDisconnected();
-  EthEventData.processedDisconnect = true;
-  EthEventData.ethConnectAttemptNeeded = true;
-  if (Settings.UseRules)
-  {
-    eventQueue.add(F("Ethernet#Disconnected"));
-  }
-}
-
-void processEthernetGotIP() {
-  if (EthEventData.processedGotIP || !EthEventData.ethInitSuccess) {
-    return;
-  }
-  if (ethUseStaticIP()) {
-    ethSetupStaticIPconfig();
-  } 
-  const IPAddress ip       = NetworkLocalIP();
-
-  if (!ip) { 
-    return;
-  }
-
-  const IPAddress gw       = NetworkGatewayIP();
-  const IPAddress subnet   = NetworkSubnetMask();
-
-  IPAddress dns0     = NetworkDnsIP(0);
-  IPAddress dns1     = NetworkDnsIP(1);
-  const LongTermTimer::Duration dhcp_duration = EthEventData.lastConnectMoment.timeDiff(EthEventData.lastGetIPmoment);
-
-  if (!dns0 && !dns1) {
-    addLog(LOG_LEVEL_ERROR, F("ETH  : No DNS server received via DHCP, use cached DNS IP"));
-    ethSetDNS(EthEventData.dns0_cache, EthEventData.dns1_cache);
-  } else {
-    EthEventData.dns0_cache = dns0;
-    EthEventData.dns1_cache = dns1;
-  }
-
-  if (loglevelActiveFor(LOG_LEVEL_INFO))
-  {
-    String log;
-    if (log.reserve(160)) {
-      log = F("ETH MAC: ");
-      log += NetworkMacAddress().toString();
-      log += ' ';
-      if (ethUseStaticIP()) {
-        log += F("Static");
-      } else {
-        log += F("DHCP");
-      }
-      log += F(" IP: ");
-      log += ip.toString();
-      log += ' ';
-      log += wrap_braces(NetworkGetHostname());
-      log += F(" GW: ");
-      log += gw.toString();
-      log += F(" SN: ");
-      log += subnet.toString();
-      log += F(" DNS: ");
-      log += dns0.toString();
-      log += '/';
-      log += dns1.toString();
-
-      if (EthLinkUp()) {
-        if (EthFullDuplex()) {
-          log += F(" FULL_DUPLEX");
-        }
-        log += ' ';
-        log += EthLinkSpeed();
-        log += F("Mbps");
-      } else {
-        log += F(" Link Down");
-      }
-      
-      if ((dhcp_duration > 0ll) && (dhcp_duration < 30000000ll)) {
-        // Just log times when they make sense.
-        log += F("   duration: ");
-        log += static_cast<int32_t>(dhcp_duration / 1000);
-        log += F(" ms");
-      }
-
-      addLogMove(LOG_LEVEL_INFO, log);
-    }
-  }
-
-  // First try to get the time, since that may be used in logs
-  if (node_time.systemTimePresent()) {
-    node_time.initTime();
-  }
-#if FEATURE_MQTT
-  mqtt_reconnect_count        = 0;
-  MQTTclient_should_reconnect = true;
-  timermqtt_interval          = 100;
-  Scheduler.setIntervalTimer(ESPEasy_Scheduler::IntervalTimer_e::TIMER_MQTT);
-  scheduleNextMQTTdelayQueue();
-#endif // if FEATURE_MQTT
-  Scheduler.sendGratuitousARP_now();
-
-  if (Settings.UseRules)
-  {
-    eventQueue.add(F("Ethernet#Connected"));
-  }
-  statusLED(true);
-  logConnectionStatus();
-
-  EthEventData.processedGotIP = true;
-  EthEventData.setEthGotIP();
-  CheckRunningServices();
-}
-
-#endif // if FEATURE_ETHERNET

--- a/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
@@ -59,6 +59,7 @@ void handle_unprocessedNetworkEvents()
   }
 
   if (active_network_medium == NetworkMedium_t::Ethernet) {
+    const bool EthServices_was_initialized = EthEventData.EthServicesInitialized();
     if (!EthEventData.EthServicesInitialized() || EthEventData.unprocessedEthEvents())
     {
       if (!EthEventData.unprocessedEthEvents() && EthEventData.EthConnectAllowed()) {
@@ -81,6 +82,9 @@ void handle_unprocessedNetworkEvents()
       }
     }
     EthEventData.setEthServicesInitialized();
+    if (!EthServices_was_initialized && EthEventData.setEthServicesInitialized()) {
+      registerEthEventHandler();
+    }
   }
 #endif // if FEATURE_ETHERNET
   if (active_network_medium == NetworkMedium_t::WIFI) {

--- a/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
@@ -654,7 +654,7 @@ void processEthernetDisconnected() {
   EthEventData.ethConnectAttemptNeeded = true;
   if (Settings.UseRules)
   {
-    eventQueue.add(F("ETHERNET#Disconnected"));
+    eventQueue.add(F("Ethernet#Disconnected"));
   }
 }
 

--- a/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
@@ -671,6 +671,9 @@ void processEthernetGotIP() {
   if (EthEventData.processedGotIP || !EthEventData.ethInitSuccess) {
     return;
   }
+  if (ethUseStaticIP()) {
+    ethSetupStaticIPconfig();
+  } 
   const IPAddress ip       = NetworkLocalIP();
 
   if (!ip) { 
@@ -699,7 +702,7 @@ void processEthernetGotIP() {
       log = F("ETH MAC: ");
       log += NetworkMacAddress().toString();
       log += ' ';
-      if (useStaticIP()) {
+      if (ethUseStaticIP()) {
         log += F("Static");
       } else {
         log += F("DHCP");

--- a/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.h
+++ b/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.h
@@ -1,5 +1,5 @@
-#ifndef ESPEASYWIFI_PROCESSEVENT_H
-#define ESPEASYWIFI_PROCESSEVENT_H
+#ifndef ESPEASYCORE_ESPEASYWIFI_PROCESSEVENT_H
+#define ESPEASYCORE_ESPEASYWIFI_PROCESSEVENT_H
 
 #include "../../ESPEasy_common.h"
 
@@ -12,10 +12,4 @@ void processConnectAPmode();
 void processDisableAPmode();
 void processScanDone();
 
-#if FEATURE_ETHERNET
-void processEthernetConnected();
-void processEthernetDisconnected();
-void processEthernetGotIP();
-#endif // if FEATURE_ETHERNET
-
-#endif //ESPEASYWIFI_PROCESSEVENT_H
+#endif // ifndef ESPEASYCORE_ESPEASYWIFI_PROCESSEVENT_H

--- a/src/src/Globals/ESPEasyEthEvent.cpp
+++ b/src/src/Globals/ESPEasyEthEvent.cpp
@@ -1,0 +1,8 @@
+#include "../Globals/ESPEasyEthEvent.h"
+
+#include "../../ESPEasy_common.h"
+
+#if FEATURE_ETHERNET
+EthernetEventData_t EthEventData;
+#endif
+

--- a/src/src/Globals/ESPEasyEthEvent.h
+++ b/src/src/Globals/ESPEasyEthEvent.h
@@ -1,0 +1,15 @@
+#ifndef GLOBALS_ESPEASYETHEVENT_H
+#define GLOBALS_ESPEASYETHEVENT_H
+
+
+#include "../../ESPEasy_common.h"
+#if FEATURE_ETHERNET
+
+# include "../DataStructs/EthernetEventData.h"
+
+
+extern EthernetEventData_t EthEventData;
+
+#endif // if FEATURE_ETHERNET
+
+#endif // ifndef GLOBALS_ESPEASYETHEVENT_H

--- a/src/src/Globals/ESPEasyWiFiEvent.cpp
+++ b/src/src/Globals/ESPEasyWiFiEvent.cpp
@@ -2,8 +2,6 @@
 
 #include "../../ESPEasy_common.h"
 
-// FIXME TD-er: Rename this to ESPEasyNetworkEvent
-
 
 #ifdef ESP8266
 WiFiEventHandler stationConnectedHandler;
@@ -17,7 +15,4 @@ WiFiEventHandler APModeStationDisconnectedHandler;
 
 WiFiEventData_t WiFiEventData;
 
-#if FEATURE_ETHERNET
-EthernetEventData_t EthEventData;
-#endif
 

--- a/src/src/Globals/ESPEasyWiFiEvent.cpp
+++ b/src/src/Globals/ESPEasyWiFiEvent.cpp
@@ -21,7 +21,3 @@ WiFiEventData_t WiFiEventData;
 EthernetEventData_t EthEventData;
 #endif
 
-
-#ifdef ESP32
-WiFiEventId_t wm_event_id;
-#endif // ifdef ESP32

--- a/src/src/Globals/ESPEasyWiFiEvent.h
+++ b/src/src/Globals/ESPEasyWiFiEvent.h
@@ -5,9 +5,6 @@
 #include "../../ESPEasy_common.h"
 
 #include "../DataStructs/WiFiEventData.h"
-#if FEATURE_ETHERNET
-#include "../DataStructs/EthernetEventData.h"
-#endif
 
 #include <Arduino.h>
 #include <IPAddress.h>
@@ -37,10 +34,6 @@ extern WiFiEventHandler APModeStationDisconnectedHandler;
 
 
 extern WiFiEventData_t WiFiEventData;
-
-#if FEATURE_ETHERNET
-extern EthernetEventData_t EthEventData;
-#endif
 
 
 #endif // GLOBALS_ESPEASYWIFIEVENT_H

--- a/src/src/Globals/ESPEasyWiFiEvent.h
+++ b/src/src/Globals/ESPEasyWiFiEvent.h
@@ -42,9 +42,5 @@ extern WiFiEventData_t WiFiEventData;
 extern EthernetEventData_t EthEventData;
 #endif
 
-#ifdef ESP32
-extern WiFiEventId_t wm_event_id;
-#endif // ifdef ESP32
-
 
 #endif // GLOBALS_ESPEASYWIFIEVENT_H

--- a/src/src/Helpers/ESPEasy_Storage.cpp
+++ b/src/src/Helpers/ESPEasy_Storage.cpp
@@ -472,6 +472,40 @@ bool GarbageCollection() {
   #endif // ifdef CORE_POST_2_6_0
 }
 
+bool computeChecksum(
+  uint8_t checksum[16], 
+  uint8_t * data, 
+  size_t struct_size, 
+  size_t len_upto_md5,
+  bool updateChecksum)
+{
+  if (len_upto_md5 > struct_size) len_upto_md5 = struct_size;
+  MD5Builder md5;
+  md5.begin();
+
+  if (len_upto_md5 > 0) {
+    md5.add(data, len_upto_md5);
+  }
+  if ((len_upto_md5 + 16) < struct_size) {
+    data += len_upto_md5 + 16;
+    const int len_after_md5 = struct_size - 16 - len_upto_md5;
+    if (len_after_md5 > 0) {
+      md5.add(data, len_after_md5);
+    }
+  }
+  md5.calculate();
+  uint8_t    tmp_md5[16] = { 0 };
+  md5.getBytes(tmp_md5);
+  if (memcmp(tmp_md5, checksum, 16) != 0) {
+    // Data has changed, copy computed checksum
+    if (updateChecksum) {
+      memcpy(checksum, tmp_md5, 16);
+    }
+    return false;
+  }
+  return true;
+}
+
 /********************************************************************************************\
    Save settings to file system
  \*********************************************************************************************/
@@ -486,20 +520,21 @@ String SaveSettings()
 
     // FIXME @TD-er: As discussed in #1292, the CRC for the settings is now disabled.
 
-    /*
-      MD5Builder md5;
-      uint8_t    tmp_md5[16] = { 0 };
-      memcpy( Settings.ProgmemMd5, CRCValues.runTimeMD5, 16);
-      md5.begin();
-      md5.add(reinterpret_cast<const uint8_t *>(&Settings), sizeof(Settings)-16);
-      md5.calculate();
-      md5.getBytes(tmp_md5);
-      if (memcmp(tmp_md5, Settings.md5, 16) != 0) {
-        // Settings have changed, save to file.
-        memcpy(Settings.md5, tmp_md5, 16);
-    */
     Settings.validate();
-    err = SaveToFile(SettingsType::getSettingsFileName(SettingsType::Enum::BasicSettings_Type).c_str(), 0, reinterpret_cast<const uint8_t *>(&Settings), sizeof(Settings));
+
+    if (!COMPUTE_STRUCT_CHECKSUM_UPDATE(SettingsStruct, Settings)
+    /*
+    computeChecksum(
+        Settings.md5,
+        reinterpret_cast<uint8_t *>(&Settings),
+        sizeof(SettingsStruct),
+        offsetof(SettingsStruct, md5))
+    */
+        ) {
+      err = SaveToFile(SettingsType::getSettingsFileName(SettingsType::Enum::BasicSettings_Type).c_str(), 0, reinterpret_cast<const uint8_t *>(&Settings), sizeof(Settings));
+    } else {
+      addLog(LOG_LEVEL_INFO, F("Skip saving settings, not changed"));
+    }
   }
 
   if (err.length()) {
@@ -515,41 +550,35 @@ String SaveSettings()
   //  }
 
   err = SaveSecuritySettings();
-  if (!NetworkConnected()) {
-    if (SecuritySettings.hasWiFiCredentials() && active_network_medium == NetworkMedium_t::WIFI) {
-      WiFiEventData.wifiConnectAttemptNeeded = true;
-      WiFi_AP_Candidates.force_reload(); // Force reload of the credentials and found APs from the last scan
-      resetWiFi();
-      AttemptWiFiConnect();
-    }
-  }
 
   return err;
 }
 
 String SaveSecuritySettings() {
-  MD5Builder md5;
-  uint8_t    tmp_md5[16] = { 0 };
   String     err;
 
   SecuritySettings.validate();
   memcpy(SecuritySettings.ProgmemMd5, CRCValues.runTimeMD5, 16);
-  md5.begin();
-  md5.add(reinterpret_cast<uint8_t *>(&SecuritySettings), static_cast<uint16_t>(sizeof(SecuritySettings) - 16));
-  md5.calculate();
-  md5.getBytes(tmp_md5);
 
-  if (memcmp(tmp_md5, SecuritySettings.md5, 16) != 0) {
+  if (!COMPUTE_STRUCT_CHECKSUM_UPDATE(SecurityStruct, SecuritySettings)) {
     // Settings have changed, save to file.
-    memcpy(SecuritySettings.md5, tmp_md5, 16);
     err = SaveToFile(SettingsType::getSettingsFileName(SettingsType::Enum::SecuritySettings_Type).c_str(), 0, reinterpret_cast<const uint8_t *>(&SecuritySettings), sizeof(SecuritySettings));
 
-    if (WifiIsAP(WiFi.getMode())) {
-      // Security settings are saved, may be update of WiFi settings or hostname.
-      WiFiEventData.wifiSetupConnect         = true;
-      WiFiEventData.wifiConnectAttemptNeeded = true;
+    // Security settings are saved, may be update of WiFi settings or hostname.
+    if (!NetworkConnected()) {
+      if (SecuritySettings.hasWiFiCredentials() && active_network_medium == NetworkMedium_t::WIFI) {
+        WiFiEventData.wifiConnectAttemptNeeded = true;
+        WiFi_AP_Candidates.force_reload(); // Force reload of the credentials and found APs from the last scan
+        resetWiFi();
+        AttemptWiFiConnect();
+      }
     }
+  } else {
+    addLog(LOG_LEVEL_INFO, F("Skip saving SecuritySettings, not changed"));
+
   }
+
+  // FIXME TD-er: How to check if these have changed?
   ExtendedControllerCredentials.save();
   afterloadSettings();
   return err;
@@ -597,8 +626,6 @@ String LoadSettings()
   checkRAM(F("LoadSettings"));
   #endif
   String  err;
-  uint8_t calculatedMd5[16];
-  MD5Builder md5;
 
   err = LoadFromFile(SettingsType::getSettingsFileName(SettingsType::Enum::BasicSettings_Type).c_str(), 0, reinterpret_cast<uint8_t *>(&Settings), sizeof(SettingsStruct));
 
@@ -607,33 +634,15 @@ String LoadSettings()
   }
   Settings.validate();
 
-  // FIXME @TD-er: As discussed in #1292, the CRC for the settings is now disabled.
-
-  /*
-     if (Settings.StructSize > 16) {
-      md5.begin();
-      md5.add(reinterpret_cast<const uint8_t *>(&Settings), Settings.StructSize -16);
-      md5.calculate();
-      md5.getBytes(calculatedMd5);
-     }
-     if (memcmp (calculatedMd5, Settings.md5,16)==0){
-      addLog(LOG_LEVEL_INFO,  F("CRC  : Settings CRC           ...OK"));
-      if (memcmp(Settings.ProgmemMd5, CRCValues.runTimeMD5, 16)!=0)
-        addLog(LOG_LEVEL_INFO, F("CRC  : binary has changed since last save of Settings"));
-     }
-     else{
-      addLog(LOG_LEVEL_ERROR, F("CRC  : Settings CRC           ...FAIL"));
-     }
-   */
+  if (COMPUTE_STRUCT_CHECKSUM(SettingsStruct, Settings)) {
+    addLog(LOG_LEVEL_INFO,  F("CRC  : Settings CRC           ...OK"));
+  } else{
+    addLog(LOG_LEVEL_ERROR, F("CRC  : Settings CRC           ...FAIL"));
+  }
 
   err = LoadFromFile(SettingsType::getSettingsFileName(SettingsType::Enum::SecuritySettings_Type).c_str(), 0, reinterpret_cast<uint8_t *>(&SecuritySettings), sizeof(SecurityStruct));
 
-  md5.begin();
-  md5.add(reinterpret_cast< uint8_t *>(&SecuritySettings), sizeof(SecuritySettings) - 16);
-  md5.calculate();
-  md5.getBytes(calculatedMd5);
-
-  if (memcmp(calculatedMd5, SecuritySettings.md5, 16) == 0) {
+  if (COMPUTE_STRUCT_CHECKSUM(SecurityStruct, SecuritySettings)) {
     addLog(LOG_LEVEL_INFO, F("CRC  : SecuritySettings CRC   ...OK "));
 
     if (memcmp(SecuritySettings.ProgmemMd5, CRCValues.runTimeMD5, 16) != 0) {
@@ -1163,20 +1172,13 @@ String LoadCustomControllerSettings(controllerIndex_t ControllerIndex, uint8_t *
  \*********************************************************************************************/
 String saveProvisioningSettings(ProvisioningStruct& ProvisioningSettings)
 {
-  MD5Builder md5;
-  uint8_t    tmp_md5[16] = { 0 };
   String     err;
 
   ProvisioningSettings.validate();
   memcpy(ProvisioningSettings.ProgmemMd5, CRCValues.runTimeMD5, 16);
-  md5.begin();
-  md5.add((uint8_t *)&ProvisioningSettings + 16, sizeof(ProvisioningSettings) - 16);
-  md5.calculate();
-  md5.getBytes(tmp_md5);
-
-  if (memcmp(tmp_md5, ProvisioningSettings.md5, 16) != 0) {
+  if (!COMPUTE_STRUCT_CHECKSUM_UPDATE(ProvisioningStruct, ProvisioningSettings))
+  {
     // Settings have changed, save to file.
-    memcpy(ProvisioningSettings.md5, tmp_md5, 16);
     err = SaveToFile_trunc(getFileName(FileType::PROVISIONING_DAT, 0).c_str(), 0, (uint8_t *)&ProvisioningSettings, sizeof(ProvisioningStruct));
   }
   return err;
@@ -1187,16 +1189,10 @@ String saveProvisioningSettings(ProvisioningStruct& ProvisioningSettings)
  \*********************************************************************************************/
 String loadProvisioningSettings(ProvisioningStruct& ProvisioningSettings)
 {
-  uint8_t calculatedMd5[16] = { 0 };
-  MD5Builder md5;
-
   String err = LoadFromFile(getFileName(FileType::PROVISIONING_DAT, 0).c_str(), 0, (uint8_t *)&ProvisioningSettings, sizeof(ProvisioningStruct));
-  md5.begin();
-  md5.add(((uint8_t *)&ProvisioningSettings) + 16, sizeof(ProvisioningSettings) - 16);
-  md5.calculate();
-  md5.getBytes(calculatedMd5);
 
-  if (memcmp(calculatedMd5, ProvisioningSettings.md5, 16) == 0) {
+  if (COMPUTE_STRUCT_CHECKSUM(ProvisioningStruct, ProvisioningSettings))
+  {
     addLog(LOG_LEVEL_INFO, F("CRC  : ProvisioningSettings CRC   ...OK "));
 
     if (memcmp(ProvisioningSettings.ProgmemMd5, CRCValues.runTimeMD5, 16) != 0) {

--- a/src/src/Helpers/ESPEasy_Storage.cpp
+++ b/src/src/Helpers/ESPEasy_Storage.cpp
@@ -24,11 +24,13 @@
 #include "../Globals/ESPEasy_time.h"
 #include "../Globals/EventQueue.h"
 #include "../Globals/ExtraTaskSettings.h"
+#include "../Globals/NetworkState.h"
 #include "../Globals/Plugins.h"
 #include "../Globals/RTC.h"
 #include "../Globals/ResetFactoryDefaultPref.h"
 #include "../Globals/SecuritySettings.h"
 #include "../Globals/Settings.h"
+#include "../Globals/WiFi_AP_Candidates.h"
 
 #include "../Helpers/ESPEasyRTC.h"
 #include "../Helpers/ESPEasy_checks.h"
@@ -513,6 +515,15 @@ String SaveSettings()
   //  }
 
   err = SaveSecuritySettings();
+  if (!NetworkConnected()) {
+    if (SecuritySettings.hasWiFiCredentials() && active_network_medium == NetworkMedium_t::WIFI) {
+      WiFiEventData.wifiConnectAttemptNeeded = true;
+      WiFi_AP_Candidates.force_reload(); // Force reload of the credentials and found APs from the last scan
+      resetWiFi();
+      AttemptWiFiConnect();
+    }
+  }
+
   return err;
 }
 

--- a/src/src/Helpers/ESPEasy_Storage.h
+++ b/src/src/Helpers/ESPEasy_Storage.h
@@ -61,6 +61,31 @@ int  getPartionCount(uint8_t pType, uint8_t pSubType = 0xFF);
  \*********************************************************************************************/
 bool GarbageCollection();
 
+// Compute checksum of the data.
+// Skip the part where the checksum may be located in the data
+// @param checksum The expected checksum. Will contain checksum after call finished.
+// @retval true when checksum matches
+bool computeChecksum(
+  uint8_t checksum[16], 
+  uint8_t * data, 
+  size_t struct_size, 
+  size_t len_upto_md5,
+  bool updateChecksum = true);
+
+#define COMPUTE_STRUCT_CHECKSUM_UPDATE(STRUCT,OBJECT) \
+   computeChecksum(OBJECT.md5,\
+                   reinterpret_cast<uint8_t *>(&OBJECT),\
+                   sizeof(STRUCT),\
+                   offsetof(STRUCT, md5),\
+                   true)
+
+#define COMPUTE_STRUCT_CHECKSUM(STRUCT,OBJECT) \
+   computeChecksum(OBJECT.md5,\
+                   reinterpret_cast<uint8_t *>(&OBJECT),\
+                   sizeof(STRUCT),\
+                   offsetof(STRUCT, md5),\
+                   false)
+
 /********************************************************************************************\
    Save settings to file system
  \*********************************************************************************************/

--- a/src/src/Helpers/ESPEasy_checks.cpp
+++ b/src/src/Helpers/ESPEasy_checks.cpp
@@ -76,10 +76,10 @@ void run_compiletime_checks() {
   check_size<CRCStruct,                             204u>();
   check_size<SecurityStruct,                        593u>();
   #ifdef ESP32
-  const unsigned int SettingsStructSize = (316 + 84 * TASKS_MAX);
+  const unsigned int SettingsStructSize = (332 + 84 * TASKS_MAX);
   #endif
   #ifdef ESP8266
-  const unsigned int SettingsStructSize = (292 + 84 * TASKS_MAX);
+  const unsigned int SettingsStructSize = (308 + 84 * TASKS_MAX);
   #endif
   #if FEATURE_CUSTOM_PROVISIONING
   check_size<ProvisioningStruct,                    256u>();  

--- a/src/src/Helpers/Networking.cpp
+++ b/src/src/Helpers/Networking.cpp
@@ -921,6 +921,15 @@ bool hasIPaddr() {
 #endif // ifdef CORE_POST_2_5_0
 }
 
+bool useStaticIP() {
+  #if FEATURE_ETHERNET
+  if (active_network_medium == NetworkMedium_t::Ethernet) {
+    return ethUseStaticIP();
+  }
+  #endif
+  return WiFiUseStaticIP();
+}
+
 // Check connection. Maximum timeout 500 msec.
 bool NetworkConnected(uint32_t timeout_ms) {
 

--- a/src/src/Helpers/Networking.h
+++ b/src/src/Helpers/Networking.h
@@ -141,6 +141,8 @@ bool getSubnetRange(IPAddress& low, IPAddress& high);
 
 bool hasIPaddr();
 
+bool useStaticIP();
+
 // Check connection. Maximum timeout 500 msec.
 bool NetworkConnected(uint32_t timeout_ms);
 

--- a/src/src/Helpers/PeriodicalActions.cpp
+++ b/src/src/Helpers/PeriodicalActions.cpp
@@ -15,6 +15,9 @@
 #include "../ESPEasyCore/ESPEasyRules.h"
 #include "../ESPEasyCore/Serial.h"
 #include "../Globals/ESPEasyWiFiEvent.h"
+#if FEATURE_ETHERNET
+#include "../Globals/ESPEasyEthEvent.h"
+#endif
 #include "../Globals/ESPEasy_Scheduler.h"
 #include "../Globals/ESPEasy_time.h"
 #include "../Globals/EventQueue.h"

--- a/src/src/Helpers/StringProvider.cpp
+++ b/src/src/Helpers/StringProvider.cpp
@@ -17,6 +17,11 @@
 #include "../Globals/ESPEasy_Scheduler.h"
 #include "../Globals/ESPEasy_time.h"
 #include "../Globals/ESPEasyWiFiEvent.h"
+
+#if FEATURE_ETHERNET
+#include "../Globals/ESPEasyEthEvent.h"
+#endif
+
 #include "../Globals/NetworkState.h"
 #include "../Globals/SecuritySettings.h"
 #include "../Globals/Settings.h"


### PR DESCRIPTION
On ESP32, the event handling for WiFi (and Ethernet) needs to be re-registered when interfaces are turned on/off. Otherwise events like connect to ESP AP will not be registered and thus the captive login page will not be served.

Also Favicon and CSS were not properly shown on the setup page on ESP32/ESP32-S2 due to a mismatch in file name comparison.