### PR TITLE
[Build] Fix missing include + some define checks

### DIFF
--- a/src/src/Commands/Common.cpp
+++ b/src/src/Commands/Common.cpp
@@ -11,6 +11,7 @@
 #include "../ESPEasyCore/ESPEasyWifi.h"
 #include "../ESPEasyCore/Serial.h"
 
+#include "../Helpers/Networking.h"
 #include "../Helpers/Numerical.h"
 #include "../Helpers/StringConverter.h"
 

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -398,7 +398,10 @@ To create/register a plugin, you have to :
       #define PLUGIN_DESCR  "Minimal 1M OTA"
     #endif
 
-    #define CONTROLLER_SET_NONE
+
+    #ifndef CONTROLLER_SET_NONE
+      #define CONTROLLER_SET_NONE
+    #endif
 
     #define BUILD_MINIMAL_OTA
     #ifndef BUILD_NO_DEBUG
@@ -417,9 +420,13 @@ To create/register a plugin, you have to :
 //    #define USES_C013   // ESPEasy P2P network
 
 //    #define NOTIFIER_SET_STABLE
-    #define NOTIFIER_SET_NONE
+    #ifndef NOTIFIER_SET_NONE
+      #define NOTIFIER_SET_NONE
+    #endif
 
-    #define PLUGIN_SET_NONE
+    #ifndef PLUGIN_SET_NONE
+      #define PLUGIN_SET_NONE
+    #endif
 
     #ifdef FEATURE_SETTINGS_ARCHIVE
         #undef FEATURE_SETTINGS_ARCHIVE


### PR DESCRIPTION
When making a custom build with one or more of these defines, it may result in lots of warnings, slowing down the build process considerably.