### PR TITLE
[PIO Build] Remove concat work-around for ESP32 builds

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -70,13 +70,13 @@ build_flags               = -DMQTT_MAX_PACKET_SIZE=1024
 
 [extra_scripts_default]
 extra_scripts             = pre:tools/pio/set-ci-defines.py
-                            pre:tools/pio/concat_cpp_files.py
                             pre:tools/pio/generate-compiletime-defines.py
                             tools/pio/copy_files.py
-                            post:tools/pio/remove_concat_cpp_files.py
 
 [extra_scripts_esp8266]
 extra_scripts             = tools/pio/gzip-firmware.py
+                            pre:tools/pio/concat_cpp_files.py
+                            post:tools/pio/remove_concat_cpp_files.py
                             ${extra_scripts_default.extra_scripts}
 
 
@@ -87,7 +87,7 @@ upload_speed              = 115200
 monitor_speed             = 115200
 ;targets                   = size, checkprogsize
 targets                   =
-src_filter                = +<*> -<.git/> -<.svn/> -<example/> -<examples/> -<test/> -<tests/> -<*/Commands/> -<*/ControllerQueue/> -<*/DataStructs/> -<*/DataTypes/> -<*/Globals/> -<*/Helpers/> -<*/PluginStructs/>  -<*/WebServer/>
+src_filter                = +<*> -<.git/> -<.svn/> -<example/> -<examples/> -<test/> -<tests/> -<*/Commands_tmp/> -<*/ControllerQueue_tmp/> -<*/DataStructs_tmp/> -<*/DataTypes_tmp/> -<*/Globals_tmp/> -<*/Helpers_tmp/> -<*/PluginStructs_tmp/>  -<*/WebServer_tmp/>
 
 ; Backwards compatibility: https://github.com/platformio/platformio-core/issues/4270
 ;build_src_filter  = +<*> -<.git/> -<.svn/> -<example/> -<examples/> -<test/> -<tests/> -<*/Commands/> -<*/ControllerQueue/> -<*/DataStructs/> -<*/DataTypes/> -<*/Globals/> -<*/Helpers/> -<*/PluginStructs/>  -<*/WebServer/>

--- a/platformio_esp82xx_base.ini
+++ b/platformio_esp82xx_base.ini
@@ -111,6 +111,8 @@ lib_ignore                = ${esp82xx_defaults.lib_ignore}
 monitor_filters           = esp8266_exception_decoder
 extra_scripts             = pre:tools/pio/pre_default_check.py
                             ${extra_scripts_esp8266.extra_scripts}
+src_filter                = +<*> -<.git/> -<.svn/> -<example/> -<examples/> -<test/> -<tests/> -<*/Commands/> -<*/ControllerQueue/> -<*/DataStructs/> -<*/DataTypes/> -<*/Globals/> -<*/Helpers/> -<*/PluginStructs/>  -<*/WebServer/>
+
 
 
 

--- a/src/src/DataStructs/PluginStats.h
+++ b/src/src/DataStructs/PluginStats.h
@@ -6,6 +6,8 @@
 #if FEATURE_PLUGIN_STATS
 
 # include "../DataStructs/ChartJS_dataset_config.h"
+#include "../DataTypes/TaskIndex.h"
+
 
 # include <CircularBuffer.h>
 

--- a/src/src/Helpers/ESPEasy_time.cpp
+++ b/src/src/Helpers/ESPEasy_time.cpp
@@ -4,6 +4,7 @@
 
 #include "../CustomBuild/CompiletimeDefines.h"
 
+#include "../DataStructs/TimingStats.h"
 #include "../DataTypes/TimeSource.h"
 
 #include "../ESPEasyCore/ESPEasy_Log.h"
@@ -21,6 +22,7 @@
 #include "../Helpers/Misc.h"
 #include "../Helpers/Networking.h"
 #include "../Helpers/Numerical.h"
+#include "../Helpers/StringConverter.h"
 
 #include "../Helpers/ESPEasy_time_calc.h"
 

--- a/src/src/Helpers/Networking.cpp
+++ b/src/src/Helpers/Networking.cpp
@@ -7,6 +7,7 @@
 #include "../DataTypes/EventValueSource.h"
 #include "../ESPEasyCore/ESPEasy_Log.h"
 #include "../ESPEasyCore/ESPEasy_backgroundtasks.h"
+#include "../ESPEasyCore/ESPEasyEth.h"
 #include "../ESPEasyCore/ESPEasyNetwork.h"
 #include "../ESPEasyCore/ESPEasyWifi.h"
 #include "../Globals/ESPEasyWiFiEvent.h"

--- a/src/src/Helpers/StringProvider.cpp
+++ b/src/src/Helpers/StringProvider.cpp
@@ -31,6 +31,7 @@
 #include "../Helpers/ESPEasy_Storage.h"
 #include "../Helpers/Memory.h"
 #include "../Helpers/Misc.h"
+#include "../Helpers/Networking.h"
 #include "../Helpers/Scheduler.h"
 #include "../Helpers/StringConverter.h"
 #include "../Helpers/StringGenerator_System.h"

--- a/src/src/WebServer/SysInfoPage.cpp
+++ b/src/src/WebServer/SysInfoPage.cpp
@@ -17,6 +17,7 @@
 
 #include "../DataStructs/RTCStruct.h"
 
+#include "../ESPEasyCore/ESPEasyEth.h"
 #include "../ESPEasyCore/ESPEasyNetwork.h"
 #include "../ESPEasyCore/ESPEasyWifi.h"
 
@@ -33,6 +34,7 @@
 #include "../Helpers/Hardware.h"
 #include "../Helpers/Memory.h"
 #include "../Helpers/Misc.h"
+#include "../Helpers/Networking.h"
 #include "../Helpers/OTA.h"
 #include "../Helpers/StringConverter.h"
 #include "../Helpers/StringGenerator_GPIO.h"


### PR DESCRIPTION
To build (and link) on Windows, we needed to concat the .cpp files into temporary files.
This way there were fewer .o files to link.
The linker command on Windows exceeded the max. command line length and thus failed.

On ESP32 platform this has been fixed, but for ESP8266 we still need it to build core 2.7.4.