### PR TITLE
[Build] Revert Espressif32 framework to 2.0.4.1 to fix NeoPixel/RMT related issues

### DIFF
--- a/platformio_core_defs.ini
+++ b/platformio_core_defs.ini
@@ -233,7 +233,7 @@ build_flags               = ${esp82xx_3_0_x.build_flags}
 ;platform                    = https://github.com/Jason2866/platform-espressif32.git
 ;platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/938/framework-arduinoespressif32-443_esp421-10ab11e815.tar.gz
 
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.5.2/platform-espressif32-2.0.5.2.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.4.1/platform-espressif32-2.0.4.1.zip
 platform_packages           =
 
 build_flags                 = -DESP32_STAGE


### PR DESCRIPTION
Resolves #4332 

Revert Espressif32 framework to known working version, as 2.0.5.x crashes with RMT related errors.