### PR TITLE
[Build] Update platform to 2.0.5.2, enable PSRAM for 16M8M envs, prepare PSRAM fix config

### DIFF
--- a/boards/esp32_16M8M.json
+++ b/boards/esp32_16M8M.json
@@ -5,7 +5,7 @@
       "memory_type": "dio_qspi"
     },
     "core": "esp32",
-    "extra_flags": "-DARDUINO_ESP32_DEV -DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_16M",
+    "extra_flags": "-DARDUINO_ESP32_DEV -DBOARD_HAS_PSRAM -DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_16M",
     "f_cpu": "240000000L",
     "f_flash": "40000000L",
     "flash_mode": "dio",

--- a/boards/esp32_4M_fix.json
+++ b/boards/esp32_4M_fix.json
@@ -5,13 +5,13 @@
       "memory_type": "dio_qspi"
     },
     "core": "esp32",
-    "extra_flags": "-DARDUINO_ESP32_DEV -DBOARD_HAS_PSRAM -DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_16M",
+    "extra_flags": "-DARDUINO_ESP32_DEV -DBOARD_HAS_PSRAM -DHAS_PSRAM_FIX -mfix-esp32-psram-cache-issue -mfix-esp32-psram-cache-strategy=memw -DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_4M",
     "f_cpu": "240000000L",
     "f_flash": "40000000L",
     "flash_mode": "dio",
     "mcu": "esp32",
     "variant": "esp32",
-    "partitions": "esp32_partition_app4096k_spiffs8124k.csv"
+    "partitions": "esp32_partition_app1810k_spiffs316k.csv"
   },
   "connectivity": [
     "wifi",
@@ -26,12 +26,15 @@
     "arduino",
     "espidf"
   ],
-  "name": "Espressif Generic ESP32 16M Flash PSRAM ESPEasy 4M Code/OTA 8M FS",
+  "name": "Espressif Generic ESP32 4M Flash ESPEasy 1810k Code/OTA 316k FS",
   "upload": {
-    "flash_size": "16MB",
+    "flash_size": "4MB",
     "maximum_ram_size": 327680,
-    "maximum_size": 16777216,
+    "maximum_size": 1900544,
     "require_upload_port": true,
+    "resetmethod": "nodemcu",
+    "before_reset": "default_reset",
+    "after_reset": "hard_reset",
     "speed": 460800
   },
   "url": "https://en.wikipedia.org/wiki/ESP32",

--- a/platformio_core_defs.ini
+++ b/platformio_core_defs.ini
@@ -233,7 +233,7 @@ build_flags               = ${esp82xx_3_0_x.build_flags}
 ;platform                    = https://github.com/Jason2866/platform-espressif32.git
 ;platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/938/framework-arduinoespressif32-443_esp421-10ab11e815.tar.gz
 
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.4.1/platform-espressif32-2.0.4.1.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.5.2/platform-espressif32-2.0.5.2.zip
 platform_packages           =
 
 build_flags                 = -DESP32_STAGE

--- a/platformio_esp32_envs.ini
+++ b/platformio_esp32_envs.ini
@@ -104,10 +104,6 @@ extends                   = esp32_custom_base_LittleFS
 board                     = esp32_16M8M
 board_upload.flash_size   = 16MB
 
-[env:custom_ESP32_16M8M_PSRAM_LittleFS]
-extends                   = env:custom_ESP32_16M8M_LittleFS
-board                     = esp32_16M8M_psram
-
 [env:custom_IR_ESP32_4M316k]
 extends                   = esp32_base
 board                     = esp32_4M
@@ -335,10 +331,6 @@ build_flags               = ${esp32_base.build_flags}
 extra_scripts             = ${esp32_base.extra_scripts}
 board_build.filesystem    = littlefs
 
-[env:max_ESP32_16M8M_PSRAM_LittleFS]
-extends                   = env:max_ESP32_16M8M_LittleFS
-board                     = esp32_16M8M_psram
-
 ; If you have a board with Ethernet integrated and 16MB Flash, then this configuration could be enabled, it's based on the max_ESP32_16M8M_LittleFS definition
 [env:max_ESP32_16M8M_LittleFS_ETH]
 extends                   = env:max_ESP32_16M8M_LittleFS
@@ -346,9 +338,6 @@ board                     = ${env:max_ESP32_16M8M_LittleFS.board}
 build_flags               = ${env:max_ESP32_16M8M_LittleFS.build_flags}
                             -DFEATURE_ETHERNET=1
 
-[env:max_ESP32_16M8M_PSRAM_LittleFS_ETH]
-extends                   = env:max_ESP32_16M8M_LittleFS_ETH
-board                     = esp32_16M8M_psram
 
 
 

--- a/src/src/PluginStructs/P002_data_struct.cpp
+++ b/src/src/PluginStructs/P002_data_struct.cpp
@@ -36,9 +36,9 @@ P002_data_struct::P002_data_struct(struct EventStruct *event)
     _calib_out1           = P002_CALIBRATION_VALUE1;
     _calib_out2           = P002_CALIBRATION_VALUE2;
   }
-# ifndef LIMIT_BUILD_SIZE
   LoadTaskSettings(event->TaskIndex);
   _nrDecimals        = ExtraTaskSettings.TaskDeviceValueDecimals[0];
+# ifndef LIMIT_BUILD_SIZE
   _nrMultiPointItems = P002_NR_MULTIPOINT_ITEMS;
   _useMultipoint     = P002_MULTIPOINT_ENABLED;
 


### PR DESCRIPTION
Features:
- Update to Espressif32 framework 2.0.5.2
- Enable PSRAM for 16M8M build envs
- Remove specific PSRAM build envs
- Prepare PSRAM fix config (unused yet)
