### PR TITLE
[ESP32 2.0.5.x] Fix crashes calling noInterrupt() in ISR callback

### DIFF
--- a/platformio_core_defs.ini
+++ b/platformio_core_defs.ini
@@ -233,7 +233,8 @@ build_flags               = ${esp82xx_3_0_x.build_flags}
 ;platform                    = https://github.com/Jason2866/platform-espressif32.git
 ;platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/938/framework-arduinoespressif32-443_esp421-10ab11e815.tar.gz
 
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.5.2/platform-espressif32-2.0.5.2.zip
+;platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.5.2/platform-espressif32-2.0.5.2.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.5.3/platform-espressif32-2.0.5.3.zip
 platform_packages           =
 
 build_flags                 = -DESP32_STAGE

--- a/src/_P018_Dust.ino
+++ b/src/_P018_Dust.ino
@@ -69,7 +69,7 @@ boolean Plugin_018(uint8_t function, struct EventStruct *event, String& string)
     case PLUGIN_READ:
       {
         Plugin_GP2Y10_LED_Pin = CONFIG_PIN1;
-        noInterrupts();
+        ISR_noInterrupts();
         uint8_t x;
         int value;
         value = 0;
@@ -82,7 +82,7 @@ boolean Plugin_018(uint8_t function, struct EventStruct *event, String& string)
           digitalWrite(Plugin_GP2Y10_LED_Pin, HIGH);
           delayMicroseconds(9680);
         }
-        interrupts();
+        ISR_interrupts();
         UserVar[event->BaseVarIndex] = value;
         if (loglevelActiveFor(LOG_LEVEL_INFO)) {
           String log = F("GPY  : Dust value: ");

--- a/src/include/ESPEasy_config.h
+++ b/src/include/ESPEasy_config.h
@@ -52,8 +52,8 @@
 
 /*
   #ifndef CORE_POST_2_5_0
-    #define STR_HELPER(x) #x
-    #define STR(x) STR_HELPER(x)
+ #define STR_HELPER(x) #x
+ #define STR(x) STR_HELPER(x)
   #endif
 */
 
@@ -82,26 +82,44 @@
 #define ZERO_FILL(S)  memset((S), 0, sizeof(S))
 #define ZERO_TERMINATE(S)  S[sizeof(S) - 1] = 0
 
+#ifdef ESP32
+  // Special macros to disable interrupts from within an ISR function.
+  //
+  // See:
+  // Re-added interrupt code again for ESP32:
+  // https://github.com/espressif/arduino-esp32/commit/55d608e322443b7ac080b0ab62d5a93f26d2212f
+  // However this code cannot be called from an interrupt service routine.
+  // See comments at portDISABLE_INTERRUPTS
+  #  define ISR_noInterrupts()                           \
+  portMUX_TYPE updateMux = portMUX_INITIALIZER_UNLOCKED; \
+  portTRY_ENTER_CRITICAL_ISR(&updateMux, 1000);
 
-
+  #  define ISR_interrupts() portEXIT_CRITICAL(&updateMux);
+# endif // ifdef ESP32
+# ifdef ESP8266
+  #  define ISR_noInterrupts() noInterrupts();
+  #  define ISR_interrupts() interrupts();
+# endif // ifdef ESP8266
 
 
 // User configuration
-// Include Custom.h before ESPEasyDefaults.h. 
-#ifdef USE_CUSTOM_H
-  // make the compiler show a warning to confirm that this file is inlcuded
-  //#warning "**** Using Settings from Custom.h File ***"
-  #include "../Custom.h"
-#endif
+// Include Custom.h before ESPEasyDefaults.h.
+# ifdef USE_CUSTOM_H
+
+// make the compiler show a warning to confirm that this file is included
+// #warning "**** Using Settings from Custom.h File ***"
+  #  include "../Custom.h"
+# endif // ifdef USE_CUSTOM_H
 
 // Check if any deprecated '#define <variable>' (Custom.h) or '-D<variable>' (pre_custom_esp82xx.py/pre_custom_esp32.py) are used
 
-#include "../src/CustomBuild/check_defines_custom.h" // Check for replaced #define variables, see https://github.com/letscontrolit/ESPEasy/pull/4153
+# include "../src/CustomBuild/check_defines_custom.h" // Check for replaced #define variables, see
+                                                      // https://github.com/letscontrolit/ESPEasy/pull/4153
 
 // Include custom first, then build info. (one may want to set BUILD_GIT for example)
-#include "../src/CustomBuild/ESPEasy_buildinfo.h"
-#include "../src/CustomBuild/ESPEasyLimits.h"
-#include "../src/CustomBuild/define_plugin_sets.h"
+# include "../src/CustomBuild/ESPEasy_buildinfo.h"
+# include "../src/CustomBuild/ESPEasyLimits.h"
+# include "../src/CustomBuild/define_plugin_sets.h"
 
 
 #endif // ifdef __cplusplus

--- a/src/src/Helpers/Dallas1WireHelper.cpp
+++ b/src/src/Helpers/Dallas1WireHelper.cpp
@@ -633,7 +633,7 @@ uint8_t Dallas_reset(int8_t gpio_pin_rx, int8_t gpio_pin_tx)
 {
   uint8_t retries = 125;
 
-  noInterrupts();
+  ISR_noInterrupts();
 
 #ifdef DEBUG_LOGIC_ANALYZER_PIN
   // DEBUG code using logic analyzer for timings
@@ -736,7 +736,7 @@ uint8_t Dallas_reset(int8_t gpio_pin_rx, int8_t gpio_pin_tx)
       delayMicroseconds(2);
     }
   }
-  interrupts();
+  ISR_interrupts();
 
   if (presence_end != 0) {
     const long presence_duration = presence_end - presence_start;
@@ -976,7 +976,7 @@ uint8_t DALLAS_IRAM_ATTR Dallas_read_bit_ISR(
   uint8_t r;
 
   {
-    noInterrupts();
+    ISR_noInterrupts();
     start = getMicros64();
     DIRECT_pinWrite(gpio_pin_tx, 0);
     if (gpio_pin_rx == gpio_pin_tx) {
@@ -999,7 +999,7 @@ uint8_t DALLAS_IRAM_ATTR Dallas_read_bit_ISR(
     }
     r = DIRECT_pinRead(gpio_pin_rx);
 
-    interrupts();
+    ISR_interrupts();
   }
   return r;
 }
@@ -1032,7 +1032,7 @@ void DALLAS_IRAM_ATTR Dallas_write_bit_ISR(uint8_t   v,
                                            long      high_time,
                                            uint64_t& start)
 {
-  noInterrupts();
+  ISR_noInterrupts();
   start     = getMicros64();
   DIRECT_pinWrite(gpio_pin_tx, 0);
 
@@ -1041,7 +1041,7 @@ void DALLAS_IRAM_ATTR Dallas_write_bit_ISR(uint8_t   v,
   }
   start = getMicros64();
   DIRECT_pinWrite(gpio_pin_tx, 1);
-  interrupts();
+  ISR_interrupts();
 }
 
 /*********************************************************************************************\

--- a/src/src/Helpers/_Internal_GPIO_pulseHelper.cpp
+++ b/src/src/Helpers/_Internal_GPIO_pulseHelper.cpp
@@ -367,7 +367,7 @@ void Internal_GPIO_pulseHelper::processStablePulse(int pinState, uint64_t pulseC
 
 void IRAM_ATTR Internal_GPIO_pulseHelper::ISR_edgeCheck(Internal_GPIO_pulseHelper *self)
 {
-  noInterrupts(); // s0170071: avoid nested interrups due to bouncing.
+  ISR_noInterrupts(); // s0170071: avoid nested interrups due to bouncing.
 
   // legacy edge Mode types
   // KP: we use here P003_currentStableStartTime[taskID] to persist the PulseTime (pulseTimePrevious)
@@ -382,12 +382,12 @@ void IRAM_ATTR Internal_GPIO_pulseHelper::ISR_edgeCheck(Internal_GPIO_pulseHelpe
     self->ISRdata.pulseTime              = timeSinceLastTrigger;
     self->ISRdata.currentStableStartTime = currentTime; // reset when counted to determine interval between counted pulses
   }
-  interrupts(); // enable interrupts again.
+  ISR_interrupts(); // enable interrupts again.
 }
 
 void IRAM_ATTR Internal_GPIO_pulseHelper::ISR_pulseCheck(Internal_GPIO_pulseHelper *self)
 {
-  noInterrupts(); // s0170071: avoid nested interrups due to bouncing.
+  ISR_noInterrupts(); // s0170071: avoid nested interrups due to bouncing.
 
   // processing for new PULSE mode types
   #ifdef PULSE_STATISTIC
@@ -402,7 +402,7 @@ void IRAM_ATTR Internal_GPIO_pulseHelper::ISR_pulseCheck(Internal_GPIO_pulseHelp
     self->ISRdata.initStepsFlags   = true; // PLUGIN_FIFTY_PER_SECOND is polling for this flag set
     self->ISRdata.triggerTimestamp = getMicros64();
   }
-  interrupts(); // enable interrupts again.
+  ISR_interrupts(); // enable interrupts again.
 }
 
 #ifdef PULSE_STATISTIC

--- a/src/src/PluginStructs/P005_data_struct.cpp
+++ b/src/src/PluginStructs/P005_data_struct.cpp
@@ -154,7 +154,7 @@ bool P005_data_struct::readDHT(struct EventStruct *event) {
   uint8_t timings[16] = { 0 };
 
 
-  noInterrupts();
+  ISR_noInterrupts();
   receive_start = waitState(0) && waitState(1) && waitState(0);
 
 #ifdef DEBUG_LOGIC_ANALYZER_PIN
@@ -238,7 +238,7 @@ bool P005_data_struct::readDHT(struct EventStruct *event) {
       }
     }
   }
-  interrupts();
+  ISR_interrupts();
 
 
   if (!receive_start) {

--- a/src/src/PluginStructs/P092_data_struct.cpp
+++ b/src/src/PluginStructs/P092_data_struct.cpp
@@ -73,11 +73,11 @@ void DLBus::attachDLBusInterrupt(void)
 
 void DLBus::StartReceiving(void)
 {
-  noInterrupts(); // make sure we don't get interrupted before we are ready
+  ISR_noInterrupts(); // make sure we don't get interrupted before we are ready
   ISR_PulseCount      = 0;
   ISR_Receiving       = (ISR_PtrChangeBitStream != nullptr);
   ISR_AllBitsReceived = false;
-  interrupts(); // interrupts allowed now, next instruction WILL be executed
+  ISR_interrupts(); // interrupts allowed now, next instruction WILL be executed
 }
 
 void IRAM_ATTR DLBus::ISR(void)

--- a/src/src/PluginStructs/P098_data_struct.cpp
+++ b/src/src/PluginStructs/P098_data_struct.cpp
@@ -394,7 +394,7 @@ void ICACHE_RAM_ATTR P098_data_struct::process_limit_switch(
   volatile P098_limit_switch_state& switch_state,
   int                               position)
 {
-  noInterrupts();
+  ISR_noInterrupts();
   {
     // Don't call gpio_config.readState() here
     const bool pinState        = gpio_config.inverted ? digitalRead(gpio_config.gpio) == 0 : digitalRead(gpio_config.gpio) != 0;
@@ -434,7 +434,7 @@ void ICACHE_RAM_ATTR P098_data_struct::process_limit_switch(
         break;
     }
   }
-  interrupts(); // enable interrupts again.
+  ISR_interrupts(); // enable interrupts again.
 }
 
 void ICACHE_RAM_ATTR P098_data_struct::ISRlimitA(P098_data_struct *self)
@@ -449,7 +449,7 @@ void ICACHE_RAM_ATTR P098_data_struct::ISRlimitB(P098_data_struct *self)
 
 void ICACHE_RAM_ATTR P098_data_struct::ISRencoder(P098_data_struct *self)
 {
-  noInterrupts();
+  ISR_noInterrupts();
 
   switch (self->state) {
     case P098_data_struct::State::RunFwd:
@@ -459,11 +459,11 @@ void ICACHE_RAM_ATTR P098_data_struct::ISRencoder(P098_data_struct *self)
       --(self->position);
       break;
     default:
-      interrupts(); // enable interrupts again.
+      ISR_interrupts(); // enable interrupts again.
       return;
   }
   self->enc_lastChanged_us = getMicros64();
-  interrupts(); // enable interrupts again.
+  ISR_interrupts(); // enable interrupts again.
 }
 
 #endif // ifdef USES_P098


### PR DESCRIPTION
On ESP32 SDK 2.0.5.x ESPEasy would crash when calling `noInterrupt()` in an interrupt callback function.

Re-added interrupt code again for ESP32:
https://github.com/espressif/arduino-esp32/commit/55d608e322443b7ac080b0ab62d5a93f26d2212f

However this code cannot be called from an interrupt service routine.
See comments at portDISABLE_INTERRUPTS macros.

Now using ISR safe FreeRTOS critical section macros with a timeout.