### PR TITLE
[SendToHTTP] Only include "Authorization" header  when credentials set

### DIFF
--- a/src/src/DataStructs/ExtendedControllerCredentialsStruct.cpp
+++ b/src/src/DataStructs/ExtendedControllerCredentialsStruct.cpp
@@ -46,6 +46,10 @@ String ExtendedControllerCredentialsStruct::load()
                     0,
                     _strings, CONTROLLER_MAX * 2, 0);
 
+  for (int i = 0; i < CONTROLLER_MAX * 2; ++i) {
+    _strings[i].trim();
+  }
+
   // Update the checksum after loading.
   computeChecksum(last_ExtendedControllerCredentialsStruct_md5);
 

--- a/src/src/Helpers/_CPlugin_Helper.cpp
+++ b/src/src/Helpers/_CPlugin_Helper.cpp
@@ -279,7 +279,9 @@ String getControllerUser(controllerIndex_t controller_idx, const ControllerSetti
   if (ControllerSettings.useExtendedCredentials()) {
     return ExtendedControllerCredentials.getControllerUser(controller_idx);
   }
-  return SecuritySettings.ControllerUser[controller_idx];
+  String res(SecuritySettings.ControllerUser[controller_idx]);
+  res.trim();
+  return res;
 }
 
 String getControllerPass(controllerIndex_t controller_idx, const ControllerSettingsStruct& ControllerSettings)
@@ -289,7 +291,9 @@ String getControllerPass(controllerIndex_t controller_idx, const ControllerSetti
   if (ControllerSettings.useExtendedCredentials()) {
     return ExtendedControllerCredentials.getControllerPass(controller_idx);
   }
-  return SecuritySettings.ControllerPassword[controller_idx];
+  String res(SecuritySettings.ControllerPassword[controller_idx]);
+  res.trim();
+  return res;
 }
 
 void setControllerUser(controllerIndex_t controller_idx, const ControllerSettingsStruct& ControllerSettings, const String& value)


### PR DESCRIPTION
Fixes: https://github.com/letscontrolit/ESPEasy/issues/4355