### PR TITLE
[Cache Controller] Speedup ESP32 + LittleFS use.

### DIFF
--- a/boards/esp8266_16M14M_board.json
+++ b/boards/esp8266_16M14M_board.json
@@ -4,7 +4,7 @@
       "ldscript": "eagle.flash.16m14m.ld"
     },
     "core": "esp8266",
-    "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DARDUINO_ESP8266_ESP01 -DESP8266_4M -DESP8266_4M3M",
+    "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DARDUINO_ESP8266_ESP01 -DESP8266_4M -DESP8266_16M14M",
     "f_cpu": "80000000L",
     "f_flash": "40000000L",
     "flash_mode": "dout",

--- a/boards/esp8266_4M1M_board.json
+++ b/boards/esp8266_4M1M_board.json
@@ -4,7 +4,7 @@
       "ldscript": "eagle.flash.4m1m.ld"
     },
     "core": "esp8266",
-    "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DARDUINO_ESP8266_ESP01 -DESP8266_4M -DESP8266_4M3M",
+    "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DARDUINO_ESP8266_ESP01 -DESP8266_4M -DESP8266_4M1M",
     "f_cpu": "80000000L",
     "f_flash": "40000000L",
     "flash_mode": "dout",

--- a/src/src/DataStructs/ESPEasyControllerCache.h
+++ b/src/src/DataStructs/ESPEasyControllerCache.h
@@ -11,8 +11,8 @@ struct ControllerCache_struct {
   ~ControllerCache_struct();
 
   // Write a single sample set to the buffer
-  bool write(const uint8_t     *data,
-             unsigned int size);
+  bool write(const uint8_t *data,
+             unsigned int   size);
 
   // Read a single sample set, either from file or buffer.
   // May delete a file if it is all read and not written to.
@@ -24,7 +24,7 @@ struct ControllerCache_struct {
 
   void   init();
 
-  bool   isInitialized();
+  bool   isInitialized() const;
 
   // Clear all caches
   void   clearCache();
@@ -37,9 +37,9 @@ struct ControllerCache_struct {
 
   // Read data without marking it as being read.
   bool   peek(uint8_t     *data,
-              unsigned int size);
+              unsigned int size) const;
 
-  String getPeekCacheFileName(bool& islast);
+  String getPeekCacheFileName(bool& islast) const;
 
   int readFileNr = 0;
   int readPos    = 0;

--- a/src/src/DataStructs/ESPEasyControllerCache.h
+++ b/src/src/DataStructs/ESPEasyControllerCache.h
@@ -31,6 +31,8 @@ struct ControllerCache_struct {
 
   bool   deleteOldestCacheBlock();
 
+  bool   deleteAllCacheBlocks();
+
   void   resetpeek();
 
   // Read data without marking it as being read.

--- a/src/src/DataStructs/ESPeasyControllerCache.cpp
+++ b/src/src/DataStructs/ESPeasyControllerCache.cpp
@@ -36,7 +36,7 @@ void ControllerCache_struct::init() {
   }
 }
 
-bool ControllerCache_struct::isInitialized() {
+bool ControllerCache_struct::isInitialized() const {
   return _RTC_cache_handler != nullptr;
 }
 
@@ -64,14 +64,14 @@ void ControllerCache_struct::resetpeek() {
 }
 
 // Read data without marking it as being read.
-bool ControllerCache_struct::peek(uint8_t *data, unsigned int size) {
+bool ControllerCache_struct::peek(uint8_t *data, unsigned int size) const {
   if (_RTC_cache_handler == nullptr) {
     return false;
   }
   return _RTC_cache_handler->peek(data, size);
 }
 
-String ControllerCache_struct::getPeekCacheFileName(bool& islast) {
+String ControllerCache_struct::getPeekCacheFileName(bool& islast) const {
   if (_RTC_cache_handler == nullptr) {
     return "";
   }

--- a/src/src/DataStructs/ESPeasyControllerCache.cpp
+++ b/src/src/DataStructs/ESPeasyControllerCache.cpp
@@ -50,6 +50,13 @@ bool ControllerCache_struct::deleteOldestCacheBlock() {
   return false;
 }
 
+bool ControllerCache_struct::deleteAllCacheBlocks() {
+  if (_RTC_cache_handler != nullptr) {
+    return _RTC_cache_handler->deleteAllCacheBlocks();
+  }
+  return false;
+}
+
 void ControllerCache_struct::resetpeek() {
   if (_RTC_cache_handler != nullptr) {
     _RTC_cache_handler->resetpeek();

--- a/src/src/DataStructs/RTCStruct.h
+++ b/src/src/DataStructs/RTCStruct.h
@@ -10,14 +10,19 @@
 
 #ifdef ESP8266
 #define RTC_CACHE_DATA_SIZE 240  // 10 elements
+#define CACHE_FILE_MAX_SIZE 24000
 #endif
 #ifdef ESP32
 // TODO TD-er: ESP32 can store much more samples in its RTC
 // However we must make sure the data can be flushed on demand or else 
 // one may have to wait for a long time to be able to read the data from the filesystem
-#define RTC_CACHE_DATA_SIZE 240 // 10 elements
-#endif
+#define RTC_CACHE_DATA_SIZE 768 // 32 elements
+#ifdef USE_LITTLEFS
+#define CACHE_FILE_MAX_SIZE 262144
+#else
 #define CACHE_FILE_MAX_SIZE 24000
+#endif
+#endif
 
 /*********************************************************************************************\
  * RTCStruct

--- a/src/src/DataStructs/RTCStruct.h
+++ b/src/src/DataStructs/RTCStruct.h
@@ -4,60 +4,70 @@
 #include "../../ESPEasy_common.h"
 
 // this offsets are in blocks, bytes = blocks * 4
-#define RTC_BASE_STRUCT 64
-#define RTC_BASE_USERVAR 74
-#define RTC_BASE_CACHE 124
+#define RTC_BASE_STRUCT   64
+#define RTC_BASE_USERVAR  74
+#define RTC_BASE_CACHE   124
 
 #ifdef ESP8266
-#define RTC_CACHE_DATA_SIZE 240  // 10 elements
-#define CACHE_FILE_MAX_SIZE 24000
-#endif
+# define RTC_CACHE_DATA_SIZE 240 // 10 elements, limited by RTC memory
+# ifdef ESP8266_16M14M
+#  ifdef USE_LITTLEFS
+#   define CACHE_FILE_MAX_SIZE 262144 // LittleFS can handle larger files just fine.
+#  else // ifdef USE_LITTLEFS
+#   define CACHE_FILE_MAX_SIZE 48000 // Try to reduce the nr. of files, but SPIFFS still slows down on lager files.
+#  endif // ifdef USE_LITTLEFS
+# else  // ifdef ESP8266_16M14M
+#  define CACHE_FILE_MAX_SIZE 24000
+# endif // ifdef ESP8266_16M14M
+#endif // ifdef ESP8266
 #ifdef ESP32
+
 // TODO TD-er: ESP32 can store much more samples in its RTC
-// However we must make sure the data can be flushed on demand or else 
+// However we must make sure the data can be flushed on demand or else
 // one may have to wait for a long time to be able to read the data from the filesystem
-#define RTC_CACHE_DATA_SIZE 768 // 32 elements
-#ifdef USE_LITTLEFS
-#define CACHE_FILE_MAX_SIZE 262144
-#else
-#define CACHE_FILE_MAX_SIZE 24000
-#endif
-#endif
+# define RTC_CACHE_DATA_SIZE 768 // 32 elements
+# ifdef USE_LITTLEFS
+#  define CACHE_FILE_MAX_SIZE 262144
+# else // ifdef USE_LITTLEFS
+#  define CACHE_FILE_MAX_SIZE 24000
+# endif // ifdef USE_LITTLEFS
+#endif  // ifdef ESP32
 
 /*********************************************************************************************\
- * RTCStruct
+* RTCStruct
 \*********************************************************************************************/
-//max 40 bytes: ( 74 - 64 ) * 4
+
+// max 40 bytes: ( 74 - 64 ) * 4
 struct RTCStruct
 {
   RTCStruct() = default;
 
   RTCStruct(const RTCStruct& other) = delete;
 
-  RTCStruct& operator=(const RTCStruct&) = default; 
+  RTCStruct& operator=(const RTCStruct&) = default;
 
-  void init();
+  void       init();
 
-  void clearLastWiFi();
+  void       clearLastWiFi();
 
-  bool lastWiFi_set() const;
+  bool       lastWiFi_set() const;
 
 
-  uint8_t ID1 = 0;
-  uint8_t ID2 = 0;
-  uint8_t lastWiFiChannel = 0;
-  uint8_t factoryResetCounter = 0;
-  uint8_t deepSleepState = 0;
-  uint8_t bootFailedCount = 0;
-  uint8_t flashDayCounter = 0;
-  uint8_t lastWiFiSettingsIndex = 0;
-  unsigned long flashCounter = 0;
-  unsigned long bootCounter = 0;
-  unsigned long lastMixedSchedulerId = 0;
-  uint8_t lastBSSID[6] = { 0 };
-  uint8_t unused1 = 0;  // Force alignment to 4 bytes
-  uint8_t unused2 = 0;
-  unsigned long lastSysTime = 0;
+  uint8_t       ID1                   = 0;
+  uint8_t       ID2                   = 0;
+  uint8_t       lastWiFiChannel       = 0;
+  uint8_t       factoryResetCounter   = 0;
+  uint8_t       deepSleepState        = 0;
+  uint8_t       bootFailedCount       = 0;
+  uint8_t       flashDayCounter       = 0;
+  uint8_t       lastWiFiSettingsIndex = 0;
+  unsigned long flashCounter          = 0;
+  unsigned long bootCounter           = 0;
+  unsigned long lastMixedSchedulerId  = 0;
+  uint8_t       lastBSSID[6]          = { 0 };
+  uint8_t       unused1               = 0; // Force alignment to 4 bytes
+  uint8_t       unused2               = 0;
+  unsigned long lastSysTime           = 0;
 };
 
 

--- a/src/src/DataStructs/RTC_cache_handler_struct.cpp
+++ b/src/src/DataStructs/RTC_cache_handler_struct.cpp
@@ -4,25 +4,25 @@
 #include "../DataStructs/RTCStruct.h"
 #include "../Helpers/CRC_functions.h"
 #include "../Helpers/ESPEasy_Storage.h"
+#include "../Helpers/StringConverter.h"
 
+#include "../ESPEasyCore/ESPEasy_backgroundtasks.h"
 #include "../ESPEasyCore/ESPEasy_Log.h"
 
 #ifdef ESP8266
-#include <user_interface.h>
-#endif
+# include <user_interface.h>
+#endif // ifdef ESP8266
 
 #ifdef ESP32
-  #include <soc/rtc.h>
+  # include <soc/rtc.h>
 
-  // For ESP32 the RTC mapped structure may not be a member of an object, 
-  // but must be declared 'static'
-  // This also means we can only have a single instance of this 
-  // RTC_cache_handler_struct.
-  RTC_NOINIT_ATTR RTC_cache_struct    RTC_cache;
-  RTC_NOINIT_ATTR uint8_t RTC_cache_data[RTC_CACHE_DATA_SIZE];
-#endif
-
-
+// For ESP32 the RTC mapped structure may not be a member of an object,
+// but must be declared 'static'
+// This also means we can only have a single instance of this
+// RTC_cache_handler_struct.
+RTC_NOINIT_ATTR RTC_cache_struct RTC_cache;
+RTC_NOINIT_ATTR uint8_t RTC_cache_data[RTC_CACHE_DATA_SIZE];
+#endif // ifdef ESP32
 
 
 /********************************************************************************************\
@@ -136,9 +136,9 @@ bool RTC_cache_handler_struct::flush() {
   if (prepareFileForWrite()) {
     if (RTC_cache.writePos > 0) {
       #ifdef RTC_STRUCT_DEBUG
-      size_t filesize    = fw.size();
-      #endif
-      int    bytesWriten = fw.write(&RTC_cache_data[0], RTC_cache.writePos);
+      size_t filesize = fw.size();
+      #endif // ifdef RTC_STRUCT_DEBUG
+      int bytesWriten = fw.write(&RTC_cache_data[0], RTC_cache.writePos);
 
       delay(0);
       fw.flush();
@@ -149,15 +149,16 @@ bool RTC_cache_handler_struct::flush() {
 
       if ((bytesWriten < RTC_cache.writePos) /*|| (fw.size() == filesize)*/) {
           #ifdef RTC_STRUCT_DEBUG
-          if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
-            String log = F("RTC  : error writing file. Size before: ");
-            log += filesize;
-            log += F(" after: ");
-            log += fw.size();
-            log += F(" writen: ");
-            log += bytesWriten;
-            addLogMove(LOG_LEVEL_ERROR, log);
-          }
+
+        if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
+          String log = F("RTC  : error writing file. Size before: ");
+          log += filesize;
+          log += F(" after: ");
+          log += fw.size();
+          log += F(" writen: ");
+          log += bytesWriten;
+          addLogMove(LOG_LEVEL_ERROR, log);
+        }
           #endif // ifdef RTC_STRUCT_DEBUG
         fw.close();
 
@@ -220,7 +221,7 @@ String RTC_cache_handler_struct::getPeekCacheFileName(bool& islast) {
   if (fileExists(fname)) {
     return fname;
   }
-  return "";
+  return EMPTY_STRING;
 }
 
 bool RTC_cache_handler_struct::deleteOldestCacheBlock() {
@@ -232,14 +233,58 @@ bool RTC_cache_handler_struct::deleteOldestCacheBlock() {
       String fname = createCacheFilename(RTC_cache.readFileNr);
 
       writeerror = false;
+
       if (tryDeleteFile(fname)) {
           #ifdef RTC_STRUCT_DEBUG
+
+        if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+          String log = F("RTC  : Removed file from FS: ");
+          log += fname;
+          addLogMove(LOG_LEVEL_INFO, log);
+        }
+          #endif // ifdef RTC_STRUCT_DEBUG
+        updateRTC_filenameCounters();
+        return true;
+      }
+    }
+  }
+#ifdef RTC_STRUCT_DEBUG
+
+  if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+    addLog(LOG_LEVEL_INFO, F("RTC  : No Cache files found"));
+  }
+#endif // ifdef RTC_STRUCT_DEBUG
+  return false;
+}
+
+bool RTC_cache_handler_struct::deleteAllCacheBlocks()
+{
+  if (updateRTC_filenameCounters()) {
+    const int nrCacheFiles = RTC_cache.writeFileNr - RTC_cache.readFileNr;
+
+    if (nrCacheFiles > 1) {
+      bool fileDeleted = false;
+      int count = 0;
+
+      for (int fileNr = RTC_cache.readFileNr; count < 25 && fileNr < RTC_cache.writeFileNr; ++fileNr)
+      {
+        String fname = createCacheFilename(fileNr);
+
+        if (tryDeleteFile(fname)) {
+          ++count;
+          fileDeleted = true;
+          #ifdef RTC_STRUCT_DEBUG
+
           if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-            String log = F("RTC  : Removed file from FS: ");
-            log += fname;
-            addLogMove(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, concat(F("RTC  : Removed file from FS: "), fname));
           }
           #endif // ifdef RTC_STRUCT_DEBUG
+          backgroundtasks();
+        }
+      }
+
+      if (fileDeleted) {
+        writeerror = false;
         updateRTC_filenameCounters();
         return true;
       }
@@ -253,10 +298,11 @@ bool RTC_cache_handler_struct::loadMetaData()
   // No need to load on ESP32, as the data is already allocated to the RTC memory by the compiler
 
   #ifdef ESP8266
+
   if (!system_rtc_mem_read(RTC_BASE_CACHE, reinterpret_cast<uint8_t *>(&RTC_cache), sizeof(RTC_cache))) {
     return false;
   }
-  #endif
+  #endif // ifdef ESP8266
 
   return RTC_cache.checksumMetadata == calc_CRC32(reinterpret_cast<const uint8_t *>(&RTC_cache), sizeof(RTC_cache) - sizeof(uint32_t));
 }
@@ -267,15 +313,16 @@ bool RTC_cache_handler_struct::loadData()
 
   // No need to load on ESP32, as the data is already allocated to the RTC memory by the compiler
   #ifdef ESP8266
+
   if (!system_rtc_mem_read(RTC_BASE_CACHE + (sizeof(RTC_cache) / 4), reinterpret_cast<uint8_t *>(&RTC_cache_data[0]), RTC_CACHE_DATA_SIZE)) {
     return false;
   }
-  #endif
+  #endif // ifdef ESP8266
 
   if (RTC_cache.checksumData != getDataChecksum()) {
-        # ifdef RTC_STRUCT_DEBUG
+        #ifdef RTC_STRUCT_DEBUG
     addLog(LOG_LEVEL_ERROR, F("RTC  : Checksum error reading RTC cache data"));
-        # endif // ifdef RTC_STRUCT_DEBUG
+        #endif // ifdef RTC_STRUCT_DEBUG
     return false;
   }
   return RTC_cache.checksumData == getDataChecksum();
@@ -291,9 +338,10 @@ bool RTC_cache_handler_struct::saveRTCcache(unsigned int startOffset, size_t nrB
   RTC_cache.checksumMetadata = calc_CRC32(reinterpret_cast<const uint8_t *>(&RTC_cache), sizeof(RTC_cache) - sizeof(uint32_t));
   #ifdef ESP32
   return true;
-  #endif
+  #endif // ifdef ESP32
 
   #ifdef ESP8266
+
   if (!system_rtc_mem_write(RTC_BASE_CACHE, reinterpret_cast<const uint8_t *>(&RTC_cache), sizeof(RTC_cache)) || !loadMetaData())
   {
         # ifdef RTC_STRUCT_DEBUG
@@ -318,19 +366,20 @@ bool RTC_cache_handler_struct::saveRTCcache(unsigned int startOffset, size_t nrB
         # endif // ifdef RTC_STRUCT_DEBUG
   }
   return true;
-  #endif
+  #endif // ifdef ESP8266
 }
 
 uint32_t RTC_cache_handler_struct::getDataChecksum() {
   initRTCcache_data();
-  /*
-  size_t dataLength = RTC_cache.writePos;
 
-  if (dataLength > RTC_CACHE_DATA_SIZE) {
-    // Is this allowed to happen?
-    dataLength = RTC_CACHE_DATA_SIZE;
-  }
-  */
+  /*
+     size_t dataLength = RTC_cache.writePos;
+
+     if (dataLength > RTC_CACHE_DATA_SIZE) {
+     // Is this allowed to happen?
+     dataLength = RTC_CACHE_DATA_SIZE;
+     }
+   */
 
   // Only compute the checksum over the number of samples stored.
   return calc_CRC32(reinterpret_cast<const uint8_t *>(&RTC_cache_data[0]), /*dataLength*/ RTC_CACHE_DATA_SIZE);
@@ -338,10 +387,11 @@ uint32_t RTC_cache_handler_struct::getDataChecksum() {
 
 void RTC_cache_handler_struct::initRTCcache_data() {
   #ifdef ESP8266
+
   if (RTC_cache_data.size() != RTC_CACHE_DATA_SIZE) {
     RTC_cache_data.resize(RTC_CACHE_DATA_SIZE);
   }
-  #endif
+  #endif // ifdef ESP8266
 
   if (RTC_cache.writeFileNr == 0) {
     // RTC value not reliable
@@ -439,6 +489,7 @@ bool RTC_cache_handler_struct::prepareFileForWrite() {
 void RTC_cache_handler_struct::rtc_debug_log(const String& description, size_t nrBytes) {
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
     String log;
+
     if (log.reserve(18 + description.length())) {
       log  = F("RTC  : ");
       log += description;

--- a/src/src/DataStructs/RTC_cache_handler_struct.cpp
+++ b/src/src/DataStructs/RTC_cache_handler_struct.cpp
@@ -138,7 +138,7 @@ bool RTC_cache_handler_struct::flush() {
       #ifdef RTC_STRUCT_DEBUG
       size_t filesize = fw.size();
       #endif // ifdef RTC_STRUCT_DEBUG
-      int bytesWriten = fw.write(&RTC_cache_data[0], RTC_cache.writePos);
+      int bytesWritten = fw.write(&RTC_cache_data[0], RTC_cache.writePos);
 
       delay(0);
       fw.flush();
@@ -147,7 +147,7 @@ bool RTC_cache_handler_struct::flush() {
         #endif // ifdef RTC_STRUCT_DEBUG
 
 
-      if ((bytesWriten < RTC_cache.writePos) /*|| (fw.size() == filesize)*/) {
+      if ((bytesWritten < RTC_cache.writePos) /*|| (fw.size() == filesize)*/) {
           #ifdef RTC_STRUCT_DEBUG
 
         if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
@@ -155,8 +155,8 @@ bool RTC_cache_handler_struct::flush() {
           log += filesize;
           log += F(" after: ");
           log += fw.size();
-          log += F(" writen: ");
-          log += bytesWriten;
+          log += F(" written: ");
+          log += bytesWritten;
           addLogMove(LOG_LEVEL_ERROR, log);
         }
           #endif // ifdef RTC_STRUCT_DEBUG
@@ -164,7 +164,7 @@ bool RTC_cache_handler_struct::flush() {
 
         if (!GarbageCollection()) {
           // Garbage collection was not able to remove anything
-          writeerror = true;
+          writeError = true;
         }
         return false;
       }
@@ -202,7 +202,7 @@ String RTC_cache_handler_struct::getReadCacheFileName(int& readPos) {
   // No file found
   RTC_cache.readPos = 0;
   readPos           = RTC_cache.readPos;
-  return "";
+  return EMPTY_STRING;
 }
 
 String RTC_cache_handler_struct::getPeekCacheFileName(bool& islast) {
@@ -232,7 +232,7 @@ bool RTC_cache_handler_struct::deleteOldestCacheBlock() {
       // read and write file nr are not the same file, remove the read file nr.
       String fname = createCacheFilename(RTC_cache.readFileNr);
 
-      writeerror = false;
+      writeError = false;
 
       if (tryDeleteFile(fname)) {
           #ifdef RTC_STRUCT_DEBUG
@@ -264,7 +264,7 @@ bool RTC_cache_handler_struct::deleteAllCacheBlocks()
 
     if (nrCacheFiles > 1) {
       bool fileDeleted = false;
-      int count = 0;
+      int  count       = 0;
 
       for (int fileNr = RTC_cache.readFileNr; count < 25 && fileNr < RTC_cache.writeFileNr; ++fileNr)
       {
@@ -284,7 +284,7 @@ bool RTC_cache_handler_struct::deleteAllCacheBlocks()
       }
 
       if (fileDeleted) {
-        writeerror = false;
+        writeError = false;
         updateRTC_filenameCounters();
         return true;
       }
@@ -366,7 +366,7 @@ bool RTC_cache_handler_struct::saveRTCcache(unsigned int startOffset, size_t nrB
         # endif // ifdef RTC_STRUCT_DEBUG
   }
   return true;
-  #endif // ifdef ESP8266
+  #endif        // ifdef ESP8266
 }
 
 uint32_t RTC_cache_handler_struct::getDataChecksum() {
@@ -448,7 +448,7 @@ bool RTC_cache_handler_struct::prepareFileForWrite() {
       initRTCcache_data();
 
       if (updateRTC_filenameCounters()) {
-        if (writeerror || (SpiffsFreeSpace() < ((2 * CACHE_FILE_MAX_SIZE) + SpiffsBlocksize()))) {
+        if (writeError || (SpiffsFreeSpace() < ((2 * CACHE_FILE_MAX_SIZE) + SpiffsBlocksize()))) {
           // Not enough room for another file, remove the oldest one.
           deleteOldestCacheBlock();
         }

--- a/src/src/DataStructs/RTC_cache_handler_struct.h
+++ b/src/src/DataStructs/RTC_cache_handler_struct.h
@@ -55,6 +55,8 @@ struct RTC_cache_handler_struct
 
   bool   deleteOldestCacheBlock();
 
+  bool   deleteAllCacheBlocks();
+
 private:
 
   bool     loadMetaData();

--- a/src/src/DataStructs/RTC_cache_handler_struct.h
+++ b/src/src/DataStructs/RTC_cache_handler_struct.h
@@ -24,7 +24,7 @@
 #define CACHE_STORAGE_BEHIND_SPIFFS 3
 
 
-//#define RTC_STRUCT_DEBUG
+// #define RTC_STRUCT_DEBUG
 
 /********************************************************************************************\
    RTC located cache
@@ -41,8 +41,8 @@ struct RTC_cache_handler_struct
                     unsigned int size);
 
   // Write a single sample set to the buffer
-  bool write(const uint8_t     *data,
-             unsigned int size);
+  bool write(const uint8_t *data,
+             unsigned int   size);
 
   // Mark all content as being processed and empty buffer.
   bool flush();
@@ -87,15 +87,15 @@ private:
 #ifdef ESP8266
   RTC_cache_struct    RTC_cache;
   std::vector<uint8_t>RTC_cache_data;
-#endif
-  fs::File            fw;
-  fs::File            fr;
-  fs::File            fp;
-  size_t              peekfilenr  = 0;
-  size_t              peekreadpos = 0;
+#endif // ifdef ESP8266
+  fs::File fw;
+  fs::File fr;
+  fs::File fp;
+  size_t   peekfilenr  = 0;
+  size_t   peekreadpos = 0;
 
   uint8_t storageLocation = CACHE_STORAGE_SPIFFS;
-  bool writeerror      = false;
+  bool    writeError      = false;
 };
 
 #endif // ifndef DATASTRUCTS_RTC_CACHE_HANDLER_STRUCT_H

--- a/src/src/Globals/C016_ControllerCache.cpp
+++ b/src/src/Globals/C016_ControllerCache.cpp
@@ -20,6 +20,10 @@ bool C016_deleteOldestCacheBlock() {
   return ControllerCache.deleteOldestCacheBlock();
 }
 
+bool C016_deleteAllCacheBlocks() {
+  return ControllerCache.deleteAllCacheBlocks();
+}
+
 bool C016_getCSVline(
   unsigned long& timestamp,
   uint8_t& controller_idx,

--- a/src/src/Globals/C016_ControllerCache.h
+++ b/src/src/Globals/C016_ControllerCache.h
@@ -20,6 +20,8 @@ String C016_getCacheFileName(bool& islast);
 
 bool C016_deleteOldestCacheBlock();
 
+bool C016_deleteAllCacheBlocks();
+
 bool C016_getCSVline(
   unsigned long& timestamp,
   uint8_t& controller_idx,

--- a/src/src/WebServer/FileList.cpp
+++ b/src/src/WebServer/FileList.cpp
@@ -156,9 +156,8 @@ void handle_filelist() {
   # ifdef USES_C016
 
   if (hasArg(F("delcache"))) {
-    while (C016_deleteOldestCacheBlock()) {
-      delay(1);
-    }
+    addLog(LOG_LEVEL_INFO, F("RTC  : delcache"));
+    C016_deleteAllCacheBlocks();
 
     while (GarbageCollection()) {
       delay(1);
@@ -299,7 +298,7 @@ void handle_filelist_buttons(int start_prev, int start_next, bool cacheFilesPres
 
   if (cacheFilesPresent) {
     html_add_button_prefix(F("red"), true);
-    addHtml(F("filelist?delcache'>Delete Cache Files</a>"));
+    addHtml(F("filelist?delcache=1'>Delete Cache Files</a>"));
   }
   addHtml(F("<BR><BR>"));
   sendHeadandTail_stdtemplate(_TAIL);


### PR DESCRIPTION
Especially on larger file systems like on the 16M8M builds, it was unusable slow.

- Increase nr. of samples in RTC memory on ESP32 to 32 samples (10 on ESP8266)
- Increase max. file size to 256k (ESP32 + LittleFS)

Handling 400 files of 24k was unusable on ESP32.
Deleting a single file could take several tens of seconds when the file system was almost full.