### PR TITLE
[LongPulse] Fix recurring longPulse

### DIFF
--- a/src/src/Commands/GPIO.cpp
+++ b/src/src/Commands/GPIO.cpp
@@ -229,33 +229,34 @@ const __FlashStringHelper * Command_GPIO_LongPulse_Ms(struct EventStruct *event,
     #endif
 
     if (!usingWaveForm) {
-      int repeatInterval = 0;
-      int repeatCount = 0;
+      // Par1 = pinnr
+      // Par2 = pin state
+      // Par3 = timeHigh in msec
+      // Par4 = timeLow in msec
+      // Par5 = repeat count
       GPIO_Write(pluginID, event->Par1, event->Par2);
       if (event->Par4 > 0 && event->Par5 != 0) {
         // Compute repeat interval
-        repeatInterval = event->Par3 + event->Par4;
-        repeatCount    = event->Par5;
 
         // Schedule switching pin to given state for repeat
         Scheduler.setGPIOTimer(
-          repeatInterval,   // msecFromNow
+          event->Par3,   // msecFromNow
           pluginID,    
           event->Par1,   // Pin/port nr
           event->Par2,   // pin state
-          repeatInterval,
-          repeatCount);
+          event->Par3,   // repeat interval (high)
+          event->Par5,   // repeat count
+          event->Par4);  // alternate interval (low)
+      } else {
+        // Schedule switching pin back to original state
+        Scheduler.setGPIOTimer(
+          event->Par3,   // msecFromNow
+          pluginID,    
+          event->Par1,   // Pin/port nr
+          !event->Par2,  // pin state
+          0, // repeatInterva
+          0); // repeatCount
       }
-
-
-      // Schedule switching pin back to original state
-      Scheduler.setGPIOTimer(
-        event->Par3,   // msecFromNow
-        pluginID,    
-        event->Par1,   // Pin/port nr
-        !event->Par2,  // pin state
-        repeatInterval,
-        repeatCount);
     }
 
 

--- a/src/src/DataStructs/ESPEasy_EventStruct.cpp
+++ b/src/src/DataStructs/ESPEasy_EventStruct.cpp
@@ -9,23 +9,30 @@
 #include "../../_Plugin_Helper.h"
 
 EventStruct::EventStruct(taskIndex_t taskIndex) :
-  TaskIndex(taskIndex), BaseVarIndex(taskIndex * VARS_PER_TASK) 
-{}
+  TaskIndex(taskIndex), BaseVarIndex(taskIndex * VARS_PER_TASK)
+{
+  if (taskIndex >= INVALID_TASK_INDEX) {
+    BaseVarIndex = 0;
+  }
+}
 
 void EventStruct::deep_copy(const struct EventStruct& other) {
   this->operator=(other);
 }
 
-void EventStruct::deep_copy(const struct EventStruct* other) {
+void EventStruct::deep_copy(const struct EventStruct *other) {
   if (other != nullptr) {
     deep_copy(*other);
   }
 }
 
 void EventStruct::setTaskIndex(taskIndex_t taskIndex) {
-  TaskIndex    = taskIndex;
-  BaseVarIndex = taskIndex * VARS_PER_TASK;
-  sensorType   = Sensor_VType::SENSOR_TYPE_NOT_SET;
+  TaskIndex = taskIndex;
+
+  if (TaskIndex < INVALID_TASK_INDEX) {
+    BaseVarIndex = taskIndex * VARS_PER_TASK;
+  }
+  sensorType = Sensor_VType::SENSOR_TYPE_NOT_SET;
 }
 
 void EventStruct::clear() {
@@ -34,6 +41,7 @@ void EventStruct::clear() {
 
 Sensor_VType EventStruct::getSensorType() {
   const int tmp_idx = idx;
+
   checkDeviceVTypeForTask(this);
   idx = tmp_idx;
   return sensorType;

--- a/src/src/DataStructs/ESPEasy_EventStruct.h
+++ b/src/src/DataStructs/ESPEasy_EventStruct.h
@@ -12,7 +12,6 @@
 #include "../DataStructs/DeviceStruct.h"
 
 
-
 /*********************************************************************************************\
 * EventStruct
 * This should not be copied, only moved.

--- a/src/src/DataStructs/SystemTimerStruct.cpp
+++ b/src/src/DataStructs/SystemTimerStruct.cpp
@@ -1,62 +1,110 @@
 #include "../DataStructs/SystemTimerStruct.h"
 
+#include "../DataStructs/ESPEasy_EventStruct.h"
 #include "../ESPEasyCore/ESPEasy_Log.h"
 
 
 // Rules Timer use
 // ***************
-systemTimerStruct::systemTimerStruct(int recurringCount, unsigned long msecFromNow, unsigned int timerIndex) :
-  Par1(recurringCount), Par2(msecFromNow), Par3(timerIndex), Par4(0), Par5(1)
+systemTimerStruct::systemTimerStruct(int recurringCount, unsigned long msecFromNow, unsigned int timerIndex, int alternateInterval) :
+  _recurringCount(recurringCount), _interval(msecFromNow), _timerIndex(timerIndex), _remainder(0), _loopCount(1), _alternateInterval(
+    alternateInterval)
 {
-  if (recurringCount > 0) {
-    // Will run with Par1 == 0, so must subtract one when setting the value.
-    Par1--;
+  if ((recurringCount > 0) && !hasAlternateInterval()) {
+    // Will run with _recurringCount == 0, so must subtract one when setting the value.
+    _recurringCount--;
   }
 
   if (msecFromNow == 0) {
     // Create a new timer which should be "scheduled" now to clear up any data
-    Par1 = 0; // Do not reschedule
-    Par5 = 0; // Do not execute
+    _recurringCount = 0; // Do not reschedule
+    _loopCount      = 0; // Do not execute
     addLog(LOG_LEVEL_INFO, F("TIMER: disable timer"));
   }
+
+  if (hasAlternateInterval()) {
+    // Need to double the recurring count, or at least set it to 1 to make sure the alternate interval is also ran at least once.
+    if (_recurringCount > 0) {
+      _recurringCount *= 2;
+    } else if (_recurringCount == 0) {
+      _recurringCount = 1;
+    }
+  }
+}
+
+struct EventStruct systemTimerStruct::toEvent() const {
+  struct EventStruct TempEvent(TaskIndex);
+
+  TempEvent.Par1 = _recurringCount;
+  TempEvent.Par2 = _interval;
+  TempEvent.Par3 = _timerIndex;
+  TempEvent.Par4 = _remainder;
+  TempEvent.Par5 = _loopCount;
+  return TempEvent;
+}
+
+void systemTimerStruct::fromEvent(taskIndex_t taskIndex,
+                                  int         Par1,
+                                  int         Par2,
+                                  int         Par3,
+                                  int         Par4,
+                                  int         Par5)
+{
+  TaskIndex       = taskIndex;
+  _recurringCount = Par1;
+  _interval       = Par2;
+  _timerIndex     = Par3;
+  _remainder      = Par4;
+  _loopCount      = Par5;
 }
 
 bool systemTimerStruct::isRecurring() const {
-  return Par1 != 0;
+  return _recurringCount != 0;
 }
 
 void systemTimerStruct::markNextRecurring() {
-  if (Par1 > 0) {
+  toggleAlternateState(); // Will only toggle if it has an alternate state
+
+  if (_recurringCount > 0) {
     // This is a timer with a limited number of runs, so decrease its value.
-    Par1--;
+    _recurringCount--;
   }
 
-  if (Par5 > 0) {
+  if (_loopCount > 0) {
     // This one should be executed, so increase the count.
-    Par5++;
+    _loopCount++;
   }
 }
 
 unsigned long systemTimerStruct::getInterval() const {
-  return Par2;
+  return _alternateState ? _alternateInterval : _interval;
 }
 
 unsigned int systemTimerStruct::getTimerIndex() const {
-  return Par3;
+  return _timerIndex;
 }
 
 bool systemTimerStruct::isPaused() const {
-  return Par4 != 0;
+  return _remainder != 0;
 }
 
 int systemTimerStruct::getRemainder() const {
-  return Par4;
+  return _remainder;
 }
 
 void systemTimerStruct::setRemainder(int timeLeft) {
-  Par4 = timeLeft;
+  _remainder = timeLeft;
 }
 
 int systemTimerStruct::getLoopCount() const {
-  return Par5;
+  if (hasAlternateInterval()) { return _loopCount / 2; }
+  return _loopCount;
+}
+
+void systemTimerStruct::toggleAlternateState() {
+  if (hasAlternateInterval()) {
+    _alternateState = !_alternateState;
+  } else {
+    _alternateState = false;
+  }
 }

--- a/src/src/DataStructs/SystemTimerStruct.h
+++ b/src/src/DataStructs/SystemTimerStruct.h
@@ -12,20 +12,35 @@ struct systemTimerStruct
 {
   systemTimerStruct() {}
 
-  int         Par1      = 0;
-  int         Par2      = 0;
-  int         Par3      = 0;
-  int         Par4      = 0;
-  int         Par5      = 0;
-  taskIndex_t TaskIndex = INVALID_TASK_INDEX;
+private:
 
+  int         _recurringCount    = 0;
+  int         _interval          = 0;
+  int         _timerIndex        = 0;
+  int         _remainder         = 0;
+  int         _loopCount         = 0;
+  int         _alternateInterval = 0;
+  taskIndex_t TaskIndex          = INVALID_TASK_INDEX;
+  bool        _alternateState    = false;
+
+public:
 
   // ***************
   // Rules Timer use
   // ***************
   systemTimerStruct(int           recurringCount,
                     unsigned long msecFromNow,
-                    unsigned int  timerIndex);
+                    unsigned int  timerIndex,
+                    int alternateInterval = 0);
+
+  struct EventStruct toEvent() const;
+
+  void               fromEvent(taskIndex_t TaskIndex,
+                               int         Par1,
+                               int         Par2,
+                               int         Par3,
+                               int         Par4,
+                               int         Par5);
 
   bool          isRecurring() const;
 
@@ -42,6 +57,16 @@ struct systemTimerStruct
   void          setRemainder(int timeLeft);
 
   int           getLoopCount() const;
+
+  void          toggleAlternateState();
+
+  bool          isAlternateState() const {
+    return _alternateState;
+  }
+
+  bool hasAlternateInterval() const {
+    return _alternateInterval > 0;
+  }
 };
 
 

--- a/src/src/DataStructs/TimingStats.cpp
+++ b/src/src/DataStructs/TimingStats.cpp
@@ -239,6 +239,7 @@ const __FlashStringHelper* getMiscStatsName_F(int stat) {
     case WIFI_SCAN_ASYNC:            return F("WiFi Scan Async");
     case WIFI_SCAN_SYNC:             return F("WiFi Scan Sync (blocking)");
     case NTP_SUCCESS:                return F("NTP Success");
+    case NTP_FAIL:                   return F("NTP Fail");
     case SYSTIME_UPDATED:            return F("Systime Set");
     case C018_AIR_TIME:              return F("C018 LoRa TTN - Air Time");
   }

--- a/src/src/Helpers/ESPEasy_checks.cpp
+++ b/src/src/Helpers/ESPEasy_checks.cpp
@@ -115,7 +115,7 @@ void run_compiletime_checks() {
   #if FEATURE_ESPEASY_P2P
   check_size<NodeStruct,                            66u>();
   #endif
-  check_size<systemTimerStruct,                     24u>();
+  check_size<systemTimerStruct,                     28u>();
   check_size<RTCStruct,                             32u>();
   check_size<portStatusStruct,                      6u>();
   check_size<ResetFactoryDefaultPreference_struct,  4u>();

--- a/src/src/Helpers/Scheduler.cpp
+++ b/src/src/Helpers/Scheduler.cpp
@@ -315,6 +315,10 @@ void ESPEasy_Scheduler::handle_schedule() {
 * These timers set a new scheduled timer, based on the old value.
 * This will make their interval as constant as possible.
 \*********************************************************************************************/
+
+// Interval where it is more important to actually run the scheduled job, instead of keeping the time drift to a minimum.
+// For example running the PLUGIN_FIFTY_PER_SECOND calls probably need to run as fast as possible as they need to fetch data before a buffer overflow happens.
+// For those it is more important to actually run it than keeping pace.
 void ESPEasy_Scheduler::setNextTimeInterval(unsigned long& timer, const unsigned long step) {
   timer += step;
   const long passed = timePassedSince(timer);
@@ -332,6 +336,22 @@ void ESPEasy_Scheduler::setNextTimeInterval(unsigned long& timer, const unsigned
 
   // Try to get in sync again.
   timer = millis() + (step - passed);
+}
+
+// More strict interval where no time drift is more important than missing a scheduled interval.
+// For example timing for repeating longPulse where 2 scheduled intervals need to be at constant 'distance' from each other.
+void ESPEasy_Scheduler::setNextStrictTimeInterval(unsigned long     & timer,
+                                                  const unsigned long step) {
+  timer += step;
+  const long passed = timePassedSince(timer);
+
+  if (passed <= 0) {
+    // Event has not yet happened, which is fine.
+    return;
+  }
+  // Try to get in sync again.
+  const unsigned long stepsMissed = static_cast<unsigned long>(passed) / step;
+  timer += (stepsMissed + 1) * step;
 }
 
 void ESPEasy_Scheduler::setIntervalTimer(IntervalTimer_e id) {
@@ -619,12 +639,7 @@ void ESPEasy_Scheduler::setPluginTaskTimer(unsigned long msecFromNow, taskIndex_
 
   systemTimerStruct timer_data;
 
-  timer_data.TaskIndex       = taskIndex;
-  timer_data.Par1            = Par1;
-  timer_data.Par2            = Par2;
-  timer_data.Par3            = Par3;
-  timer_data.Par4            = Par4;
-  timer_data.Par5            = Par5;
+  timer_data.fromEvent(taskIndex, Par1, Par2, Par3, Par4, Par5);
   systemTimers[mixedTimerId] = timer_data;
   setNewTimerAt(mixedTimerId, millis() + msecFromNow);
 }
@@ -639,13 +654,7 @@ void ESPEasy_Scheduler::process_plugin_task_timer(unsigned long id) {
 
   if (it == systemTimers.end()) { return; }
 
-  struct EventStruct TempEvent(it->second.TaskIndex);
-
-  TempEvent.Par1 = it->second.Par1;
-  TempEvent.Par2 = it->second.Par2;
-  TempEvent.Par3 = it->second.Par3;
-  TempEvent.Par4 = it->second.Par4;
-  TempEvent.Par5 = it->second.Par5;
+  struct EventStruct TempEvent(it->second.toEvent());
 
   // TD-er: Not sure if we have to keep original source for notifications.
   TempEvent.Source = EventValueSource::Enum::VALUE_SOURCE_SYSTEM;
@@ -818,11 +827,7 @@ void ESPEasy_Scheduler::setPluginTimer(unsigned long msecFromNow, pluginID_t plu
   systemTimerStruct   timer_data;
 
   // PLUGIN_DEVICETIMER_IN does not address a task, so don't set TaskIndex
-  timer_data.Par1            = Par1;
-  timer_data.Par2            = Par2;
-  timer_data.Par3            = Par3;
-  timer_data.Par4            = Par4;
-  timer_data.Par5            = Par5;
+  timer_data.fromEvent(INVALID_TASK_INDEX, Par1, Par2, Par3, Par4, Par5);
   systemTimers[mixedTimerId] = timer_data;
   setNewTimerAt(mixedTimerId, millis() + msecFromNow);
 }
@@ -838,18 +843,12 @@ void ESPEasy_Scheduler::process_plugin_timer(unsigned long id) {
 
   if (it == systemTimers.end()) { return; }
 
-  struct EventStruct TempEvent;
+  struct EventStruct TempEvent(it->second.toEvent());
 
   // PLUGIN_DEVICETIMER_IN does not address a task, so don't set TaskIndex
 
   // extract deviceID from timer id:
   const deviceIndex_t deviceIndex = ((1 << 8) - 1) & id;
-
-  TempEvent.Par1 = it->second.Par1;
-  TempEvent.Par2 = it->second.Par2;
-  TempEvent.Par3 = it->second.Par3;
-  TempEvent.Par4 = it->second.Par4;
-  TempEvent.Par5 = it->second.Par5;
 
   // TD-er: Not sure if we have to keep original source for notifications.
   TempEvent.Source = EventValueSource::Enum::VALUE_SOURCE_SYSTEM;
@@ -893,7 +892,8 @@ void ESPEasy_Scheduler::setGPIOTimer(
   int        pinnr,
   int        state,
   int        repeatInterval,
-  int        recurringCount)
+  int        recurringCount,
+  int        alternateInterval)
 {
   uint8_t GPIOType = GPIO_TYPE_INVALID;
 
@@ -918,7 +918,8 @@ void ESPEasy_Scheduler::setGPIOTimer(
     const systemTimerStruct timer_data(
       recurringCount, 
       repeatInterval, 
-      state);
+      state,
+      alternateInterval);
     systemTimers[mixedTimerId] = timer_data;
     setNewTimerAt(mixedTimerId, millis() + msecFromNow);
   }
@@ -967,15 +968,19 @@ void ESPEasy_Scheduler::process_gpio_timer(unsigned long id, unsigned long lastt
   // Reschedule before sending the event, as it may get rescheduled in handling the timer event.
   if (it->second.isRecurring()) {
     // Recurring timer
+    it->second.markNextRecurring();
+    
     unsigned long newTimer = lasttimer;
     setNextTimeInterval(newTimer, it->second.getInterval());
     setNewTimerAt(mixedTimerId, newTimer);
-    it->second.markNextRecurring();
   }
 
   uint8_t GPIOType      = static_cast<uint8_t>((id) & 0xFF);
   uint8_t pinNumber     = static_cast<uint8_t>((id >> 8) & 0xFF);
   uint8_t pinStateValue = static_cast<uint8_t>((id >> 16) & 0xFF);
+  if (it->second.isAlternateState()) {
+    pinStateValue = (pinStateValue > 0) ? 0 : 1;
+  }
 
   uint8_t pluginID = PLUGIN_GPIO;
 

--- a/src/src/Helpers/Scheduler.h
+++ b/src/src/Helpers/Scheduler.h
@@ -127,6 +127,9 @@ public:
   void                 setNextTimeInterval(unsigned long     & timer,
                                            const unsigned long step);
 
+  void                 setNextStrictTimeInterval(unsigned long     & timer,
+                                                 const unsigned long step);
+
   void                 setIntervalTimer(IntervalTimer_e id);
   void                 setIntervalTimerAt(IntervalTimer_e id,
                                           unsigned long   newtimer);
@@ -217,7 +220,8 @@ public:
                     int           pinnr,
                     int           state = 0,
                     int           repeatInterval = 0,
-                    int           recurringCount = 0);
+                    int           recurringCount = 0,
+                    int           alternateInterval = 0);
 
   void clearGPIOTimer(pluginID_t pluginID, int pinnr);
 


### PR DESCRIPTION
The set pulse count was off by one.
Also the "up" and "down" switches were running a separate scheduled job, which could eventually run out of phase. Now the system timer used for this can have an alternative interval. This means there is a single scheduled timer which can thus never run out of phase anymore.