### PR TITLE
[Command parsing] Non-numeric arguments could return uninitialized data

### DIFF
--- a/src/src/Helpers/Rules_calculate.cpp
+++ b/src/src/Helpers/Rules_calculate.cpp
@@ -617,7 +617,7 @@ String RulesCalculate_t::preProces(const String& input)
 * Helper functions to actually interact with the rules calculation functions.
 * *****************************************************************************************/
 int CalculateParam(const String& TmpStr) {
-  int returnValue;
+  int returnValue = 0;
 
   // Minimize calls to the Calulate function.
   // Only if TmpStr starts with '=' then call Calculate(). Otherwise do not call it


### PR DESCRIPTION
Fixes #4374 

Non-numeric command arguments, as can be used in the Task* commands, could return uninitialized data. This was detected on ESP32, but not (yet) on ESP8266. Initializing the used variable to 0 solves this.