### PR TITLE
[JSON] show used gpio in JSON for P001

### DIFF
--- a/src/src/WebServer/JSON.cpp
+++ b/src/src/WebServer/JSON.cpp
@@ -448,15 +448,11 @@ void handle_json()
         stream_next_json_object_value(F("Type"),             getPluginNameFromDeviceIndex(DeviceIndex));
         stream_next_json_object_value(F("TaskName"),         getTaskDeviceName(TaskIndex));
         stream_next_json_object_value(F("TaskDeviceNumber"), Settings.TaskDeviceNumber[TaskIndex]);
-        for(int i = 0; i < 3; i++)
-        {
+        for(int i = 0; i < 3; i++) {
           if (Settings.TaskDevicePin[i][TaskIndex] != -1) {
-             int gpioNr = Settings.TaskDevicePin[i][TaskIndex];
-              if (i==0) {stream_next_json_object_value(F("TaskDeviceGPIO1"), gpioNr);}
-              if (i==1) {stream_next_json_object_value(F("TaskDeviceGPIO2"), gpioNr);} 
-              if (i==2) {stream_next_json_object_value(F("TaskDeviceGPIO3"), gpioNr);} 
-            }
+            stream_next_json_object_value(concat(F("TaskDeviceGPIO"), i + 1) , String(Settings.TaskDevicePin[i][TaskIndex]));
           }
+        }
         
         #if FEATURE_I2CMULTIPLEXER
         if (Device[DeviceIndex].Type == DEVICE_TYPE_I2C && isI2CMultiplexerEnabled()) {

--- a/src/src/WebServer/JSON.cpp
+++ b/src/src/WebServer/JSON.cpp
@@ -448,8 +448,11 @@ void handle_json()
         stream_next_json_object_value(F("Type"),             getPluginNameFromDeviceIndex(DeviceIndex));
         stream_next_json_object_value(F("TaskName"),         getTaskDeviceName(TaskIndex));
         stream_next_json_object_value(F("TaskDeviceNumber"), Settings.TaskDeviceNumber[TaskIndex]);
-        if (Settings.TaskDeviceNumber[TaskIndex] == 1) {
-          stream_next_json_object_value(F("TaskDeviceGPIO"), Settings.TaskDevicePin1[TaskIndex]);
+        for(int i = 0; i < 3; i++)
+        {
+          if (Settings.TaskDevicePin[i][TaskIndex] != -1) {
+    	      stream_next_json_object_value(F("TaskDeviceGPIO") , Settings.TaskDevicePin[i][TaskIndex]);
+          }
         }
 
         #if FEATURE_I2CMULTIPLEXER

--- a/src/src/WebServer/JSON.cpp
+++ b/src/src/WebServer/JSON.cpp
@@ -448,6 +448,10 @@ void handle_json()
         stream_next_json_object_value(F("Type"),             getPluginNameFromDeviceIndex(DeviceIndex));
         stream_next_json_object_value(F("TaskName"),         getTaskDeviceName(TaskIndex));
         stream_next_json_object_value(F("TaskDeviceNumber"), Settings.TaskDeviceNumber[TaskIndex]);
+        if (getPluginNameFromDeviceIndex(DeviceIndex) == "Switch input - Switch") {
+          stream_next_json_object_value(F("TaskDeviceGPIO"), Settings.TaskDevicePin1[TaskIndex]);
+        }
+        
         #if FEATURE_I2CMULTIPLEXER
         if (Device[DeviceIndex].Type == DEVICE_TYPE_I2C && isI2CMultiplexerEnabled()) {
           int8_t channel = Settings.I2C_Multiplexer_Channel[TaskIndex];

--- a/src/src/WebServer/JSON.cpp
+++ b/src/src/WebServer/JSON.cpp
@@ -449,11 +449,11 @@ void handle_json()
         stream_next_json_object_value(F("TaskName"),         getTaskDeviceName(TaskIndex));
         stream_next_json_object_value(F("TaskDeviceNumber"), Settings.TaskDeviceNumber[TaskIndex]);
         for(int i = 0; i < 3; i++) {
-          if (Settings.TaskDevicePin[i][TaskIndex] != -1) {
+          if (Settings.TaskDevicePin[i][TaskIndex] >= 0) {
             stream_next_json_object_value(concat(F("TaskDeviceGPIO"), i + 1) , String(Settings.TaskDevicePin[i][TaskIndex]));
           }
         }
-        
+
         #if FEATURE_I2CMULTIPLEXER
         if (Device[DeviceIndex].Type == DEVICE_TYPE_I2C && isI2CMultiplexerEnabled()) {
           int8_t channel = Settings.I2C_Multiplexer_Channel[TaskIndex];

--- a/src/src/WebServer/JSON.cpp
+++ b/src/src/WebServer/JSON.cpp
@@ -448,10 +448,10 @@ void handle_json()
         stream_next_json_object_value(F("Type"),             getPluginNameFromDeviceIndex(DeviceIndex));
         stream_next_json_object_value(F("TaskName"),         getTaskDeviceName(TaskIndex));
         stream_next_json_object_value(F("TaskDeviceNumber"), Settings.TaskDeviceNumber[TaskIndex]);
-        if (getPluginNameFromDeviceIndex(DeviceIndex) == "Switch input - Switch") {
+        if (Settings.TaskDeviceNumber[TaskIndex] == 1) {
           stream_next_json_object_value(F("TaskDeviceGPIO"), Settings.TaskDevicePin1[TaskIndex]);
         }
-        
+
         #if FEATURE_I2CMULTIPLEXER
         if (Device[DeviceIndex].Type == DEVICE_TYPE_I2C && isI2CMultiplexerEnabled()) {
           int8_t channel = Settings.I2C_Multiplexer_Channel[TaskIndex];

--- a/src/src/WebServer/JSON.cpp
+++ b/src/src/WebServer/JSON.cpp
@@ -451,10 +451,13 @@ void handle_json()
         for(int i = 0; i < 3; i++)
         {
           if (Settings.TaskDevicePin[i][TaskIndex] != -1) {
-    	      stream_next_json_object_value(F("TaskDeviceGPIO") , Settings.TaskDevicePin[i][TaskIndex]);
+             int gpioNr = Settings.TaskDevicePin[i][TaskIndex];
+              if (i==0) {stream_next_json_object_value(F("TaskDeviceGPIO1"), gpioNr);}
+              if (i==1) {stream_next_json_object_value(F("TaskDeviceGPIO2"), gpioNr);} 
+              if (i==2) {stream_next_json_object_value(F("TaskDeviceGPIO3"), gpioNr);} 
+            }
           }
-        }
-
+        
         #if FEATURE_I2CMULTIPLEXER
         if (Device[DeviceIndex].Type == DEVICE_TYPE_I2C && isI2CMultiplexerEnabled()) {
           int8_t channel = Settings.I2C_Multiplexer_Channel[TaskIndex];


### PR DESCRIPTION
I actually didn´t want to interfere with ESPEasy code wise because of "easyfetch".
But this would make interaction with virtual buttons a bit easier for beginner since they simply would need to add a switch-plugin (for output  ;) )  and "easyfetch" would generate a functioning virtual button without further ado.

