### PR TITLE
[WiFi] Fix WiFi (re)connect not starting AP immediately

### DIFF
--- a/src/src/ESPEasyCore/ESPEasyWifi.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi.cpp
@@ -496,7 +496,7 @@ bool prepareWiFi() {
     // No need to wait longer to start AP mode.
     if (!Settings.DoNotStartAP()) {
       WifiScan(false);
-      setAP(true);
+//      setAP(true);
     }
     return false;
   }

--- a/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
@@ -568,8 +568,7 @@ void processScanDone() {
       temp_disable_EspEasy_now_timer = millis() + 20000;
 #endif
     }
-  }
-  if (!NetworkConnected()) {
+  } else if (!NetworkConnected()) {
     WiFiEventData.timerAPstart.setNow();
   }
 


### PR DESCRIPTION
The AP mode was started almost immediately before actually connecting to an AP.
This caused some strange issues and also a disconnect/reconnect when the AP mode was disabled after 300 sec.

Hopefully it doesn't break WiFi on those nodes that finally were able to have a stable WiFi.