### PR TITLE
[WiFi] Fix loop WIFI_STA and WIFI_OFF preventing boot/wificonnect

### DIFF
--- a/src/src/DataStructs/WiFiEventData.cpp
+++ b/src/src/DataStructs/WiFiEventData.cpp
@@ -28,6 +28,7 @@ bool WiFiEventData_t::WiFiConnectAllowed() const {
     }
   }
   if (!wifiConnectAttemptNeeded) return false;
+  if (intent_to_reboot) return false;
   if (wifiSetupConnect) return true;
   if (wifiConnectInProgress) {
     if (last_wifi_connect_attempt_moment.isSet() && 
@@ -135,6 +136,8 @@ bool WiFiEventData_t::WiFiServicesInitialized() const {
 void WiFiEventData_t::setWiFiDisconnected() {
   wifiConnectInProgress = false;
   wifiStatus            = ESPEASY_WIFI_DISCONNECTED;
+  last_wifi_connect_attempt_moment.clear();
+  wifiConnectInProgress = false;
 }
 
 void WiFiEventData_t::setWiFiGotIP() {
@@ -188,7 +191,10 @@ void WiFiEventData_t::markDisconnect(WiFiDisconnectReason reason) {
     // There was an unsuccessful connection attempt
     lastConnectedDuration_us = last_wifi_connect_attempt_moment.timeDiff(lastDisconnectMoment);
   } else {
-    lastConnectedDuration_us = lastConnectMoment.timeDiff(lastDisconnectMoment);
+    if (last_wifi_connect_attempt_moment.isSet())
+      lastConnectedDuration_us = lastConnectMoment.timeDiff(lastDisconnectMoment);
+    else 
+      lastConnectedDuration_us = 0;
   }
   lastDisconnectReason = reason;
   processedDisconnect  = false;

--- a/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
@@ -210,6 +210,8 @@ void handle_unprocessedNetworkEvents()
 // These functions are called from Setup() or Loop() and thus may call delay() or yield()
 // ********************************************************************************
 void processDisconnect() {
+  if (WiFiEventData.processedDisconnect) { return; }
+
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
     String log = F("WIFI : Disconnected! Reason: '");
     log += getLastDisconnectReason();
@@ -218,8 +220,6 @@ void processDisconnect() {
     if (WiFiEventData.lastConnectedDuration_us > 0) {
       log += F(" Connected for ");
       log += format_msec_duration(WiFiEventData.lastConnectedDuration_us / 1000ll);
-    } else {
-      log += F(" Connected for a long time...");
     }
     addLogMove(LOG_LEVEL_INFO, log);
   }
@@ -249,10 +249,13 @@ void processDisconnect() {
   bool mustRestartWiFi = Settings.WiFiRestart_connection_lost();
   if (WiFiEventData.lastConnectedDuration_us > 0 && (WiFiEventData.lastConnectedDuration_us / 1000) < 5000) {
     if (!WiFi_AP_Candidates.getBestCandidate().usable())
+//      addLog(LOG_LEVEL_INFO, F("WIFI : !getBestCandidate().usable()  => mustRestartWiFi = true"));
+
       mustRestartWiFi = true;
   }
   
   if (WiFi.status() == WL_IDLE_STATUS) {
+//    addLog(LOG_LEVEL_INFO, F("WIFI : WiFi.status() == WL_IDLE_STATUS  => mustRestartWiFi = true"));
     mustRestartWiFi = true;
   }
 
@@ -493,11 +496,12 @@ void processConnectAPmode() {
 void processDisableAPmode() {
   if (!WiFiEventData.timerAPoff.isSet()) { return; }
 
-  if (WifiIsAP(WiFi.getMode())) {
-    // disable AP after timeout and no clients connected.
-    if (WiFiEventData.timerAPoff.timeReached() && (WiFi.softAPgetStationNum() == 0)) {
-      setAP(false);
-    }
+  if (!WifiIsAP(WiFi.getMode())) {
+    return;
+  }
+  // disable AP after timeout and no clients connected.
+  if (WiFiEventData.timerAPoff.timeReached() && (WiFi.softAPgetStationNum() == 0)) {
+    setAP(false);
   }
 
   if (!WifiIsAP(WiFi.getMode())) {
@@ -563,7 +567,7 @@ void processScanDone() {
       #endif
 
 //      setSTA(false);
-      NetworkConnectRelaxed();
+//      NetworkConnectRelaxed();
 #ifdef USES_ESPEASY_NOW
       temp_disable_EspEasy_now_timer = millis() + 20000;
 #endif

--- a/src/src/Helpers/PeriodicalActions.cpp
+++ b/src/src/Helpers/PeriodicalActions.cpp
@@ -467,6 +467,7 @@ void flushAndDisconnectAllClients() {
 
 void prepareShutdown(ESPEasy_Scheduler::IntendedRebootReason_e reason)
 {
+  WiFiEventData.intent_to_reboot = true;
 #if FEATURE_MQTT
   runPeriodicalMQTT(); // Flush outstanding MQTT messages
 #endif // if FEATURE_MQTT

--- a/src/src/Helpers/StringGenerator_WiFi.cpp
+++ b/src/src/Helpers/StringGenerator_WiFi.cpp
@@ -105,7 +105,7 @@ const __FlashStringHelper * getLastDisconnectReason(WiFiDisconnectReason reason)
     case WIFI_DISCONNECT_REASON_NO_AP_FOUND:                return F("No AP found");              
     case WIFI_DISCONNECT_REASON_AUTH_FAIL:                  return F("Auth fail");                
     case WIFI_DISCONNECT_REASON_ASSOC_FAIL:                 return F("Assoc fail");               
-    case WIFI_DISCONNECT_REASON_HANDSHAKE_TIMEOUT:          return F("Handshake timeout");        
+    case WIFI_DISCONNECT_REASON_HANDSHAKE_TIMEOUT:          return F("Handshake timeout");
     default:  return F("Unknown");
   }
 }


### PR DESCRIPTION
Some strange situation where ESP8266 SDK seems to toggle WiFi mode, leaving the state unexpected for ESPEasy. This ended up in an infinite loop switching between WIFI_STA and WIFI_OFF. This happened on an old Sonoff POW.
No idea what may have caused this.

Other fixes:
- No longer trying to automatically reconnect when trying to reboot.
- Deal with disconnect events before trying to reconnect.
- Don't force WiFi disconnect when AP is turned off.
- Register WiFi event handlers on ESP8266 only once (as we already did on ESP32) to make sure we don't get multiple of the same events.

Fixes: #4410 