### PR TITLE
[Build] Enable I2C Multiplexer in most ESP8266 4M builds

### DIFF
--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -1317,6 +1317,7 @@ To create/register a plugin, you have to :
       #define WEBSERVER_USE_CDN_JS_CSS
     #endif
   #endif
+  #define KEEP_I2C_MULTIPLEXER
 #endif
 
 // COLLECTIONS #####################################
@@ -1484,6 +1485,7 @@ To create/register a plugin, you have to :
    #if !defined(LIMIT_BUILD_SIZE) && (defined(ESP8266) || !(ESP_IDF_VERSION_MAJOR > 3))
      #ifndef PLUGIN_BUILD_MAX_ESP32
        #define LIMIT_BUILD_SIZE // Reduce buildsize (on ESP8266 / pre-IDF4.x) to fit in all Display plugins
+       #define KEEP_I2C_MULTIPLEXER
      #endif
    #endif
    #if !defined(FEATURE_SD) && !defined(ESP8266)
@@ -2177,10 +2179,12 @@ To create/register a plugin, you have to :
   #ifndef BUILD_NO_SPECIAL_CHARACTERS_STRINGCONVERTER
     #define BUILD_NO_SPECIAL_CHARACTERS_STRINGCONVERTER
   #endif
-  #ifdef FEATURE_I2CMULTIPLEXER
-    #undef FEATURE_I2CMULTIPLEXER
+  #ifndef KEEP_I2C_MULTIPLEXER
+    #ifdef FEATURE_I2CMULTIPLEXER
+      #undef FEATURE_I2CMULTIPLEXER
+    #endif
+    #define FEATURE_I2CMULTIPLEXER  0
   #endif
-  #define FEATURE_I2CMULTIPLEXER  0
   #ifdef FEATURE_SETTINGS_ARCHIVE
     #undef FEATURE_SETTINGS_ARCHIVE
   #endif


### PR DESCRIPTION
The I2C Multiplexer was not included in builds that have the flag `LIMIT_BUILD_SIZE` enabled, but these builds contain a lot of I2C devices, validating the availability of the I2C Multiplexer.
This concerns these builds:
- All ESP8266 `Collection` builds
- The ESP8266 `Energy` build
- The ESP8266 `Display` build

Not enabled for the ESP8266 `Neopixel` builds, as there it is much less likely to be needed.

For all ESP32 builds the I2C Multiplexer was already available by default.