### PR TITLE
[Controller] Allow system variables in controller username

### DIFF
--- a/src/src/DataStructs/ExtendedControllerCredentialsStruct.cpp
+++ b/src/src/DataStructs/ExtendedControllerCredentialsStruct.cpp
@@ -71,7 +71,7 @@ String ExtendedControllerCredentialsStruct::getControllerUser(controllerIndex_t 
   if (validControllerIndex(controller_idx)) {
     return _strings[controller_idx * 2 + EXT_CONTR_CRED_USER_OFFSET];
   }
-  return "";
+  return EMPTY_STRING;
 }
 
 String ExtendedControllerCredentialsStruct::getControllerPass(controllerIndex_t controller_idx) const
@@ -79,7 +79,7 @@ String ExtendedControllerCredentialsStruct::getControllerPass(controllerIndex_t 
   if (validControllerIndex(controller_idx)) {
     return _strings[controller_idx * 2 + EXT_CONTR_CRED_PASS_OFFSET];
   }
-  return "";
+  return EMPTY_STRING;
 }
 
 void ExtendedControllerCredentialsStruct::setControllerUser(controllerIndex_t controller_idx, const String& user)

--- a/src/src/Helpers/_CPlugin_Helper.cpp
+++ b/src/src/Helpers/_CPlugin_Helper.cpp
@@ -272,15 +272,20 @@ String send_via_http(int                             controller_number,
 
 
 
-String getControllerUser(controllerIndex_t controller_idx, const ControllerSettingsStruct& ControllerSettings)
+String getControllerUser(controllerIndex_t controller_idx, const ControllerSettingsStruct& ControllerSettings, bool doParseTemplate)
 {
   if (!validControllerIndex(controller_idx)) { return EMPTY_STRING; }
 
+  String res;
   if (ControllerSettings.useExtendedCredentials()) {
-    return ExtendedControllerCredentials.getControllerUser(controller_idx);
+    res = ExtendedControllerCredentials.getControllerUser(controller_idx);
+  } else {
+    res = String(SecuritySettings.ControllerUser[controller_idx]);
   }
-  String res(SecuritySettings.ControllerUser[controller_idx]);
   res.trim();
+  if (doParseTemplate) {
+    res = parseTemplate(res);
+  }
   return res;
 }
 
@@ -320,6 +325,6 @@ void setControllerPass(controllerIndex_t controller_idx, const ControllerSetting
 
 bool hasControllerCredentialsSet(controllerIndex_t controller_idx, const ControllerSettingsStruct& ControllerSettings)
 {
-  return !getControllerUser(controller_idx, ControllerSettings).isEmpty() &&
+  return !getControllerUser(controller_idx, ControllerSettings, false).isEmpty() &&
          !getControllerPass(controller_idx, ControllerSettings).isEmpty();
 }

--- a/src/src/Helpers/_CPlugin_Helper.h
+++ b/src/src/Helpers/_CPlugin_Helper.h
@@ -65,7 +65,7 @@ String send_via_http(int                             controller_number,
 #endif // FEATURE_HTTP_CLIENT
                      
 
-String getControllerUser(controllerIndex_t controller_idx, const ControllerSettingsStruct& ControllerSettings);
+String getControllerUser(controllerIndex_t controller_idx, const ControllerSettingsStruct& ControllerSettings, bool parseTemplate = true);
 String getControllerPass(controllerIndex_t controller_idx, const ControllerSettingsStruct& ControllerSettings);
 void setControllerUser(controllerIndex_t controller_idx, const ControllerSettingsStruct& ControllerSettings, const String& value);
 void setControllerPass(controllerIndex_t controller_idx, const ControllerSettingsStruct& ControllerSettings, const String& value);

--- a/src/src/Helpers/_CPlugin_Helper_webform.cpp
+++ b/src/src/Helpers/_CPlugin_Helper_webform.cpp
@@ -161,7 +161,7 @@ void addControllerParameterForm(const ControllerSettingsStruct& ControllerSettin
         ControllerSettings.useExtendedCredentials() ? EXT_SECURITY_MAX_USER_LENGTH : sizeof(SecuritySettings.ControllerUser[0]) - 1;
       addFormTextBox(displayName,
                      internalName,
-                     getControllerUser(controllerindex, ControllerSettings),
+                     getControllerUser(controllerindex, ControllerSettings, false),
                      fieldMaxLength);
       break;
     }


### PR DESCRIPTION
This allows for some more generic configs to be shared among nodes.
Typical use cases for controller user name:
- `%sysname%_%unit%`
- `foo_%unit%`
- `foo_%mac%`
- `foo_%cpu_id%`