### PR TITLE
[ESP32] Fix ECO mode on ESP32

### DIFF
--- a/docs/source/Tools/Tools.rst
+++ b/docs/source/Tools/Tools.rst
@@ -144,7 +144,7 @@ All these values are described in great detail in the Advanced section, where th
 
 * **Force WiFi B/G**:	Shows whether the ESPEasy node is forced into 802.11b/g mode.
 * **Restart WiFi Lost Conn**:	Shows whether the ESPEasy node is configured to restart the WiFi radio when connection is lost. When reporting false (the default), the WiFi radio is not restarted, but it just retries to connect to WiFi.
-* **Force WiFi No Sleep**:	``true`` indicates the WiFi radio is not allowed to enter low power mode to conserve energy.
+* **Force WiFi No Sleep**:	``true`` indicates the WiFi radio is not allowed to enter low power mode to conserve energy. The ESP may need to reconnect or sometimes even reboot to activate a change of this setting. It may sometimes not be able to reconnect on its own when changed, so be careful when changing this.
 * **Periodical send Gratuitous ARP**:	``true`` indicates the ESPEasy node will send Gratuitous ARP packets to improve reachability from the network to the node.
 * **Connection Failure Threshold**:	Counter indicating the number of failed connection attempts needed to perform a reboot.
 * **Max WiFi TX Power**:	The set maximum TX power in dBm.
@@ -153,6 +153,8 @@ All these values are described in great detail in the Advanced section, where th
 * **Send With Max TX Power**:	``true`` indicates the WiFi TX power will not be changed and thus is sending at maximum TX power for the active WiFi mode (802.11 b/g/n)
 * **Extra WiFi scan loops**:	The set number of extra scans of all channels when a WiFi scan is needed.
 * **Use Last Connected AP from RTC**:	``false`` means the ESPEasy node needs to scan at reboot and cannot reuse the last used connection before the reboot.
+
+.. note:: On ESP32, WiFi TX power settings are disabled as these may cause undesired behavior and also use more power compared to using the ECO mode.
 
 Firmware
 --------

--- a/docs/source/WiFi/WiFi.rst
+++ b/docs/source/WiFi/WiFi.rst
@@ -99,6 +99,8 @@ A typical beacon interval is ~100 msec (102.4 msec).
 When you try to send data to a connected WiFi station, your access point first tries to send directly to the node and if it doesn't immediately reply, the access point includes a notification for this node in such a beacon package.
 Meaning, if you send a ping (or just any package) to a WiFi connected node, the first reply typically takes half this interval. (later ping replies may receive a response more quickly as the radio may be on continuously)
 
+.. note:: On ESP32, setting the ECO mode will also reduce the CPU clock to 80 MHz. (added: 2022/12/15)
+
 If the ESP (or any other WiFi device in "power save mode") is not listening to each beacon interval, it may take longer to reach the node.
 Such a "listen interval" is called a DTIM interval and is often set between 1 and 3 for almost all WiFi devices.
 I'm not entirely sure what the ESP uses when consuming ~80 mA, but I think it has the radio on all the time, effectively receiving packets before the next beacon interval.

--- a/platformio_core_defs.ini
+++ b/platformio_core_defs.ini
@@ -241,6 +241,9 @@ build_flags                 = -DESP32_STAGE
                               -DESP_IDF_VERSION_MAJOR=4
                               -DMUSTFIX_CLIENT_TIMEOUT_IN_SECONDS
                               -DLIBRARIES_NO_LOG=1
+                              -DCONFIG_PM_ENABLE
+                              -DCONFIG_FREERTOS_USE_TICKLESS_IDLE=1
+                              -DCONFIG_FREERTOS_IDLE_TIME_BEFORE_SLEEP=3
                               -I$PROJECT_DIR/src/include
                               -include "sdkconfig.h"
                               -include "ESPEasy_config.h"

--- a/src/src/DataStructs_templ/SettingsStruct.cpp
+++ b/src/src/DataStructs_templ/SettingsStruct.cpp
@@ -90,11 +90,7 @@ void SettingsStruct_tmpl<N_TASKS>::EcoPowerMode(bool value) {
 
 template<unsigned int N_TASKS>
 bool SettingsStruct_tmpl<N_TASKS>::WifiNoneSleep() const {
-  #ifdef ESP32
-  return true;
-  #else
   return bitRead(VariousBits1, 7);
-  #endif
 }
 
 template<unsigned int N_TASKS>

--- a/src/src/ESPEasyCore/ESPEasy_setup.cpp
+++ b/src/src/ESPEasyCore/ESPEasy_setup.cpp
@@ -44,6 +44,9 @@
 #include <soc/boot_mode.h>
 #include <soc/gpio_reg.h>
 #include <soc/efuse_reg.h>
+
+#include <esp_pm.h>
+
 #endif
 
 
@@ -268,6 +271,33 @@ void ESPEasy_setup()
   #ifndef BUILD_NO_RAM_TRACKER
   logMemUsageAfter(F("LoadSettings()"));
   #endif
+
+#ifdef ESP32
+  if (Settings.EcoPowerMode()) {
+    // Configure dynamic frequency scaling:
+    // maximum and minimum frequencies are set in sdkconfig,
+    // automatic light sleep is enabled if tickless idle support is enabled.
+#if CONFIG_IDF_TARGET_ESP32
+    esp_pm_config_esp32_t pm_config = {
+#elif CONFIG_IDF_TARGET_ESP32S2
+    esp_pm_config_esp32s2_t pm_config = {
+#elif CONFIG_IDF_TARGET_ESP32C3
+    esp_pm_config_esp32c3_t pm_config = {
+#elif CONFIG_IDF_TARGET_ESP32S3
+    esp_pm_config_esp32s3_t pm_config = {
+#elif CONFIG_IDF_TARGET_ESP32C2
+    esp_pm_config_esp32c2_t pm_config = {
+#endif
+            .max_freq_mhz = 240,
+            .min_freq_mhz = 80,
+#if CONFIG_FREERTOS_USE_TICKLESS_IDLE
+            .light_sleep_enable = true
+#endif
+    };
+    esp_pm_configure(&pm_config);
+  }
+#endif
+
 
   #ifndef BUILD_NO_RAM_TRACKER
   checkRAM(F("hardwareInit"));

--- a/src/src/ESPEasyCore/ESPEasy_setup.cpp
+++ b/src/src/ESPEasyCore/ESPEasy_setup.cpp
@@ -279,16 +279,20 @@ void ESPEasy_setup()
     // automatic light sleep is enabled if tickless idle support is enabled.
 #if CONFIG_IDF_TARGET_ESP32
     esp_pm_config_esp32_t pm_config = {
+            .max_freq_mhz = 240,
 #elif CONFIG_IDF_TARGET_ESP32S2
     esp_pm_config_esp32s2_t pm_config = {
+            .max_freq_mhz = 240,
 #elif CONFIG_IDF_TARGET_ESP32C3
     esp_pm_config_esp32c3_t pm_config = {
+            .max_freq_mhz = 160,
 #elif CONFIG_IDF_TARGET_ESP32S3
     esp_pm_config_esp32s3_t pm_config = {
+            .max_freq_mhz = 240,
 #elif CONFIG_IDF_TARGET_ESP32C2
     esp_pm_config_esp32c2_t pm_config = {
+            .max_freq_mhz = 120,
 #endif
-            .max_freq_mhz = 240,
             .min_freq_mhz = 80,
 #if CONFIG_FREERTOS_USE_TICKLESS_IDLE
             .light_sleep_enable = true

--- a/src/src/Helpers/ESPEasyRTC.cpp
+++ b/src/src/Helpers/ESPEasyRTC.cpp
@@ -106,14 +106,13 @@ RTC_NOINIT_ATTR uint32_t UserVar_checksum;
  \*********************************************************************************************/
 bool saveToRTC()
 {
+  START_TIMER
   // ESP8266 has the RTC struct stored in memory which we must actively fetch
   // ESP32 can use a compiler flag to mark a struct to be located in RTC_SLOW memory
   #if defined(ESP32)
   RTC_tmp = RTC;
-  return true;
   #else // if defined(ESP32)
 
-  START_TIMER
   if (!system_rtc_mem_write(RTC_BASE_STRUCT, reinterpret_cast<const uint8_t *>(&RTC), sizeof(RTC)) || !readFromRTC())
   {
       # ifdef RTC_STRUCT_DEBUG
@@ -121,12 +120,9 @@ bool saveToRTC()
       # endif // ifdef RTC_STRUCT_DEBUG
     return false;
   }
-  else
-  {
-    STOP_TIMER(SAVE_TO_RTC);
-    return true;
-  }
   #endif // if defined(ESP32)
+  STOP_TIMER(SAVE_TO_RTC);
+  return true;
 }
 
 /********************************************************************************************\

--- a/src/src/Helpers/ESPEasy_Storage.cpp
+++ b/src/src/Helpers/ESPEasy_Storage.cpp
@@ -610,6 +610,9 @@ void afterloadSettings() {
     ResetFactoryDefaultPreference = pref_temp;
   }
   Scheduler.setEcoMode(Settings.EcoPowerMode());
+  #ifdef ESP32
+  setCpuFrequencyMhz(Settings.EcoPowerMode() ? 80 : 240);
+  #endif
 
   if (!Settings.UseRules) {
     eventQueue.clear();

--- a/src/src/Helpers/msecTimerHandlerStruct.cpp
+++ b/src/src/Helpers/msecTimerHandlerStruct.cpp
@@ -5,7 +5,7 @@
 #include "../Helpers/ESPEasy_time_calc.h"
 
 
-#define MAX_SCHEDULER_WAIT_TIME 5 // Max delay used in the scheduler for passing idle time.
+#define MAX_SCHEDULER_WAIT_TIME 50 // Max delay used in the scheduler for passing idle time.
 
   msecTimerHandlerStruct::msecTimerHandlerStruct() : get_called(0), get_called_ret_id(0), max_queue_length(0),
     last_exec_time_usec(0), total_idle_time_usec(0),  idle_time_pct(0.0f), is_idle(false), eco_mode(true)

--- a/src/src/WebServer/AdvancedConfigPage.cpp
+++ b/src/src/WebServer/AdvancedConfigPage.cpp
@@ -292,10 +292,8 @@ void handle_advanced() {
 #endif // ifdef ESP32
 
   addFormCheckBox(LabelType::RESTART_WIFI_LOST_CONN, Settings.WiFiRestart_connection_lost());
-#ifdef ESP8266
   addFormCheckBox(LabelType::FORCE_WIFI_NOSLEEP,     Settings.WifiNoneSleep());
   addFormNote(F("Change WiFi sleep settings requires reboot to activate"));
-#endif
 #ifdef SUPPORT_ARP
   addFormCheckBox(LabelType::PERIODICAL_GRAT_ARP, Settings.gratuitousARP());
 #endif // ifdef SUPPORT_ARP

--- a/src/src/WebServer/JSON.cpp
+++ b/src/src/WebServer/JSON.cpp
@@ -252,9 +252,7 @@ void handle_json()
         LabelType::WIFI_STORED_SSID2,
         LabelType::FORCE_WIFI_BG,
         LabelType::RESTART_WIFI_LOST_CONN,
-#ifdef ESP8266
         LabelType::FORCE_WIFI_NOSLEEP,
-#endif // ifdef ESP8266
 #ifdef SUPPORT_ARP
         LabelType::PERIODICAL_GRAT_ARP,
 #endif // ifdef SUPPORT_ARP

--- a/src/src/WebServer/SysInfoPage.cpp
+++ b/src/src/WebServer/SysInfoPage.cpp
@@ -475,9 +475,7 @@ void handle_sysinfo_WiFiSettings() {
   addTableSeparator(F("WiFi Settings"), 2, 3);
   addRowLabelValue(LabelType::FORCE_WIFI_BG);
   addRowLabelValue(LabelType::RESTART_WIFI_LOST_CONN);
-# ifdef ESP8266
   addRowLabelValue(LabelType::FORCE_WIFI_NOSLEEP);
-# endif // ifdef ESP8266
 # ifdef SUPPORT_ARP
   addRowLabelValue(LabelType::PERIODICAL_GRAT_ARP);
 # endif // ifdef SUPPORT_ARP


### PR DESCRIPTION
The option to force WiFi no sleep was unavailable on ESP32. This effectively made the ECO mode useless on ESP32. Now this is available again, the current consumption will reduce when enabling ECO mode. However the current consumption can be lowered even more by switching the ESP32 to 80 MHz. This will only be set at boot, as dynamic frequency switching is a bit funky. However Espressif's dynamic frequency scaling does seem to work well, so this is also enabled at boot when ECO mode is set.

The WiFi TX power settings, which are present on ESP8266, are still disabled on ESP32 as it does result in less reliable WiFi connection and higher current consumption compared to the dynamic wifi light sleep mode.