### PR TITLE
[Plugin] Get pinstate/duty-cycle for [Plugin#<Plugin>#Pinstate#N] for registered pins

### DIFF
--- a/docs/source/Rules/Rules.rst
+++ b/docs/source/Rules/Rules.rst
@@ -743,7 +743,7 @@ You must not use the task names ``Plugin``, ``var`` ``int`` as these have specia
 
 ``[Plugin#PCF#Pinstate#N]`` to get the pin state of a PCF pin.
 
-Since 2022-12-27:
+Since 2022-12-27: (Enabled for all builds with flash size > 1MB)
 
 - For GPIO, MCP or PCF pins set to PWM or SERVO output, the last set duty-cycle is returned instead of the current pin state (that was of no use).
 

--- a/docs/source/Rules/Rules.rst
+++ b/docs/source/Rules/Rules.rst
@@ -743,11 +743,18 @@ You must not use the task names ``Plugin``, ``var`` ``int`` as these have specia
 
 ``[Plugin#PCF#Pinstate#N]`` to get the pin state of a PCF pin.
 
+Since 2022-12-27:
+
+- For GPIO, MCP or PCF pins set to PWM or SERVO output, the last set duty-cycle is returned instead of the current pin state (that was of no use).
+
+- For any plugin that registers the used pin(s), the last set pin state can be retrieved, either regular pin state or PWM state, by using this syntax: ``[Plugin#<pluginId>#Pinstate#N]``. Some plugins that use pin registration are 59 (:ref:`p059_page`), 22 (:ref:`p022_page`), 11 (:ref:`p011_page`) and 63 (:ref:`p063_page`)
+
+
 For expanders you can use also the following:
 
-``[Plugin#MCP#PinRange#x-y]`` to get the pin state of a range of MCP pins from x o y.
+``[Plugin#MCP#PinRange#x-y]`` to get the pin state of a range of MCP pins from x to y.
 
-``[Plugin#PCF#PinRange#x-y]`` to get the pin state of a range of PCF pins from x o y.
+``[Plugin#PCF#PinRange#x-y]`` to get the pin state of a range of PCF pins from x to y.
 
 ``Var`` and ``int`` are used for internal variables. 
 The variables set with the ``Let`` command will be available in rules

--- a/src/src/Commands/Diagnostic.cpp
+++ b/src/src/Commands/Diagnostic.cpp
@@ -178,7 +178,7 @@ void createLogPortStatus(std::map<uint32_t, portStatusStruct>::iterator it)
     log += F("PortStatus detail: Port=");
     log += getPortFromKey(it->first);
     log += F(" State=");
-    log += it->second.state;
+    log += it->second.getValue();
     log += F(" Output=");
     log += it->second.output;
     log += F(" Mode=");

--- a/src/src/Commands/GPIO.cpp
+++ b/src/src/Commands/GPIO.cpp
@@ -1194,11 +1194,21 @@ bool getGPIOPinStateValues(String& str) {
     if (validArgument) {
       switch (device[0]) {
         case 'g':
+        {
+          const uint32_t key = createKey(PLUGIN_GPIO, par1);
+          const auto it = globalMapPortStatus.find(key);
 
-          str       = digitalRead(par1);
+          if (it != globalMapPortStatus.end() && ((it->second.mode == PIN_MODE_PWM) || (it->second.mode == PIN_MODE_SERVO))) {
+            // For PWM or SERVO mode get the last set duty cycle
+            str = it->second.getValue();
+          } else {
+            // Just read the current pinstate
+            str = digitalRead(par1);
+          }
           logPrefix = F("GPIO");
           success   = true;
           break;
+        }
 
 #ifdef USES_P009
         case 'm':

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -2654,5 +2654,12 @@ To create/register a plugin, you have to :
   #endif
 #endif
 
+#ifndef FEATURE_PINSTATE_EXTENDED
+  #ifdef ESP8266_1M
+    #define FEATURE_PINSTATE_EXTENDED           0 // Don't use extended pinstate feature on 1M builds
+  #else
+    #define FEATURE_PINSTATE_EXTENDED           1 // Enable by default for all other builds
+  #endif
+#endif
 
 #endif // CUSTOMBUILD_DEFINE_PLUGIN_SETS_H


### PR DESCRIPTION
From a [Forum request](https://www.letscontrolit.com/forum/viewtopic.php?t=9384)

Features:
- `[Plugin#<Plugin>#Pinstate#<pin>]` value returns the duty-cycle for any registered plugin/pin, and retrieves PWM or SERVO setting where applicable
  - `<Plugin>` can be `GPIO`, `MCP`, `PCF` or a numeric plugin ID for a plugin that registers its pins/ports (f.e. plugins 11 (ProMini extender), 22 (PCA9685), 59 (Rotary encoder) and 63 (TTP229 touch))
- Diagnostics output returns the duty-cycle for pins set to PWM or SERVO output

NB: Not available in 1M builds to preserve some space.

TODO:
- [x] Check possible other occurrences
- [x] Update documentation