### PR TITLE
[DNS] Fix restoring DNS server config on DHCP renewal

### DIFF
--- a/platformio_esp82xx_base.ini
+++ b/platformio_esp82xx_base.ini
@@ -232,6 +232,7 @@ build_flags               = -DBUILD_NO_DEBUG
                             -DFEATURE_SD=0
                             -Os
                             -s
+                            -DNO_GLOBAL_MDNS
                             ${esp82xx_common.build_flags}
 extra_scripts             = ${esp82xx_common.extra_scripts}
 lib_ignore                = ${esp82xx_common.lib_ignore}
@@ -250,24 +251,19 @@ extends                   = esp82xx_1M
 board                     = esp8266_1M128k
 build_flags               = ${esp82xx_1M.build_flags}
 extra_scripts             = ${esp82xx_1M.extra_scripts}
+lib_ignore                = ${esp82xx_1M.lib_ignore}
 
 
 ;;; Minimal ***********************************************************
 ; Minimal build size for OTA                                          ;
 ; *********************************************************************
-[esp82xx_1M_OTA]
+[esp8266_1M_OTA]
 extends                   = esp82xx_1M
+board                     = esp8266_1M128k_OTA
 build_flags               = ${esp82xx_1M.build_flags}
                             -DPLUGIN_BUILD_MINIMAL_OTA
                             -DDISABLE_SC16IS752_Serial
                             -DFEATURE_GPIO_USE_ESP8266_WAVEFORM=0
-                  
-
-
-[esp8266_1M_OTA]
-extends                   = esp82xx_1M_OTA
-board                     = esp8266_1M128k_OTA
-build_flags               = ${esp82xx_1M_OTA.build_flags}
 lib_ignore                = ${esp82xx_1M.lib_ignore}
 ; Adding the libs below to the lib_ignore will even increase build size
 ;                            Adafruit TCS34725

--- a/platformio_esp82xx_envs.ini
+++ b/platformio_esp82xx_envs.ini
@@ -2,6 +2,10 @@
 ; Use either the plugins defined in                                   ;
 ; pre_custom_esp82xx.py or Custom.h                                   ;
 ; *********************************************************************
+[limited_build_size]
+build_flags               = -DNO_GLOBAL_MDNS
+
+
 
 [hard_esp82xx]
 platform                  = ${regular_platform.platform}
@@ -513,6 +517,7 @@ platform_packages         = ${ir.platform_packages}
 lib_ignore                = ${ir.lib_ignore}  
 build_flags               = ${normal_ir_extended_no_rx.build_flags}
                             ${esp8266_4M2M.build_flags}
+                            ${limited_build_size.build_flags}
                             -DLIMIT_BUILD_SIZE
 extra_scripts             = ${esp8266_4M2M.extra_scripts}
                             pre:tools/pio/ir_build_check.py
@@ -530,6 +535,7 @@ platform                  = ${collection.platform}
 platform_packages         = ${collection.platform_packages}
 build_flags               = ${collection.build_flags}
                             ${esp8266_4M1M.build_flags}
+                            ${limited_build_size.build_flags}
 
 [collection_alt_wifi_ESP8266_4M1M]
 extends                   = esp8266_4M1M

--- a/src/src/DataStructs/EthernetEventData.cpp
+++ b/src/src/DataStructs/EthernetEventData.cpp
@@ -43,8 +43,8 @@ void EthernetEventData_t::clearAll() {
   processedGotIP            = true;
   processedDHCPTimeout      = true;
   ethConnectAttemptNeeded  = true;
-  dns0_cache.clear();
-  dns1_cache.clear();
+  dns0_cache = IPAddress();
+  dns1_cache = IPAddress();
 }
 
 void EthernetEventData_t::markEthBegin() {

--- a/src/src/DataStructs/EthernetEventData.cpp
+++ b/src/src/DataStructs/EthernetEventData.cpp
@@ -43,6 +43,8 @@ void EthernetEventData_t::clearAll() {
   processedGotIP            = true;
   processedDHCPTimeout      = true;
   ethConnectAttemptNeeded  = true;
+  dns0_cache.clear();
+  dns1_cache.clear();
 }
 
 void EthernetEventData_t::markEthBegin() {
@@ -94,6 +96,9 @@ void EthernetEventData_t::setEthConnected() {
 bool EthernetEventData_t::setEthServicesInitialized() {
   if (!unprocessedEthEvents() && !EthServicesInitialized()) {
     if (EthGotIP() && EthConnected()) {
+      dns0_cache = WiFi.dnsIP(0);
+      dns1_cache = WiFi.dnsIP(1);
+
       #ifndef BUILD_NO_DEBUG
       addLog(LOG_LEVEL_DEBUG, F("Eth : Eth services initialized"));
       #endif
@@ -156,7 +161,6 @@ String EthernetEventData_t::ESPEasyEthStatusToString() const {
     }
   }
   return log;
-
 }
 
 #endif

--- a/src/src/DataStructs/EthernetEventData.h
+++ b/src/src/DataStructs/EthernetEventData.h
@@ -63,8 +63,8 @@ struct EthernetEventData_t {
   LongTermTimer           lastGetIPmoment;
   LongTermTimer::Duration lastConnectedDuration_us = 0ll;
 
-  IPAddress dns0_cache;
-  IPAddress dns1_cache;
+  IPAddress dns0_cache{};
+  IPAddress dns1_cache{};
 
   // Semaphore like bools for processing data gathered from Eth events.
   bool processedConnect          = true;

--- a/src/src/DataStructs/WiFiEventData.cpp
+++ b/src/src/DataStructs/WiFiEventData.cpp
@@ -104,6 +104,8 @@ void WiFiEventData_t::clear_processed_flags() {
   wifiConnectAttemptNeeded  = true;
   wifiConnectInProgress     = false;
   processingDisconnect.clear();
+  dns0_cache.clear();
+  dns1_cache.clear();
 }
 
 void WiFiEventData_t::markWiFiBegin() {
@@ -143,6 +145,8 @@ void WiFiEventData_t::setWiFiDisconnected() {
 void WiFiEventData_t::setWiFiGotIP() {
   bitSet(wifiStatus, ESPEASY_WIFI_GOT_IP);
   processedGotIP = true;
+  dns0_cache = WiFi.dnsIP(0);
+  dns1_cache = WiFi.dnsIP(1);
 }
 
 void WiFiEventData_t::setWiFiConnected() {
@@ -158,6 +162,8 @@ void WiFiEventData_t::setWiFiServicesInitialized() {
     bitSet(wifiStatus, ESPEASY_WIFI_SERVICES_INITIALIZED);
     wifiConnectInProgress = false;
     wifiConnectAttemptNeeded = false;
+    dns0_cache = WiFi.dnsIP(0);
+    dns1_cache = WiFi.dnsIP(1);
   }
 }
 

--- a/src/src/DataStructs/WiFiEventData.cpp
+++ b/src/src/DataStructs/WiFiEventData.cpp
@@ -104,8 +104,8 @@ void WiFiEventData_t::clear_processed_flags() {
   wifiConnectAttemptNeeded  = true;
   wifiConnectInProgress     = false;
   processingDisconnect.clear();
-  dns0_cache.clear();
-  dns1_cache.clear();
+  dns0_cache = IPAddress();
+  dns1_cache = IPAddress();
 }
 
 void WiFiEventData_t::markWiFiBegin() {

--- a/src/src/DataStructs/WiFiEventData.h
+++ b/src/src/DataStructs/WiFiEventData.h
@@ -98,6 +98,8 @@ struct WiFiEventData_t {
   MAC_address             lastMacConnectedAPmode;
   MAC_address             lastMacDisconnectedAPmode;
 
+  IPAddress dns0_cache{};
+  IPAddress dns1_cache{};
 
   // processDisconnect() may clear all WiFi settings, resulting in clearing processedDisconnect
   // This can cause recursion, so a semaphore is needed here.

--- a/src/src/ESPEasyCore/ESPEasyEth.cpp
+++ b/src/src/ESPEasyCore/ESPEasyEth.cpp
@@ -12,6 +12,7 @@
 #include "../Globals/NetworkState.h"
 #include "../Globals/Settings.h"
 #include "../Helpers/StringConverter.h"
+#include "../Helpers/Networking.h"
 
 #include <ETH.h>
 #include <lwip/dns.h>
@@ -54,35 +55,8 @@ void ethSetupStaticIPconfig() {
     addLogMove(LOG_LEVEL_INFO, log);
   }
   ETH.config(ip, gw, subnet, dns);
-  ethSetDNS(EthEventData.dns0_cache, EthEventData.dns1_cache);
-}
-
-void ethSetDNS(const IPAddress& dns0, const IPAddress& dns1) 
-{
-  ip_addr_t d;
-  d.type = IPADDR_TYPE_V4;
-  bool set_dns = false;
-
-  if(dns0 != (uint32_t)0x00000000 && dns0 != INADDR_NONE) {
-    // Set DNS0-Server
-    d.u_addr.ip4.addr = static_cast<uint32_t>(dns0);
-    dns_setserver(0, &d);
-    set_dns = true;
-  }
-
-  if(dns1 != (uint32_t)0x00000000 && dns1 != INADDR_NONE) {
-    // Set DNS1-Server
-    d.u_addr.ip4.addr = static_cast<uint32_t>(dns1);
-    dns_setserver(1, &d);
-    set_dns = true;
-  }
-  if (set_dns && loglevelActiveFor(LOG_LEVEL_INFO)) {
-    String log = F("ETH IP   : Set DNS: ");
-    log += formatIP(dns0);
-    log += '/';
-    log += formatIP(dns1);
-    addLogMove(LOG_LEVEL_INFO, log);
-  }
+  setDNS(0, EthEventData.dns0_cache);
+  setDNS(1, EthEventData.dns1_cache);
 }
 
 bool ethCheckSettings() {

--- a/src/src/ESPEasyCore/ESPEasyEth.h
+++ b/src/src/ESPEasyCore/ESPEasyEth.h
@@ -11,7 +11,6 @@
 
 bool     ethUseStaticIP();
 void     ethSetupStaticIPconfig();
-void     ethSetDNS(const IPAddress& dns0, const IPAddress& dns1);
 bool     ethCheckSettings();
 bool     ethPrepare();
 void     ethPrintSettings();

--- a/src/src/ESPEasyCore/ESPEasyEth_ProcessEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyEth_ProcessEvent.cpp
@@ -18,9 +18,11 @@
 # include "../Globals/Settings.h"
 
 # include "../Helpers/Network.h"
+# include "../Helpers/Networking.h"
 # include "../Helpers/PeriodicalActions.h"
 # include "../Helpers/StringConverter.h"
 
+# include <ETH.h>
 
 void handle_unprocessedEthEvents() {
   if (EthEventData.unprocessedEthEvents()) {
@@ -86,12 +88,13 @@ void check_Eth_DNS_valid() {
     const bool has_cache = !EthEventData.dns0_cache && !EthEventData.dns1_cache;
 
     if (has_cache) {
-      const IPAddress dns0 = NetworkDnsIP(0);
-      const IPAddress dns1 = NetworkDnsIP(1);
+      const IPAddress dns0 = ETH.dnsIP(0);
+      const IPAddress dns1 = ETH.dnsIP(1);
 
       if (!dns0 && !dns1) {
         addLog(LOG_LEVEL_ERROR, F("ETH  : DNS server was cleared, use cached DNS IP"));
-        ethSetDNS(EthEventData.dns0_cache, EthEventData.dns1_cache);
+        setDNS(0, EthEventData.dns0_cache);
+        setDNS(1, EthEventData.dns1_cache);
       }
     }
   }
@@ -143,13 +146,14 @@ void processEthernetGotIP() {
   const IPAddress gw     = NetworkGatewayIP();
   const IPAddress subnet = NetworkSubnetMask();
 
-  IPAddress dns0                              = NetworkDnsIP(0);
-  IPAddress dns1                              = NetworkDnsIP(1);
+  IPAddress dns0                              = ETH.dnsIP(0);
+  IPAddress dns1                              = ETH.dnsIP(1);
   const LongTermTimer::Duration dhcp_duration = EthEventData.lastConnectMoment.timeDiff(EthEventData.lastGetIPmoment);
 
   if (!dns0 && !dns1) {
     addLog(LOG_LEVEL_ERROR, F("ETH  : No DNS server received via DHCP, use cached DNS IP"));
-    ethSetDNS(EthEventData.dns0_cache, EthEventData.dns1_cache);
+    setDNS(0, EthEventData.dns0_cache);
+    setDNS(1, EthEventData.dns1_cache);
   } else {
     EthEventData.dns0_cache = dns0;
     EthEventData.dns1_cache = dns1;

--- a/src/src/ESPEasyCore/ESPEasyNetwork.cpp
+++ b/src/src/ESPEasyCore/ESPEasyNetwork.cpp
@@ -9,6 +9,7 @@
 #include "../Globals/Settings.h"
 
 #include "../Helpers/Network.h"
+#include "../Helpers/Networking.h"
 #include "../Helpers/StringConverter.h"
 #include "../Helpers/MDNS_Helper.h"
 
@@ -116,7 +117,8 @@ IPAddress NetworkGatewayIP() {
   return WiFi.gatewayIP();
 }
 
-IPAddress NetworkDnsIP (uint8_t dns_no) {
+IPAddress NetworkDnsIP(uint8_t dns_no) {
+  scrubDNS();
   #if FEATURE_ETHERNET
   if(active_network_medium == NetworkMedium_t::Ethernet) {
     if(EthEventData.ethInitSuccess) {

--- a/src/src/ESPEasyCore/ESPEasyWifi.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi.cpp
@@ -21,6 +21,7 @@
 #include "../Helpers/Networking.h"
 #include "../Helpers/StringConverter.h"
 #include "../Helpers/StringGenerator_WiFi.h"
+#include "../Helpers/StringProvider.h"
 
 #ifdef ESP32
 #include <WiFiGeneric.h>
@@ -1447,18 +1448,17 @@ void setupStaticIPconfig() {
   const IPAddress subnet = Settings.Subnet;
   const IPAddress dns    = Settings.DNS;
 
+  WiFiEventData.dns0_cache = Settings.DNS;
+
+  WiFi.config(ip, gw, subnet, dns);
+
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
     String log = F("IP   : Static IP : ");
-    log += formatIP(ip);
-    log += F(" GW: ");
-    log += formatIP(gw);
-    log += F(" SN: ");
-    log += formatIP(subnet);
-    log += F(" DNS: ");
-    log += formatIP(dns);
+    log += concat(F(" GW: "), formatIP(gw));
+    log += concat(F(" SN: "), formatIP(subnet));
+    log += concat(F(" DNS: "), getValue(LabelType::DNS));
     addLogMove(LOG_LEVEL_INFO, log);
   }
-  WiFi.config(ip, gw, subnet, dns);
 }
 
 // ********************************************************************************

--- a/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
@@ -28,6 +28,7 @@
 #include "../Helpers/PeriodicalActions.h"
 #include "../Helpers/StringConverter.h"
 #include "../Helpers/StringGenerator_WiFi.h"
+#include "../Helpers/StringProvider.h"
 
 // #include "../ESPEasyCore/ESPEasyEth.h"
 // #include "../ESPEasyCore/ESPEasyWiFiEvent.h"
@@ -384,19 +385,20 @@ void processGotIP() {
       return;
     }
   }
-  const IPAddress gw       = NetworkGatewayIP();
-  const IPAddress subnet   = NetworkSubnetMask();
+  const IPAddress gw       = WiFi.gatewayIP();
+  const IPAddress subnet   = WiFi.subnetMask();
   const LongTermTimer::Duration dhcp_duration = WiFiEventData.lastConnectMoment.timeDiff(WiFiEventData.lastGetIPmoment);
+  WiFiEventData.dns0_cache = WiFi.dnsIP(0);
+  WiFiEventData.dns1_cache = WiFi.dnsIP(1);
 
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
     String log = concat(F("WIFI : "), useStaticIP() ? F("Static IP: ") : F("DHCP IP: "));
     log += formatIP(ip);
     log += ' ';
     log += wrap_braces(NetworkGetHostname());
-    log += F(" GW: ");
-    log += formatIP(gw);
-    log += F(" SN: ");
-    log += formatIP(subnet);
+    log += concat(F(" GW: "), formatIP(gw));
+    log += concat(F(" SN: "), formatIP(subnet));
+    log += concat(F(" DNS: "), getValue(LabelType::DNS));
 
     if ((dhcp_duration > 0ll) && (dhcp_duration < 30000000ll)) {
       // Just log times when they make sense.
@@ -416,7 +418,7 @@ void processGotIP() {
     if (loglevelActiveFor(LOG_LEVEL_INFO)) {
       addLogMove(LOG_LEVEL_INFO, concat(F("IP   : Fixed IP octet:"), formatIP(ip)));
     }
-    WiFi.config(ip, gw, subnet, NetworkDnsIP(0), NetworkDnsIP(1));
+    WiFi.config(ip, gw, subnet, WiFiEventData.dns0_cache, WiFiEventData.dns1_cache);
   }
 
 #if FEATURE_MQTT

--- a/src/src/Helpers/Networking.cpp
+++ b/src/src/Helpers/Networking.cpp
@@ -10,6 +10,7 @@
 #include "../ESPEasyCore/ESPEasyEth.h"
 #include "../ESPEasyCore/ESPEasyNetwork.h"
 #include "../ESPEasyCore/ESPEasyWifi.h"
+#include "../Globals/ESPEasyEthEvent.h"
 #include "../Globals/ESPEasyWiFiEvent.h"
 #include "../Globals/ESPEasy_Scheduler.h"
 
@@ -36,6 +37,7 @@
 #include <base64.h>
 #include <MD5Builder.h>
 
+#include <lwip/dns.h>
 
 // Generic Networking routines
 
@@ -1038,6 +1040,44 @@ bool connectClient(WiFiClient& client, IPAddress ip, uint16_t port, uint32_t tim
 }
 #endif // FEATURE_HTTP_CLIENT
 
+void scrubDNS() {
+  #if FEATURE_ETHERNET
+  if (active_network_medium == NetworkMedium_t::Ethernet) {
+    if (EthEventData.EthServicesInitialized()) {
+      setDNS(0, EthEventData.dns0_cache);
+      setDNS(1, EthEventData.dns1_cache);
+    }
+    return;
+  }
+  #endif
+  if (WiFiEventData.WiFiServicesInitialized()) {
+    setDNS(0, WiFiEventData.dns0_cache);
+    setDNS(1, WiFiEventData.dns1_cache);
+  }
+}
+
+bool setDNS(int index, const IPAddress& dns) {
+  if (index >= 2) return false;
+  ip_addr_t d;
+  d.type = IPADDR_TYPE_V4;
+
+  if (dns != (uint32_t)0x00000000 && dns  != INADDR_NONE) {
+    // Set DNS0-Server
+    d.u_addr.ip4.addr = static_cast<uint32_t>(dns);
+    const ip_addr_t* cur_dns = dns_getserver(index);
+    if (cur_dns != nullptr && cur_dns->u_addr.ip4.addr == d.u_addr.ip4.addr) {
+      // Still the same as before
+      return false;
+    }
+    dns_setserver(index, &d);
+    if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+      addLogMove(LOG_LEVEL_INFO, concat(F("IP   : Set DNS: "),  formatIP(dns)));
+    }
+    return true;
+  }
+  return false;
+}
+
 bool resolveHostByName(const char *aHostname, IPAddress& aResult, uint32_t timeout_ms) {
   START_TIMER;
 
@@ -1046,6 +1086,9 @@ bool resolveHostByName(const char *aHostname, IPAddress& aResult, uint32_t timeo
   }
 
   FeedSW_watchdog();
+
+  // FIXME TD-er: Must try to restore DNS server entries.
+  scrubDNS();
 
 #if defined(ARDUINO_ESP8266_RELEASE_2_3_0) || defined(ESP32)
   bool resolvedIP = WiFi.hostByName(aHostname, aResult) == 1;
@@ -1407,6 +1450,7 @@ int http_authenticate(const String& logIdentifier,
   http.addHeader(F("X-Forwarded-For"), NetworkLocalIP().toString());
 
   delay(0);
+  scrubDNS();
 #if defined(CORE_POST_2_6_0) || defined(ESP32)
   http.begin(client, host, port, uri, false); // HTTP
 #else // if defined(CORE_POST_2_6_0) || defined(ESP32)

--- a/src/src/Helpers/Networking.cpp
+++ b/src/src/Helpers/Networking.cpp
@@ -1058,6 +1058,16 @@ void scrubDNS() {
 
 bool setDNS(int index, const IPAddress& dns) {
   if (index >= 2) return false;
+  #ifdef ESP8266
+  if(dns.isSet() && dns != WiFi.dnsIP(index)) {
+    dns_setserver(index, dns);
+    if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+      addLogMove(LOG_LEVEL_INFO, concat(F("IP   : Set DNS: "),  formatIP(dns)));
+    }
+    return true;
+  }
+  #endif
+  #ifdef ESP32
   ip_addr_t d;
   d.type = IPADDR_TYPE_V4;
 
@@ -1075,6 +1085,7 @@ bool setDNS(int index, const IPAddress& dns) {
     }
     return true;
   }
+  #endif
   return false;
 }
 

--- a/src/src/Helpers/Networking.h
+++ b/src/src/Helpers/Networking.h
@@ -154,6 +154,10 @@ bool connectClient(WiFiClient& client, const char *hostname, uint16_t port, uint
 bool connectClient(WiFiClient& client, IPAddress ip, uint16_t port, uint32_t timeout_ms = 100);
 #endif // FEATURE_HTTP_CLIENT
 
+void scrubDNS();
+
+bool setDNS(int index, const IPAddress& dns);
+
 bool resolveHostByName(const char *aHostname, IPAddress& aResult, uint32_t timeout_ms = 1000);
 
 bool hostReachable(const String& hostname);

--- a/src/src/PluginStructs/P089_data_struct.cpp
+++ b/src/src/PluginStructs/P089_data_struct.cpp
@@ -3,6 +3,8 @@
 #if defined(USES_P089) && defined(ESP8266)
 
 
+#include "../Helpers/Networking.h"
+
 P089_data_struct::P089_data_struct() {
   destIPAddress.addr = 0;
   idseq              = 0;

--- a/src/src/PluginStructs/P089_data_struct.cpp
+++ b/src/src/PluginStructs/P089_data_struct.cpp
@@ -51,7 +51,7 @@ bool P089_data_struct::send_ping(struct EventStruct *event) {
   LoadCustomTaskSettings(event->TaskIndex, (uint8_t *)&hostname, PLUGIN_089_HOSTNAME_SIZE);
 
   /* This one lost as well, DNS dead? */
-  if (WiFi.hostByName(hostname, ip) == false) {
+  if (!resolveHostByName(hostname, ip)) {
     return true;
   }
   destIPAddress.addr = ip;

--- a/tools/pio/pre_custom_esp32.py
+++ b/tools/pio/pre_custom_esp32.py
@@ -42,10 +42,10 @@ else:
     "-DUSES_P080",  # Dallas iButton
     "-DUSES_P081",  # Cron
     "-DUSES_P082",  # GPS
-    "-DUSES_P085",  # AcuDC24x
+#   "-DUSES_P085",  # AcuDC24x
     "-DUSES_P098",  # PWM motor
 
-    "-DUSES_P100",  # Pulse Counter - DS2423
+#   "-DUSES_P100",  # Pulse Counter - DS2423
 #   "-DUSES_P087",  # Serial Proxy
 #   "-DUSES_P094",  # CUL Reader
 #   "-DUSES_P095",  # TFT ILI9341

--- a/tools/pio/pre_custom_esp82xx.py
+++ b/tools/pio/pre_custom_esp82xx.py
@@ -42,10 +42,10 @@ else:
 #    "-DUSES_P080",  # Dallas iButton
     "-DUSES_P081",  # Cron
     "-DUSES_P082",  # GPS
-    "-DUSES_P085",  # AcuDC24x
+#   "-DUSES_P085",  # AcuDC24x
     "-DUSES_P098",  # PWM motor
 
-    "-DUSES_P100",  # Pulse Counter - DS2423
+#   "-DUSES_P100",  # Pulse Counter - DS2423
 #   "-DUSES_P087",  # Serial Proxy
 #   "-DUSES_P094",  # CUL Reader
 #   "-DUSES_P095",  # TFT ILI9341


### PR DESCRIPTION
Especially on ESP32, the DNS config may get erased. For example when starting Ethernet and then shutting down WiFi, this will clear the DNS record config.

But on recent ESP32 SDKs, just the DHCP renewal may also set the DNS server to some bogus value (253.0.0.0 on my setup, no idea if this is random)