### PR TITLE
[Github] Replace deprecated set-output command by environment file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   generate-matrix:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -32,7 +32,7 @@ jobs:
 
   build:
     needs: generate-matrix
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     steps:
@@ -56,7 +56,7 @@ jobs:
           key: ${{ runner.os }}-esp8266-${{ hashFiles('platformio*.ini') }}
       - name: Dependencies
         run: |
-          sudo apt install binutils build-essential libffi-dev python-dev libgit2-dev
+          sudo apt install binutils build-essential libffi-dev libgit2-dev
           pip install -r requirements.txt
           platformio update
       - name: Build and archive
@@ -74,7 +74,7 @@ jobs:
 
   prepare-dist:
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -106,7 +106,7 @@ jobs:
 
   prepare-notes:
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       notes: ${{ steps.release-notes.outputs.result }}
     steps:
@@ -131,7 +131,7 @@ jobs:
     permissions:
       contents: write # for ncipollo/release-action
     needs: [build, prepare-dist, prepare-notes]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/setup-python@v4
         with:

--- a/tools/ci/generate-matrix.py
+++ b/tools/ci/generate-matrix.py
@@ -6,6 +6,7 @@
 # These are the same environment names as with tools/build_ESPeasy.sh (i.e. all of them)
 
 import json
+import os
 from platformio.project.config import ProjectConfig
 
 
@@ -40,4 +41,5 @@ if __name__ == "__main__":
         sort.sort(key=str.casefold)
 
     serialized = json.dumps({"include": jobs})
-    print("::set-output name=matrix::{}".format(serialized))
+    with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+        print("matrix={}".format(serialized), file=fh)


### PR DESCRIPTION
Resolves #4311 

Update the `generate-matrix.py` script to no longer use the deprecated `set-output` command, but use environment file(s) instead.

Applied same change to `release.yml` we did for `build.yml`: Switch job-runners to Ubuntu-22.04