### PR TITLE
[CDN] Update link for Chart.js

### DIFF
--- a/src/Custom-sample.h
+++ b/src/Custom-sample.h
@@ -208,6 +208,11 @@
 #endif // ifdef ESP32
 #define FEATURE_CHART_JS  1        // Support for drawing charts, like PluginStats historic data
 
+// Optional alternative CDN links:
+// Chart.js: (only used when FEATURE_CHART_JS is enabled)
+// #define CDN_URL_CHART_JS "https://cdn.jsdelivr.net/npm/chart.js@4.1.2/dist/chart.umd.min.js"
+// JQuery:
+// #define CDN_URL_JQUERY "https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"
 
 
 // #define FEATURE_SETTINGS_ARCHIVE 1

--- a/src/src/WebServer/HTML_wrappers.cpp
+++ b/src/src/WebServer/HTML_wrappers.cpp
@@ -281,7 +281,10 @@ void html_add_form() {
 }
 
 void html_add_JQuery_script() {
-  addHtml(F("<script src=\"https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js\"></script>"));
+  #ifndef CDN_URL_JQUERY
+    #define CDN_URL_JQUERY "https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"
+  #endif // ifndef CDN_URL_JQUERY
+  addHtml(F("<script src=\"" CDN_URL_JQUERY "\"></script>"));
 }
 
 #if FEATURE_CHART_JS
@@ -290,7 +293,10 @@ void html_add_ChartJS_script() {
   // - Select a CDN (jsdelivr is fine)
   // - Select the chart.js file (may be called chart.umd.min.js) and copy the url
   // - Replace the url in below script src element, keeping the quotes
-  addHtml(F("<script src=\"https://cdn.jsdelivr.net/npm/chart.js@4.1.2/dist/chart.umd.min.js\"></script>"));
+  #ifndef CDN_URL_CHART_JS
+    #define CDN_URL_CHART_JS "https://cdn.jsdelivr.net/npm/chart.js@4.1.2/dist/chart.umd.min.js"
+  #endif // ifndef CDN_URL_CHART_JS
+  addHtml(F("<script src=\"" CDN_URL_CHART_JS "\"></script>"));
 }
 #endif // if FEATURE_CHART_JS
 

--- a/src/src/WebServer/HTML_wrappers.cpp
+++ b/src/src/WebServer/HTML_wrappers.cpp
@@ -286,7 +286,11 @@ void html_add_JQuery_script() {
 
 #if FEATURE_CHART_JS
 void html_add_ChartJS_script() {
-  addHtml(F("<script src=\"https://cdn.jsdelivr.net/npm/chart.js\"></script>"));
+  // To update the CDN link go to: https://www.chartjs.org/docs/latest/getting-started/installation.html
+  // - Select a CDN (jsdelivr is fine)
+  // - Select the chart.js file (may be called chart.umd.min.js) and copy the url
+  // - Replace the url in below script src element, keeping the quotes
+  addHtml(F("<script src=\"https://cdn.jsdelivr.net/npm/chart.js@4.1.2/dist/chart.umd.min.js\"></script>"));
 }
 #endif // if FEATURE_CHART_JS
 


### PR DESCRIPTION
Resolves #4460 

- Update CDN link (now includes explicit version to avoid surprises when there are breaking changes)
- Add update procedure in comments
- Enable overriding the CDN url's (also for JQuery), so a locally hosted file or different version can be used