### PR TITLE
Reduce load save controllersettings

### DIFF
--- a/src/_P012_LCD.ino
+++ b/src/_P012_LCD.ino
@@ -129,7 +129,7 @@ boolean Plugin_012(uint8_t function, struct EventStruct *event, String& string)
       P012_INVERSE_BTN = isFormItemChecked(F("pinv_btn")) ? 1 : 0;
 
       // FIXME TD-er: This is a huge stack allocated object.
-      char   deviceTemplate[P12_Nlines][P12_Nchars];
+      char   deviceTemplate[P12_Nlines][P12_Nchars] = {};
       String error;
 
       for (uint8_t varNr = 0; varNr < P12_Nlines; varNr++)

--- a/src/_P023_OLED.ino
+++ b/src/_P023_OLED.ino
@@ -119,7 +119,7 @@ boolean Plugin_023(uint8_t function, struct EventStruct *event, String& string)
 
 
       // FIXME TD-er: This is a huge stack allocated object.
-      char   deviceTemplate[P23_Nlines][P23_Nchars];
+      char   deviceTemplate[P23_Nlines][P23_Nchars] = {};
       String error;
 
       for (uint8_t varNr = 0; varNr < P23_Nlines; varNr++) {

--- a/src/_P075_Nextion.ino
+++ b/src/_P075_Nextion.ino
@@ -146,7 +146,7 @@ boolean Plugin_075(uint8_t function, struct EventStruct *event, String& string)
     case PLUGIN_WEBFORM_SAVE: {
       {
         // FIXME TD-er: This is a huge object allocated on the Stack.
-        char deviceTemplate[P75_Nlines][P75_Nchars];
+        char deviceTemplate[P75_Nlines][P75_Nchars] = {};
         String error;
 
         for (uint8_t varNr = 0; varNr < P75_Nlines; varNr++)

--- a/src/_P076_HLW8012.ino
+++ b/src/_P076_HLW8012.ino
@@ -554,7 +554,7 @@ void Plugin076_SaveMultipliers() {
   if (StoredTaskIndex < 0) {
     return; // Not yet initialized.
   }
-  double hlwMultipliers[3];
+  double hlwMultipliers[3]{};
 
   if (Plugin076_ReadMultipliers(hlwMultipliers[0], hlwMultipliers[1], hlwMultipliers[2])) {
     SaveCustomTaskSettings(StoredTaskIndex, reinterpret_cast<const uint8_t *>(&hlwMultipliers),

--- a/src/_P081_Cron.ino
+++ b/src/_P081_Cron.ino
@@ -83,8 +83,7 @@ boolean Plugin_081(uint8_t function, struct EventStruct *event, String& string)
       String expression = webArg(F("p081_cron_exp"));
       String log;
       {
-        char expression_c[PLUGIN_081_EXPRESSION_SIZE];
-        ZERO_FILL(expression_c);
+        char expression_c[PLUGIN_081_EXPRESSION_SIZE] = {};
         safe_strncpy(expression_c, expression, PLUGIN_081_EXPRESSION_SIZE);
         log = SaveCustomTaskSettings(event->TaskIndex, reinterpret_cast<const uint8_t *>(&expression_c), PLUGIN_081_EXPRESSION_SIZE);
       }

--- a/src/_P089_Ping.ino
+++ b/src/_P089_Ping.ino
@@ -70,7 +70,7 @@ boolean Plugin_089(uint8_t function, struct EventStruct *event, String& string)
 
     case PLUGIN_WEBFORM_SAVE:
     {
-      char hostname[PLUGIN_089_HOSTNAME_SIZE];
+      char hostname[PLUGIN_089_HOSTNAME_SIZE] = {};
 
       // Reset "Fails" if settings updated
       UserVar[event->BaseVarIndex] = 0;

--- a/src/_P101_WakeOnLan.ino
+++ b/src/_P101_WakeOnLan.ino
@@ -175,7 +175,7 @@ boolean Plugin_101(uint8_t function, struct EventStruct *event, String& string)
     case PLUGIN_WEBFORM_SAVE: {
       char   ipString[IP_BUFF_SIZE_P101]   = {0};
       char   macString[MAC_BUFF_SIZE_P101] = {0};
-      char   deviceTemplate[2][CUSTOMTASK_STR_SIZE_P101];
+      char   deviceTemplate[2][CUSTOMTASK_STR_SIZE_P101] = {};
       String errorStr;
       String msgStr;
       const String wolStr = F(LOG_NAME_P101);

--- a/src/src/DataStructs/Caches.cpp
+++ b/src/src/DataStructs/Caches.cpp
@@ -53,7 +53,7 @@ bool Caches::matchChecksumExtraTaskSettings(taskIndex_t TaskIndex, const Checksu
     auto it = extraTaskSettings_cache.find(TaskIndex);
 
     if (it != extraTaskSettings_cache.end()) {
-      return checksum.matchChecksum(it->second.md5checksum);
+      return checksum == it->second.md5checksum;
     }
   }
   return false;
@@ -248,7 +248,7 @@ void Caches::updateExtraTaskSettingsCache()
 
     if (it != extraTaskSettings_cache.end()) {
       // We need to keep the original checksum, from when loaded from storage
-      memcpy(tmp.md5checksum, it->second.md5checksum, 16);
+      tmp.md5checksum = it->second.md5checksum;
 
       // Now clear it so we can create a fresh copy.
       extraTaskSettings_cache.erase(it);
@@ -322,7 +322,7 @@ void Caches::updateExtraTaskSettingsCache_afterLoad_Save()
   it = extraTaskSettings_cache.find(ExtraTaskSettings.TaskIndex);
 
   if (it != extraTaskSettings_cache.end()) {
-    ExtraTaskSettings.computeChecksum().getChecksum(it->second.md5checksum);
+    it->second.md5checksum = ExtraTaskSettings.computeChecksum();
   }
 }
 

--- a/src/src/DataStructs/Caches.cpp
+++ b/src/src/DataStructs/Caches.cpp
@@ -47,13 +47,13 @@ void Caches::clearFileCaches()
   fileCacheClearMoment = 0;
 }
 
-bool Caches::matchChecksumExtraTaskSettings(taskIndex_t TaskIndex, uint8_t checksum[16]) const
+bool Caches::matchChecksumExtraTaskSettings(taskIndex_t TaskIndex, const ChecksumType& checksum) const
 {
   if (validTaskIndex(TaskIndex)) {
     auto it = extraTaskSettings_cache.find(TaskIndex);
 
     if (it != extraTaskSettings_cache.end()) {
-      return memcmp(checksum, it->second.md5checksum, 16) == 0;
+      return checksum.matchChecksum(it->second.md5checksum);
     }
   }
   return false;
@@ -301,7 +301,7 @@ void Caches::updateExtraTaskSettingsCache()
   }
 }
 
-void Caches::updateExtraTaskSettingsCache(uint8_t checksum[16]) 
+void Caches::updateExtraTaskSettingsCache(const ChecksumType& checksum) 
 {
   if (!validTaskIndex(ExtraTaskSettings.TaskIndex)) {
     return;
@@ -310,7 +310,7 @@ void Caches::updateExtraTaskSettingsCache(uint8_t checksum[16])
   // Check if we need to update the cache
   auto it = extraTaskSettings_cache.find(ExtraTaskSettings.TaskIndex);
   if (it != extraTaskSettings_cache.end()) {
-    if (memcmp(it->second.md5checksum, checksum, 16) == 0) {
+    if (checksum.matchChecksum(it->second.md5checksum)) {
       return;
     }
   }
@@ -322,7 +322,7 @@ void Caches::updateExtraTaskSettingsCache(uint8_t checksum[16])
   it = extraTaskSettings_cache.find(ExtraTaskSettings.TaskIndex);
 
   if (it != extraTaskSettings_cache.end()) {
-    memcpy(it->second.md5checksum, checksum, 16);
+    checksum.getChecksum(it->second.md5checksum);
   }
 }
 

--- a/src/src/DataStructs/Caches.cpp
+++ b/src/src/DataStructs/Caches.cpp
@@ -301,7 +301,7 @@ void Caches::updateExtraTaskSettingsCache()
   }
 }
 
-void Caches::updateExtraTaskSettingsCache(const ChecksumType& checksum) 
+void Caches::updateExtraTaskSettingsCache_afterLoad_Save() 
 {
   if (!validTaskIndex(ExtraTaskSettings.TaskIndex)) {
     return;
@@ -310,7 +310,7 @@ void Caches::updateExtraTaskSettingsCache(const ChecksumType& checksum)
   // Check if we need to update the cache
   auto it = extraTaskSettings_cache.find(ExtraTaskSettings.TaskIndex);
   if (it != extraTaskSettings_cache.end()) {
-    if (checksum.matchChecksum(it->second.md5checksum)) {
+    if (ExtraTaskSettings.computeChecksum() == it->second.md5checksum) {
       return;
     }
   }
@@ -322,7 +322,7 @@ void Caches::updateExtraTaskSettingsCache(const ChecksumType& checksum)
   it = extraTaskSettings_cache.find(ExtraTaskSettings.TaskIndex);
 
   if (it != extraTaskSettings_cache.end()) {
-    checksum.getChecksum(it->second.md5checksum);
+    ExtraTaskSettings.computeChecksum().getChecksum(it->second.md5checksum);
   }
 }
 

--- a/src/src/DataStructs/Caches.h
+++ b/src/src/DataStructs/Caches.h
@@ -33,7 +33,7 @@ struct ExtraTaskSettings_cache_t {
   String TaskDeviceValueNames[VARS_PER_TASK];
   String TaskDeviceName;
   #endif // ifdef ESP32
-  uint8_t md5checksum[16] = { 0 };
+  ChecksumType md5checksum;
   uint8_t decimals[VARS_PER_TASK] = { 0 };
   #if FEATURE_PLUGIN_STATS
   uint8_t enabledPluginStats = 0;

--- a/src/src/DataStructs/Caches.h
+++ b/src/src/DataStructs/Caches.h
@@ -4,6 +4,7 @@
 #include <map>
 #include "../../ESPEasy_common.h"
 #include "../CustomBuild/ESPEasyLimits.h"
+#include "../DataStructs/ChecksumType.h"
 #include "../Globals/Plugins.h"
 
 #include "../Helpers/RulesHelper.h"
@@ -54,7 +55,7 @@ struct Caches {
 
   void    clearFileCaches();
 
-  bool    matchChecksumExtraTaskSettings(taskIndex_t TaskIndex, uint8_t checksum[16]) const;
+  bool    matchChecksumExtraTaskSettings(taskIndex_t TaskIndex, const ChecksumType& checksum) const;
 
   void    updateActiveTaskUseSerial0();
 
@@ -87,7 +88,7 @@ struct Caches {
   // Update the cached value.
   // Only to be called from LoadTaskSettings() or SaveTaskSettings()
   // since only those functions know the checksum of what has been stored.
-  void updateExtraTaskSettingsCache(uint8_t checksum[16]);
+  void updateExtraTaskSettingsCache(const ChecksumType& checksum);
 
 private:
 
@@ -108,7 +109,9 @@ private:
 
 public:
 
-  uint32_t fileCacheClearMoment = 0;
+  ChecksumType controllerSettings_checksums[CONTROLLER_MAX] = {};
+  uint32_t     fileCacheClearMoment = 0;
+
 
   bool activeTaskUseSerial0 = false;
 };

--- a/src/src/DataStructs/Caches.h
+++ b/src/src/DataStructs/Caches.h
@@ -88,7 +88,7 @@ struct Caches {
   // Update the cached value.
   // Only to be called from LoadTaskSettings() or SaveTaskSettings()
   // since only those functions know the checksum of what has been stored.
-  void updateExtraTaskSettingsCache(const ChecksumType& checksum);
+  void updateExtraTaskSettingsCache_afterLoad_Save();
 
 private:
 

--- a/src/src/DataStructs/ChecksumType.cpp
+++ b/src/src/DataStructs/ChecksumType.cpp
@@ -22,6 +22,19 @@ ChecksumType::ChecksumType(const uint8_t *data,
   computeChecksum(_checksum, data, data_length, len_upto_md5, true);
 }
 
+ChecksumType::ChecksumType(const String strings[], size_t nrStrings)
+{
+  MD5Builder md5;
+
+  md5.begin();
+
+  for (size_t i = 0; i < nrStrings; ++i) {
+    md5.add(strings[i].c_str());
+  }
+  md5.calculate();
+  md5.getBytes(_checksum);
+}
+
 bool ChecksumType::computeChecksum(
   uint8_t  checksum[16],
   const uint8_t *data,

--- a/src/src/DataStructs/ChecksumType.cpp
+++ b/src/src/DataStructs/ChecksumType.cpp
@@ -1,5 +1,7 @@
 #include "../DataStructs/ChecksumType.h"
 
+#include "../Helpers/StringConverter.h"
+
 #include <MD5Builder.h>
 
 ChecksumType::ChecksumType(uint8_t checksum[16])
@@ -80,4 +82,8 @@ bool ChecksumType::operator==(const ChecksumType& rhs) const {
 ChecksumType& ChecksumType::operator=(const ChecksumType& rhs) {
   memcpy(_checksum, rhs._checksum, 16);
   return *this;
+}
+
+String ChecksumType::toString() const {
+  return formatToHex_array(_checksum, 16);
 }

--- a/src/src/DataStructs/ChecksumType.cpp
+++ b/src/src/DataStructs/ChecksumType.cpp
@@ -7,13 +7,13 @@ ChecksumType::ChecksumType(uint8_t checksum[16])
   memcpy(_checksum, checksum, 16);
 }
 
-ChecksumType::ChecksumType(uint8_t *data,
+ChecksumType::ChecksumType(const uint8_t *data,
                            size_t   data_length)
 {
   computeChecksum(_checksum, data, data_length, data_length, true);
 }
 
-ChecksumType::ChecksumType(uint8_t *data,
+ChecksumType::ChecksumType(const uint8_t *data,
                            size_t   data_length,
                            size_t   len_upto_md5)
 {
@@ -22,7 +22,7 @@ ChecksumType::ChecksumType(uint8_t *data,
 
 bool ChecksumType::computeChecksum(
   uint8_t  checksum[16],
-  uint8_t *data,
+  const uint8_t *data,
   size_t   data_length,
   size_t   len_upto_md5,
   bool     updateChecksum)
@@ -33,7 +33,8 @@ bool ChecksumType::computeChecksum(
   md5.begin();
 
   if (len_upto_md5 > 0) {
-    md5.add(data, len_upto_md5);
+    // MD5Builder::add has non-const argument
+    md5.add(const_cast<uint8_t *>(data), len_upto_md5);
   }
 
   if ((len_upto_md5 + 16) < data_length) {
@@ -41,7 +42,8 @@ bool ChecksumType::computeChecksum(
     const int len_after_md5 = data_length - 16 - len_upto_md5;
 
     if (len_after_md5 > 0) {
-      md5.add(data, len_after_md5);
+      // MD5Builder::add has non-const argument
+      md5.add(const_cast<uint8_t *>(data), len_after_md5);
     }
   }
   md5.calculate();
@@ -69,4 +71,13 @@ void ChecksumType::setChecksum(const uint8_t checksum[16]) {
 
 bool ChecksumType::matchChecksum(const uint8_t checksum[16]) const {
   return memcmp(_checksum, checksum, 16) == 0;
+}
+
+bool ChecksumType::operator==(const ChecksumType& rhs) const {
+  return memcmp(_checksum, rhs._checksum, 16) == 0;
+}
+
+ChecksumType& ChecksumType::operator=(const ChecksumType& rhs) {
+  memcpy(_checksum, rhs._checksum, 16);
+  return *this;
 }

--- a/src/src/DataStructs/ChecksumType.cpp
+++ b/src/src/DataStructs/ChecksumType.cpp
@@ -1,0 +1,72 @@
+#include "../DataStructs/ChecksumType.h"
+
+#include <MD5Builder.h>
+
+ChecksumType::ChecksumType(uint8_t checksum[16])
+{
+  memcpy(_checksum, checksum, 16);
+}
+
+ChecksumType::ChecksumType(uint8_t *data,
+                           size_t   data_length)
+{
+  computeChecksum(_checksum, data, data_length, data_length, true);
+}
+
+ChecksumType::ChecksumType(uint8_t *data,
+                           size_t   data_length,
+                           size_t   len_upto_md5)
+{
+  computeChecksum(_checksum, data, data_length, len_upto_md5, true);
+}
+
+bool ChecksumType::computeChecksum(
+  uint8_t  checksum[16],
+  uint8_t *data,
+  size_t   data_length,
+  size_t   len_upto_md5,
+  bool     updateChecksum)
+{
+  if (len_upto_md5 > data_length) { len_upto_md5 = data_length; }
+  MD5Builder md5;
+
+  md5.begin();
+
+  if (len_upto_md5 > 0) {
+    md5.add(data, len_upto_md5);
+  }
+
+  if ((len_upto_md5 + 16) < data_length) {
+    data += len_upto_md5 + 16;
+    const int len_after_md5 = data_length - 16 - len_upto_md5;
+
+    if (len_after_md5 > 0) {
+      md5.add(data, len_after_md5);
+    }
+  }
+  md5.calculate();
+  uint8_t tmp_md5[16] = { 0 };
+
+  md5.getBytes(tmp_md5);
+
+  if (memcmp(tmp_md5, checksum, 16) != 0) {
+    // Data has changed, copy computed checksum
+    if (updateChecksum) {
+      memcpy(checksum, tmp_md5, 16);
+    }
+    return false;
+  }
+  return true;
+}
+
+void ChecksumType::getChecksum(uint8_t checksum[16]) const {
+  memcpy(checksum, _checksum, 16);
+}
+
+void ChecksumType::setChecksum(const uint8_t checksum[16]) {
+  memcpy(_checksum, checksum, 16);
+}
+
+bool ChecksumType::matchChecksum(const uint8_t checksum[16]) const {
+  return memcmp(_checksum, checksum, 16) == 0;
+}

--- a/src/src/DataStructs/ChecksumType.h
+++ b/src/src/DataStructs/ChecksumType.h
@@ -17,6 +17,8 @@ struct ChecksumType {
                size_t   data_length,
                size_t   len_upto_md5);
 
+  ChecksumType(const String strings[], size_t nrStrings);
+
   // Compute checksum of the data.
   // Skip the part where the checksum may be located in the data
   // @param checksum The expected checksum. Will contain checksum after call finished.

--- a/src/src/DataStructs/ChecksumType.h
+++ b/src/src/DataStructs/ChecksumType.h
@@ -1,0 +1,40 @@
+#ifndef DATASTRUCTS_CHECKSUMTYPE_H
+#define DATASTRUCTS_CHECKSUMTYPE_H
+
+#include "../../ESPEasy_common.h"
+
+struct ChecksumType {
+  // Empty checksum
+  ChecksumType() = default;
+
+  ChecksumType(uint8_t checksum[16]);
+
+  // Construct with checksum over entire range of given data
+  ChecksumType(uint8_t *data,
+               size_t   data_length);
+
+  ChecksumType(uint8_t *data,
+               size_t   data_length,
+               size_t   len_upto_md5);
+
+  // Compute checksum of the data.
+  // Skip the part where the checksum may be located in the data
+  // @param checksum The expected checksum. Will contain checksum after call finished.
+  // @retval true when checksum matches
+  static bool computeChecksum(
+    uint8_t  checksum[16],
+    uint8_t *data,
+    size_t   data_length,
+    size_t   len_upto_md5,
+    bool     updateChecksum = true);
+
+  void getChecksum(uint8_t checksum[16]) const;
+  void setChecksum(const uint8_t checksum[16]);
+  bool matchChecksum(const uint8_t checksum[16]) const;
+
+private:
+
+  uint8_t _checksum[16] = { 0 };
+};
+
+#endif // ifndef DATASTRUCTS_CHECKSUMTYPE_H

--- a/src/src/DataStructs/ChecksumType.h
+++ b/src/src/DataStructs/ChecksumType.h
@@ -34,6 +34,8 @@ struct ChecksumType {
   bool operator==(const ChecksumType& rhs) const;
   ChecksumType& operator=(const ChecksumType& rhs);
 
+  String toString() const;
+
 private:
 
   uint8_t _checksum[16] = { 0 };

--- a/src/src/DataStructs/ChecksumType.h
+++ b/src/src/DataStructs/ChecksumType.h
@@ -10,10 +10,10 @@ struct ChecksumType {
   ChecksumType(uint8_t checksum[16]);
 
   // Construct with checksum over entire range of given data
-  ChecksumType(uint8_t *data,
+  ChecksumType(const uint8_t *data,
                size_t   data_length);
 
-  ChecksumType(uint8_t *data,
+  ChecksumType(const uint8_t *data,
                size_t   data_length,
                size_t   len_upto_md5);
 
@@ -23,7 +23,7 @@ struct ChecksumType {
   // @retval true when checksum matches
   static bool computeChecksum(
     uint8_t  checksum[16],
-    uint8_t *data,
+    const uint8_t *data,
     size_t   data_length,
     size_t   len_upto_md5,
     bool     updateChecksum = true);
@@ -31,6 +31,8 @@ struct ChecksumType {
   void getChecksum(uint8_t checksum[16]) const;
   void setChecksum(const uint8_t checksum[16]);
   bool matchChecksum(const uint8_t checksum[16]) const;
+  bool operator==(const ChecksumType& rhs) const;
+  ChecksumType& operator=(const ChecksumType& rhs);
 
 private:
 

--- a/src/src/DataStructs/ControllerSettingsStruct.cpp
+++ b/src/src/DataStructs/ControllerSettingsStruct.cpp
@@ -16,7 +16,7 @@
 
 ControllerSettingsStruct::ControllerSettingsStruct()
 {
-  reset();
+  safe_strncpy(ClientID, F(CONTROLLER_DEFAULT_CLIENTID), sizeof(ClientID));
 }
 
 void ControllerSettingsStruct::reset() {

--- a/src/src/DataStructs/ControllerSettingsStruct.cpp
+++ b/src/src/DataStructs/ControllerSettingsStruct.cpp
@@ -77,6 +77,10 @@ void ControllerSettingsStruct::validate() {
   ZERO_TERMINATE(LWTMessageDisconnect);
 }
 
+ChecksumType ControllerSettingsStruct::computeChecksum() const {
+  return ChecksumType(reinterpret_cast<const uint8_t *>(this), sizeof(ControllerSettingsStruct));
+}
+
 IPAddress ControllerSettingsStruct::getIP() const {
   IPAddress host(IP[0], IP[1], IP[2], IP[3]);
 

--- a/src/src/DataStructs/ControllerSettingsStruct.h
+++ b/src/src/DataStructs/ControllerSettingsStruct.h
@@ -151,25 +151,24 @@ struct ControllerSettingsStruct
   bool      useLocalSystemTime() const;
   void      useLocalSystemTime(bool value);
   
-
-  bool         UseDNS;
-  uint8_t      IP[4];
-  unsigned int Port;
-  char         HostName[65];
-  char         Publish[129];
-  char         Subscribe[129];
-  char         MQTTLwtTopic[129];
-  char         LWTMessageConnect[129];
-  char         LWTMessageDisconnect[129];
-  unsigned int MinimalTimeBetweenMessages;
-  unsigned int MaxQueueDepth;
-  unsigned int MaxRetry;
-  bool         DeleteOldest;       // Action to perform when buffer full, delete oldest, or ignore newest.
-  unsigned int ClientTimeout;
-  bool         MustCheckReply;     // When set to false, a sent message is considered always successful.
-  taskIndex_t  SampleSetInitiator; // The first task to start a sample set.
-  uint32_t     VariousFlags;       // Various flags
-  char         ClientID[65];       // Used to define the Client ID used by the controller
+  bool         UseDNS = DEFAULT_SERVER_USEDNS;
+  uint8_t      IP[4] = {};
+  unsigned int Port = DEFAULT_PORT;
+  char         HostName[65] = {};
+  char         Publish[129] = {};
+  char         Subscribe[129] = {};
+  char         MQTTLwtTopic[129] = {};
+  char         LWTMessageConnect[129] = {};
+  char         LWTMessageDisconnect[129] = {};
+  unsigned int MinimalTimeBetweenMessages = CONTROLLER_DELAY_QUEUE_DELAY_DFLT;
+  unsigned int MaxQueueDepth = CONTROLLER_DELAY_QUEUE_DEPTH_DFLT;
+  unsigned int MaxRetry = CONTROLLER_DELAY_QUEUE_RETRY_DFLT;
+  bool         DeleteOldest = DEFAULT_CONTROLLER_DELETE_OLDEST;       // Action to perform when buffer full, delete oldest, or ignore newest.
+  unsigned int ClientTimeout = CONTROLLER_CLIENTTIMEOUT_DFLT;
+  bool         MustCheckReply = DEFAULT_CONTROLLER_MUST_CHECK_REPLY;     // When set to false, a sent message is considered always successful.
+  taskIndex_t  SampleSetInitiator = INVALID_TASK_INDEX; // The first task to start a sample set.
+  uint32_t     VariousFlags = 0;       // Various flags
+  char         ClientID[65] = {};       // Used to define the Client ID used by the controller
 
 private:
 

--- a/src/src/DataStructs/ControllerSettingsStruct.h
+++ b/src/src/DataStructs/ControllerSettingsStruct.h
@@ -151,24 +151,24 @@ struct ControllerSettingsStruct
   bool      useLocalSystemTime() const;
   void      useLocalSystemTime(bool value);
   
-  bool         UseDNS = DEFAULT_SERVER_USEDNS;
-  uint8_t      IP[4] = {};
-  unsigned int Port = DEFAULT_PORT;
-  char         HostName[65] = {};
-  char         Publish[129] = {};
-  char         Subscribe[129] = {};
-  char         MQTTLwtTopic[129] = {};
-  char         LWTMessageConnect[129] = {};
-  char         LWTMessageDisconnect[129] = {};
-  unsigned int MinimalTimeBetweenMessages = CONTROLLER_DELAY_QUEUE_DELAY_DFLT;
-  unsigned int MaxQueueDepth = CONTROLLER_DELAY_QUEUE_DEPTH_DFLT;
-  unsigned int MaxRetry = CONTROLLER_DELAY_QUEUE_RETRY_DFLT;
-  bool         DeleteOldest = DEFAULT_CONTROLLER_DELETE_OLDEST;       // Action to perform when buffer full, delete oldest, or ignore newest.
-  unsigned int ClientTimeout = CONTROLLER_CLIENTTIMEOUT_DFLT;
-  bool         MustCheckReply = DEFAULT_CONTROLLER_MUST_CHECK_REPLY;     // When set to false, a sent message is considered always successful.
-  taskIndex_t  SampleSetInitiator = INVALID_TASK_INDEX; // The first task to start a sample set.
-  uint32_t     VariousFlags = 0;       // Various flags
-  char         ClientID[65] = {};       // Used to define the Client ID used by the controller
+  bool         UseDNS;
+  uint8_t      IP[4];
+  unsigned int Port;
+  char         HostName[65];
+  char         Publish[129];
+  char         Subscribe[129];
+  char         MQTTLwtTopic[129];
+  char         LWTMessageConnect[129];
+  char         LWTMessageDisconnect[129];
+  unsigned int MinimalTimeBetweenMessages;
+  unsigned int MaxQueueDepth;
+  unsigned int MaxRetry;
+  bool         DeleteOldest;       // Action to perform when buffer full, delete oldest, or ignore newest.
+  unsigned int ClientTimeout;
+  bool         MustCheckReply;     // When set to false, a sent message is considered always successful.
+  taskIndex_t  SampleSetInitiator; // The first task to start a sample set.
+  uint32_t     VariousFlags;       // Various flags
+  char         ClientID[65];       // Used to define the Client ID used by the controller
 
 private:
 

--- a/src/src/DataStructs/ControllerSettingsStruct.h
+++ b/src/src/DataStructs/ControllerSettingsStruct.h
@@ -13,6 +13,7 @@
 #include <WiFiUdp.h>
 
 #include "../../ESPEasy_common.h"
+#include "../DataStructs/ChecksumType.h"
 #include "../Globals/Plugins.h"
 
 // Minimum delay between messages for a controller to send in msec.
@@ -100,6 +101,8 @@ struct ControllerSettingsStruct
   bool      isSet() const;
 
   void      validate();
+
+  ChecksumType computeChecksum() const;
 
   IPAddress getIP() const;
 

--- a/src/src/DataStructs/ExtendedControllerCredentialsStruct.h
+++ b/src/src/DataStructs/ExtendedControllerCredentialsStruct.h
@@ -14,9 +14,8 @@ struct ExtendedControllerCredentialsStruct
   ExtendedControllerCredentialsStruct();
 
   // Compute checksum of the data.
-  // @param checksum The expected checksum. Will contain checksum after call finished.
   // @retval true when checksum matches
-  bool computeChecksum(uint8_t checksum[16]) const;
+  bool validateChecksum() const;
 
   String load();
   String save() const;

--- a/src/src/DataStructs/ExtraTaskSettingsStruct.cpp
+++ b/src/src/DataStructs/ExtraTaskSettingsStruct.cpp
@@ -41,6 +41,10 @@ void ExtraTaskSettingsStruct::validate() {
   }
 }
 
+ChecksumType ExtraTaskSettingsStruct::computeChecksum() const {
+  return ChecksumType(reinterpret_cast<const uint8_t *>(this), sizeof(ExtraTaskSettingsStruct));
+}
+
 bool ExtraTaskSettingsStruct::checkUniqueValueNames() const {
   for (int i = 0; i < (VARS_PER_TASK - 1); ++i) {
     for (int j = i; j < VARS_PER_TASK; ++j) {

--- a/src/src/DataStructs/ExtraTaskSettingsStruct.cpp
+++ b/src/src/DataStructs/ExtraTaskSettingsStruct.cpp
@@ -7,14 +7,13 @@
 
 #define EXTRA_TASK_SETTINGS_VERSION 1
 
-uint8_t last_ExtraTaskSettingsStruct_md5[16] = { 0 };
 
 void ExtraTaskSettingsStruct::clear() {
   // Need to make sure every byte between the members is also zero
   // Otherwise the checksum will fail and settings will be saved too often.
   memset(this, 0, sizeof(ExtraTaskSettingsStruct));
-  
   TaskIndex = INVALID_TASK_INDEX;
+  dummy1 = 0;
   version = EXTRA_TASK_SETTINGS_VERSION;
   for (int i = 0; i < VARS_PER_TASK; ++i) {
     TaskDeviceValueDecimals[i] = 2;

--- a/src/src/DataStructs/ExtraTaskSettingsStruct.cpp
+++ b/src/src/DataStructs/ExtraTaskSettingsStruct.cpp
@@ -10,7 +10,15 @@
 uint8_t last_ExtraTaskSettingsStruct_md5[16] = { 0 };
 
 void ExtraTaskSettingsStruct::clear() {
-  *this = ExtraTaskSettingsStruct();
+  // Need to make sure every byte between the members is also zero
+  // Otherwise the checksum will fail and settings will be saved too often.
+  memset(this, 0, sizeof(ExtraTaskSettingsStruct));
+  
+  TaskIndex = INVALID_TASK_INDEX;
+  version = EXTRA_TASK_SETTINGS_VERSION;
+  for (int i = 0; i < VARS_PER_TASK; ++i) {
+    TaskDeviceValueDecimals[i] = 2;
+  }
 }
 
 void ExtraTaskSettingsStruct::validate() {

--- a/src/src/DataStructs/ExtraTaskSettingsStruct.h
+++ b/src/src/DataStructs/ExtraTaskSettingsStruct.h
@@ -60,20 +60,19 @@ struct ExtraTaskSettingsStruct
                                             uint8_t                    defaultDecimals,
                                             bool                       displayString);
 
-  taskIndex_t TaskIndex                                                        = INVALID_TASK_INDEX; // Always < TASKS_MAX or
-                                                                                                     // INVALID_TASK_INDEX
-  char        TaskDeviceName[NAME_FORMULA_LENGTH_MAX + 1]                      = {};
-  char        TaskDeviceFormula[VARS_PER_TASK][NAME_FORMULA_LENGTH_MAX + 1]    = {};
-  char        TaskDeviceValueNames[VARS_PER_TASK][NAME_FORMULA_LENGTH_MAX + 1] = {};
+  taskIndex_t TaskIndex = INVALID_TASK_INDEX; // Always < TASKS_MAX or INVALID_TASK_INDEX
+  char        TaskDeviceName[NAME_FORMULA_LENGTH_MAX + 1];
+  char        TaskDeviceFormula[VARS_PER_TASK][NAME_FORMULA_LENGTH_MAX + 1];
+  char        TaskDeviceValueNames[VARS_PER_TASK][NAME_FORMULA_LENGTH_MAX + 1];
   uint8_t     dummy1                                                           = 0;
   uint8_t     version                                                          = 1;
-  long        TaskDevicePluginConfigLong[PLUGIN_EXTRACONFIGVAR_MAX]            = {};
-  uint8_t     TaskDeviceValueDecimals[VARS_PER_TASK]                           = {2,2,2,2};
-  int16_t     TaskDevicePluginConfig[PLUGIN_EXTRACONFIGVAR_MAX]                = {};
-  float       TaskDeviceMinValue[VARS_PER_TASK]                                = {};
-  float       TaskDeviceMaxValue[VARS_PER_TASK]                                = {};
-  float       TaskDeviceErrorValue[VARS_PER_TASK]                              = {};
-  uint32_t    VariousBits[VARS_PER_TASK]                                       = {};
+  long        TaskDevicePluginConfigLong[PLUGIN_EXTRACONFIGVAR_MAX];
+  uint8_t     TaskDeviceValueDecimals[VARS_PER_TASK];
+  int16_t     TaskDevicePluginConfig[PLUGIN_EXTRACONFIGVAR_MAX];
+  float       TaskDeviceMinValue[VARS_PER_TASK];
+  float       TaskDeviceMaxValue[VARS_PER_TASK];
+  float       TaskDeviceErrorValue[VARS_PER_TASK];
+  uint32_t    VariousBits[VARS_PER_TASK];
 };
 
 

--- a/src/src/DataStructs/ExtraTaskSettingsStruct.h
+++ b/src/src/DataStructs/ExtraTaskSettingsStruct.h
@@ -8,6 +8,7 @@
 #include <Arduino.h>
 
 #include "../CustomBuild/ESPEasyLimits.h"
+#include "../DataStructs/ChecksumType.h"
 #include "../Globals/Plugins.h"
 
 // This is only used by some plugins to store extra settings like formula descriptions.
@@ -21,6 +22,8 @@ struct ExtraTaskSettingsStruct
   void          clear();
 
   void          validate();
+ 
+  ChecksumType  computeChecksum() const;
 
   bool          checkUniqueValueNames() const;
 

--- a/src/src/DataStructs/NotificationSettingsStruct.h
+++ b/src/src/DataStructs/NotificationSettingsStruct.h
@@ -33,7 +33,13 @@ struct NotificationSettingsStruct
 
 typedef std::shared_ptr<NotificationSettingsStruct> NotificationSettingsStruct_ptr_type;
 #define MakeNotificationSettings(T) NotificationSettingsStruct_ptr_type NotificationSettingsStruct_ptr(new (std::nothrow)  NotificationSettingsStruct());\
-                                    NotificationSettingsStruct& T = *NotificationSettingsStruct_ptr;
+                                    NotificationSettingsStruct& T = *NotificationSettingsStruct_ptr; \
+                                    if (NotificationSettingsStruct_ptr) { memset(&T, 0, sizeof(NotificationSettingsStruct)); }
+
+// Need to make sure every byte between the members is also zero
+// Otherwise the checksum will fail and settings will be saved too often.
+// The memset above is just for this.
+
 
 #endif
 #endif // DATASTRUCTS_NOTIFICATIONSETTINGSSTRUCT_H

--- a/src/src/DataStructs/ProvisioningStruct.h
+++ b/src/src/DataStructs/ProvisioningStruct.h
@@ -36,7 +36,13 @@ struct ProvisioningStruct
 
 typedef std::shared_ptr<ProvisioningStruct> ProvisioningStruct_ptr_type;
 # define MakeProvisioningSettings(T) ProvisioningStruct_ptr_type ProvisioningStruct_ptr(new (std::nothrow)  ProvisioningStruct()); \
-  ProvisioningStruct& T = *ProvisioningStruct_ptr;
+  ProvisioningStruct& T = *ProvisioningStruct_ptr;  \
+  if (ProvisioningStruct_ptr) { memset(&T, 0, sizeof(ProvisioningStruct)); }
+
+// Need to make sure every byte between the members is also zero
+// Otherwise the checksum will fail and settings will be saved too often.
+// The memset above is just for this.
+
 
 // Check to see if MakeProvisioningSettings was successful
 # define AllocatedProvisioningSettings() (ProvisioningStruct_ptr.get() != nullptr)

--- a/src/src/DataStructs/RTC_cache_handler_struct.h
+++ b/src/src/DataStructs/RTC_cache_handler_struct.h
@@ -1,10 +1,10 @@
 #ifndef DATASTRUCTS_RTC_CACHE_HANDLER_STRUCT_H
 #define DATASTRUCTS_RTC_CACHE_HANDLER_STRUCT_H
 
+#include "../../ESPEasy_common.h"
+
 
 #include "../DataStructs/RTCCacheStruct.h"
-
-#include "../../ESPEasy_common.h"
 
 #include <FS.h>
 #include <vector>
@@ -97,5 +97,6 @@ private:
   uint8_t storageLocation = CACHE_STORAGE_SPIFFS;
   bool    writeError      = false;
 };
+
 
 #endif // ifndef DATASTRUCTS_RTC_CACHE_HANDLER_STRUCT_H

--- a/src/src/DataStructs/SecurityStruct.cpp
+++ b/src/src/DataStructs/SecurityStruct.cpp
@@ -19,6 +19,27 @@ SecurityStruct::SecurityStruct() {
   ZERO_FILL(Password);
 }
 
+ChecksumType SecurityStruct::computeChecksum() const {
+  constexpr size_t len_upto_md5 = offsetof(SecurityStruct, md5);
+  return ChecksumType(
+    reinterpret_cast<const uint8_t *>(this), 
+    sizeof(SecurityStruct),
+    len_upto_md5);
+}
+
+bool SecurityStruct::checksumMatch() const {
+  return computeChecksum().matchChecksum(md5);
+}
+
+bool SecurityStruct::updateChecksum() {
+  const ChecksumType checksum = computeChecksum();
+  if (checksum.matchChecksum(md5)) {
+    return false;
+  }
+  checksum.getChecksum(md5);
+  return true;
+}
+
 void SecurityStruct::validate() {
   ZERO_TERMINATE(WifiSSID);
   ZERO_TERMINATE(WifiKey);

--- a/src/src/DataStructs/SecurityStruct.h
+++ b/src/src/DataStructs/SecurityStruct.h
@@ -3,6 +3,7 @@
 
 #include "../../ESPEasy_common.h"
 #include "../CustomBuild/ESPEasyLimits.h"
+#include "../DataStructs/ChecksumType.h"
 
 /*********************************************************************************************\
  * SecurityStruct
@@ -16,6 +17,15 @@ struct SecurityStruct
 
 
   SecurityStruct();
+
+  ChecksumType computeChecksum() const;
+
+  // Return true when stored checksum matches.
+  bool checksumMatch() const;
+
+  // Check and update checksum when content was changed.
+  // Return true when stored checksum is updated.
+  bool updateChecksum();
 
   void validate();
 

--- a/src/src/DataStructs/SettingsStruct.h
+++ b/src/src/DataStructs/SettingsStruct.h
@@ -5,6 +5,7 @@
 #include "../../ESPEasy_common.h"
 
 #include "../CustomBuild/ESPEasyLimits.h"
+#include "../DataStructs/ChecksumType.h"
 #include "../DataStructs/DeviceStruct.h"
 #include "../DataTypes/EthernetParameters.h"
 #include "../DataTypes/NetworkMedium.h"

--- a/src/src/DataStructs/TimingStats.cpp
+++ b/src/src/DataStructs/TimingStats.cpp
@@ -238,6 +238,7 @@ const __FlashStringHelper* getMiscStatsName_F(int stat) {
     case PARSE_SYSVAR:               return F("parseSystemVariables()");
     case PARSE_SYSVAR_NOCHANGE:      return F("parseSystemVariables() No change");
     case HANDLE_SERVING_WEBPAGE:     return F("handle webpage");
+    case HANDLE_SERVING_WEBPAGE_JSON: return F("handle webpage JSON");
     case WIFI_SCAN_ASYNC:            return F("WiFi Scan Async");
     case WIFI_SCAN_SYNC:             return F("WiFi Scan Sync (blocking)");
     case NTP_SUCCESS:                return F("NTP Success");

--- a/src/src/DataStructs/TimingStats.cpp
+++ b/src/src/DataStructs/TimingStats.cpp
@@ -7,10 +7,9 @@
 # include "../Helpers/_CPlugin_Helper.h"
 # include "../Helpers/StringConverter.h"
 
-
 std::map<int, TimingStats> pluginStats;
 std::map<int, TimingStats> controllerStats;
-std::map<int, TimingStats> miscStats;
+std::map<TimingStatsElements, TimingStats> miscStats;
 unsigned long timingstats_last_reset(0);
 
 
@@ -193,87 +192,120 @@ bool mustLogCFunction(CPlugin::Function function) {
 }
 
 // Return flash string type to reduce bin size
-const __FlashStringHelper* getMiscStatsName_F(int stat) {
+const __FlashStringHelper* getMiscStatsName_F(TimingStatsElements stat) {
   switch (stat) {
-    case LOADFILE_STATS:             return F("Load File");
-    case SAVEFILE_STATS:             return F("Save File");
-    case LOOP_STATS:                 return F("Loop");
-    case PLUGIN_CALL_50PS:           return F("Plugin call 50 p/s");
-    case PLUGIN_CALL_10PS:           return F("Plugin call 10 p/s");
-    case PLUGIN_CALL_10PSU:          return F("Plugin call 10 p/s U");
-    case PLUGIN_CALL_1PS:            return F("Plugin call  1 p/s");
-    case CPLUGIN_CALL_50PS:          return F("CPlugin call 50 p/s");
-    case CPLUGIN_CALL_10PS:          return F("CPlugin call 10 p/s");
-    case SENSOR_SEND_TASK:           return F("SensorSendTask()");
-    case SEND_DATA_STATS:            return F("sendData()");
-    case COMPUTE_FORMULA_STATS:      return F("Compute formula");
-    case PLUGIN_CALL_DEVICETIMER_IN: return F("PLUGIN_DEVICETIMER_IN");
-    case SET_NEW_TIMER:              return F("setNewTimerAt()");
-    case TIME_DIFF_COMPUTE:          return F("timeDiff()");
-    case MQTT_DELAY_QUEUE:           return F("Delay queue MQTT");
-    case TRY_CONNECT_HOST_TCP:       return F("try_connect_host() (TCP)");
-    case TRY_CONNECT_HOST_UDP:       return F("try_connect_host() (UDP)");
-    case HOST_BY_NAME_STATS:         return F("hostByName()");
-    case CONNECT_CLIENT_STATS:       return F("connectClient()");
-    case LOAD_CUSTOM_TASK_STATS:     return F("LoadCustomTaskSettings()");
-    case WIFI_ISCONNECTED_STATS:     return F("WiFi.isConnected()");
-    case WIFI_NOTCONNECTED_STATS:    return F("WiFi.isConnected() (fail)");
-    case LOAD_TASK_SETTINGS:         return F("LoadTaskSettings()");
-    case LOAD_TASK_SETTINGS_CACHED:  return F("LoadTaskSettings() (cached)");
-    case SAVE_TASK_SETTINGS:         return F("SaveTaskSettings()");
-    case TRY_OPEN_FILE:              return F("TryOpenFile()");
-    case FS_GC_SUCCESS:              return F("ESPEASY_FS GC success");
-    case FS_GC_FAIL:                 return F("ESPEASY_FS GC fail");
-    case RULES_PROCESSING:           return F("rulesProcessing()");
-    case RULES_PARSE_LINE:           return F("parseCompleteNonCommentLine()");
-    case RULES_PROCESS_MATCHED:      return F("processMatchedRule()");
-    case RULES_MATCH:                return F("rulesMatch()");
-    case GRAT_ARP_STATS:             return F("sendGratuitousARP()");
-    case SAVE_TO_RTC:                return F("saveToRTC()");
-    case BACKGROUND_TASKS:           return F("backgroundtasks()");
-    case PROCESS_SYSTEM_EVENT_QUEUE: return F("process_system_event_queue()");
-    case HANDLE_SCHEDULER_IDLE:      return F("handle_schedule() idle");
-    case HANDLE_SCHEDULER_TASK:      return F("handle_schedule() task");
-    case PARSE_TEMPLATE_PADDED:      return F("parseTemplate_padded()");
-    case PARSE_SYSVAR:               return F("parseSystemVariables()");
-    case PARSE_SYSVAR_NOCHANGE:      return F("parseSystemVariables() No change");
-    case HANDLE_SERVING_WEBPAGE:     return F("handle webpage");
-    case HANDLE_SERVING_WEBPAGE_JSON: return F("handle webpage JSON");
-    case WIFI_SCAN_ASYNC:            return F("WiFi Scan Async");
-    case WIFI_SCAN_SYNC:             return F("WiFi Scan Sync (blocking)");
-    case NTP_SUCCESS:                return F("NTP Success");
-    case NTP_FAIL:                   return F("NTP Fail");
-    case SYSTIME_UPDATED:            return F("Systime Set");
-    case C018_AIR_TIME:              return F("C018 LoRa TTN - Air Time");
+    case TimingStatsElements::LOADFILE_STATS:             return F("Load File");
+    case TimingStatsElements::SAVEFILE_STATS:             return F("Save File");
+    case TimingStatsElements::LOOP_STATS:                 return F("Loop");
+    case TimingStatsElements::PLUGIN_CALL_50PS:           return F("Plugin call 50 p/s");
+    case TimingStatsElements::PLUGIN_CALL_10PS:           return F("Plugin call 10 p/s");
+    case TimingStatsElements::PLUGIN_CALL_10PSU:          return F("Plugin call 10 p/s U");
+    case TimingStatsElements::PLUGIN_CALL_1PS:            return F("Plugin call  1 p/s");
+    case TimingStatsElements::CPLUGIN_CALL_50PS:          return F("CPlugin call 50 p/s");
+    case TimingStatsElements::CPLUGIN_CALL_10PS:          return F("CPlugin call 10 p/s");
+    case TimingStatsElements::SENSOR_SEND_TASK:           return F("SensorSendTask()");
+    case TimingStatsElements::SEND_DATA_STATS:            return F("sendData()");
+    case TimingStatsElements::COMPUTE_FORMULA_STATS:      return F("Compute formula");
+    case TimingStatsElements::PLUGIN_CALL_DEVICETIMER_IN: return F("PLUGIN_DEVICETIMER_IN");
+    case TimingStatsElements::SET_NEW_TIMER:              return F("setNewTimerAt()");
+    case TimingStatsElements::TIME_DIFF_COMPUTE:          return F("timeDiff()");
+    case TimingStatsElements::MQTT_DELAY_QUEUE:           return F("Delay queue MQTT");
+    case TimingStatsElements::TRY_CONNECT_HOST_TCP:       return F("try_connect_host() (TCP)");
+    case TimingStatsElements::TRY_CONNECT_HOST_UDP:       return F("try_connect_host() (UDP)");
+    case TimingStatsElements::HOST_BY_NAME_STATS:         return F("hostByName()");
+    case TimingStatsElements::CONNECT_CLIENT_STATS:       return F("connectClient()");
+    case TimingStatsElements::LOAD_CUSTOM_TASK_STATS:     return F("LoadCustomTaskSettings()");
+    case TimingStatsElements::WIFI_ISCONNECTED_STATS:     return F("WiFi.isConnected()");
+    case TimingStatsElements::WIFI_NOTCONNECTED_STATS:    return F("WiFi.isConnected() (fail)");
+    case TimingStatsElements::LOAD_TASK_SETTINGS:         return F("LoadTaskSettings()");
+    case TimingStatsElements::SAVE_TASK_SETTINGS:         return F("SaveTaskSettings()");
+    case TimingStatsElements::LOAD_CONTROLLER_SETTINGS:   return F("LoadControllerSettings()");
+    case TimingStatsElements::TRY_OPEN_FILE:              return F("TryOpenFile()");
+    case TimingStatsElements::FS_GC_SUCCESS:              return F("ESPEASY_FS GC success");
+    case TimingStatsElements::FS_GC_FAIL:                 return F("ESPEASY_FS GC fail");
+    case TimingStatsElements::RULES_PROCESSING:           return F("rulesProcessing()");
+    case TimingStatsElements::RULES_PARSE_LINE:           return F("parseCompleteNonCommentLine()");
+    case TimingStatsElements::RULES_PROCESS_MATCHED:      return F("processMatchedRule()");
+    case TimingStatsElements::RULES_MATCH:                return F("rulesMatch()");
+    case TimingStatsElements::GRAT_ARP_STATS:             return F("sendGratuitousARP()");
+    case TimingStatsElements::SAVE_TO_RTC:                return F("saveToRTC()");
+    case TimingStatsElements::BACKGROUND_TASKS:           return F("backgroundtasks()");
+    case TimingStatsElements::PROCESS_SYSTEM_EVENT_QUEUE: return F("process_system_event_queue()");
+    case TimingStatsElements::HANDLE_SCHEDULER_IDLE:      return F("handle_schedule() idle");
+    case TimingStatsElements::HANDLE_SCHEDULER_TASK:      return F("handle_schedule() task");
+    case TimingStatsElements::PARSE_TEMPLATE_PADDED:      return F("parseTemplate_padded()");
+    case TimingStatsElements::PARSE_SYSVAR:               return F("parseSystemVariables()");
+    case TimingStatsElements::PARSE_SYSVAR_NOCHANGE:      return F("parseSystemVariables() No change");
+    case TimingStatsElements::HANDLE_SERVING_WEBPAGE:     return F("handle webpage");
+    case TimingStatsElements::HANDLE_SERVING_WEBPAGE_JSON: return F("handle webpage JSON");
+    case TimingStatsElements::WIFI_SCAN_ASYNC:            return F("WiFi Scan Async");
+    case TimingStatsElements::WIFI_SCAN_SYNC:             return F("WiFi Scan Sync (blocking)");
+    case TimingStatsElements::NTP_SUCCESS:                return F("NTP Success");
+    case TimingStatsElements::NTP_FAIL:                   return F("NTP Fail");
+    case TimingStatsElements::SYSTIME_UPDATED:            return F("Systime Set");
+    case TimingStatsElements::C018_AIR_TIME:              return F("C018 LoRa TTN - Air Time");
+#ifdef LIMIT_BUILD_SIZE
+    default: break;
+#else
+    // Include all elements of the enum, to allow the compiler to check if we missed some
+    case TimingStatsElements::C001_DELAY_QUEUE:
+    case TimingStatsElements::C002_DELAY_QUEUE:
+    case TimingStatsElements::C003_DELAY_QUEUE:
+    case TimingStatsElements::C004_DELAY_QUEUE:
+    case TimingStatsElements::C005_DELAY_QUEUE:
+    case TimingStatsElements::C006_DELAY_QUEUE:
+    case TimingStatsElements::C007_DELAY_QUEUE:
+    case TimingStatsElements::C008_DELAY_QUEUE:
+    case TimingStatsElements::C009_DELAY_QUEUE:
+    case TimingStatsElements::C010_DELAY_QUEUE:
+    case TimingStatsElements::C011_DELAY_QUEUE:
+    case TimingStatsElements::C012_DELAY_QUEUE:
+    case TimingStatsElements::C013_DELAY_QUEUE:
+    case TimingStatsElements::C014_DELAY_QUEUE:
+    case TimingStatsElements::C015_DELAY_QUEUE:
+    case TimingStatsElements::C016_DELAY_QUEUE:
+    case TimingStatsElements::C017_DELAY_QUEUE:
+    case TimingStatsElements::C018_DELAY_QUEUE:
+    case TimingStatsElements::C019_DELAY_QUEUE:
+    case TimingStatsElements::C020_DELAY_QUEUE:
+    case TimingStatsElements::C021_DELAY_QUEUE:
+    case TimingStatsElements::C022_DELAY_QUEUE:
+    case TimingStatsElements::C023_DELAY_QUEUE:
+    case TimingStatsElements::C024_DELAY_QUEUE:
+    case TimingStatsElements::C025_DELAY_QUEUE:
+      break;
+
+#endif
   }
   return F("Unknown");
 }
 
-String getMiscStatsName(int stat) {
-  if ((stat >= C001_DELAY_QUEUE) && (stat <= C025_DELAY_QUEUE)) {
+String getMiscStatsName(TimingStatsElements stat) {
+  if ((stat >= TimingStatsElements::C001_DELAY_QUEUE) && 
+      (stat <= TimingStatsElements::C025_DELAY_QUEUE)) {
     return concat(
       F("Delay queue "),
-      get_formatted_Controller_number(static_cast<cpluginID_t>(stat - C001_DELAY_QUEUE + 1)));
+      get_formatted_Controller_number(static_cast<cpluginID_t>(static_cast<int>(stat) - static_cast<int>(TimingStatsElements::C001_DELAY_QUEUE) + 1)));
   }
-  return getMiscStatsName_F(stat);
+  return getMiscStatsName_F(static_cast<TimingStatsElements>(stat));
 }
 
-void stopTimerTask(int T, int F, uint64_t statisticsTimerStart)
+void stopTimerTask(deviceIndex_t T, int F, uint64_t statisticsTimerStart)
 {
-  if (mustLogFunction(F)) { pluginStats[(T) * 256 + (F)].add(usecPassedSince(statisticsTimerStart)); }
+  if (mustLogFunction(F)) { pluginStats[static_cast<int>(T) * 256 + (F)].add(usecPassedSince(statisticsTimerStart)); }
 }
 
-void stopTimerController(int T, CPlugin::Function F, uint64_t statisticsTimerStart)
+void stopTimerController(protocolIndex_t T, CPlugin::Function F, uint64_t statisticsTimerStart)
 {
-  if (mustLogCFunction(F)) { controllerStats[(T) * 256 + static_cast<int>(F)].add(usecPassedSince(statisticsTimerStart)); }
+  if (mustLogCFunction(F)) { controllerStats[static_cast<int>(T) * 256 + static_cast<int>(F)].add(usecPassedSince(statisticsTimerStart)); }
 }
 
-void stopTimer(int L, uint64_t statisticsTimerStart)
+void stopTimer(TimingStatsElements L, uint64_t statisticsTimerStart)
 {
   if (Settings.EnableTimingStats()) { miscStats[L].add(usecPassedSince(statisticsTimerStart)); }
 }
 
-void addMiscTimerStat(int L, int64_t T)
+void addMiscTimerStat(TimingStatsElements L, int64_t T)
 {
   if (Settings.EnableTimingStats()) { miscStats[L].add(T); }
 }

--- a/src/src/DataStructs/TimingStats.h
+++ b/src/src/DataStructs/TimingStats.h
@@ -5,96 +5,102 @@
 
 #if FEATURE_TIMING_STATS
 
+# include "../DataTypes/DeviceIndex.h"
 # include "../DataTypes/ESPEasy_plugin_functions.h"
+# include "../DataTypes/ProtocolIndex.h"
 # include "../Globals/Settings.h"
 # include "../Helpers/ESPEasy_time_calc.h"
 
 # include <Arduino.h>
 # include <map>
+#endif // if FEATURE_TIMING_STATS
 
 
 /*********************************************************************************************\
 * TimingStats
 \*********************************************************************************************/
 
+// These TimingStatsElements must not be excluded when FEATURE_TIMING_STATS is not defined.
+// The Cxxx_DELAY_QUEUE defines are used in the macros to process the controller queues.
+enum class TimingStatsElements {
+  LOADFILE_STATS,
+  SAVEFILE_STATS,
+  LOOP_STATS,
+  PLUGIN_CALL_50PS,
+  PLUGIN_CALL_10PS,
+  PLUGIN_CALL_10PSU,
+  PLUGIN_CALL_1PS,
+  SENSOR_SEND_TASK,
+  CPLUGIN_CALL_10PS,
+  CPLUGIN_CALL_50PS,
+  SEND_DATA_STATS,
+  COMPUTE_FORMULA_STATS,
+  PLUGIN_CALL_DEVICETIMER_IN,
+  SET_NEW_TIMER,
+  TIME_DIFF_COMPUTE,
+  MQTT_DELAY_QUEUE,
+  C001_DELAY_QUEUE,
+  C002_DELAY_QUEUE,
+  C003_DELAY_QUEUE,
+  C004_DELAY_QUEUE,
+  C005_DELAY_QUEUE,
+  C006_DELAY_QUEUE,
+  C007_DELAY_QUEUE,
+  C008_DELAY_QUEUE,
+  C009_DELAY_QUEUE,
+  C010_DELAY_QUEUE,
+  C011_DELAY_QUEUE,
+  C012_DELAY_QUEUE,
+  C013_DELAY_QUEUE,
+  C014_DELAY_QUEUE,
+  C015_DELAY_QUEUE,
+  C016_DELAY_QUEUE,
+  C017_DELAY_QUEUE,
+  C018_DELAY_QUEUE,
+  C019_DELAY_QUEUE,
+  C020_DELAY_QUEUE,
+  C021_DELAY_QUEUE,
+  C022_DELAY_QUEUE,
+  C023_DELAY_QUEUE,
+  C024_DELAY_QUEUE,
+  C025_DELAY_QUEUE,
+  C018_AIR_TIME,
+  LOAD_TASK_SETTINGS,
+  SAVE_TASK_SETTINGS,
+  LOAD_CUSTOM_TASK_STATS,
+  LOAD_CONTROLLER_SETTINGS,
+  TRY_OPEN_FILE,
+  FS_GC_SUCCESS,
+  FS_GC_FAIL,
+  PARSE_SYSVAR,
+  PARSE_SYSVAR_NOCHANGE,
+  PARSE_TEMPLATE_PADDED,
+  RULES_PROCESSING,
+  RULES_PARSE_LINE,
+  RULES_PROCESS_MATCHED,
+  RULES_MATCH,
+  GRAT_ARP_STATS,
+  SAVE_TO_RTC,
+  BACKGROUND_TASKS,
+  PROCESS_SYSTEM_EVENT_QUEUE,
+  HANDLE_SCHEDULER_IDLE,
+  HANDLE_SCHEDULER_TASK,
+  HANDLE_SERVING_WEBPAGE,
+  HANDLE_SERVING_WEBPAGE_JSON,
+  TRY_CONNECT_HOST_TCP,
+  TRY_CONNECT_HOST_UDP,
+  HOST_BY_NAME_STATS,
+  WIFI_ISCONNECTED_STATS,
+  WIFI_NOTCONNECTED_STATS,
+  CONNECT_CLIENT_STATS,
+  WIFI_SCAN_ASYNC,
+  WIFI_SCAN_SYNC,
+  NTP_SUCCESS,
+  NTP_FAIL,
+  SYSTIME_UPDATED
+};
 
-# define LOADFILE_STATS                 0
-# define SAVEFILE_STATS                 1
-# define LOOP_STATS                     2
-# define PLUGIN_CALL_50PS               3
-# define PLUGIN_CALL_10PS               4
-# define PLUGIN_CALL_10PSU              5
-# define PLUGIN_CALL_1PS                6
-# define SENSOR_SEND_TASK               7
-# define CPLUGIN_CALL_10PS              8
-# define CPLUGIN_CALL_50PS              9
-# define SEND_DATA_STATS                10
-# define COMPUTE_FORMULA_STATS          11
-# define PLUGIN_CALL_DEVICETIMER_IN     12
-# define SET_NEW_TIMER                  13
-# define TIME_DIFF_COMPUTE              14
-# define MQTT_DELAY_QUEUE               15
-# define C001_DELAY_QUEUE               16
-# define C002_DELAY_QUEUE               17
-# define C003_DELAY_QUEUE               18
-# define C004_DELAY_QUEUE               19
-# define C005_DELAY_QUEUE               20
-# define C006_DELAY_QUEUE               21
-# define C007_DELAY_QUEUE               22
-# define C008_DELAY_QUEUE               23
-# define C009_DELAY_QUEUE               24
-# define C010_DELAY_QUEUE               25
-# define C011_DELAY_QUEUE               26
-# define C012_DELAY_QUEUE               27
-# define C013_DELAY_QUEUE               28
-# define C014_DELAY_QUEUE               29
-# define C015_DELAY_QUEUE               30
-# define C016_DELAY_QUEUE               31
-# define C017_DELAY_QUEUE               32
-# define C018_DELAY_QUEUE               33
-# define C019_DELAY_QUEUE               34
-# define C020_DELAY_QUEUE               35
-# define C021_DELAY_QUEUE               36
-# define C022_DELAY_QUEUE               37
-# define C023_DELAY_QUEUE               38
-# define C024_DELAY_QUEUE               39
-# define C025_DELAY_QUEUE               40
-# define C018_AIR_TIME                  41
-# define TRY_CONNECT_HOST_TCP           42
-# define TRY_CONNECT_HOST_UDP           43
-# define HOST_BY_NAME_STATS             44
-# define CONNECT_CLIENT_STATS           45
-# define LOAD_CUSTOM_TASK_STATS         46
-# define WIFI_ISCONNECTED_STATS         47
-# define WIFI_NOTCONNECTED_STATS        48
-# define LOAD_TASK_SETTINGS             49
-# define LOAD_TASK_SETTINGS_CACHED      50
-# define SAVE_TASK_SETTINGS             51
-# define TRY_OPEN_FILE                  52
-# define FS_GC_SUCCESS                  53
-# define FS_GC_FAIL                     54
-# define PARSE_SYSVAR                   55
-# define PARSE_SYSVAR_NOCHANGE          56
-# define PARSE_TEMPLATE_PADDED          57
-# define RULES_PROCESSING               58
-# define RULES_PARSE_LINE               59
-# define RULES_PROCESS_MATCHED          60
-# define RULES_MATCH                    61
-# define GRAT_ARP_STATS                 62
-# define SAVE_TO_RTC                    63
-# define BACKGROUND_TASKS               64
-# define PROCESS_SYSTEM_EVENT_QUEUE     65
-# define HANDLE_SCHEDULER_IDLE          66
-# define HANDLE_SCHEDULER_TASK          67
-# define HANDLE_SERVING_WEBPAGE         68
-# define HANDLE_SERVING_WEBPAGE_JSON    69
-# define WIFI_SCAN_ASYNC                70
-# define WIFI_SCAN_SYNC                 71
-# define NTP_SUCCESS                    72
-# define NTP_FAIL                       73
-# define SYSTIME_UPDATED                74
-
-
+#if FEATURE_TIMING_STATS
 class TimingStats {
 public:
 
@@ -121,22 +127,22 @@ const __FlashStringHelper* getPluginFunctionName(int function);
 bool                       mustLogFunction(int function);
 const __FlashStringHelper* getCPluginCFunctionName(CPlugin::Function function);
 bool                       mustLogCFunction(CPlugin::Function function);
-String                     getMiscStatsName(int stat);
+String                     getMiscStatsName(TimingStatsElements stat);
 
-void                       stopTimerTask(int      T,
-                                         int      F,
-                                         uint64_t statisticsTimerStart);
-void                       stopTimerController(int               T,
+void                       stopTimerTask(deviceIndex_t T,
+                                         int           F,
+                                         uint64_t      statisticsTimerStart);
+void                       stopTimerController(protocolIndex_t   T,
                                                CPlugin::Function F,
                                                uint64_t          statisticsTimerStart);
-void                       stopTimer(int      L,
-                                     uint64_t statisticsTimerStart);
-void                       addMiscTimerStat(int     L,
-                                            int64_t T);
+void                       stopTimer(TimingStatsElements L,
+                                     uint64_t            statisticsTimerStart);
+void                       addMiscTimerStat(TimingStatsElements L,
+                                            int64_t             T);
 
 extern std::map<int, TimingStats> pluginStats;
 extern std::map<int, TimingStats> controllerStats;
-extern std::map<int, TimingStats> miscStats;
+extern std::map<TimingStatsElements, TimingStats> miscStats;
 extern unsigned long timingstats_last_reset;
 
 # define START_TIMER const uint64_t statisticsTimerStart(getMicros64());
@@ -144,10 +150,11 @@ extern unsigned long timingstats_last_reset;
 # define STOP_TIMER_CONTROLLER(T, F) stopTimerController(T, F, statisticsTimerStart);
 
 // #define STOP_TIMER_LOADFILE miscStats[LOADFILE_STATS].add(usecPassedSince(statisticsTimerStart));
-# define STOP_TIMER(L) stopTimer(L, statisticsTimerStart);
+# define STOP_TIMER(L) stopTimer(TimingStatsElements::L, statisticsTimerStart);
+# define STOP_TIMER_VAR(L) stopTimer(L, statisticsTimerStart);
 
 // Add a timer statistic value in usec.
-# define ADD_TIMER_STAT(L, T) addMiscTimerStat(L, T);
+# define ADD_TIMER_STAT(L, T) addMiscTimerStat(TimingStatsElements::L, T);
 
 #else // if FEATURE_TIMING_STATS
 

--- a/src/src/DataStructs/TimingStats.h
+++ b/src/src/DataStructs/TimingStats.h
@@ -87,11 +87,12 @@
 # define HANDLE_SCHEDULER_IDLE          66
 # define HANDLE_SCHEDULER_TASK          67
 # define HANDLE_SERVING_WEBPAGE         68
-# define WIFI_SCAN_ASYNC                69
-# define WIFI_SCAN_SYNC                 70
-# define NTP_SUCCESS                    71
-# define NTP_FAIL                       72
-# define SYSTIME_UPDATED                73
+# define HANDLE_SERVING_WEBPAGE_JSON    69
+# define WIFI_SCAN_ASYNC                70
+# define WIFI_SCAN_SYNC                 71
+# define NTP_SUCCESS                    72
+# define NTP_FAIL                       73
+# define SYSTIME_UPDATED                74
 
 
 class TimingStats {

--- a/src/src/DataStructs_templ/SettingsStruct.cpp
+++ b/src/src/DataStructs_templ/SettingsStruct.cpp
@@ -23,6 +23,7 @@ SettingsStruct_tmpl<N_TASKS>::SettingsStruct_tmpl() : ResetFactoryDefaultPrefere
   clearNetworkSettings();
 }
 
+
 // VariousBits1 defaults to 0, keep in mind when adding bit lookups.
 template<unsigned int N_TASKS>
 bool SettingsStruct_tmpl<N_TASKS>::appendUnitToHostname()  const {

--- a/src/src/ESPEasyCore/ESPEasyWifi.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi.cpp
@@ -1040,7 +1040,13 @@ void WifiScan(bool async, uint8_t channel) {
       processScanDone();
     }
   }
-  STOP_TIMER(async ? WIFI_SCAN_ASYNC : WIFI_SCAN_SYNC);
+#if FEATURE_TIMING_STATS
+  if (async) {
+    STOP_TIMER(WIFI_SCAN_ASYNC);
+  } else {
+    STOP_TIMER(WIFI_SCAN_SYNC);
+  }
+#endif
 
 #ifdef ESP32
   RTC.clearLastWiFi();

--- a/src/src/ESPEasyCore/ESPEasy_loop.cpp
+++ b/src/src/ESPEasyCore/ESPEasy_loop.cpp
@@ -32,7 +32,7 @@ void updateLoopStats() {
   const int64_t usecSince = usecPassedSince(lastLoopStart);
 
   #if FEATURE_TIMING_STATS
-  miscStats[LOOP_STATS].add(usecSince);
+  ADD_TIMER_STAT(LOOP_STATS, usecSince);
   #endif // if FEATURE_TIMING_STATS
 
   loop_usec_duration_total += usecSince;

--- a/src/src/Helpers/ESPEasyStatistics.cpp
+++ b/src/src/Helpers/ESPEasyStatistics.cpp
@@ -158,7 +158,7 @@ void jsonStatistics(bool clearStats) {
     if (!x.second.isEmpty()) {
       json_open(); // open new misc item
       json_prop(F("name"), getMiscStatsName(x.first));
-      json_prop(F("id"),   String(x.first));
+      json_prop(F("id"),   String(static_cast<int>(x.first)));
       json_open(true, F("function")); // open function
       json_open(); // open first function element
       // Stream function timing stats

--- a/src/src/Helpers/ESPEasy_Storage.cpp
+++ b/src/src/Helpers/ESPEasy_Storage.cpp
@@ -1027,7 +1027,6 @@ String LoadTaskSettings(taskIndex_t TaskIndex)
     // No need to load from storage, as there is no plugin assigned to this task.
     ExtraTaskSettings.TaskIndex = TaskIndex; // Needed when an empty task was requested
     Cache.updateExtraTaskSettingsCache_afterLoad_Save();
-    STOP_TIMER(LOAD_TASK_SETTINGS_CACHED);
     return EMPTY_STRING;
   }
   #ifndef BUILD_NO_RAM_TRACKER
@@ -1172,6 +1171,7 @@ String LoadControllerSettings(controllerIndex_t ControllerIndex, ControllerSetti
   #ifndef BUILD_NO_RAM_TRACKER
   checkRAM(F("LoadControllerSettings"));
   #endif
+  START_TIMER
   String result =
     LoadFromFile(SettingsType::Enum::ControllerSettings_Type, ControllerIndex,
                  reinterpret_cast<uint8_t *>(&controller_settings), sizeof(controller_settings));
@@ -1179,6 +1179,7 @@ String LoadControllerSettings(controllerIndex_t ControllerIndex, ControllerSetti
   controller_settings.validate(); // Make sure the loaded controller settings have proper values.
 
   Cache.controllerSettings_checksums[ControllerIndex] = controller_settings.computeChecksum();
+  STOP_TIMER(LOAD_CONTROLLER_SETTINGS);
   return result;
 }
 
@@ -1710,7 +1711,7 @@ bool SpiffsFull() {
   return SpiffsFreeSpace() == 0;
 }
 
-#if FEATURE_RTC_CACHE_STORAGE
+
 /********************************************************************************************\
    Handling cached data
  \*********************************************************************************************/
@@ -1808,7 +1809,7 @@ bool getCacheFileCounters(uint16_t& lowest, uint16_t& highest, size_t& filesizeH
   highest = 0;
   return false;
 }
-#endif
+
 
 /********************************************************************************************\
    Get partition table information

--- a/src/src/Helpers/ESPEasy_Storage.cpp
+++ b/src/src/Helpers/ESPEasy_Storage.cpp
@@ -547,7 +547,7 @@ String SaveSecuritySettings() {
   SecuritySettings.validate();
   memcpy(SecuritySettings.ProgmemMd5, CRCValues.runTimeMD5, 16);
 
-  if (!COMPUTE_STRUCT_CHECKSUM_UPDATE(SecurityStruct, SecuritySettings)) {
+  if (SecuritySettings.updateChecksum()) {
     // Settings have changed, save to file.
     err = SaveToFile(SettingsType::getSettingsFileName(SettingsType::Enum::SecuritySettings_Type).c_str(), 0, reinterpret_cast<const uint8_t *>(&SecuritySettings), sizeof(SecuritySettings));
 
@@ -646,7 +646,7 @@ String LoadSettings()
   err = LoadFromFile(SettingsType::getSettingsFileName(SettingsType::Enum::SecuritySettings_Type).c_str(), 0, reinterpret_cast<uint8_t *>(&SecuritySettings), sizeof(SecurityStruct));
 
 #ifndef BUILD_NO_DEBUG
-  if (COMPUTE_STRUCT_CHECKSUM(SecurityStruct, SecuritySettings)) {
+  if (SecuritySettings.checksumMatch()) {
     addLog(LOG_LEVEL_INFO, F("CRC  : SecuritySettings CRC   ...OK "));
 
     if (memcmp(SecuritySettings.ProgmemMd5, CRCValues.runTimeMD5, 16) != 0) {
@@ -986,11 +986,9 @@ String SaveTaskSettings(taskIndex_t TaskIndex)
     ExtraTaskSettings.validate(); // Validate before saving will reduce nr of saves as it is more likely to not have changed the next time it will be saved.
 
     // Call to validate() may have changed the content, so re-compute the checksum.
-    computeChecksum(checksum, reinterpret_cast<uint8_t *>(&ExtraTaskSettings), structSize, structSize, true);
-
     // This is how it is now stored, so we can now also update the 
     // ExtraTaskSettings cache. This may prevent a reload.
-    Cache.updateExtraTaskSettingsCache(checksum);
+    Cache.updateExtraTaskSettingsCache_afterLoad_Save();
 
     err = SaveToFile(SettingsType::Enum::TaskSettings_Type,
                             TaskIndex,
@@ -1032,9 +1030,7 @@ String LoadTaskSettings(taskIndex_t TaskIndex)
   if (!validDeviceIndex(DeviceIndex)) {
     // No need to load from storage, as there is no plugin assigned to this task.
     ExtraTaskSettings.TaskIndex = TaskIndex; // Needed when an empty task was requested
-    uint8_t checksum[16] = {0};
-    computeChecksum(checksum, reinterpret_cast<uint8_t *>(&ExtraTaskSettings), structSize, structSize, true);
-    Cache.updateExtraTaskSettingsCache(checksum);
+    Cache.updateExtraTaskSettingsCache_afterLoad_Save();
     STOP_TIMER(LOAD_TASK_SETTINGS_CACHED);
     return EMPTY_STRING;
   }
@@ -1068,9 +1064,7 @@ String LoadTaskSettings(taskIndex_t TaskIndex)
     PluginCall(PLUGIN_GET_DEVICEVALUENAMES, &TempEvent, tmp);
   }
   ExtraTaskSettings.validate();
-  uint8_t checksum[16] = {0};
-  computeChecksum(checksum, reinterpret_cast<uint8_t *>(&ExtraTaskSettings), structSize, structSize, true);
-  Cache.updateExtraTaskSettingsCache(checksum);
+  Cache.updateExtraTaskSettingsCache_afterLoad_Save();
   STOP_TIMER(LOAD_TASK_SETTINGS);
 
   return result;
@@ -1157,9 +1151,14 @@ String SaveControllerSettings(controllerIndex_t ControllerIndex, ControllerSetti
   #ifndef BUILD_NO_RAM_TRACKER
   checkRAM(F("SaveControllerSettings"));
   #endif
+  if (controller_settings.computeChecksum() == (Cache.controllerSettings_checksums[ControllerIndex])) {
+    return EMPTY_STRING;
+  }
   controller_settings.validate(); // Make sure the saved controller settings have proper values.
-  return SaveToFile(SettingsType::Enum::ControllerSettings_Type, ControllerIndex,
+  const String res = SaveToFile(SettingsType::Enum::ControllerSettings_Type, ControllerIndex,
                     reinterpret_cast<const uint8_t *>(&controller_settings), sizeof(controller_settings));
+  Cache.controllerSettings_checksums[ControllerIndex] = controller_settings.computeChecksum();
+  return res;
 }
 
 /********************************************************************************************\
@@ -1173,6 +1172,7 @@ String LoadControllerSettings(controllerIndex_t ControllerIndex, ControllerSetti
     LoadFromFile(SettingsType::Enum::ControllerSettings_Type, ControllerIndex,
                  reinterpret_cast<uint8_t *>(&controller_settings), sizeof(controller_settings));
   controller_settings.validate(); // Make sure the loaded controller settings have proper values.
+  Cache.controllerSettings_checksums[ControllerIndex] = controller_settings.computeChecksum();
   return result;
 }
 

--- a/src/src/Helpers/ESPEasy_Storage.h
+++ b/src/src/Helpers/ESPEasy_Storage.h
@@ -64,6 +64,7 @@ int  getPartionCount(uint8_t pType, uint8_t pSubType = 0xFF);
 bool GarbageCollection();
 
 
+// Macros needed for template class types, like SettingsStruct
 #define COMPUTE_STRUCT_CHECKSUM_UPDATE(STRUCT,OBJECT) \
    ChecksumType::computeChecksum(OBJECT.md5,\
                    reinterpret_cast<uint8_t *>(&OBJECT),\

--- a/src/src/Helpers/ESPEasy_Storage.h
+++ b/src/src/Helpers/ESPEasy_Storage.h
@@ -294,6 +294,7 @@ size_t SpiffsFreeSpace();
 
 bool SpiffsFull();
 
+#if FEATURE_RTC_CACHE_STORAGE
 /********************************************************************************************\
    Handling cached data
  \*********************************************************************************************/
@@ -305,6 +306,7 @@ int getCacheFileCountFromFilename(const String& fname);
 // Look into the filesystem to see if there are any cache files present on the filesystem
 // Return true if any found.
 bool getCacheFileCounters(uint16_t& lowest, uint16_t& highest, size_t& filesizeHighest);
+#endif
 
 /********************************************************************************************\
    Get partition table information

--- a/src/src/Helpers/ESPEasy_Storage.h
+++ b/src/src/Helpers/ESPEasy_Storage.h
@@ -6,11 +6,13 @@
 
 #include "../Helpers/FS_Helper.h"
 
+#include "../DataStructs/ChecksumType.h"
 #include "../DataStructs/ProvisioningStruct.h"
 #include "../DataTypes/ESPEasyFileType.h"
 #include "../DataTypes/SettingsType.h"
 #include "../Globals/Plugins.h"
 #include "../Globals/CPlugins.h"
+
 
 /********************************************************************************************\
    file system error handling
@@ -61,26 +63,16 @@ int  getPartionCount(uint8_t pType, uint8_t pSubType = 0xFF);
  \*********************************************************************************************/
 bool GarbageCollection();
 
-// Compute checksum of the data.
-// Skip the part where the checksum may be located in the data
-// @param checksum The expected checksum. Will contain checksum after call finished.
-// @retval true when checksum matches
-bool computeChecksum(
-  uint8_t checksum[16], 
-  uint8_t * data, 
-  size_t struct_size, 
-  size_t len_upto_md5,
-  bool updateChecksum = true);
 
 #define COMPUTE_STRUCT_CHECKSUM_UPDATE(STRUCT,OBJECT) \
-   computeChecksum(OBJECT.md5,\
+   ChecksumType::computeChecksum(OBJECT.md5,\
                    reinterpret_cast<uint8_t *>(&OBJECT),\
                    sizeof(STRUCT),\
                    offsetof(STRUCT, md5),\
                    true)
 
 #define COMPUTE_STRUCT_CHECKSUM(STRUCT,OBJECT) \
-   computeChecksum(OBJECT.md5,\
+   ChecksumType::computeChecksum(OBJECT.md5,\
                    reinterpret_cast<uint8_t *>(&OBJECT),\
                    sizeof(STRUCT),\
                    offsetof(STRUCT, md5),\

--- a/src/src/Helpers/ESPEasy_Storage.h
+++ b/src/src/Helpers/ESPEasy_Storage.h
@@ -294,7 +294,7 @@ size_t SpiffsFreeSpace();
 
 bool SpiffsFull();
 
-#if FEATURE_RTC_CACHE_STORAGE
+
 /********************************************************************************************\
    Handling cached data
  \*********************************************************************************************/
@@ -306,7 +306,7 @@ int getCacheFileCountFromFilename(const String& fname);
 // Look into the filesystem to see if there are any cache files present on the filesystem
 // Return true if any found.
 bool getCacheFileCounters(uint16_t& lowest, uint16_t& highest, size_t& filesizeHighest);
-#endif
+
 
 /********************************************************************************************\
    Get partition table information

--- a/src/src/Helpers/Networking.cpp
+++ b/src/src/Helpers/Networking.cpp
@@ -35,7 +35,7 @@
 
 #include <IPAddress.h>
 #include <base64.h>
-#include <MD5Builder.h>
+#include <MD5Builder.h> // for getDigestAuth
 
 #include <lwip/dns.h>
 

--- a/src/src/Helpers/StringConverter.cpp
+++ b/src/src/Helpers/StringConverter.cpp
@@ -680,6 +680,9 @@ bool safe_strncpy(char *dest, const char *source, size_t max_size) {
     result     = false;
   }
   strncpy_P(dest, source, str_length);
+  for (size_t i = str_length; i < max_size; ++i) {
+    dest[i] = 0;
+  }
   dest[max_size - 1] = 0;
   return result;
 }

--- a/src/src/Helpers/StringConverter.cpp
+++ b/src/src/Helpers/StringConverter.cpp
@@ -680,9 +680,6 @@ bool safe_strncpy(char *dest, const char *source, size_t max_size) {
     result     = false;
   }
   strncpy_P(dest, source, str_length);
-  for (size_t i = str_length; i < max_size; ++i) {
-    dest[i] = 0;
-  }
   dest[max_size - 1] = 0;
   return result;
 }

--- a/src/src/PluginStructs/P050_data_struct.h
+++ b/src/src/PluginStructs/P050_data_struct.h
@@ -7,7 +7,7 @@
 # include <Adafruit_TCS34725.h>
 
 typedef struct {
-  float matrix[3][3];
+  float matrix[3][3]={};
 } tcsTransformationSettings_t;
 
 struct P050_data_struct : public PluginTaskData_base {

--- a/src/src/PluginStructs/P062_data_struct.h
+++ b/src/src/PluginStructs/P062_data_struct.h
@@ -44,10 +44,10 @@ public:
   };
 
   struct tP062_StoredSettings_struct {
-    tP062_Sensitivity TouchObjects[P062_MaxTouchObjects];
+    tP062_Sensitivity TouchObjects[P062_MaxTouchObjects] = {};
   };
 
-  tP062_StoredSettings_struct StoredSettings;
+  tP062_StoredSettings_struct StoredSettings{};
 
   /**
    * Structs for Calbration values

--- a/src/src/PluginStructs/P109_data_struct.h
+++ b/src/src/PluginStructs/P109_data_struct.h
@@ -105,7 +105,7 @@ private:
   String _title;
   bool   _alternateTitle = true;
 
-  char _deviceTemplate[P109_Nlines][P109_Nchars];
+  char _deviceTemplate[P109_Nlines][P109_Nchars] = {};
 
   bool _initialized  = false;
   bool _showWiFiName = true;

--- a/src/src/WebServer/ControllerPage.cpp
+++ b/src/src/WebServer/ControllerPage.cpp
@@ -54,6 +54,10 @@ void handle_controllers() {
       if (!AllocatedControllerSettings()) {
         addHtmlError(F("Not enough free memory to save settings"));
       } else {
+        // Need to make sure every byte between the members is also zero
+        // Otherwise the checksum will fail and settings will be saved too often.
+        memset(&ControllerSettings, 0, sizeof(ControllerSettingsStruct));
+        ControllerSettings.reset();
         if (Settings.Protocol[controllerindex] != protocol)
         {
           // Protocol has changed.

--- a/src/src/WebServer/FileList.cpp
+++ b/src/src/WebServer/FileList.cpp
@@ -180,9 +180,7 @@ void handle_filelist() {
   int count = -1;
 
   bool moreFilesPresent  = false;
-#if FEATURE_RTC_CACHE_STORAGE
   bool cacheFilesPresent = false;
-#endif
 
 # if defined(ESP8266)
 
@@ -200,12 +198,10 @@ void handle_filelist() {
       if (f) {
         filesize = f.size();
       }
-#if FEATURE_RTC_CACHE_STORAGE
       if (!cacheFilesPresent && (getCacheFileCountFromFilename(dir.fileName()) != -1))
       {
         cacheFilesPresent = true;
       }
-#endif
       handle_filelist_add_file(dir.fileName(), filesize, startIdx);
     }
   }
@@ -222,12 +218,10 @@ void handle_filelist() {
 
       if (count >= startIdx)
       {
-#if FEATURE_RTC_CACHE_STORAGE
         if (!cacheFilesPresent && (getCacheFileCountFromFilename(file.name()) != -1))
         {
           cacheFilesPresent = true;
         }
-#endif
         handle_filelist_add_file(file.name(), file.size(), startIdx);
       }
     }
@@ -247,11 +241,7 @@ void handle_filelist() {
   if ((count >= endIdx) && moreFilesPresent) {
     start_next = endIdx + 1;
   }
-#if FEATURE_RTC_CACHE_STORAGE
   handle_filelist_buttons(start_prev, start_next, cacheFilesPresent);
-#else
-  handle_filelist_buttons(start_prev, start_next, false);
-#endif
 }
 
 void handle_filelist_add_file(const String& filename, int filesize, int startIdx) {
@@ -304,12 +294,10 @@ void handle_filelist_buttons(int start_prev, int start_next, bool cacheFilesPres
     addHtmlInt(start_next);
     addHtml(F("'>Next</a>"));
   }
-#if FEATURE_RTC_CACHE_STORAGE
   if (cacheFilesPresent) {
     html_add_button_prefix(F("red"), true);
     addHtml(F("filelist?delcache=1'>Delete Cache Files</a>"));
   }
-#endif
   addHtml(F("<BR><BR>"));
   sendHeadandTail_stdtemplate(_TAIL);
   TXBuffer.endStream();

--- a/src/src/WebServer/FileList.cpp
+++ b/src/src/WebServer/FileList.cpp
@@ -180,7 +180,9 @@ void handle_filelist() {
   int count = -1;
 
   bool moreFilesPresent  = false;
+#if FEATURE_RTC_CACHE_STORAGE
   bool cacheFilesPresent = false;
+#endif
 
 # if defined(ESP8266)
 
@@ -198,11 +200,12 @@ void handle_filelist() {
       if (f) {
         filesize = f.size();
       }
-
+#if FEATURE_RTC_CACHE_STORAGE
       if (!cacheFilesPresent && (getCacheFileCountFromFilename(dir.fileName()) != -1))
       {
         cacheFilesPresent = true;
       }
+#endif
       handle_filelist_add_file(dir.fileName(), filesize, startIdx);
     }
   }
@@ -219,10 +222,12 @@ void handle_filelist() {
 
       if (count >= startIdx)
       {
+#if FEATURE_RTC_CACHE_STORAGE
         if (!cacheFilesPresent && (getCacheFileCountFromFilename(file.name()) != -1))
         {
           cacheFilesPresent = true;
         }
+#endif
         handle_filelist_add_file(file.name(), file.size(), startIdx);
       }
     }
@@ -242,7 +247,11 @@ void handle_filelist() {
   if ((count >= endIdx) && moreFilesPresent) {
     start_next = endIdx + 1;
   }
+#if FEATURE_RTC_CACHE_STORAGE
   handle_filelist_buttons(start_prev, start_next, cacheFilesPresent);
+#else
+  handle_filelist_buttons(start_prev, start_next, false);
+#endif
 }
 
 void handle_filelist_add_file(const String& filename, int filesize, int startIdx) {
@@ -295,11 +304,12 @@ void handle_filelist_buttons(int start_prev, int start_next, bool cacheFilesPres
     addHtmlInt(start_next);
     addHtml(F("'>Next</a>"));
   }
-
+#if FEATURE_RTC_CACHE_STORAGE
   if (cacheFilesPresent) {
     html_add_button_prefix(F("red"), true);
     addHtml(F("filelist?delcache=1'>Delete Cache Files</a>"));
   }
+#endif
   addHtml(F("<BR><BR>"));
   sendHeadandTail_stdtemplate(_TAIL);
   TXBuffer.endStream();

--- a/src/src/WebServer/JSON.cpp
+++ b/src/src/WebServer/JSON.cpp
@@ -105,6 +105,7 @@ void handle_csvval()
 // ********************************************************************************
 void handle_json()
 {
+  START_TIMER
   const taskIndex_t taskNr    = getFormItemInt(F("tasknr"), INVALID_TASK_INDEX);
   const bool showSpecificTask = validTaskIndex(taskNr);
   bool showSystem             = true;
@@ -496,6 +497,7 @@ void handle_json()
   }
 
   TXBuffer.endStream();
+  STOP_TIMER(HANDLE_SERVING_WEBPAGE_JSON);
 }
 
 // ********************************************************************************

--- a/src/src/WebServer/JSON.cpp
+++ b/src/src/WebServer/JSON.cpp
@@ -6,6 +6,8 @@
 
 #include "../CustomBuild/CompiletimeDefines.h"
 
+#include "../DataStructs/TimingStats.h"
+
 #include "../Globals/Cache.h"
 #include "../Globals/Nodes.h"
 #include "../Globals/Device.h"


### PR DESCRIPTION
The ControllerSettingsStruct has some 'gaps' between members.
Thus the heap-allocated struct may not be the same even though its content is the same.
By properly clearing the struct and then filling its content before saving, the checksum can be used to decide whether a file has changed or not.