### PR TITLE
[WiFi] Workaround Arduino ESP8266 issue, correct TaskExit event generation

### DIFF
--- a/src/src/ESPEasyCore/ESPEasyWifi.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi.cpp
@@ -1449,10 +1449,10 @@ void setupStaticIPconfig() {
   setUseStaticIP(WiFiUseStaticIP());
 
   if (!WiFiUseStaticIP()) { return; }
-  const IPAddress ip     = IPAddress(Settings.IP);
-  const IPAddress gw     = IPAddress(Settings.Gateway);
-  const IPAddress subnet = IPAddress(Settings.Subnet);
-  const IPAddress dns    = IPAddress(Settings.DNS);
+  const IPAddress ip     (Settings.IP);
+  const IPAddress gw     (Settings.Gateway);
+  const IPAddress subnet (Settings.Subnet);
+  const IPAddress dns    (Settings.DNS);
 
   WiFiEventData.dns0_cache = dns;
 

--- a/src/src/ESPEasyCore/ESPEasyWifi.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi.cpp
@@ -1449,12 +1449,12 @@ void setupStaticIPconfig() {
   setUseStaticIP(WiFiUseStaticIP());
 
   if (!WiFiUseStaticIP()) { return; }
-  const IPAddress ip     = Settings.IP;
-  const IPAddress gw     = Settings.Gateway;
-  const IPAddress subnet = Settings.Subnet;
-  const IPAddress dns    = Settings.DNS;
+  const IPAddress ip     = IPAddress(Settings.IP);
+  const IPAddress gw     = IPAddress(Settings.Gateway);
+  const IPAddress subnet = IPAddress(Settings.Subnet);
+  const IPAddress dns    = IPAddress(Settings.DNS);
 
-  WiFiEventData.dns0_cache = Settings.DNS;
+  WiFiEventData.dns0_cache = dns;
 
   WiFi.config(ip, gw, subnet, dns);
 

--- a/src/src/Globals/Plugins.cpp
+++ b/src/src/Globals/Plugins.cpp
@@ -694,9 +694,9 @@ bool PluginCall(uint8_t Function, struct EventStruct *event, String& str)
           queueTaskEvent(F("TaskInit"), event->TaskIndex, retval);
         }
         if (Function == PLUGIN_EXIT) {
-          queueTaskEvent(F("TaskExit"), event->TaskIndex, retval);
           clearPluginTaskData(event->TaskIndex);
           initSerial();
+          queueTaskEvent(F("TaskExit"), event->TaskIndex, retval);
           updateActiveTaskUseSerial0();
         }
         STOP_TIMER_TASK(DeviceIndex, Function);

--- a/src/src/Globals/Plugins.cpp
+++ b/src/src/Globals/Plugins.cpp
@@ -694,9 +694,9 @@ bool PluginCall(uint8_t Function, struct EventStruct *event, String& str)
           queueTaskEvent(F("TaskInit"), event->TaskIndex, retval);
         }
         if (Function == PLUGIN_EXIT) {
+          queueTaskEvent(F("TaskExit"), event->TaskIndex, retval);
           clearPluginTaskData(event->TaskIndex);
           initSerial();
-          queueTaskEvent(F("TaskExit"), event->TaskIndex, retval);
           updateActiveTaskUseSerial0();
         }
         STOP_TIMER_TASK(DeviceIndex, Function);

--- a/src/src/WebServer/AccessControl.cpp
+++ b/src/src/WebServer/AccessControl.cpp
@@ -58,8 +58,8 @@ bool getIPallowedRange(IPAddress& low, IPAddress& high)
       }
       return getSubnetRange(low, high);
     case ONLY_IP_RANGE_ALLOWED:
-      low  = SecuritySettings.AllowedIPrangeLow;
-      high = SecuritySettings.AllowedIPrangeHigh;
+      low  = IPAddress(SecuritySettings.AllowedIPrangeLow);
+      high = IPAddress(SecuritySettings.AllowedIPrangeHigh);
       break;
     default:
       low  = IPAddress(0, 0, 0, 0);

--- a/src/src/WebServer/DevicesPage.cpp
+++ b/src/src/WebServer/DevicesPage.cpp
@@ -386,6 +386,10 @@ void handle_devices_CopySubmittedSettings(taskIndex_t taskIndex, pluginID_t task
   }
   ExtraTaskSettings.clearUnusedValueNames(valueCount);
 
+  // ExtraTaskSettings has changed.
+  // The content of it is needed for sending CPLUGIN_TASK_CHANGE_NOTIFICATION and TaskInit/TaskExit events
+  Cache.updateExtraTaskSettingsCache();
+
   // allow the plugin to save plugin-specific form settings.
   {
     String dummy;
@@ -406,8 +410,7 @@ void handle_devices_CopySubmittedSettings(taskIndex_t taskIndex, pluginID_t task
     }    
   }
 
-  // ExtraTaskSetting has changed.
-  // The content of it is needed for sending CPLUGIN_TASK_CHANGE_NOTIFICATION
+  // ExtraTaskSettings may have changed during PLUGIN_WEBFORM_SAVE, so again update the cache.
   Cache.updateExtraTaskSettingsCache();
 
   // notify controllers: CPlugin::Function::CPLUGIN_TASK_CHANGE_NOTIFICATION


### PR DESCRIPTION
Adjustments for:
- Workaround for ESP8266 Arduino issue in `IPAddress::operator=` (See: https://github.com/esp8266/Arduino/issues/8817)
- Fix `TaskExit` event to include the Taskname