### PR TITLE
Added Start and End Pixel feature for scan and dualscan modes

### DIFF
--- a/docs/source/Plugin/P128_commands.repl
+++ b/docs/source/Plugin/P128_commands.repl
@@ -88,12 +88,12 @@
     | Run a theatre effect across the pixels, using optional backgroundcolor, count (default: 1) and speed values (range: -50..50, default: 25, negative = reverse). Colors are to be specified in a hex RRGGBB value.
     "
     "
-    | ``nfx,scan,<color>[,backgroundcolor[,speed]]``
+    | ``nfx,scan,<color>[,backgroundcolor[,speed[,startpixel[,endpixel]]]]``
     ","
     | Run a scan effect across the pixels, using optional backgroundcolor and speed values (range: -50..50, default: 25, negative = reverse). Colors are to be specified in a hex RRGGBB value.
     "
     "
-    | ``nfx,dualscan,<color>[,backgroundcolor[,speed]]``
+    | ``nfx,dualscan,<color>[,backgroundcolor[,speed[,startpixel[,endpixel]]]]``
     ","
     | Run a dual scan effect, 2 scans in opposite direction, across the pixels, using optional backgroundcolor and speed values (range: -50..50, default: 25, negative = reverse). Colors are to be specified in a hex RRGGBB value.
     "

--- a/src/_P128_NeoPixelBusFX.ino
+++ b/src/_P128_NeoPixelBusFX.ino
@@ -63,9 +63,9 @@
 
    nfx theatre color [backgroundcolor] [count] [speed]
 
-   nfx scan color [backgroundcolor] [speed]
+   nfx scan color [backgroundcolor] [speed] [startpixel] [endpixel]
 
-   nfx dualscan color [backgroundcolor] [speed]
+   nfx dualscan color [backgroundcolor] [speed] [startpixel] [endpixel]
 
    nfx twinkle color [backgroundcolor] [speed]
 

--- a/src/src/PluginStructs/P128_data_struct.cpp
+++ b/src/src/PluginStructs/P128_data_struct.cpp
@@ -363,7 +363,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
 
       _counter_mode_step = 0;
 
-      hex2rrggbb("000000");
+      hex2rrggbb(F("000000"));
     /*CLEAN ALL PIXELS */
       for (int i = 0; i < pixelCount; i++) {
       Plugin_128_pixels->SetPixelColor(i, rrggbb);
@@ -376,7 +376,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
           ? defaultspeed
           : str5i;
       ledi = str6.isEmpty()
-          ? int(1)
+          ? 1
           : str6i;
       ledf = str7.isEmpty()
           ? pixelCount
@@ -389,7 +389,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
       mode    = P128_modetype::Dualscan;
 
       _counter_mode_step = 0;
- hex2rrggbb("000000");
+ hex2rrggbb(F("000000"));
     /*CLEAN ALL PIXELS */
       for (int i = 0; i < pixelCount; i++) {
       Plugin_128_pixels->SetPixelColor(i, rrggbb);
@@ -402,7 +402,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
           ? defaultspeed
           : str5i;
        ledi = str6.isEmpty()
-          ? int(1)
+          ? 1
           : str6i;
        ledf = str7.isEmpty()
           ? pixelCount
@@ -464,7 +464,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
       if (!str4.isEmpty()) {
         hex2rrggbb(str4);
       } else {
-        hex2rrggbb("000000");
+        hex2rrggbb(F("000000"));
       }
 
       speed = str5.isEmpty()
@@ -483,7 +483,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
       if (!str4.isEmpty()) {
         hex2rrggbb(str4);
       } else {
-        hex2rrggbb("000000");
+        hex2rrggbb(F("000000"));
       }
 
       speed = str5.isEmpty()

--- a/src/src/PluginStructs/P128_data_struct.h
+++ b/src/src/PluginStructs/P128_data_struct.h
@@ -2335,7 +2335,9 @@ private:
   const uint8_t  maxBright = 0;
 
   int16_t fadedelay = 20;
-
+  
+  uint16_t ledi = 0;
+  uint16_t ledf = 0;
 
   int8_t defaultspeed  = 25;
   int8_t rainbowspeed  = 1;


### PR DESCRIPTION
Hi friends! This is my litlle contribution to the library that I use in my projects ( https://www.youtube.com/watch?v=5eGMTzRoKV4 ).
I have a led controled bins for storage, and I want to add effects to my bins. 
But I need run effects only in litlle part of the led string.

I added two optional parameters to the scan and dualscan functions, startpixel and endpixel. 
Thank for your work, and I hope you can add my litle contribution to the project.
Best Regards.
