### PR TITLE
[P042] Reduce size by minifying js scripts, implement jscolor latest updates

### DIFF
--- a/src/_P042_Candle.ino
+++ b/src/_P042_Candle.ino
@@ -1,8 +1,9 @@
 #include "_Plugin_Helper.h"
 #ifdef USES_P042
-//#######################################################################################################
-//######################################## Plugin 042: NeoPixel Candle ##################################
-//#######################################################################################################
+
+// #######################################################################################################
+// ######################################## Plugin 042: NeoPixel Candle ##################################
+// #######################################################################################################
 
 // PROJECT INFO
 // Wifi Candle for ESPEasy by Dominik Schmidt (10.2016)
@@ -57,14 +58,14 @@
 // https://www.ruinelli.ch/rgb-to-hsv               Code
 // http://stackoverflow.com/questions/3018313/algorithm-to-convert-rgb-to-hsv-and-hsv-to-rgb-in-range-0-255-for-both    Code Sammlung
 
-#include <Adafruit_NeoPixel.h>
+# include <Adafruit_NeoPixel.h>
 
 
-#define NUM_PIXEL       20         // Defines the amount of LED Pixel
-#define NUM_PIXEL_ROW    5         // Defines the amount of LED Pixel per Row
-#define RANDOM_PIXEL    70         // Defines the Flicker Level for Simple Candle
-#define BRIGHT_START   128         // Defines the Start Brightness
-#define BASE_TEMP       21         // Defines the Base Temp for TempRange Transformation
+# define NUM_PIXEL       20 // Defines the amount of LED Pixel
+# define NUM_PIXEL_ROW    5 // Defines the amount of LED Pixel per Row
+# define RANDOM_PIXEL    70 // Defines the Flicker Level for Simple Candle
+# define BRIGHT_START   128 // Defines the Start Brightness
+# define BASE_TEMP       21 // Defines the Base Temp for TempRange Transformation
 
 enum SimType {
   TypeOff,
@@ -82,27 +83,27 @@ enum ColorType {
   ColorSelected
 };
 
-uint8_t Candle_red = 0;
-uint8_t Candle_green = 0;
-uint8_t Candle_blue = 0;
-uint8_t Candle_bright = 128;
-SimType Candle_type = TypeSimpleCandle;
-ColorType Candle_color = ColorDefault;
+uint8_t   Candle_red    = 0;
+uint8_t   Candle_green  = 0;
+uint8_t   Candle_blue   = 0;
+uint8_t   Candle_bright = 128;
+SimType   Candle_type   = TypeSimpleCandle;
+ColorType Candle_color  = ColorDefault;
 
 // global variables
 unsigned long Candle_Update = 0;
-word Candle_Temp[4] = { 0, 0, 0 };     // Temp variables
-int Candle_Temp4 = 0;
-boolean GPIO_Set = false;
+word Candle_Temp[4]         = { 0, 0, 0 }; // Temp variables
+int  Candle_Temp4           = 0;
+boolean GPIO_Set            = false;
 
 Adafruit_NeoPixel *Candle_pixels;
 
-#define PLUGIN_042
-#define PLUGIN_ID_042         42
-#define PLUGIN_NAME_042       "Output - NeoPixel (Candle)"
-#define PLUGIN_VALUENAME1_042 "Color"
-#define PLUGIN_VALUENAME2_042 "Brightness"
-#define PLUGIN_VALUENAME3_042 "Type"
+# define PLUGIN_042
+# define PLUGIN_ID_042         42
+# define PLUGIN_NAME_042       "Output - NeoPixel (Candle)"
+# define PLUGIN_VALUENAME1_042 "Color"
+# define PLUGIN_VALUENAME2_042 "Brightness"
+# define PLUGIN_VALUENAME3_042 "Type"
 
 boolean Plugin_042(uint8_t function, struct EventStruct *event, String& string)
 {
@@ -110,397 +111,412 @@ boolean Plugin_042(uint8_t function, struct EventStruct *event, String& string)
 
   switch (function)
   {
-
     case PLUGIN_DEVICE_ADD:
-      {
-        Device[++deviceCount].Number = PLUGIN_ID_042;
-        Device[deviceCount].Type = DEVICE_TYPE_SINGLE;
-        Device[deviceCount].VType = Sensor_VType::SENSOR_TYPE_TRIPLE;
-        Device[deviceCount].Ports = 0;
-        Device[deviceCount].PullUpOption = false;
-        Device[deviceCount].InverseLogicOption = false;
-        Device[deviceCount].FormulaOption = false;
-        Device[deviceCount].ValueCount = 3;
-        Device[deviceCount].SendDataOption = true;
-        Device[deviceCount].TimerOption = true;
-        Device[deviceCount].GlobalSyncOption = false;
-        break;
-      }
+    {
+      Device[++deviceCount].Number           = PLUGIN_ID_042;
+      Device[deviceCount].Type               = DEVICE_TYPE_SINGLE;
+      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TRIPLE;
+      Device[deviceCount].Ports              = 0;
+      Device[deviceCount].PullUpOption       = false;
+      Device[deviceCount].InverseLogicOption = false;
+      Device[deviceCount].FormulaOption      = false;
+      Device[deviceCount].ValueCount         = 3;
+      Device[deviceCount].SendDataOption     = true;
+      Device[deviceCount].TimerOption        = true;
+      Device[deviceCount].GlobalSyncOption   = false;
+      break;
+    }
 
     case PLUGIN_GET_DEVICENAME:
-      {
-        string = F(PLUGIN_NAME_042);
-        break;
-      }
+    {
+      string = F(PLUGIN_NAME_042);
+      break;
+    }
 
     case PLUGIN_GET_DEVICEVALUENAMES:
-      {
-        strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[0], PSTR(PLUGIN_VALUENAME1_042));
-        strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[1], PSTR(PLUGIN_VALUENAME2_042));
-        strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[2], PSTR(PLUGIN_VALUENAME3_042));
-        break;
-      }
+    {
+      strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[0], PSTR(PLUGIN_VALUENAME1_042));
+      strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[1], PSTR(PLUGIN_VALUENAME2_042));
+      strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[2], PSTR(PLUGIN_VALUENAME3_042));
+      break;
+    }
 
     case PLUGIN_GET_DEVICEGPIONAMES:
-      {
-        event->String1 = formatGpioName_output(F("Data"));
-        break;
-      }
-      
+    {
+      event->String1 = formatGpioName_output(F("Data"));
+      break;
+    }
+
     case PLUGIN_WEBFORM_LOAD:
+    {
+      addHtml(F("<script src=\"jscolor.min.js\"></script>\n"));
+
       {
-        addHtml(F("<script src=\"jscolor.min.js\"></script>\n"));
+        const __FlashStringHelper *options[8] = {
+          F("Off"),
+          F("Static Light"),
+          F("Simple Candle"),
+          F("Advanced Candle"),
+          F("Police"),
+          F("Blink"),
+          F("Strobe"),
+          F("Color Fader")
+        };
 
+        // int optionValues[8];
+
+        uint8_t choice = PCONFIG(4);
+
+        if (choice > sizeof(options) - 1)
         {
-          const __FlashStringHelper * options[8] = {
-            F("Off"),
-            F("Static Light"),
-            F("Simple Candle"),
-            F("Advanced Candle"),
-            F("Police"),
-            F("Blink"),
-            F("Strobe"),
-            F("Color Fader")
-          };
-          // int optionValues[8];
-
-          uint8_t choice = PCONFIG(4);
-          if (choice > sizeof(options) - 1)
-          {
-            choice = 2;
-          }
-
-          // Candle Type Selection
-          addFormSelector(F("Flame Type"), F("cType"), 8, options, nullptr, choice);
+          choice = 2;
         }
 
-        // Advanced Color options
-        Candle_color = static_cast<ColorType>(PCONFIG(5));
-        addRowLabel(F("Color Handling")); // checked
-        addHtml(F("<input type='radio' id='clrDefault' name='clrType' value='0'"));
-        if (Candle_color == ColorDefault) {
-          addHtml(F(" checked>"));
-        } else {
-          addHtml('>');
-        }
-        addHtml(F("<label for='clrDefault'> Use default color</label><br>"));
-        addHtml(F("<input type='radio' id='clrSelect' name='clrType' value='1'"));
-        if (Candle_color == ColorSelected) {
-          addHtml(F(" checked>"));
-        } else {
-          addHtml('>');
-        }
-        addHtml(F("<label for='clrSelect'> Use selected color</label><br>"));
-
-        // Color Selection
-        // char hexvalue[7] = {0};
-        // sprintf_P(hexvalue, PSTR("%02X%02X%02X"),     // Create Hex value for color
-        //           PCONFIG(0),
-        //           PCONFIG(1),
-        //           PCONFIG(2));
-
-        // http://jscolor.com/examples/
-        addRowLabel(F("Color"));
-        addHtml(F("<input data-jscolor=\"{onInput:'update(this)',position:'top',value:'#"));
-        addHtml(formatToHex_no_prefix(PCONFIG(0), 2));
-        addHtml(formatToHex_no_prefix(PCONFIG(1), 2));
-        addHtml(formatToHex_no_prefix(PCONFIG(2), 2));
-        addHtml(F("'}\">"));
-        addFormNumericBox(F("RGB Color"), F("wRed"), PCONFIG(0), 0, 255);
-        addNumericBox(F("wGreen"), PCONFIG(1), 0, 255);
-        addNumericBox(F("wBlue"), PCONFIG(2), 0, 255);
-
-        // Brightness Selection
-        addRowLabel(F("Brightness"));
-        addHtml(F("min<input type='range' id='brSlide' min='0' max='255' value='"));
-        addHtmlInt(PCONFIG(3));
-        addHtml(F("'> max"));
-
-        {
-          // char tmpString[128];
-          // sprintf_P(tmpString, PSTR("<input type='text' name='brText' id='brText' size='3' value='%u'>"), PCONFIG(3));
-          // addHtml(concat(F("<input type='text' name='brText' id='brText' size='3' value='"),) + F("'>"));
-          addFormNumericBox(F("Brightness Value"), F("brText"), PCONFIG(3), 0, 255);
-        }
-
-        // Some Javascript we need to update the items
-        addHtml(F("<script script type='text/javascript'>"));
-        // "function update(picker) {"
-        // "    document.getElementById('wRed').value = Math.round(picker.rgb[0]);"
-        // "    document.getElementById('wGreen').value = Math.round(picker.rgb[1]);"
-        // "    document.getElementById('wBlue').value = Math.round(picker.rgb[2]);"
-        // '}'
-        // Minified:
-        addHtml(F("function update(e){document.getElementById('wRed').value=Math.round(e.channel('R')),document.getElementById('wGreen').value=Math.round(e.channel('G')),document.getElementById('wBlue').value=Math.round(e.channel('B'))}"));
-
-        // "window.addEventListener('load', function(){"
-        // "var slider = document.getElementById('brSlide');"
-        // "slider.addEventListener('change', function(){"
-        // "document.getElementById('brText').value = this.value;"
-        // "});"
-        // "});</script>"
-        // Minified:
-        addHtml(F("window.addEventListener('load',function(){document.getElementById('brSlide').addEventListener('input',function(){document.getElementById('brText').value=this.value})});"));
-        addHtml(F("</script>"));
-
-        success = true;
-        break;
+        // Candle Type Selection
+        addFormSelector(F("Flame Type"), F("cType"), 8, options, nullptr, choice);
       }
+
+      // Advanced Color options
+      Candle_color = static_cast<ColorType>(PCONFIG(5));
+      addRowLabel(F("Color Handling")); // checked
+      addHtml(F("<input type='radio' id='clrDefault' name='clrType' value='0'"));
+
+      if (Candle_color == ColorDefault) {
+        addHtml(F(" checked>"));
+      } else {
+        addHtml('>');
+      }
+      addHtml(F("<label for='clrDefault'> Use default color</label><br>"));
+      addHtml(F("<input type='radio' id='clrSelect' name='clrType' value='1'"));
+
+      if (Candle_color == ColorSelected) {
+        addHtml(F(" checked>"));
+      } else {
+        addHtml('>');
+      }
+      addHtml(F("<label for='clrSelect'> Use selected color</label><br>"));
+
+      // Color Selection
+      // char hexvalue[7] = {0};
+      // sprintf_P(hexvalue, PSTR("%02X%02X%02X"),     // Create Hex value for color
+      //           PCONFIG(0),
+      //           PCONFIG(1),
+      //           PCONFIG(2));
+
+      // http://jscolor.com/examples/
+      addRowLabel(F("Color"));
+      addHtml(F("<input data-jscolor=\"{onInput:'update(this)',position:'top',value:'#"));
+      addHtml(formatToHex_no_prefix(PCONFIG(0), 2));
+      addHtml(formatToHex_no_prefix(PCONFIG(1), 2));
+      addHtml(formatToHex_no_prefix(PCONFIG(2), 2));
+      addHtml(F("'}\">"));
+      addFormNumericBox(F("RGB Color"), F("wRed"), PCONFIG(0), 0, 255);
+      addNumericBox(F("wGreen"), PCONFIG(1), 0, 255);
+      addNumericBox(F("wBlue"),  PCONFIG(2), 0, 255);
+
+      // Brightness Selection
+      addRowLabel(F("Brightness"));
+      addHtml(F("min<input type='range' id='brSlide' min='0' max='255' value='"));
+      addHtmlInt(PCONFIG(3));
+      addHtml(F("'> max"));
+
+      {
+        // char tmpString[128];
+        // sprintf_P(tmpString, PSTR("<input type='text' name='brText' id='brText' size='3' value='%u'>"), PCONFIG(3));
+        // addHtml(concat(F("<input type='text' name='brText' id='brText' size='3' value='"),) + F("'>"));
+        addFormNumericBox(F("Brightness Value"), F("brText"), PCONFIG(3), 0, 255);
+      }
+
+      // Some Javascript we need to update the items
+      addHtml(F("<script script type='text/javascript'>"));
+
+      // "function update(picker) {"
+      // "    document.getElementById('wRed').value = Math.round(picker.rgb[0]);"
+      // "    document.getElementById('wGreen').value = Math.round(picker.rgb[1]);"
+      // "    document.getElementById('wBlue').value = Math.round(picker.rgb[2]);"
+      // '}'
+      // Minified:
+      addHtml(F(
+                "function update(e){document.getElementById('wRed').value=Math.round(e.channel('R')),document.getElementById('wGreen').value=Math.round(e.channel('G')),document.getElementById('wBlue').value=Math.round(e.channel('B'))}"));
+
+      // "window.addEventListener('load', function(){"
+      // "var slider = document.getElementById('brSlide');"
+      // "slider.addEventListener('change', function(){"
+      // "document.getElementById('brText').value = this.value;"
+      // "});"
+      // "});</script>"
+      // Minified:
+      addHtml(F(
+                "window.addEventListener('load',function(){document.getElementById('brSlide').addEventListener('input',function(){document.getElementById('brText').value=this.value})});"));
+      addHtml(F("</script>"));
+
+      success = true;
+      break;
+    }
 
     case PLUGIN_WEBFORM_SAVE:
-      {
-        PCONFIG(0) = getFormItemInt(F("wRed"));
-        PCONFIG(1) = getFormItemInt(F("wGreen"));
-        PCONFIG(2) = getFormItemInt(F("wBlue"));
-        PCONFIG(3) = getFormItemInt(F("brText"));
-        PCONFIG(4) = getFormItemInt(F("cType"));
-        PCONFIG(5) = getFormItemInt(F("clrType"));
+    {
+      PCONFIG(0) = getFormItemInt(F("wRed"));
+      PCONFIG(1) = getFormItemInt(F("wGreen"));
+      PCONFIG(2) = getFormItemInt(F("wBlue"));
+      PCONFIG(3) = getFormItemInt(F("brText"));
+      PCONFIG(4) = getFormItemInt(F("cType"));
+      PCONFIG(5) = getFormItemInt(F("clrType"));
 
-        Candle_red = PCONFIG(0);
-        Candle_green = PCONFIG(1);
-        Candle_blue = PCONFIG(2);
-        if (Candle_bright > 255) {
-          Candle_bright = 255;
-        }
-        Candle_bright = PCONFIG(3);
-        Candle_type = (SimType)PCONFIG(4);
-        Candle_color = (ColorType)PCONFIG(5);
+      Candle_red   = PCONFIG(0);
+      Candle_green = PCONFIG(1);
+      Candle_blue  = PCONFIG(2);
 
-        success = true;
-        break;
+      if (Candle_bright > 255) {
+        Candle_bright = 255;
       }
+      Candle_bright = PCONFIG(3);
+      Candle_type   = (SimType)PCONFIG(4);
+      Candle_color  = (ColorType)PCONFIG(5);
+
+      success = true;
+      break;
+    }
 
     case PLUGIN_INIT:
-      {
-        Candle_red = PCONFIG(0);
-        Candle_green = PCONFIG(1);
-        Candle_blue = PCONFIG(2);
-        Candle_bright = PCONFIG(3);
-        if (Candle_red == 0 && Candle_green == 0 && Candle_blue == 0) {
-          Candle_bright = BRIGHT_START;
-        }
-        Candle_type = static_cast<SimType>(PCONFIG(4));
-        Candle_color = static_cast<ColorType>(PCONFIG(5));
+    {
+      Candle_red    = PCONFIG(0);
+      Candle_green  = PCONFIG(1);
+      Candle_blue   = PCONFIG(2);
+      Candle_bright = PCONFIG(3);
 
-        if (!Candle_pixels || GPIO_Set == false)
-        {
-          GPIO_Set = validGpio(CONFIG_PIN1);
-          if (Candle_pixels) {
-            delete Candle_pixels;
-          }
-          Candle_pixels = new (std::nothrow) Adafruit_NeoPixel(NUM_PIXEL, CONFIG_PIN1, NEO_GRB + NEO_KHZ800);
-          if (Candle_pixels != nullptr) {
-            SetPixelsBlack();
-            Candle_pixels->setBrightness(Candle_bright);
-            Candle_pixels->begin();
-          }
-
-          #ifndef BUILD_NO_DEBUG
-          if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
-            addLogMove(LOG_LEVEL_DEBUG, concat(F("CAND : Init WS2812 Pin : "), static_cast<int>(CONFIG_PIN1)));
-          }
-          #endif
-        }
-
-        success = Candle_pixels != nullptr;
-        break;
+      if ((Candle_red == 0) && (Candle_green == 0) && (Candle_blue == 0)) {
+        Candle_bright = BRIGHT_START;
       }
+      Candle_type  = static_cast<SimType>(PCONFIG(4));
+      Candle_color = static_cast<ColorType>(PCONFIG(5));
+
+      if (!Candle_pixels || (GPIO_Set == false))
+      {
+        GPIO_Set = validGpio(CONFIG_PIN1);
+
+        if (Candle_pixels) {
+          delete Candle_pixels;
+        }
+        Candle_pixels = new (std::nothrow) Adafruit_NeoPixel(NUM_PIXEL, CONFIG_PIN1, NEO_GRB + NEO_KHZ800);
+
+        if (Candle_pixels != nullptr) {
+          SetPixelsBlack();
+          Candle_pixels->setBrightness(Candle_bright);
+          Candle_pixels->begin();
+        }
+
+          # ifndef BUILD_NO_DEBUG
+
+        if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+          addLogMove(LOG_LEVEL_DEBUG, concat(F("CAND : Init WS2812 Pin : "), static_cast<int>(CONFIG_PIN1)));
+        }
+          # endif // ifndef BUILD_NO_DEBUG
+      }
+
+      success = Candle_pixels != nullptr;
+      break;
+    }
 
     case PLUGIN_EXIT:
-      {
-        if (Candle_pixels != nullptr) {
-          delete Candle_pixels;
-          Candle_pixels = nullptr;
-        }
-        break;
+    {
+      if (Candle_pixels != nullptr) {
+        delete Candle_pixels;
+        Candle_pixels = nullptr;
       }
+      break;
+    }
 
     case PLUGIN_ONCE_A_SECOND:
-      {
-        Candle_pixels->setBrightness(Candle_bright);
-        Candle_pixels->show(); // This sends the updated pixel color to the hardware.
-        success = true;
-        break;
-      }
+    {
+      Candle_pixels->setBrightness(Candle_bright);
+      Candle_pixels->show(); // This sends the updated pixel color to the hardware.
+      success = true;
+      break;
+    }
 
     case PLUGIN_FIFTY_PER_SECOND:
+    {
+      switch (Candle_type)
       {
-        switch (Candle_type)
+        case 0: // "Update" for OFF
         {
-          case 0:   // "Update" for OFF
-            {
-              type_Off();
-              break;
-            }
-
-          case 1:   // Update for LIGHT
-            {
-              type_Static_Light();
-              break;
-            }
-
-          case 2: // Random Updates for Simple Candle, Advanced Candle, Fire Simulation
-          case 3:
-            {
-              if (timeOutReached(Candle_Update)) {
-                if (Candle_type == 2) {
-                  type_Simple_Candle();
-                }
-                if (Candle_type == 3) {
-                  type_Advanced_Candle();
-                }
-                Candle_Update = millis() + random(25, 150);
-              }
-              break;
-            }
-
-          case 4:   // Update for Police
-            {
-              if (timeOutReached(Candle_Update)) {
-                type_Police();
-                Candle_Update = millis() + 150;
-              }
-              break;
-            }
-
-          case 5:   // Update for Blink
-            {
-              if (timeOutReached(Candle_Update)) {
-                type_BlinkStrobe();
-                Candle_Update = millis() + 100;
-              }
-              break;
-            }
-
-          case 6:   // Update for Strobe
-            {
-              type_BlinkStrobe();
-              break;
-            }
-          case 7:   // Update for ColorFader
-            {
-              if (timeOutReached(Candle_Update)) {
-                type_ColorFader();
-                Candle_Update = millis() + 2000;
-              }
-              break;
-            }
+          type_Off();
+          break;
         }
 
-        Candle_pixels->show();
+        case 1: // Update for LIGHT
+        {
+          type_Static_Light();
+          break;
+        }
 
-        success = true;
-        break;
+        case 2: // Random Updates for Simple Candle, Advanced Candle, Fire Simulation
+        case 3:
+        {
+          if (timeOutReached(Candle_Update)) {
+            if (Candle_type == 2) {
+              type_Simple_Candle();
+            }
+
+            if (Candle_type == 3) {
+              type_Advanced_Candle();
+            }
+            Candle_Update = millis() + random(25, 150);
+          }
+          break;
+        }
+
+        case 4: // Update for Police
+        {
+          if (timeOutReached(Candle_Update)) {
+            type_Police();
+            Candle_Update = millis() + 150;
+          }
+          break;
+        }
+
+        case 5: // Update for Blink
+        {
+          if (timeOutReached(Candle_Update)) {
+            type_BlinkStrobe();
+            Candle_Update = millis() + 100;
+          }
+          break;
+        }
+
+        case 6: // Update for Strobe
+        {
+          type_BlinkStrobe();
+          break;
+        }
+        case 7: // Update for ColorFader
+        {
+          if (timeOutReached(Candle_Update)) {
+            type_ColorFader();
+            Candle_Update = millis() + 2000;
+          }
+          break;
+        }
       }
+
+      Candle_pixels->show();
+
+      success = true;
+      break;
+    }
 
     case PLUGIN_READ:
-      {
-        UserVar[event->BaseVarIndex] = Candle_red * 65536 + Candle_green * 256 + Candle_blue;
-        UserVar[event->BaseVarIndex + 1] = Candle_bright;
-        UserVar[event->BaseVarIndex + 2] = Candle_type;
+    {
+      UserVar[event->BaseVarIndex]     = Candle_red * 65536 + Candle_green * 256 + Candle_blue;
+      UserVar[event->BaseVarIndex + 1] = Candle_bright;
+      UserVar[event->BaseVarIndex + 2] = Candle_type;
 
-        success = true;
-        break;
-      }
+      success = true;
+      break;
+    }
 
     case PLUGIN_WRITE:
-      {
-        String tmpString  = string;
+    {
+      String tmpString = string;
 
-        // Test
-        // MQTT   : mosquitto_pub -d -t sensors/espeasy/ESP_Candle/cmd  -m "CANDLE_OFF"
-        // HTTP   : http://192.168.30.183/tools?cmd=CANDLE%3A5%3AFF0000%3A200
-        //          http://192.168.30.183/tools?cmd=CANDLE:4:FF0000:200
-        // SERIAL : CANDLE:4:FF0000:200<CR><LF>
+      // Test
+      // MQTT   : mosquitto_pub -d -t sensors/espeasy/ESP_Candle/cmd  -m "CANDLE_OFF"
+      // HTTP   : http://192.168.30.183/tools?cmd=CANDLE%3A5%3AFF0000%3A200
+      //          http://192.168.30.183/tools?cmd=CANDLE:4:FF0000:200
+      // SERIAL : CANDLE:4:FF0000:200<CR><LF>
 
-        // Commands
-        // CANDLE:<FlameType>:<Color>:<Brightness>
-        //    <FlameType>  : 1 Static Light, 2 Simple Candle, 3 Advanced Candle, 4 Police, 5 Blink, 6 Strobe, 7 Color Fader
-        //    <Color>      : n.def.  Use the default color
-        //                   RRGGBB  Use color in RRGGBB style (red, green blue) as HEX
-        //    <Brightness> : 0-255
-        // Samples:   CANDLE:2::100           Simple Candle with Default color and Brigthness at 100
-        //            CANDLE:5:FF0000:200     Blink with RED Color and Brigthness at 200
-        //            CANDLE:0::              Candle OFF
-        //            CANDLE:1::255           Candle ON - White and full brigthness
+      // Commands
+      // CANDLE:<FlameType>:<Color>:<Brightness>
+      //    <FlameType>  : 1 Static Light, 2 Simple Candle, 3 Advanced Candle, 4 Police, 5 Blink, 6 Strobe, 7 Color Fader
+      //    <Color>      : n.def.  Use the default color
+      //                   RRGGBB  Use color in RRGGBB style (red, green blue) as HEX
+      //    <Brightness> : 0-255
+      // Samples:   CANDLE:2::100           Simple Candle with Default color and Brigthness at 100
+      //            CANDLE:5:FF0000:200     Blink with RED Color and Brigthness at 200
+      //            CANDLE:0::              Candle OFF
+      //            CANDLE:1::255           Candle ON - White and full brigthness
 
-        if (tmpString.startsWith(F("CANDLE:"))){
-          int idx1 = tmpString.indexOf(':');
-          int idx2 = tmpString.indexOf(':', idx1+1);
-          int idx3 = tmpString.indexOf(':', idx2+1);
-          int idx4 = tmpString.indexOf(':', idx3+1);
-          String val_Type = tmpString.substring(idx1+1, idx2);
-          String val_Color = tmpString.substring(idx2+1, idx3);
-          String val_Bright = tmpString.substring(idx3+1, idx4);
+      if (tmpString.startsWith(F("CANDLE:"))) {
+        int idx1          = tmpString.indexOf(':');
+        int idx2          = tmpString.indexOf(':', idx1 + 1);
+        int idx3          = tmpString.indexOf(':', idx2 + 1);
+        int idx4          = tmpString.indexOf(':', idx3 + 1);
+        String val_Type   = tmpString.substring(idx1 + 1, idx2);
+        String val_Color  = tmpString.substring(idx2 + 1, idx3);
+        String val_Bright = tmpString.substring(idx3 + 1, idx4);
 
-          if (!val_Type.isEmpty()) {
-             if (val_Type.toInt() > -1 && val_Type.toInt() < 8) {
-                PCONFIG(4) = val_Type.toInt();     // Type
-                Candle_type = static_cast<SimType>(PCONFIG(4));
-                #ifndef BUILD_NO_DEBUG
-                if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
-                  addLogMove(LOG_LEVEL_DEBUG, concat(F("CAND : CMD - Type : "), val_Type));
-                }
-                #endif
-             }
-          }
+        if (!val_Type.isEmpty()) {
+          if ((val_Type.toInt() > -1) && (val_Type.toInt() < 8)) {
+            PCONFIG(4)  = val_Type.toInt(); // Type
+            Candle_type = static_cast<SimType>(PCONFIG(4));
+                # ifndef BUILD_NO_DEBUG
 
-          if (!val_Bright.isEmpty()) {
-             if (val_Bright.toInt() > -1 && val_Bright.toInt() < 256) {
-                PCONFIG(3) = val_Bright.toInt();     // Brightness
-                Candle_bright = PCONFIG(3);
-                #ifndef BUILD_NO_DEBUG
-                if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
-                  addLogMove(LOG_LEVEL_DEBUG, concat(F("CAND : CMD - Bright : "), val_Bright));
-                }
-                #endif
-             }
-          }
-
-          if (!val_Color.isEmpty()) {
-            long number = strtol( &val_Color[0], nullptr, 16);
-            // Split RGB to r, g, b values
-            uint8_t r = number >> 16;
-            uint8_t g = number >> 8 & 0xFF;
-            uint8_t b = number & 0xFF;
-
-            PCONFIG(0) = r;   // R
-            PCONFIG(1) = g;   // G
-            PCONFIG(2) = b;   // B
-            Candle_red = PCONFIG(0);
-            Candle_green = PCONFIG(1);
-            Candle_blue = PCONFIG(2);
-            PCONFIG(5) = 1;
-            Candle_color = static_cast<ColorType>(PCONFIG(5));   // ColorType (ColorSelected)
-
-            #ifndef BUILD_NO_DEBUG
             if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
-              String log = F("CAND : CMD - R ");
-              log += r;
-              log += F(" G ");
-              log += g;
-              log += F(" B ");
-              log += b;
-              addLogMove(LOG_LEVEL_DEBUG, log);
+              addLogMove(LOG_LEVEL_DEBUG, concat(F("CAND : CMD - Type : "), val_Type));
             }
-            #endif
-          } else {
-            PCONFIG(5) = 0;
-            Candle_color = static_cast<ColorType>(PCONFIG(5));   // ColorType (ColorDefault)
-            #ifndef BUILD_NO_DEBUG
-            addLog(LOG_LEVEL_DEBUG, F("CAND : CMD - Color : DEFAULT"));
-            #endif
+                # endif // ifndef BUILD_NO_DEBUG
           }
-
-          //SaveTaskSettings(event->TaskIndex);
-          //SaveSettings();
-
-          success = true;
         }
 
-        break;
+        if (!val_Bright.isEmpty()) {
+          if ((val_Bright.toInt() > -1) && (val_Bright.toInt() < 256)) {
+            PCONFIG(3)    = val_Bright.toInt(); // Brightness
+            Candle_bright = PCONFIG(3);
+                # ifndef BUILD_NO_DEBUG
+
+            if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+              addLogMove(LOG_LEVEL_DEBUG, concat(F("CAND : CMD - Bright : "), val_Bright));
+            }
+                # endif // ifndef BUILD_NO_DEBUG
+          }
+        }
+
+        if (!val_Color.isEmpty()) {
+          long number = strtol(&val_Color[0], nullptr, 16);
+
+          // Split RGB to r, g, b values
+          uint8_t r = number >> 16;
+          uint8_t g = number >> 8 & 0xFF;
+          uint8_t b = number & 0xFF;
+
+          PCONFIG(0)   = r; // R
+          PCONFIG(1)   = g; // G
+          PCONFIG(2)   = b; // B
+          Candle_red   = PCONFIG(0);
+          Candle_green = PCONFIG(1);
+          Candle_blue  = PCONFIG(2);
+          PCONFIG(5)   = 1;
+          Candle_color = static_cast<ColorType>(PCONFIG(5)); // ColorType (ColorSelected)
+
+            # ifndef BUILD_NO_DEBUG
+
+          if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+            String log = F("CAND : CMD - R ");
+            log += r;
+            log += F(" G ");
+            log += g;
+            log += F(" B ");
+            log += b;
+            addLogMove(LOG_LEVEL_DEBUG, log);
+          }
+            # endif // ifndef BUILD_NO_DEBUG
+        } else {
+          PCONFIG(5) = 0;
+          Candle_color = static_cast<ColorType>(PCONFIG(5)); // ColorType (ColorDefault)
+            # ifndef BUILD_NO_DEBUG
+          addLog(LOG_LEVEL_DEBUG, F("CAND : CMD - Color : DEFAULT"));
+            # endif // ifndef BUILD_NO_DEBUG
+        }
+
+        // SaveTaskSettings(event->TaskIndex);
+        // SaveSettings();
+
+        success = true;
       }
 
+      break;
+    }
   }
   return success;
 }
@@ -522,7 +538,7 @@ void type_Off() {
 void type_Static_Light() {
   for (int i = 0; i < NUM_PIXEL; i++) {
     if (Candle_color == ColorDefault) {
-      Candle_pixels->setPixelColor(i, 255, 255, 255);     // Default is white
+      Candle_pixels->setPixelColor(i, 255, 255, 255); // Default is white
     } else {
       Candle_pixels->setPixelColor(i, Candle_red, Candle_green, Candle_blue);
     }
@@ -531,10 +547,11 @@ void type_Static_Light() {
 
 void type_Simple_Candle() {
   int r, g, b;
+
   if (Candle_color == ColorDefault) {
-    r = 226, g = 42, b =  35;   // Regular (orange) flame
-    //r = 158, g =   8, b = 148;   // Purple flame
-    //r =  74, g = 150, b =  12;   // Green flame
+    r = 226, g = 42, b =  35; // Regular (orange) flame
+    // r = 158, g =   8, b = 148;   // Purple flame
+    // r =  74, g = 150, b =  12;   // Green flame
   } else {
     r = Candle_red, g = Candle_green, b = Candle_blue;
   }
@@ -542,20 +559,23 @@ void type_Simple_Candle() {
   //  Flicker, based on our initial RGB values
   for (int i = 0; i < NUM_PIXEL; i++) {
     int flicker = random(0, RANDOM_PIXEL);
-    int r1 = r - flicker;
-    int g1 = g - flicker;
-    int b1 = b - flicker;
-    if (g1 < 0) g1 = 0;
-    if (r1 < 0) r1 = 0;
-    if (b1 < 0) b1 = 0;
+    int r1      = r - flicker;
+    int g1      = g - flicker;
+    int b1      = b - flicker;
+
+    if (g1 < 0) { g1 = 0; }
+
+    if (r1 < 0) { r1 = 0; }
+
+    if (b1 < 0) { b1 = 0; }
     Candle_pixels->setPixelColor(i, r1, g1, b1);
   }
 }
 
 void type_Advanced_Candle() {
-  Candle_Temp[0] = random(1, 4); // 1..4  LEDs in RED
+  Candle_Temp[0] = random(1, 4);                  // 1..4  LEDs in RED
   Candle_Temp[1] = random(1, 4) + Candle_Temp[0]; // 1..3  LEDs in Yellow / Orange
-  Candle_Temp[2] = random(0, 2); // 0..1  Choose Yellow = 0 / Orange = 1
+  Candle_Temp[2] = random(0, 2);                  // 0..1  Choose Yellow = 0 / Orange = 1
 
   int colorbase[3];
   int color1[3];
@@ -563,37 +583,42 @@ void type_Advanced_Candle() {
   int color3[3];
 
   if (Candle_color == ColorDefault) {
-    colorbase[0] = 255; colorbase[1] = 120; colorbase[2] = 0;   // Light Orange #FF7800
-    color1[0] = 115; color1[1] = 50; color1[2] = 0;             // Brown      #733200
-    color2[0] = 180; color2[1] = 80; color2[2] = 0;             // Orange     #B45000
-    color3[0] =  70; color3[1] = 30; color3[2] = 0;              // Dark brown #4A2000
+    colorbase[0] = 255; colorbase[1] = 120; colorbase[2] = 0; // Light Orange #FF7800
+    color1[0]    = 115; color1[1] = 50; color1[2] = 0;        // Brown      #733200
+    color2[0]    = 180; color2[1] = 80; color2[2] = 0;        // Orange     #B45000
+    color3[0]    =  70; color3[1] = 30; color3[2] = 0;        // Dark brown #4A2000
   } else {
     colorbase[0] = Candle_red; colorbase[1] = Candle_green; colorbase[2] = Candle_blue;
     double hsv[3];
+
     // Calc HSV
     RGBtoHSV(Candle_red, Candle_green, Candle_blue, hsv);
     double newH = hsv[0] - 5;
+
     if (newH < 0) { newH += 359; }
-    double newV = hsv[2] / 2;
+    double newV  = hsv[2] / 2;
     double newV2 = hsv[2] / 4;
+
     // Calc new RGBs
-    HSVtoRGB(newH, hsv[1], hsv[2], color1);
-    HSVtoRGB(hsv[0], hsv[1], newV, color2);
-    HSVtoRGB(newH, hsv[1], newV2, color3);
+    HSVtoRGB(newH,   hsv[1], hsv[2], color1);
+    HSVtoRGB(hsv[0], hsv[1], newV,   color2);
+    HSVtoRGB(newH,   hsv[1], newV2,  color3);
   }
 
   for (int j = 0; j < 4; j++) {
-    for (unsigned int i = 1; i < 6; i++){
+    for (unsigned int i = 1; i < 6; i++) {
       if (i <= Candle_Temp[0]) {
         Candle_pixels->setPixelColor(j * 5 + i - 1, colorbase[0], colorbase[1], colorbase[2]);
       }
-      if (i > Candle_Temp[0] && i <= Candle_Temp[1]) {
-        if (Candle_Temp[2] == 0){
+
+      if ((i > Candle_Temp[0]) && (i <= Candle_Temp[1])) {
+        if (Candle_Temp[2] == 0) {
           Candle_pixels->setPixelColor(j * 5 + i - 1, color1[0], color1[1], color1[2]);
         } else {
           Candle_pixels->setPixelColor(j * 5 + i - 1, color2[0], color2[1], color2[2]);
         }
       }
+
       if (i > Candle_Temp[1]) {
         Candle_pixels->setPixelColor(j * 5 + i - 1, color3[0], color3[1], color3[2]);
       }
@@ -603,6 +628,7 @@ void type_Advanced_Candle() {
 
 void type_Police() {
   Candle_Temp[0]++;
+
   if (Candle_Temp[0] > 3) {
     Candle_Temp[0] = 0;
   }
@@ -627,6 +653,7 @@ void type_Police() {
 
 void type_BlinkStrobe() {
   Candle_Temp[0]++;
+
   if (Candle_Temp[0] > 1) {
     Candle_Temp[0] = 0;
   }
@@ -636,7 +663,7 @@ void type_BlinkStrobe() {
       Candle_pixels->setPixelColor(i, 0, 0, 0);
     } else {
       if (Candle_color == ColorDefault) {
-        Candle_pixels->setPixelColor(i, 255, 255, 255);     // Default is white
+        Candle_pixels->setPixelColor(i, 255, 255, 255); // Default is white
       } else {
         Candle_pixels->setPixelColor(i, Candle_red, Candle_green, Candle_blue);
       }
@@ -647,11 +674,13 @@ void type_BlinkStrobe() {
 void type_ColorFader() {
   int colors[3];
   double hsv[3];
+
   if (Candle_color != ColorDefault) {
-    if (Candle_Temp[0] > 254 && Candle_Temp[1] == 1) {
+    if ((Candle_Temp[0] > 254) && (Candle_Temp[1] == 1)) {
       Candle_Temp[1] = 0;
     }
-    if (Candle_Temp[0] < 55 && Candle_Temp[1] == 0) {
+
+    if ((Candle_Temp[0] < 55) && (Candle_Temp[1] == 0)) {
       Candle_Temp[1] = 1;
     }
 
@@ -675,6 +704,7 @@ void type_ColorFader() {
     }
   } else {
     Candle_Temp[0]++;
+
     if (Candle_Temp[0] > 359) {
       Candle_Temp[0] = 0;
     }
@@ -691,84 +721,90 @@ void type_ColorFader() {
 // Convert HSV Color to RGB Color
 void HSVtoRGB(int hue, int sat, int val, int colors[3]) {
   // hue: 0-359, sat: 0-255, val (lightness): 0-255
-  int r=0, g=0, b=0, base=0;
+  int r = 0, g = 0, b = 0, base = 0;
 
   if (sat == 0) { // Achromatic color (gray).
-    colors[0]=val;
-    colors[1]=val;
-    colors[2]=val;
+    colors[0] = val;
+    colors[1] = val;
+    colors[2] = val;
   }
   else  {
-    base = ((255 - sat) * val)>>8;
-    switch(hue/60) {
-    case 0:
-      r = val;
-      g = (((val-base)*hue)/60)+base;
-      b = base;
-      break;
-    case 1:
-      r = (((val-base)*(60-(hue%60)))/60)+base;
-      g = val;
-      b = base;
-      break;
-    case 2:
-      r = base;
-      g = val;
-      b = (((val-base)*(hue%60))/60)+base;
-      break;
-    case 3:
-      r = base;
-      g = (((val-base)*(60-(hue%60)))/60)+base;
-      b = val;
-      break;
-    case 4:
-      r = (((val-base)*(hue%60))/60)+base;
-      g = base;
-      b = val;
-      break;
-    case 5:
-      r = val;
-      g = base;
-      b = (((val-base)*(60-(hue%60)))/60)+base;
-      break;
+    base = ((255 - sat) * val) >> 8;
+
+    switch (hue / 60) {
+      case 0:
+        r = val;
+        g = (((val - base) * hue) / 60) + base;
+        b = base;
+        break;
+      case 1:
+        r = (((val - base) * (60 - (hue % 60))) / 60) + base;
+        g = val;
+        b = base;
+        break;
+      case 2:
+        r = base;
+        g = val;
+        b = (((val - base) * (hue % 60)) / 60) + base;
+        break;
+      case 3:
+        r = base;
+        g = (((val - base) * (60 - (hue % 60))) / 60) + base;
+        b = val;
+        break;
+      case 4:
+        r = (((val - base) * (hue % 60)) / 60) + base;
+        g = base;
+        b = val;
+        break;
+      case 5:
+        r = val;
+        g = base;
+        b = (((val - base) * (60 - (hue % 60))) / 60) + base;
+        break;
     }
-    colors[0]=r;
-    colors[1]=g;
-    colors[2]=b;
+    colors[0] = r;
+    colors[1] = g;
+    colors[2] = b;
   }
 }
 
 // Convert RGB Color to HSV Color
 void RGBtoHSV(uint8_t r, uint8_t g, uint8_t b, double hsv[3]) {
-    double rd = (double) r/255;
-    double gd = (double) g/255;
-    double bd = (double) b/255;
-    double maxval = rd;
-    if (gd > maxval) { maxval = gd; }
-    if (bd > maxval) { maxval = bd; }
-    double minval = rd;
-    if (gd < minval) { minval = gd; }
-    if (bd < minval) { minval = bd; }
-    double h = 0, s, v = maxval;
-    double d = maxval - minval;
+  double rd     = (double)r / 255;
+  double gd     = (double)g / 255;
+  double bd     = (double)b / 255;
+  double maxval = rd;
 
-    s = maxval == 0 ? 0 : d / maxval;
+  if (gd > maxval) { maxval = gd; }
 
-    if (maxval == minval) {
-        h = 0; // achromatic
-    } else {
-        if (maxval == rd) {
-            h = (gd - bd) / d + (gd < bd ? 6 : 0);
-        } else if (maxval == gd) {
-            h = (bd - rd) / d + 2;
-        } else if (maxval == bd) {
-            h = (rd - gd) / d + 4;
-        }
-        h /= 6;
+  if (bd > maxval) { maxval = bd; }
+  double minval = rd;
+
+  if (gd < minval) { minval = gd; }
+
+  if (bd < minval) { minval = bd; }
+  double h = 0, s, v = maxval;
+  double d = maxval - minval;
+
+  s = maxval == 0 ? 0 : d / maxval;
+
+  if (maxval == minval) {
+    h = 0; // achromatic
+  } else {
+    if (maxval == rd) {
+      h = (gd - bd) / d + (gd < bd ? 6 : 0);
+    } else if (maxval == gd) {
+      h = (bd - rd) / d + 2;
+    } else if (maxval == bd) {
+      h = (rd - gd) / d + 4;
     }
+    h /= 6;
+  }
 
-    hsv[0] = h * 360;
-    hsv[1] = s * 255;
-    hsv[2] = v * 255;
+  hsv[0] = h * 360;
+  hsv[1] = s * 255;
+  hsv[2] = v * 255;
 }
+
 #endif // USES_P042

--- a/src/_P042_Candle.ino
+++ b/src/_P042_Candle.ino
@@ -9,6 +9,7 @@
 // Wifi Candle for ESPEasy by Dominik Schmidt (10.2016)
 
 /** Changelog:
+ * 2023-01-21 tonhuisman: Move to PluginStruct_base to enable multi-instance use of this plugin
  * 2023-01-21 tonhuisman: Further refactor and improve code, including GH feedback
  *                        Add setting for Led Count, defaults to 20 (was fixed size)
  *                        Move RGBtoHSV to misc.cpp and rename to RGB2HSV after changing to use float instead of double
@@ -61,45 +62,7 @@
 // https://www.ruinelli.ch/rgb-to-hsv               Code
 // http://stackoverflow.com/questions/3018313/algorithm-to-convert-rgb-to-hsv-and-hsv-to-rgb-in-range-0-255-for-both    Code Sammlung
 
-# include <Adafruit_NeoPixel.h>
-
-
-# define P042_NUM_PIXEL     20  // Defines the default amount of LED Pixels
-# define P042_MAX_PIXELS    300 // Max. allowed pixels
-# define P042_RANDOM_PIXEL  70  // Defines the Flicker Level for Simple Candle
-# define P042_BRIGHT_START  128 // Defines the Start Brightness
-# define P042_FLAME_OPTIONS 8   // Number of flame types
-
-enum SimType {
-  TypeOff            = 0,
-  TypeSimpleCandle   = 1,
-  TypeAdvancedCandle = 2,
-  TypeStaticLight    = 3,
-  TypePolice         = 4,
-  TypeBlink          = 5,
-  TypeStrobe         = 6,
-  TypeColorFader     = 7,
-};
-
-enum ColorType {
-  ColorDefault  = 0,
-  ColorSelected = 1,
-};
-
-uint8_t   Candle_red    = 0;
-uint8_t   Candle_green  = 0;
-uint8_t   Candle_blue   = 0;
-uint8_t   Candle_bright = 128;
-int       Candle_pxlcnt = P042_NUM_PIXEL;
-SimType   Candle_type   = TypeSimpleCandle;
-ColorType Candle_color  = ColorDefault;
-
-// global variables
-unsigned long Candle_Update = 0;
-word Candle_Temp[3]         = { 0 }; // Temp variables
-boolean GPIO_Set = false;
-
-Adafruit_NeoPixel *Candle_pixels;
+# include "src/PluginStructs/P042_data_struct.h"
 
 # define PLUGIN_042
 # define PLUGIN_ID_042         42
@@ -107,34 +70,6 @@ Adafruit_NeoPixel *Candle_pixels;
 # define PLUGIN_VALUENAME1_042 "Color"
 # define PLUGIN_VALUENAME2_042 "Brightness"
 # define PLUGIN_VALUENAME3_042 "Type"
-
-# define P042_WEBVAR_COUNT              7
-# define P042_WEBVAR_RED                _webVars[0]
-# define P042_WEBVAR_GREEN              _webVars[1]
-# define P042_WEBVAR_BLUE               _webVars[2]
-# define P042_WEBVAR_BRIGHTNESS         _webVars[3]
-# define P042_WEBVAR_CANDLETYPE         _webVars[4]
-# define P042_WEBVAR_COLORTYPE          _webVars[5]
-# define P042_WEBVAR_PIXELCOUNT         _webVars[6]
-# define P042_WEBVAR_RED_S              "wRed"
-# define P042_WEBVAR_GREEN_S            "wGreen"
-# define P042_WEBVAR_BLUE_S             "wBlue"
-# define P042_WEBVAR_BRIGHTNESS_S       "brText"
-# define P042_WEBVAR_CANDLETYPE_S       "cType"
-# define P042_WEBVAR_COLORTYPE_S        "clrType"
-# define P042_WEBVAR_PIXELCOUNT_S       "pxCnt"
-
-// Other vars
-# define P042_OTHVAR_BRIGHTNESSSLIDE_S  "brSlide"
-
-// Config defines
-# define P042_CONFIG_RED                PCONFIG(0)
-# define P042_CONFIG_GREEN              PCONFIG(1)
-# define P042_CONFIG_BLUE               PCONFIG(2)
-# define P042_CONFIG_BRIGHTNESS         PCONFIG(3)
-# define P042_CONFIG_CANDLETYPE         PCONFIG(4)
-# define P042_CONFIG_COLORTYPE          PCONFIG(5)
-# define P042_CONFIG_PIXELCOUNT         PCONFIG(6)
 
 boolean Plugin_042(uint8_t function, struct EventStruct *event, String& string)
 {
@@ -226,11 +161,11 @@ boolean Plugin_042(uint8_t function, struct EventStruct *event, String& string)
       }
 
       // Advanced Color options
-      Candle_color = static_cast<ColorType>(P042_CONFIG_COLORTYPE);
+      P042_ColorType Candle_color = static_cast<P042_ColorType>(P042_CONFIG_COLORTYPE);
       addRowLabel(F("Color Handling")); // checked
       addHtml(F("<input type='radio' id='clrDef' name='" P042_WEBVAR_COLORTYPE_S "' value='0'"));
 
-      if (Candle_color == ColorDefault) {
+      if (Candle_color == P042_ColorType::ColorDefault) {
         addHtml(F(" checked>"));
       } else {
         addHtml('>');
@@ -238,7 +173,7 @@ boolean Plugin_042(uint8_t function, struct EventStruct *event, String& string)
       addHtml(F("<label for='clrDef'> Use default color</label><br>"));
       addHtml(F("<input type='radio' id='clrSel' name='" P042_WEBVAR_COLORTYPE_S "' value='1'"));
 
-      if (Candle_color == ColorSelected) {
+      if (Candle_color == P042_ColorType::ColorSelected) {
         addHtml(F(" checked>"));
       } else {
         addHtml('>');
@@ -309,438 +244,66 @@ boolean Plugin_042(uint8_t function, struct EventStruct *event, String& string)
 
     case PLUGIN_INIT:
     {
-      if (P042_CONFIG_PIXELCOUNT == 0) { P042_CONFIG_PIXELCOUNT = P042_NUM_PIXEL; }
-      Candle_red    = P042_CONFIG_RED;
-      Candle_green  = P042_CONFIG_GREEN;
-      Candle_blue   = P042_CONFIG_BLUE;
-      Candle_bright = P042_CONFIG_BRIGHTNESS;
-      Candle_pxlcnt = P042_CONFIG_PIXELCOUNT;
+      initPluginTaskData(event->TaskIndex, new (std::nothrow) P042_data_struct());
+      P042_data_struct *P042_data = static_cast<P042_data_struct *>(getPluginTaskData(event->TaskIndex));
 
-      if ((Candle_red == 0) && (Candle_green == 0) && (Candle_blue == 0)) {
-        Candle_bright = P042_BRIGHT_START;
-      }
-      Candle_type  = static_cast<SimType>(P042_CONFIG_CANDLETYPE);
-      Candle_color = static_cast<ColorType>(P042_CONFIG_COLORTYPE);
-
-      if (!Candle_pixels || (GPIO_Set == false)) {
-        GPIO_Set = validGpio(CONFIG_PIN1);
-
-        if (GPIO_Set) {
-          if (Candle_pixels) {
-            delete Candle_pixels;
-          }
-          Candle_pixels = new (std::nothrow) Adafruit_NeoPixel(P042_CONFIG_PIXELCOUNT, CONFIG_PIN1, NEO_GRB + NEO_KHZ800);
-
-          if (Candle_pixels != nullptr) {
-            SetPixelsBlack();
-            Candle_pixels->setBrightness(Candle_bright);
-            Candle_pixels->begin();
-          }
-
-          # ifndef BUILD_NO_DEBUG
-
-          if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
-            addLogMove(LOG_LEVEL_DEBUG, concat(F("CAND : Init WS2812 Pin : "), static_cast<int>(CONFIG_PIN1)));
-          }
-          # endif // ifndef BUILD_NO_DEBUG
-        }
+      if (nullptr != P042_data) {
+        success = P042_data->plugin_init(event);
       }
 
-      success = Candle_pixels != nullptr;
       break;
     }
 
     case PLUGIN_EXIT:
     {
-      if (Candle_pixels != nullptr) {
-        delete Candle_pixels;
-        Candle_pixels = nullptr;
-      }
       break;
     }
 
     case PLUGIN_ONCE_A_SECOND:
     {
-      Candle_pixels->setBrightness(Candle_bright);
-      Candle_pixels->show(); // This sends the updated pixel color to the hardware.
-      success = true;
+      P042_data_struct *P042_data = static_cast<P042_data_struct *>(getPluginTaskData(event->TaskIndex));
+
+      if (nullptr != P042_data) {
+        success = P042_data->plugin_once_a_second(event);
+      }
+
       break;
     }
 
     case PLUGIN_FIFTY_PER_SECOND:
     {
-      switch (Candle_type)
-      {
-        case TypeOff: // "Update" for OFF
-        {
-          SetPixelsBlack();
-          break;
-        }
+      P042_data_struct *P042_data = static_cast<P042_data_struct *>(getPluginTaskData(event->TaskIndex));
 
-        case TypeSimpleCandle: // Update for LIGHT
-        {
-          type_Static_Light();
-          break;
-        }
-
-        case TypeAdvancedCandle: // Random Updates for Simple Candle, Advanced Candle, Fire Simulation
-        case TypeStaticLight:
-        {
-          if (timeOutReached(Candle_Update)) {
-            if (Candle_type == TypeAdvancedCandle) {
-              type_Simple_Candle();
-            }
-
-            if (Candle_type == TypeStaticLight) {
-              type_Advanced_Candle();
-            }
-            Candle_Update = millis() + random(25, 150);
-          }
-          break;
-        }
-
-        case TypePolice: // Update for Police
-        {
-          if (timeOutReached(Candle_Update)) {
-            type_Police();
-            Candle_Update = millis() + 150;
-          }
-          break;
-        }
-
-        case TypeBlink: // Update for Blink
-        {
-          if (timeOutReached(Candle_Update)) {
-            type_BlinkStrobe();
-            Candle_Update = millis() + 100;
-          }
-          break;
-        }
-
-        case TypeStrobe: // Update for Strobe
-        {
-          type_BlinkStrobe();
-          break;
-        }
-        case TypeColorFader: // Update for ColorFader
-        {
-          if (timeOutReached(Candle_Update)) {
-            type_ColorFader();
-            Candle_Update = millis() + 2000;
-          }
-          break;
-        }
+      if (nullptr != P042_data) {
+        success = P042_data->plugin_fifty_per_second(event);
       }
 
-      Candle_pixels->show();
-
-      success = true;
       break;
     }
 
     case PLUGIN_READ:
     {
-      UserVar[event->BaseVarIndex]     = Candle_red << 16 | Candle_green << 8 | Candle_blue;
-      UserVar[event->BaseVarIndex + 1] = Candle_bright;
-      UserVar[event->BaseVarIndex + 2] = Candle_type;
+      P042_data_struct *P042_data = static_cast<P042_data_struct *>(getPluginTaskData(event->TaskIndex));
 
-      success = true;
+      if (nullptr != P042_data) {
+        success = P042_data->plugin_read(event);
+      }
+
       break;
     }
 
     case PLUGIN_WRITE:
     {
-      char   cmdSep = ','; // Try comma first
-      String cmd    = parseString(string, 1, cmdSep);
+      P042_data_struct *P042_data = static_cast<P042_data_struct *>(getPluginTaskData(event->TaskIndex));
 
-      if (!cmd.equals(F("candle"))) {
-        cmdSep = ':'; // Fallback to colon
-        cmd    = parseString(string, 1, cmdSep);
-      }
-
-      // Test
-      // MQTT   : mosquitto_pub -d -t sensors/espeasy/ESP_Candle/cmd  -m "CANDLE_OFF"
-      // HTTP   : http://192.168.30.183/tools?cmd=CANDLE%3A5%3AFF0000%3A200
-      //          http://192.168.30.183/tools?cmd=CANDLE:4:FF0000:200
-      // SERIAL : CANDLE:4:FF0000:200<CR><LF>
-
-      // Commands
-      // CANDLE:<FlameType>:<Color>:<Brightness>
-      //    <FlameType>  : 1 Static Light, 2 Simple Candle, 3 Advanced Candle, 4 Police, 5 Blink, 6 Strobe, 7 Color Fader
-      //    <Color>      : n.def.  Use the default color
-      //                   RRGGBB  Use color in RRGGBB style (red, green blue) as HEX
-      //    <Brightness> : 0-255
-      // Samples:   CANDLE:2::100           Simple Candle with Default color and Brigthness at 100
-      //            CANDLE:5:FF0000:200     Blink with RED Color and Brigthness at 200
-      //            CANDLE:0::              Candle OFF
-      //            CANDLE:1::255           Candle ON - White and full brigthness
-      // 2023-01-21: command can also be in lowercase, and separator can either be comma or colon, but all have to be the same
-
-      if (cmd.equals(F("candle"))) {
-        const String val_Type   = parseString(string, 2, cmdSep);
-        const String val_Color  = parseString(string, 3, cmdSep);
-        const String val_Bright = parseString(string, 4, cmdSep);
-
-        if (!val_Type.isEmpty()) {
-          if ((val_Type.toInt() > -1) && (val_Type.toInt() < P042_FLAME_OPTIONS)) {
-            P042_CONFIG_CANDLETYPE = val_Type.toInt(); // Type
-            Candle_type            = static_cast<SimType>(P042_CONFIG_CANDLETYPE);
-            # ifndef BUILD_NO_DEBUG
-
-            if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
-              addLogMove(LOG_LEVEL_DEBUG, concat(F("CAND : CMD - Type : "), val_Type));
-            }
-            # endif // ifndef BUILD_NO_DEBUG
-          }
-        }
-
-        if (!val_Bright.isEmpty()) {
-          if ((val_Bright.toInt() > -1) && (val_Bright.toInt() < 256)) {
-            P042_CONFIG_BRIGHTNESS = val_Bright.toInt(); // Brightness
-            Candle_bright          = P042_CONFIG_BRIGHTNESS;
-            # ifndef BUILD_NO_DEBUG
-
-            if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
-              addLogMove(LOG_LEVEL_DEBUG, concat(F("CAND : CMD - Bright : "), val_Bright));
-            }
-            # endif // ifndef BUILD_NO_DEBUG
-          }
-        }
-
-        uint32_t number = 0;
-
-        if (!val_Color.isEmpty() && validUIntFromString(concat(F("0x"), val_Color), number)) {
-
-          // Split RGB to r, g, b values
-          P042_CONFIG_RED       = (number >> 16) & 0xFF;
-          P042_CONFIG_GREEN     = (number >> 8) & 0xFF;
-          P042_CONFIG_BLUE      = number & 0xFF;
-          Candle_red            = P042_CONFIG_RED;
-          Candle_green          = P042_CONFIG_GREEN;
-          Candle_blue           = P042_CONFIG_BLUE;
-          P042_CONFIG_COLORTYPE = 1;
-          Candle_color          = static_cast<ColorType>(P042_CONFIG_COLORTYPE); // ColorType (ColorSelected)
-
-          # ifndef BUILD_NO_DEBUG
-
-          if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
-            String log = F("CAND : CMD - R ");
-            log += Candle_red;
-            log += F(" G ");
-            log += Candle_green;
-            log += F(" B ");
-            log += Candle_blue;
-            addLogMove(LOG_LEVEL_DEBUG, log);
-          }
-          # endif // ifndef BUILD_NO_DEBUG
-        } else {
-          P042_CONFIG_COLORTYPE = 0;
-          Candle_color          = static_cast<ColorType>(P042_CONFIG_COLORTYPE); // ColorType (ColorDefault)
-          # ifndef BUILD_NO_DEBUG
-          addLog(LOG_LEVEL_DEBUG, F("CAND : CMD - Color : DEFAULT"));
-          # endif // ifndef BUILD_NO_DEBUG
-        }
-
-        success = true;
+      if (nullptr != P042_data) {
+        success = P042_data->plugin_write(event, string);
       }
 
       break;
     }
   }
   return success;
-}
-
-void SetPixelsBlack() {
-  for (int i = 0; i < Candle_pxlcnt; i++) {
-    Candle_pixels->setPixelColor(i, Candle_pixels->Color(0, 0, 0));
-  }
-}
-
-void SetPixelToColor(int PixelIdx) {
-  Candle_pixels->setPixelColor(PixelIdx, Candle_pixels->Color(Candle_red, Candle_green, Candle_blue));
-}
-
-void type_Static_Light() {
-  for (int i = 0; i < Candle_pxlcnt; i++) {
-    if (Candle_color == ColorDefault) {
-      Candle_pixels->setPixelColor(i, 255, 255, 255); // Default is white
-    } else {
-      Candle_pixels->setPixelColor(i, Candle_red, Candle_green, Candle_blue);
-    }
-  }
-}
-
-void type_Simple_Candle() {
-  int r, g, b;
-
-  if (Candle_color == ColorDefault) {
-    r = 226, g = 42, b =  35; // Regular (orange) flame
-    // r = 158, g =   8, b = 148;   // Purple flame
-    // r =  74, g = 150, b =  12;   // Green flame
-  } else {
-    r = Candle_red, g = Candle_green, b = Candle_blue;
-  }
-
-  //  Flicker, based on our initial RGB values
-  for (int i = 0; i < Candle_pxlcnt; i++) {
-    int flicker = random(0, P042_RANDOM_PIXEL);
-    int r1      = r - flicker;
-    int g1      = g - flicker;
-    int b1      = b - flicker;
-
-    if (g1 < 0) { g1 = 0; }
-
-    if (r1 < 0) { r1 = 0; }
-
-    if (b1 < 0) { b1 = 0; }
-    Candle_pixels->setPixelColor(i, r1, g1, b1);
-  }
-}
-
-void type_Advanced_Candle() {
-  Candle_Temp[0] = random(1, 4);                  // 1..4  LEDs in RED
-  Candle_Temp[1] = random(1, 4) + Candle_Temp[0]; // 1..3  LEDs in Yellow / Orange
-  Candle_Temp[2] = random(0, 2);                  // 0..1  Choose Yellow = 0 / Orange = 1
-
-  int colorbase[3];
-  int color1[3];
-  int color2[3];
-  int color3[3];
-
-  if (Candle_color == ColorDefault) {
-    colorbase[0] = 255; colorbase[1] = 120; colorbase[2] = 0; // Light Orange #FF7800
-    color1[0]    = 115; color1[1] = 50; color1[2] = 0;        // Brown      #733200
-    color2[0]    = 180; color2[1] = 80; color2[2] = 0;        // Orange     #B45000
-    color3[0]    =  70; color3[1] = 30; color3[2] = 0;        // Dark brown #4A2000
-  } else {
-    colorbase[0] = Candle_red; colorbase[1] = Candle_green; colorbase[2] = Candle_blue;
-    float hsv[3];
-
-    // Calc HSV
-    RGB2HSV(Candle_red, Candle_green, Candle_blue, hsv);
-    float newH = hsv[0] - 5.0f;
-
-    if (newH < 0) { newH += 359.0f; }
-    float newV  = hsv[2] / 2.0f;
-    float newV2 = hsv[2] / 4.0f;
-
-    // Calc new RGBs
-    HSV2RGB(newH,   hsv[1], hsv[2], color1);
-    HSV2RGB(hsv[0], hsv[1], newV,   color2);
-    HSV2RGB(newH,   hsv[1], newV2,  color3);
-  }
-
-  for (int j = 0; j < 4; j++) {
-    for (unsigned int i = 1; i < 6; i++) {
-      if (i <= Candle_Temp[0]) {
-        Candle_pixels->setPixelColor(j * 5 + i - 1, colorbase[0], colorbase[1], colorbase[2]);
-      }
-
-      if ((i > Candle_Temp[0]) && (i <= Candle_Temp[1])) {
-        if (Candle_Temp[2] == 0) {
-          Candle_pixels->setPixelColor(j * 5 + i - 1, color1[0], color1[1], color1[2]);
-        } else {
-          Candle_pixels->setPixelColor(j * 5 + i - 1, color2[0], color2[1], color2[2]);
-        }
-      }
-
-      if (i > Candle_Temp[1]) {
-        Candle_pixels->setPixelColor(j * 5 + i - 1, color3[0], color3[1], color3[2]);
-      }
-    }
-  }
-}
-
-void type_Police() {
-  Candle_Temp[0]++;
-
-  if (Candle_Temp[0] > 3) {
-    Candle_Temp[0] = 0;
-  }
-
-  for (unsigned int i = 0; i < 4; i++) {
-    if (i == Candle_Temp[0])
-    {
-      for (int j = 0; j < 5; j++) {
-        if (Candle_color == ColorDefault) {
-          Candle_pixels->setPixelColor(i * 5 + j, 0, 0, 255);
-        } else {
-          Candle_pixels->setPixelColor(i * 5 + j, Candle_red, Candle_green, Candle_blue);
-        }
-      }
-    } else {
-      for (int j = 0; j < 5; j++) {
-        Candle_pixels->setPixelColor(i * 5 + j, 0, 0, 0);
-      }
-    }
-  }
-}
-
-void type_BlinkStrobe() {
-  Candle_Temp[0]++;
-
-  if (Candle_Temp[0] > 1) {
-    Candle_Temp[0] = 0;
-  }
-
-  for (int i = 0; i < Candle_pxlcnt; i++) {
-    if (Candle_Temp[0] == 0) {
-      Candle_pixels->setPixelColor(i, 0, 0, 0);
-    } else {
-      if (Candle_color == ColorDefault) {
-        Candle_pixels->setPixelColor(i, 255, 255, 255); // Default is white
-      } else {
-        Candle_pixels->setPixelColor(i, Candle_red, Candle_green, Candle_blue);
-      }
-    }
-  }
-}
-
-void type_ColorFader() {
-  int   colors[3];
-  float hsv[3];
-
-  if (Candle_color != ColorDefault) {
-    if ((Candle_Temp[0] > 254) && (Candle_Temp[1] == 1)) {
-      Candle_Temp[1] = 0;
-    }
-
-    if ((Candle_Temp[0] < 55) && (Candle_Temp[1] == 0)) {
-      Candle_Temp[1] = 1;
-    }
-
-    if (Candle_Temp[1] > 0) {
-      Candle_Temp[0]++;
-    } else {
-      Candle_Temp[0]--;
-    }
-
-    // Calc HSV
-    // void RGB2HSV(uint8_t r, uint8_t g, uint8_t b, float hsv[3])
-    RGB2HSV(Candle_red, Candle_green, Candle_blue, hsv);
-
-    // Calc RGB with new V
-    // HSV2RGB(float hue, float sat, float val, int colors[3])
-    // hue: 0-359, sat: 0-255, val (lightness): 0-255
-    HSV2RGB(hsv[0], hsv[1], Candle_Temp[0], colors);
-
-    for (int i = 0; i < Candle_pxlcnt; i++) {
-      Candle_pixels->setPixelColor(i, colors[0], colors[1], colors[2]);
-    }
-  } else {
-    Candle_Temp[0]++;
-
-    if (Candle_Temp[0] > 359) {
-      Candle_Temp[0] = 0;
-    }
-
-    // hue: 0-359, sat: 0-255, val (lightness): 0-255
-    HSV2RGB(Candle_Temp[0], 255, 255, colors);
-
-    for (int i = 0; i < Candle_pxlcnt; i++) {
-      Candle_pixels->setPixelColor(i, colors[0], colors[1], colors[2]);
-    }
-  }
 }
 
 #endif // USES_P042

--- a/src/src/Helpers/Misc.cpp
+++ b/src/src/Helpers/Misc.cpp
@@ -416,6 +416,44 @@ void HSV2RGBW(float H, float S, float I, int rgbw[4]) {
   rgbw[3] = w;
 }
 
+// Convert RGB Color to HSV Color
+void RGB2HSV(uint8_t r, uint8_t g, uint8_t b, float hsv[3]) {
+  float rf     = static_cast<float>(r) / 255.0f;
+  float gf     = static_cast<float>(g) / 255.0f;
+  float bf     = static_cast<float>(b) / 255.0f;
+  float maxval = rf;
+
+  if (gf > maxval) { maxval = gf; }
+
+  if (bf > maxval) { maxval = bf; }
+  float minval = rf;
+
+  if (gf < minval) { minval = gf; }
+
+  if (bf < minval) { minval = bf; }
+  float h = 0.0f, s, v = maxval;
+  float f = maxval - minval;
+
+  s = maxval == 0.0f ? 0.0f : f / maxval;
+
+  if (maxval == minval) {
+    h = 0.0f; // achromatic
+  } else {
+    if (maxval == rf) {
+      h = (gf - bf) / f + (gf < bf ? 6.0f : 0.0f);
+    } else if (maxval == gf) {
+      h = (bf - rf) / f + 2.0f;
+    } else if (maxval == bf) {
+      h = (rf - gf) / f + 4.0f;
+    }
+    h /= 6.0f;
+  }
+
+  hsv[0] = h * 360.0f;
+  hsv[1] = s * 255.0f;
+  hsv[2] = v * 255.0f;
+}
+
 // Simple bitwise get/set functions
 
 uint8_t get8BitFromUL(uint32_t number, uint8_t bitnr) {

--- a/src/src/Helpers/Misc.h
+++ b/src/src/Helpers/Misc.h
@@ -150,6 +150,11 @@ void HSV2RGBW(float H,
               float I,
               int   rgbw[4]);
 
+void RGB2HSV(uint8_t r,
+             uint8_t g,
+             uint8_t b,
+             float   hsv[3]);
+
 // Simple bitwise get/set functions
 
 uint8_t get8BitFromUL(uint32_t number,

--- a/src/src/PluginStructs/P042_data_struct.cpp
+++ b/src/src/PluginStructs/P042_data_struct.cpp
@@ -1,0 +1,436 @@
+#include "../PluginStructs/P042_data_struct.h"
+
+#ifdef USES_P042
+
+P042_data_struct::P042_data_struct() {
+  //
+}
+
+P042_data_struct::~P042_data_struct() {
+  if (Candle_pixels != nullptr) {
+    SetPixelsBlack(); // Turn off
+    Candle_pixels->show();
+    delete Candle_pixels;
+    Candle_pixels = nullptr;
+  }
+}
+
+bool P042_data_struct::plugin_init(struct EventStruct *event) {
+  if (P042_CONFIG_PIXELCOUNT == 0) { P042_CONFIG_PIXELCOUNT = P042_NUM_PIXEL; }
+  Candle_red    = P042_CONFIG_RED;
+  Candle_green  = P042_CONFIG_GREEN;
+  Candle_blue   = P042_CONFIG_BLUE;
+  Candle_bright = P042_CONFIG_BRIGHTNESS;
+  Candle_pxlcnt = P042_CONFIG_PIXELCOUNT;
+  Candle_pxlcnt = P042_CONFIG_PIXELCOUNT;
+  segment       = Candle_pxlcnt / 4;
+
+  if ((Candle_red == 0) && (Candle_green == 0) && (Candle_blue == 0)) {
+    Candle_bright = P042_BRIGHT_START;
+  }
+  Candle_type  = static_cast<P042_SimType>(P042_CONFIG_CANDLETYPE);
+  Candle_color = static_cast<P042_ColorType>(P042_CONFIG_COLORTYPE);
+
+  if (!Candle_pixels || (GPIO_Set == false)) {
+    GPIO_Set = validGpio(CONFIG_PIN1);
+
+    if (GPIO_Set) {
+      if (Candle_pixels) {
+        delete Candle_pixels;
+      }
+      Candle_pixels = new (std::nothrow) Adafruit_NeoPixel(P042_CONFIG_PIXELCOUNT, CONFIG_PIN1, NEO_GRB + NEO_KHZ800);
+
+      if (Candle_pixels != nullptr) {
+        SetPixelsBlack();
+        Candle_pixels->setBrightness(Candle_bright);
+        Candle_pixels->begin();
+      }
+
+          # ifndef BUILD_NO_DEBUG
+
+      if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+        addLogMove(LOG_LEVEL_DEBUG, concat(F("CAND : Init WS2812 Pin : "), static_cast<int>(CONFIG_PIN1)));
+      }
+          # endif // ifndef BUILD_NO_DEBUG
+    }
+  }
+
+  return Candle_pixels != nullptr;
+}
+
+bool P042_data_struct::plugin_read(struct EventStruct *event) {
+  UserVar[event->BaseVarIndex]     = Candle_red << 16 | Candle_green << 8 | Candle_blue;
+  UserVar[event->BaseVarIndex + 1] = Candle_bright;
+  UserVar[event->BaseVarIndex + 2] = static_cast<float>(Candle_type);
+
+  return true;
+}
+
+bool P042_data_struct::plugin_once_a_second(struct EventStruct *event) {
+  Candle_pixels->setBrightness(Candle_bright);
+  Candle_pixels->show(); // This sends the updated pixel color to the hardware.
+  return true;
+}
+
+bool P042_data_struct::plugin_fifty_per_second(struct EventStruct *event) {
+  switch (Candle_type)
+  {
+    case P042_SimType::TypeOff: // "Update" for OFF
+    {
+      SetPixelsBlack();
+      break;
+    }
+
+    case P042_SimType::TypeSimpleCandle: // Update for LIGHT
+    {
+      type_Static_Light();
+      break;
+    }
+
+    case P042_SimType::TypeAdvancedCandle: // Random Updates for Simple Candle, Advanced Candle, Fire Simulation
+    case P042_SimType::TypeStaticLight:
+    {
+      if (timeOutReached(Candle_Update)) {
+        if (Candle_type == P042_SimType::TypeAdvancedCandle) {
+          type_Simple_Candle();
+        }
+
+        if (Candle_type == P042_SimType::TypeStaticLight) {
+          type_Advanced_Candle();
+        }
+        Candle_Update = millis() + random(25, 150);
+      }
+      break;
+    }
+
+    case P042_SimType::TypePolice: // Update for Police
+    {
+      if (timeOutReached(Candle_Update)) {
+        type_Police();
+        Candle_Update = millis() + 150;
+      }
+      break;
+    }
+
+    case P042_SimType::TypeBlink: // Update for Blink
+    {
+      if (timeOutReached(Candle_Update)) {
+        type_BlinkStrobe();
+        Candle_Update = millis() + 100;
+      }
+      break;
+    }
+
+    case P042_SimType::TypeStrobe: // Update for Strobe
+    {
+      type_BlinkStrobe();
+      break;
+    }
+    case P042_SimType::TypeColorFader: // Update for ColorFader
+    {
+      if (timeOutReached(Candle_Update)) {
+        type_ColorFader();
+        Candle_Update = millis() + 2000;
+      }
+      break;
+    }
+  }
+
+  Candle_pixels->show();
+
+  return true;
+}
+
+bool P042_data_struct::plugin_write(struct EventStruct *event,
+                                    const String      & string) {
+  bool   success = false;
+  char   cmdSep  = ','; // Try comma first
+  String cmd     = parseString(string, 1, cmdSep);
+
+  if (!cmd.equals(F("candle"))) {
+    cmdSep = ':'; // Fallback to colon
+    cmd    = parseString(string, 1, cmdSep);
+  }
+
+  // Test
+  // MQTT   : mosquitto_pub -d -t sensors/espeasy/ESP_Candle/cmd  -m "CANDLE_OFF"
+  // HTTP   : http://192.168.30.183/tools?cmd=CANDLE%3A5%3AFF0000%3A200
+  //          http://192.168.30.183/tools?cmd=CANDLE:4:FF0000:200
+  // SERIAL : CANDLE:4:FF0000:200<CR><LF>
+
+  // Commands
+  // CANDLE:<FlameType>:<Color>:<Brightness>
+  //    <FlameType>  : 1 Static Light, 2 Simple Candle, 3 Advanced Candle, 4 Police, 5 Blink, 6 Strobe, 7 Color Fader
+  //    <Color>      : n.def.  Use the default color
+  //                   RRGGBB  Use color in RRGGBB style (red, green blue) as HEX
+  //    <Brightness> : 0-255
+  // Samples:   CANDLE:2::100           Simple Candle with Default color and Brigthness at 100
+  //            CANDLE:5:FF0000:200     Blink with RED Color and Brigthness at 200
+  //            CANDLE:0::              Candle OFF
+  //            CANDLE:1::255           Candle ON - White and full brigthness
+  // 2023-01-21: command can also be in lowercase, and separator can either be comma or colon, but all have to be the same
+
+  if (cmd.equals(F("candle"))) {
+    const String val_Type   = parseString(string, 2, cmdSep);
+    const String val_Color  = parseString(string, 3, cmdSep);
+    const String val_Bright = parseString(string, 4, cmdSep);
+
+    if (!val_Type.isEmpty()) {
+      if ((val_Type.toInt() > -1) && (val_Type.toInt() < P042_FLAME_OPTIONS)) {
+        P042_CONFIG_CANDLETYPE = val_Type.toInt(); // Type
+        Candle_type            = static_cast<P042_SimType>(P042_CONFIG_CANDLETYPE);
+        # ifndef BUILD_NO_DEBUG
+
+        if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+          addLogMove(LOG_LEVEL_DEBUG, concat(F("CAND : CMD - Type : "), val_Type));
+        }
+        # endif // ifndef BUILD_NO_DEBUG
+      }
+    }
+
+    if (!val_Bright.isEmpty()) {
+      if ((val_Bright.toInt() > -1) && (val_Bright.toInt() < 256)) {
+        P042_CONFIG_BRIGHTNESS = val_Bright.toInt(); // Brightness
+        Candle_bright          = P042_CONFIG_BRIGHTNESS;
+        # ifndef BUILD_NO_DEBUG
+
+        if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+          addLogMove(LOG_LEVEL_DEBUG, concat(F("CAND : CMD - Bright : "), val_Bright));
+        }
+        # endif // ifndef BUILD_NO_DEBUG
+      }
+    }
+
+    uint32_t number = 0;
+
+    if (!val_Color.isEmpty() && validUIntFromString(concat(F("0x"), val_Color), number)) {
+      // Split RGB to r, g, b values
+      P042_CONFIG_RED       = (number >> 16) & 0xFF;
+      P042_CONFIG_GREEN     = (number >> 8) & 0xFF;
+      P042_CONFIG_BLUE      = number & 0xFF;
+      Candle_red            = P042_CONFIG_RED;
+      Candle_green          = P042_CONFIG_GREEN;
+      Candle_blue           = P042_CONFIG_BLUE;
+      P042_CONFIG_COLORTYPE = 1;
+      Candle_color          = static_cast<P042_ColorType>(P042_CONFIG_COLORTYPE);
+
+      # ifndef BUILD_NO_DEBUG
+
+      if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+        String log = F("CAND : CMD - R ");
+        log += Candle_red;
+        log += F(" G ");
+        log += Candle_green;
+        log += F(" B ");
+        log += Candle_blue;
+        addLogMove(LOG_LEVEL_DEBUG, log);
+      }
+      # endif // ifndef BUILD_NO_DEBUG
+    } else {
+      P042_CONFIG_COLORTYPE = 0;
+      Candle_color          = static_cast<P042_ColorType>(P042_CONFIG_COLORTYPE);
+      # ifndef BUILD_NO_DEBUG
+      addLog(LOG_LEVEL_DEBUG, F("CAND : CMD - Color : DEFAULT"));
+      # endif // ifndef BUILD_NO_DEBUG
+    }
+
+    success = true;
+  }
+
+  return success;
+}
+
+void P042_data_struct::SetPixelsBlack() {
+  for (int i = 0; i < Candle_pxlcnt; i++) {
+    Candle_pixels->setPixelColor(i, Candle_pixels->Color(0, 0, 0));
+  }
+}
+
+void P042_data_struct::SetPixelToColor(int PixelIdx) {
+  Candle_pixels->setPixelColor(PixelIdx, Candle_pixels->Color(Candle_red, Candle_green, Candle_blue));
+}
+
+void P042_data_struct::type_Static_Light() {
+  for (int i = 0; i < Candle_pxlcnt; i++) {
+    if (Candle_color == P042_ColorType::ColorDefault) {
+      Candle_pixels->setPixelColor(i, 255, 255, 255); // Default is white
+    } else {
+      Candle_pixels->setPixelColor(i, Candle_red, Candle_green, Candle_blue);
+    }
+  }
+}
+
+void P042_data_struct::type_Simple_Candle() {
+  int r, g, b;
+
+  if (Candle_color == P042_ColorType::ColorDefault) {
+    r = 226, g = 42, b =  35; // Regular (orange) flame
+    // r = 158, g =   8, b = 148;   // Purple flame
+    // r =  74, g = 150, b =  12;   // Green flame
+  } else {
+    r = Candle_red, g = Candle_green, b = Candle_blue;
+  }
+
+  //  Flicker, based on our initial RGB values
+  for (int i = 0; i < Candle_pxlcnt; i++) {
+    int flicker = random(0, P042_RANDOM_PIXEL);
+    int r1      = r - flicker;
+    int g1      = g - flicker;
+    int b1      = b - flicker;
+
+    if (g1 < 0) { g1 = 0; }
+
+    if (r1 < 0) { r1 = 0; }
+
+    if (b1 < 0) { b1 = 0; }
+    Candle_pixels->setPixelColor(i, r1, g1, b1);
+  }
+}
+
+void P042_data_struct::type_Advanced_Candle() {
+  Candle_Temp[0] = random(1, 4);                  // 1..4  LEDs in RED
+  Candle_Temp[1] = random(1, 4) + Candle_Temp[0]; // 1..3  LEDs in Yellow / Orange
+  Candle_Temp[2] = random(0, 2);                  // 0..1  Choose Yellow = 0 / Orange = 1
+
+  int colorbase[3];
+  int color1[3];
+  int color2[3];
+  int color3[3];
+
+  if (Candle_color == P042_ColorType::ColorDefault) {
+    colorbase[0] = 255; colorbase[1] = 120; colorbase[2] = 0; // Light Orange #FF7800
+    color1[0]    = 115; color1[1] = 50; color1[2] = 0;        // Brown      #733200
+    color2[0]    = 180; color2[1] = 80; color2[2] = 0;        // Orange     #B45000
+    color3[0]    =  70; color3[1] = 30; color3[2] = 0;        // Dark brown #4A2000
+  } else {
+    colorbase[0] = Candle_red; colorbase[1] = Candle_green; colorbase[2] = Candle_blue;
+    float hsv[3];
+
+    // Calc HSV
+    RGB2HSV(Candle_red, Candle_green, Candle_blue, hsv);
+    float newH = hsv[0] - 5.0f;
+
+    if (newH < 0) { newH += 359.0f; }
+    float newV  = hsv[2] / 2.0f;
+    float newV2 = hsv[2] / 4.0f;
+
+    // Calc new RGBs
+    HSV2RGB(newH,   hsv[1], hsv[2], color1);
+    HSV2RGB(hsv[0], hsv[1], newV,   color2);
+    HSV2RGB(newH,   hsv[1], newV2,  color3);
+  }
+
+  for (int j = 0; j < 4; j++) {
+    for (int i = 1; i <= segment; i++) {
+      if (i <= Candle_Temp[0]) {
+        Candle_pixels->setPixelColor(j * segment + i - 1, colorbase[0], colorbase[1], colorbase[2]);
+      }
+
+      if ((i > Candle_Temp[0]) && (i <= Candle_Temp[1])) {
+        if (Candle_Temp[2] == 0) {
+          Candle_pixels->setPixelColor(j * segment + i - 1, color1[0], color1[1], color1[2]);
+        } else {
+          Candle_pixels->setPixelColor(j * segment + i - 1, color2[0], color2[1], color2[2]);
+        }
+      }
+
+      if (i > Candle_Temp[1]) {
+        Candle_pixels->setPixelColor(j * segment + i - 1, color3[0], color3[1], color3[2]);
+      }
+    }
+  }
+}
+
+void P042_data_struct::type_Police() {
+  Candle_Temp[0]++;
+
+  if (Candle_Temp[0] > 3) {
+    Candle_Temp[0] = 0;
+  }
+
+  for (unsigned int i = 0; i < 4; i++) {
+    if (i == Candle_Temp[0])
+    {
+      for (int j = 0; j < segment; j++) {
+        if (Candle_color == P042_ColorType::ColorDefault) {
+          Candle_pixels->setPixelColor(i * segment + j, 0, 0, 255);
+        } else {
+          Candle_pixels->setPixelColor(i * segment + j, Candle_red, Candle_green, Candle_blue);
+        }
+      }
+    } else {
+      for (int j = 0; j < segment; j++) {
+        Candle_pixels->setPixelColor(i * segment + j, 0, 0, 0);
+      }
+    }
+  }
+}
+
+void P042_data_struct::type_BlinkStrobe() {
+  Candle_Temp[0]++;
+
+  if (Candle_Temp[0] > 1) {
+    Candle_Temp[0] = 0;
+  }
+
+  for (int i = 0; i < Candle_pxlcnt; i++) {
+    if (Candle_Temp[0] == 0) {
+      Candle_pixels->setPixelColor(i, 0, 0, 0);
+    } else {
+      if (Candle_color == P042_ColorType::ColorDefault) {
+        Candle_pixels->setPixelColor(i, 255, 255, 255); // Default is white
+      } else {
+        Candle_pixels->setPixelColor(i, Candle_red, Candle_green, Candle_blue);
+      }
+    }
+  }
+}
+
+void P042_data_struct::type_ColorFader() {
+  int   colors[3];
+  float hsv[3];
+
+  if (Candle_color != P042_ColorType::ColorDefault) {
+    if ((Candle_Temp[0] > 254) && (Candle_Temp[1] == 1)) {
+      Candle_Temp[1] = 0;
+    }
+
+    if ((Candle_Temp[0] < 55) && (Candle_Temp[1] == 0)) {
+      Candle_Temp[1] = 1;
+    }
+
+    if (Candle_Temp[1] > 0) {
+      Candle_Temp[0]++;
+    } else {
+      Candle_Temp[0]--;
+    }
+
+    // Calc HSV
+    // void RGB2HSV(uint8_t r, uint8_t g, uint8_t b, float hsv[3])
+    RGB2HSV(Candle_red, Candle_green, Candle_blue, hsv);
+
+    // Calc RGB with new V
+    // HSV2RGB(float hue, float sat, float val, int colors[3])
+    // hue: 0-359, sat: 0-255, val (lightness): 0-255
+    HSV2RGB(hsv[0], hsv[1], Candle_Temp[0], colors);
+
+    for (int i = 0; i < Candle_pxlcnt; i++) {
+      Candle_pixels->setPixelColor(i, colors[0], colors[1], colors[2]);
+    }
+  } else {
+    Candle_Temp[0]++;
+
+    if (Candle_Temp[0] > 359) {
+      Candle_Temp[0] = 0;
+    }
+
+    // hue: 0-359, sat: 0-255, val (lightness): 0-255
+    HSV2RGB(Candle_Temp[0], 255, 255, colors);
+
+    for (int i = 0; i < Candle_pxlcnt; i++) {
+      Candle_pixels->setPixelColor(i, colors[0], colors[1], colors[2]);
+    }
+  }
+}
+
+#endif // ifdef USES_P042

--- a/src/src/PluginStructs/P042_data_struct.h
+++ b/src/src/PluginStructs/P042_data_struct.h
@@ -1,0 +1,108 @@
+#ifndef PLUGINSTRUCTS_P042_DATA_STRUCT_H
+#define PLUGINSTRUCTS_P042_DATA_STRUCT_H
+
+#include "../../_Plugin_Helper.h"
+
+#ifdef USES_P042
+
+# include <Adafruit_NeoPixel.h>
+
+
+# define P042_NUM_PIXEL     20  // Defines the default amount of LED Pixels
+# define P042_MAX_PIXELS    300 // Max. allowed pixels
+# define P042_RANDOM_PIXEL  70  // Defines the Flicker Level for Simple Candle
+# define P042_BRIGHT_START  128 // Defines the Start Brightness
+# define P042_FLAME_OPTIONS 8   // Number of flame types
+
+enum class P042_SimType : uint8_t {
+  TypeOff            = 0,
+  TypeSimpleCandle   = 1,
+  TypeAdvancedCandle = 2,
+  TypeStaticLight    = 3,
+  TypePolice         = 4,
+  TypeBlink          = 5,
+  TypeStrobe         = 6,
+  TypeColorFader     = 7,
+};
+
+enum class P042_ColorType : uint8_t {
+  ColorDefault  = 0,
+  ColorSelected = 1,
+};
+
+# define P042_WEBVAR_COUNT              7
+# define P042_WEBVAR_RED                _webVars[0]
+# define P042_WEBVAR_GREEN              _webVars[1]
+# define P042_WEBVAR_BLUE               _webVars[2]
+# define P042_WEBVAR_BRIGHTNESS         _webVars[3]
+# define P042_WEBVAR_CANDLETYPE         _webVars[4]
+# define P042_WEBVAR_COLORTYPE          _webVars[5]
+# define P042_WEBVAR_PIXELCOUNT         _webVars[6]
+# define P042_WEBVAR_RED_S              "wRed"
+# define P042_WEBVAR_GREEN_S            "wGreen"
+# define P042_WEBVAR_BLUE_S             "wBlue"
+# define P042_WEBVAR_BRIGHTNESS_S       "brText"
+# define P042_WEBVAR_CANDLETYPE_S       "cType"
+# define P042_WEBVAR_COLORTYPE_S        "clrType"
+# define P042_WEBVAR_PIXELCOUNT_S       "pxCnt"
+
+// Other vars
+# define P042_OTHVAR_BRIGHTNESSSLIDE_S  "brSlide"
+
+// Config defines
+# define P042_CONFIG_RED                PCONFIG(0)
+# define P042_CONFIG_GREEN              PCONFIG(1)
+# define P042_CONFIG_BLUE               PCONFIG(2)
+# define P042_CONFIG_BRIGHTNESS         PCONFIG(3)
+# define P042_CONFIG_CANDLETYPE         PCONFIG(4)
+# define P042_CONFIG_COLORTYPE          PCONFIG(5)
+# define P042_CONFIG_PIXELCOUNT         PCONFIG(6)
+
+struct P042_data_struct : public PluginTaskData_base {
+public:
+
+  P042_data_struct();
+  virtual ~P042_data_struct();
+
+  bool plugin_init(struct EventStruct *event);
+
+  // Perform read and return true when when succesful
+  bool plugin_read(struct EventStruct *event);
+  bool plugin_once_a_second(struct EventStruct *event);
+  bool plugin_fifty_per_second(struct EventStruct *event);
+
+  // Perform write and return true when successful
+  bool plugin_write(struct EventStruct *event,
+                    const String      & string);
+
+private:
+
+  void SetPixelsBlack();
+  void SetPixelToColor(int PixelIdx);
+  void type_Static_Light();
+  void type_Simple_Candle();
+  void type_Advanced_Candle();
+  void type_Police();
+  void type_BlinkStrobe();
+  void type_ColorFader();
+
+  uint8_t        Candle_red    = 0;
+  uint8_t        Candle_green  = 0;
+  uint8_t        Candle_blue   = 0;
+  uint8_t        Candle_bright = 128;
+  int            Candle_pxlcnt = P042_NUM_PIXEL;
+  int            segment       = Candle_pxlcnt / 4;
+  P042_SimType   Candle_type   = P042_SimType::TypeSimpleCandle;
+  P042_ColorType Candle_color  = P042_ColorType::ColorDefault;
+
+  // global variables
+  unsigned long Candle_Update  = 0;
+  word          Candle_Temp[3] = { 0 }; // Temp variables
+  boolean       GPIO_Set       = false;
+
+  Adafruit_NeoPixel *Candle_pixels;
+};
+
+
+#endif // ifdef USES_P042
+#endif // ifndef PLUGINSTRUCTS_P042_DATA_STRUCT_H

--- a/src/src/WebServer/Markup.cpp
+++ b/src/src/WebServer/Markup.cpp
@@ -661,6 +661,7 @@ void addNumericBox(const String& id, int value, int min, int max
   #endif  // if FEATURE_TOOLTIPS
   addHtmlAttribute(F("type"),  F("number"));
   addHtmlAttribute(F("name"),  id);
+  addHtmlAttribute(F("id"),    id);
 
   #if FEATURE_TOOLTIPS
 
@@ -771,6 +772,7 @@ void addTextBox(const String  & id,
   addHtmlAttribute(F("class"),     classname);
   addHtmlAttribute(F("type"),      F("search"));
   addHtmlAttribute(F("name"),      id);
+  addHtmlAttribute(F("id"),        id);
   if (maxlength > 0) {
     addHtmlAttribute(F("maxlength"), maxlength);
   }
@@ -818,6 +820,7 @@ void addTextArea(const String  & id,
   addHtmlAttribute(F("class"),     F("wide"));
   addHtmlAttribute(F("type"),      F("text"));
   addHtmlAttribute(F("name"),      id);
+  addHtmlAttribute(F("id"),        id);
   if (maxlength > 0) {
     addHtmlAttribute(F("maxlength"), maxlength);
   }

--- a/src/src/WebServer/Markup_Forms.cpp
+++ b/src/src/WebServer/Markup_Forms.cpp
@@ -320,6 +320,7 @@ void addFormPasswordBox(const String& label, const String& id, const String& pas
   addHtmlAttribute(F("class"),     F("wide"));
   addHtmlAttribute(F("type"),      F("password"));
   addHtmlAttribute(F("name"),      id);
+  addHtmlAttribute(F("id"),        id);
   addHtmlAttribute(F("maxlength"), maxlength);
 
   #if FEATURE_TOOLTIPS
@@ -359,6 +360,7 @@ void addFormIPBox(const String& label, const String& id, const uint8_t ip[4])
   addHtmlAttribute(F("class"), F("wide"));
   addHtmlAttribute(F("type"),  F("text"));
   addHtmlAttribute(F("name"),  id);
+  addHtmlAttribute(F("id"),    id);
   addHtmlAttribute(F("value"), (empty_IP) ? EMPTY_STRING : formatIP(ip));
   addHtml('>');
 }


### PR DESCRIPTION
Features:
- P042 NeoPixel Candle improve used string-sizes by minifying javascript
- Implement latest `jscolor` colorpicker updates (needs manual update of `jscolor.min.js` on ESPEasy filesystem!
- Add `id` attribute for all input elements, next to name attribute, to allow `getElementById()` lookup from js scripts
- Formatted source using Uncrustify

TODO:
- [x] Fix several code issue
- [x] Deduplicate code (f.e. `HSVtoRGB` replaced by `HSV2RGB` misc function)
- [x] Make number of pixels configurable