### PR TITLE
[Rules] Accept `if` and `elseif` statements only at the start of a line

### DIFF
--- a/src/src/ESPEasyCore/ESPEasyRules.cpp
+++ b/src/src/ESPEasyCore/ESPEasyRules.cpp
@@ -815,6 +815,7 @@ void processMatchedRule(String& action, const String& event,
   String lcAction = action;
 
   lcAction.toLowerCase();
+  lcAction.trim();
 
   if (fakeIfBlock) {
     isCommand = false;
@@ -825,7 +826,7 @@ void processMatchedRule(String& action, const String& event,
     }
   }
   int split =
-    lcAction.indexOf(F("elseif ")); // check for optional "elseif" condition
+    lcAction.startsWith(F("elseif ")) ? 0 : -1; // check for optional "elseif" condition
 
   if (split != -1) {
     // Found "elseif" condition
@@ -857,7 +858,7 @@ void processMatchedRule(String& action, const String& event,
     }
   } else {
     // check for optional "if" condition
-    split = lcAction.indexOf(F("if "));
+    split = lcAction.startsWith(F("if ")) ? 0 : -1;
 
     if (split != -1) {
       if (ifBlock < RULES_IF_MAX_NESTING_LEVEL) {


### PR DESCRIPTION
From a [forum issue](https://www.letscontrolit.com/forum/viewtopic.php?t=9434#p62772)

An `if ` in any position of a line would trigger that as a valid `if` statement processing, while it should only be accepted at the start of a line. And similarly for `elseif` though that's much unlikely to appear unexpectedly 😉 