### PR TITLE
[MQTT] Publish command allow empty payload

### DIFF
--- a/docs/source/Plugin/P000_commands.repl
+++ b/docs/source/Plugin/P000_commands.repl
@@ -421,9 +421,9 @@
     "
     Publish","
     :green:`Rules`","
-    Send command using MQTT broker service
+    Send command using MQTT broker service. Uses the first enabled MQTT Controller.
 
-    ``Publish,<topic>,<value>``"
+    ``Publish,<topic>[,<payload>]``"
     "
     Reboot","
     :red:`Internal`","

--- a/src/src/Commands/InternalCommands.cpp
+++ b/src/src/Commands/InternalCommands.cpp
@@ -408,7 +408,7 @@ bool executeInternalCommand(command_case_data & data)
 #endif
       COMMAND_CASE_A(   "pulse", Command_GPIO_Pulse,        3); // GPIO.h
 #if FEATURE_MQTT
-      COMMAND_CASE_A( "publish", Command_MQTT_Publish,      2); // MQTT.h
+      COMMAND_CASE_A( "publish", Command_MQTT_Publish,     -1); // MQTT.h
 #endif // if FEATURE_MQTT
       COMMAND_CASE_A(     "pwm", Command_GPIO_PWM,          4); // GPIO.h
       break;

--- a/src/src/Commands/MQTT.cpp
+++ b/src/src/Commands/MQTT.cpp
@@ -34,10 +34,10 @@ const __FlashStringHelper * Command_MQTT_Publish(struct EventStruct *event, cons
   const String topic = parseStringKeepCase(Line, 2);
   const String value = tolerantParseStringKeepCase(Line, 3);
   # ifndef BUILD_NO_DEBUG
-  addLog(LOG_LEVEL_DEBUG, String(F("Publish: ")) + topic + value);
+  addLog(LOG_LEVEL_DEBUG, concat(F("Publish: "), topic) + value);
   #endif
 
-  if ((topic.length() > 0) && (value.length() > 0)) {
+  if (!topic.isEmpty()) {
 
     bool mqtt_retainFlag;
     {


### PR DESCRIPTION
From a [Forum request](https://www.letscontrolit.com/forum/viewtopic.php?t=9506)

Features:
- `Publish,<topic>[,<payload>]` can have an optional payload (it was required to be non-empty)
- Updated documentation

TODO:
- [x] Testing ([confirmed by user](https://www.letscontrolit.com/forum/viewtopic.php?t=9506#p62856))