### PR TITLE
[ADC] Add config commands to set calibration

### DIFF
--- a/docs/source/Plugin/P002.rst
+++ b/docs/source/Plugin/P002.rst
@@ -188,8 +188,48 @@ When entered in the 2-point calibration fields, the page will reload with these 
 * 241 mV => 9.0041
 * 565 mV => 19.9832
 
+Set Calibration via Rules
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Added: 2023/02/17
 
+Calibration values are device specific, since they depend on parts like resistors which each have some tolerance.
+This makes mass deployment of rules and settings to a number of devices somewhat impractical as these values are stored in the settings file.
+
+To ease mass deployment of rules and settings, one can set the calibration values from a separate rules file.
+For example:
+
+* ``rules1.txt`` Generic rules file with rules applying to all nodes. May be updated every now and then.
+* ``rules2.txt`` Rules file with node specific values, like node nr, calibration values, etc.
+
+Command structure to set the ADC 2-Point Calibration:
+
+* Only set first point (2nd is set to 0): ``config,task,<taskname>,SetCalib,TwoPoint,<ADC1>,<Out1>``
+* Set both points: ``config,task,<taskname>,SetCalib,TwoPoint,<ADC1>,<Out1>,<ADC2>,<Out2>``
+
+Example rules block for setting ADC calibration + unit nr based on the last 3 bytes of the MAC address:
+
+.. code-block:: none
+
+  On LoadCalibration Do
+    if %cpu_id% = 0x1280E0
+      config,task,bat,SetCalib,TwoPoint,392,13.9846,571,19.9924
+      config,task,batBackup,SetCalib,TwoPoint,1785,10.000
+      unit,2
+    elseif %cpu_id% = 0x0C17E4
+      config,task,bat,SetCalib,TwoPoint,370.8615,13,520.857,18
+      config,task,batBackup,SetCalib,TwoPoint,1785,10.000
+      unit,3
+    endif
+  EndOn
+
+This can then be activated at boot like this:
+
+.. code-block:: none
+
+  On System#Boot Do
+    Event,LoadCalibration
+  Endon
 
 Multipoint Processing
 ---------------------

--- a/platformio_core_defs.ini
+++ b/platformio_core_defs.ini
@@ -222,7 +222,7 @@ build_flags               = ${esp82xx_3_0_x.build_flags}
 ;platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.5.2/platform-espressif32-2.0.5.2.zip
 ;platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2022.12.2/platform-espressif32.zip
 platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2023.01.01/platform-espressif32.zip
-platform_packages           =
+platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/1212/framework-arduinoespressif32-release_v4.4-fb9a7685e1.zip
 build_flags                 = -DESP32_STAGE
                               -DESP_IDF_VERSION_MAJOR=4
                               -DMUSTFIX_CLIENT_TIMEOUT_IN_SECONDS

--- a/src/_P002_ADC.ino
+++ b/src/_P002_ADC.ino
@@ -153,6 +153,20 @@ boolean Plugin_002(uint8_t function, struct EventStruct *event, String& string)
 
       break;
     }
+
+    case PLUGIN_SET_CONFIG:
+    {
+      P002_data_struct *P002_data =
+        static_cast<P002_data_struct *>(getPluginTaskData(event->TaskIndex));
+
+      if (P002_data != nullptr) {
+        success = P002_data->plugin_set_config(event, string);
+        if (success) {
+          P002_data->init(event);
+        }
+      }
+      break;
+    }
   }
   return success;
 }

--- a/src/src/Globals/Plugins.cpp
+++ b/src/src/Globals/Plugins.cpp
@@ -842,7 +842,8 @@ bool PluginCall(uint8_t Function, struct EventStruct *event, String& str)
         if (Function == PLUGIN_GET_DEVICEVALUENAMES ||
             Function == PLUGIN_WEBFORM_SAVE ||
             Function == PLUGIN_SET_DEFAULTS ||
-            Function == PLUGIN_INIT_VALUE_RANGES) {
+            Function == PLUGIN_INIT_VALUE_RANGES ||
+           (Function == PLUGIN_SET_CONFIG && retval)) {
           // Each of these may update ExtraTaskSettings, but it may not have been saved yet.
           // Thus update the cache just in case something from it is requested from the cache.
           Cache.updateExtraTaskSettingsCache();

--- a/src/src/PluginStructs/P002_data_struct.cpp
+++ b/src/src/PluginStructs/P002_data_struct.cpp
@@ -1205,7 +1205,7 @@ void P002_data_struct::setTwoPointCalibration(
 
 
 /*****************************************************
- * plugin_write
+ * plugin_set_config
  ****************************************************/
 bool P002_data_struct::plugin_set_config(struct EventStruct *event,
                                     String            & string) {

--- a/src/src/PluginStructs/P002_data_struct.h
+++ b/src/src/PluginStructs/P002_data_struct.h
@@ -223,7 +223,17 @@ private:
                              float out1,
                              float out2);
 
+
+  // Map the input "point" values to the nearest int.
+  static void setTwoPointCalibration(struct EventStruct *event,
+                                     float adc1,
+                                     float adc2,
+                                     float out1,
+                                     float out2);
+
 public:
+
+  bool plugin_set_config(struct EventStruct *event, String& string);
 
   uint16_t OversamplingCount = 0;
 


### PR DESCRIPTION
```
config,task,<taskname>,SetCalib,TwoPoint,<ADC1>,<Out1>
config,task,<taskname>,SetCalib,TwoPoint,<ADC1>,<Out1>,<ADC2>,<Out2>
```

This allows for a generic 2nd (or 3rd...) rules file so all units can use the same set of rules and still have unit specific configuration.

For example:
```
On LoadCalibration Do
  if %cpu_id% = 0x1280E0
    config,task,bat,SetCalib,TwoPoint,392,13.9846,571,19.9924
    config,task,batBackup,SetCalib,TwoPoint,1785,10.000
    unit,2
  elseif %cpu_id% = 0x0C17E4
    config,task,bat,SetCalib,TwoPoint,392,13.9846,571,19.9924
    config,task,batBackup,SetCalib,TwoPoint,1785,10.000
    unit,3
  endif
EndOn
```

Fixes: #4498 