### PR TITLE
[Build] Add `concurrency` option to cancel older, still running, PR-build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,6 @@ jobs:
           python tools/ci/generate-matrix.py
 
   build:
-    name: build-all
     needs: generate-matrix
     runs-on: ubuntu-22.04
     strategy:
@@ -104,17 +103,9 @@ jobs:
 
   # Repackage separately for ESP82xx and ESP32
   repackage:
-    needs: [documentation, generate-matrix]
+    needs: build
     runs-on: ubuntu-22.04
     steps:
-      - name: Wait for build to succeed
-        uses: yogeshlonkar/wait-for-jobs@v0
-        id: wait-for-build
-        with:
-          gh-token: ${{ secrets.GITHUB_TOKEN }}
-          jobs: 'build-all'
-          interval: 10000
-          ttl: 15
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
 
   build:
     name: build-matrix
-    needs: generate-matrix
+    needs: generate-all
     runs-on: ubuntu-22.04
     strategy:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
@@ -112,7 +112,7 @@ jobs:
         id: wait-for-build
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          jobs: 'build-matrix'
+          jobs: 'build-all'
           interval: 10000
           ttl: 15
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,8 +57,8 @@ jobs:
           python tools/ci/generate-matrix.py
 
   build:
-    name: build-matrix
-    needs: generate-all
+    name: build-all
+    needs: generate-matrix
     runs-on: ubuntu-22.04
     strategy:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,7 @@ jobs:
           python tools/ci/generate-matrix.py
 
   build:
+    name: build-matrix
     needs: generate-matrix
     runs-on: ubuntu-22.04
     strategy:
@@ -111,7 +112,7 @@ jobs:
         id: wait-for-build
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          jobs: 'build'
+          jobs: 'build-matrix'
           interval: 10000
           ttl: 15
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,9 +99,18 @@ jobs:
 
   # Repackage separately for ESP82xx and ESP32
   repackage:
-    needs: build
+    needs: [documentation, generate-matrix]
     runs-on: ubuntu-22.04
     steps:
+      - name: Wait for build to succeed
+        uses: fountainhead/action-wait-for-check@v1.1.0
+        id: wait-for-build
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: build
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          timeoutSeconds: 3600
+          intervalSeconds: 30
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   documentation:
     runs-on: ubuntu-22.04
@@ -103,14 +107,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Wait for build to succeed
-        uses: fountainhead/action-wait-for-check@v1.1.0
+        uses: yogeshlonkar/wait-for-jobs@v0
         id: wait-for-build
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          checkName: build
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          timeoutSeconds: 3600
-          intervalSeconds: 30
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          jobs: 'build'
+          interval: 10000
+          ttl: 15
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Features:

- ~Improvement on the `repackage` step to be started after the `build` step has completed, and not wait for many other busy runners to finish (will block 1 runner though...)~ Action doesn't work as expected, and documentation is lacking/minimal, so removed it again.
- Introducing concurrency on PR builds, causing older, still running, builds for the same PR to be cancelled if another push comes in for the PR