### PR TITLE
Add plugin P149 - Linear Actuator

### DIFF
--- a/src/src/PluginStructs/P098_data_struct.h
+++ b/src/src/PluginStructs/P098_data_struct.h
@@ -54,6 +54,9 @@ struct P098_config_struct {
 
   bool encoder_pu = false;
   bool pwm_soft_startstop = false;
+
+  uint32_t virtualSpeed = 0; // steps per ms
+  int pos0supplement = 0; // steps
 };
 
 struct P098_limit_switch_state {
@@ -127,6 +130,7 @@ struct P098_data_struct : public PluginTaskData_base {
   void getLimitSwitchPositions(int& limitA,
                                int& limitB) const;
 
+  void timeChanged();
 
   State state       = State::Idle;
   bool  initialized = false;
@@ -138,10 +142,12 @@ private:
   volatile P098_limit_switch_state limitB;
   volatile int                     position = 0;
   volatile uint64_t                enc_lastChanged_us = 0;
+  uint64_t                         lastVirtualSpeedApplied_us = 0;
   int                              pos_dest = 0;
   int                              pos_overshoot = 0;
 
   void        startMoving();
+  void        updatePosition();
 
   void        checkLimit(volatile P098_limit_switch_state& switch_state);
   void        checkPosition();


### PR DESCRIPTION
Hey all,

I have created a simple plugin to control a linear actuator (with integrated stop switches).

It is based on P098 but simplified in the way that it does not require an encoder to set the linear actuator to a specific position.

Instead of using an encoder it uses the time to determine the current position of the linear actuator. You just have to specify the duration of moving from completely in to completely out. It is not fully precise, but simple and sufficient for at least my case of opening a window on certain levels. And if the linear actuator has integrated stop switches, the plugin automatically calibrates the position every time a limit is reached.

If you are interested I am happy to contribute it to the main project. Let me know if changes are necessary.

Best,
 Flo
