### PR TITLE
[P028] Align INFO logging with other plugins

### DIFF
--- a/src/_P028_BME280.ino
+++ b/src/_P028_BME280.ino
@@ -275,36 +275,36 @@ boolean Plugin_028(uint8_t function, struct EventStruct *event, String& string)
             UserVar[event->BaseVarIndex + 2] = P028_data->last_press_val;
           }
 
-        # ifndef LIMIT_BUILD_SIZE
+          # ifndef LIMIT_BUILD_SIZE
 
           if (loglevelActiveFor(LOG_LEVEL_INFO)) {
             String log;
 
             if (log.reserve(40)) { // Prevent re-allocation
               log  = P028_data->getDeviceName();
-              log += F(" : Address: ");
+              log += F(": Address: ");
               log += formatToHex(P028_I2C_ADDRESS, 2);
               addLogMove(LOG_LEVEL_INFO, log);
 
               // addLogMove does also clear the string.
               log  = P028_data->getDeviceName();
-              log += F(" : Temperature: ");
+              log += F(": Temperature: ");
               log += formatUserVarNoCheck(event->TaskIndex, 0);
               addLogMove(LOG_LEVEL_INFO, log);
 
               if (P028_data->hasHumidity()) {
                 log  = P028_data->getDeviceName();
-                log += F(" : Humidity: ");
+                log += F(": Humidity: ");
                 log += formatUserVarNoCheck(event->TaskIndex, 1);
                 addLogMove(LOG_LEVEL_INFO, log);
               }
               log  = P028_data->getDeviceName();
-              log += F(" : Barometric Pressure: ");
+              log += F(": Barometric Pressure: ");
               log += formatUserVarNoCheck(event->TaskIndex, 2);
               addLogMove(LOG_LEVEL_INFO, log);
             }
           }
-        # endif // ifndef LIMIT_BUILD_SIZE
+          # endif // ifndef LIMIT_BUILD_SIZE
           success = true;
         }
       }

--- a/src/src/Helpers/I2C_access.cpp
+++ b/src/src/Helpers/I2C_access.cpp
@@ -4,6 +4,7 @@
 #include "../Globals/I2Cdev.h"
 #include "../Globals/Settings.h"
 #include "../Helpers/ESPEasy_time_calc.h"
+#include "../Helpers/StringConverter.h"
 
 enum class I2C_clear_bus_state {
   Start,
@@ -364,7 +365,10 @@ bool I2C_deviceCheck(uint8_t     i2caddr,
       if (maxRetries > 0) {
         deviceCheckI2C[taskIndex]++;
         if (deviceCheckI2C[taskIndex] >= maxRetries) {
-          Settings.TaskDeviceEnabled[taskIndex] = false; // If the number of retries is reeached, disable the device
+          Settings.TaskDeviceEnabled[taskIndex] = false; // If the number of retries is reached, disable the device
+          #ifndef BUILD_NO_DEBUG
+          addLog(LOG_LEVEL_ERROR, concat(F("I2C  : Device doesn't respond for task: "), static_cast<int>(taskIndex + 1)));
+          #endif
         }
       }
     }

--- a/src/src/PluginStructs/P028_data_struct.cpp
+++ b/src/src/PluginStructs/P028_data_struct.cpp
@@ -122,7 +122,7 @@ bool P028_data_struct::updateMeasurements(taskIndex_t task_index) {
 
     // There is some offset to apply.
     if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-      log += F(" Apply temp offset ");
+      log += F(" Apply temp offset: ");
       log += temp_offset;
       log += 'C';
     }
@@ -132,7 +132,7 @@ bool P028_data_struct::updateMeasurements(taskIndex_t task_index) {
       # ifndef LIMIT_BUILD_SIZE
 
       if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-        log += F(" humidity ");
+        log += F(" humidity: ");
         log += last_hum_val;
       }
       # endif // ifndef LIMIT_BUILD_SIZE
@@ -153,7 +153,7 @@ bool P028_data_struct::updateMeasurements(taskIndex_t task_index) {
 # ifndef LIMIT_BUILD_SIZE
 
     if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-      log += F(" temperature ");
+      log += F(" temperature: ");
       log += last_temp_val;
     }
 # endif // ifndef LIMIT_BUILD_SIZE
@@ -174,7 +174,7 @@ bool P028_data_struct::updateMeasurements(taskIndex_t task_index) {
 
   if (hasHumidity()) {
     if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-      log     += F(" dew point ");
+      log     += F(" dew point: ");
       log     += last_dew_temp_val;
       log     += 'C';
       logAdded = true;
@@ -209,7 +209,7 @@ bool P028_data_struct::check() {
           setUninitialized();
 
           if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-            String log = F("BMx280 : Detected ");
+            String log = F("BMx280: Detected ");
             log += getDeviceName();
             addLogMove(LOG_LEVEL_INFO, log);
           }
@@ -226,7 +226,7 @@ bool P028_data_struct::check() {
 
   if (sensorID == Unknown_DEVICE) {
     if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-      String log = F("BMx280 : Unable to detect chip ID (");
+      String log = F("BMx280: Unable to detect chip ID (");
       log += chip_id;
 
       if (!wire_status) {


### PR DESCRIPTION
Features:
- Logging for P028 - Environment BMx280 plugin wasn't aligned with other logging from either system or other plugin logs:
Old:
```
1 : Info   : BME280: Apply temp offset 1.00C humidity 31.56% => 30.61% temperature 21.30C => 22.30C dew point 4.13C
2 : Info   : BME280 : Address: 0x76
3 : Info   : BME280 : Temperature: 22.30
4 : Info   : BME280 : Humidity: 30.61
5 : Info   : BME280 : Barometric Pressure: 1025.98
6 : Info   : EVENT: BMx280#Temperature=22.30
7 : Info   : EVENT: BMx280#Humidity=30.61
8 : Info   : EVENT: BMx280#Pressure=1025.98
```
New:
```
1 : Info   : BME280: Apply temp offset: 1.00C humidity: 31.56% => 30.61% temperature: 21.30C => 22.30C dew point: 4.13C
2 : Info   : BME280: Address: 0x76
3 : Info   : BME280: Temperature: 22.30
4 : Info   : BME280: Humidity: 30.61
5 : Info   : BME280: Barometric Pressure: 1025.98
6 : Info   : EVENT: BMx280#Temperature=22.30
7 : Info   : EVENT: BMx280#Humidity=30.61
8 : Info   : EVENT: BMx280#Pressure=1025.98
```
(time-stamp edited for readability)

- Log error if an unresponsive I2C device gets disabled, example:
`101043 : Error  : I2C  : Device doesn't respond for task: 1`