### PR TITLE
[Build] Schedule Repackage job so it starts after build completes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,9 +103,18 @@ jobs:
 
   # Repackage separately for ESP82xx and ESP32
   repackage:
-    needs: build
+    needs: [documentation, generate-matrix]
     runs-on: ubuntu-22.04
     steps:
+      - name: Wait for build to succeed
+        uses: fountainhead/action-wait-for-check@v1.1.0
+        id: wait-for-build
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          check-name: build
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          timeoutSeconds: 10800
+          intervalSeconds: 30
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
New attempt to have the `repackage` job not wait for other Action runs to complete by scheduling it to start earlier and poll for the `build` to complete.