### PR TITLE
[Displays] Don't trim spaces from text to display ([P012], [P023], [P036], [P104], [P131])

### DIFF
--- a/src/_P012_LCD.ino
+++ b/src/_P012_LCD.ino
@@ -9,6 +9,10 @@
 // #################################### Plugin 012: LCD ##################################################
 // #######################################################################################################
 
+/** Changelog:
+ * 2023-03-07 tonhuisman: Parse text to display without trimming off leading and trailing spaces
+ * 2023-03: First changelog added, older changes not logged
+ */
 
 // Sample templates
 //  Temp: [DHT11#Temperature]   Hum:[DHT11#humidity]
@@ -255,7 +259,7 @@ boolean Plugin_012(uint8_t function, struct EventStruct *event, String& string)
           success = true;
           int colPos  = event->Par2 - 1;
           int rowPos  = event->Par1 - 1;
-          String text = parseStringKeepCase(string, 4);
+          String text = parseStringKeepCase(string, 4, ',', false);
           text = P012_data->P012_parseTemplate(text, P012_data->Plugin_012_cols);
 
           P012_data->lcdWrite(text, colPos, rowPos);

--- a/src/_P012_LCD.ino
+++ b/src/_P012_LCD.ino
@@ -259,7 +259,7 @@ boolean Plugin_012(uint8_t function, struct EventStruct *event, String& string)
           success = true;
           int colPos  = event->Par2 - 1;
           int rowPos  = event->Par1 - 1;
-          String text = parseStringKeepCase(string, 4, ',', false);
+          String text = parseStringKeepCaseNoTrim(string, 4);
           text = P012_data->P012_parseTemplate(text, P012_data->Plugin_012_cols);
 
           P012_data->lcdWrite(text, colPos, rowPos);

--- a/src/_P023_OLED.ino
+++ b/src/_P023_OLED.ino
@@ -264,7 +264,7 @@ boolean Plugin_023(uint8_t function, struct EventStruct *event, String& string)
         }
         else if (equals(cmd, F("oled"))) {
           success = true;
-          String text = parseStringToEndKeepCase(string, 4, ',', false);
+          String text = parseStringToEndKeepCaseNoTrim(string, 4);
           text = P023_data->parseTemplate(text, 16);
           P023_data->sendStrXY(text.c_str(), event->Par1 - 1, event->Par2 - 1);
         }

--- a/src/_P023_OLED.ino
+++ b/src/_P023_OLED.ino
@@ -7,6 +7,7 @@
 // #######################################################################################################
 
 /** Changelog:
+ * 2023-03-07 tonhuisman: Parse text to display without trimming off leading and trailing spaces
  * 2022-10-09 tonhuisman: Deduplicate code by moving the OLed I2C Address check to OLed_helper
  * 2022-10: Start changelog, latest on top.
  */
@@ -263,7 +264,7 @@ boolean Plugin_023(uint8_t function, struct EventStruct *event, String& string)
         }
         else if (equals(cmd, F("oled"))) {
           success = true;
-          String text = parseStringToEndKeepCase(string, 4);
+          String text = parseStringToEndKeepCase(string, 4, ',', false);
           text = P023_data->parseTemplate(text, 16);
           P023_data->sendStrXY(text.c_str(), event->Par1 - 1, event->Par2 - 1);
         }

--- a/src/_P036_FrameOLED.ino
+++ b/src/_P036_FrameOLED.ino
@@ -14,6 +14,8 @@
 // Added to the main repository with some optimizations and some limitations.
 // Al long as the device is not selected, no RAM is waisted.
 //
+// @tonhuisman: 2023-03-07
+// CHG: Parse text to display without trimming off leading and trailing spaces
 // @tonhuisman: 2023-01-02
 // CHG: Reduce string sizes for input fields, uncrustify source (causing some changelog comments to be wrapped...)
 // @uwekaditz: 2022-10-17
@@ -1180,7 +1182,7 @@ boolean Plugin_036(uint8_t function, struct EventStruct *event, String& string)
           // content functions
           success = true;
           String *currentLine = &P036_data->LineContent->DisplayLinesV1[LineNo - 1].Content;
-          *currentLine = parseStringKeepCase(string, 3);
+          *currentLine = parseStringKeepCase(string, 3, ',', false);
           *currentLine = P036_data->P36_parseTemplate(*currentLine, LineNo - 1);
 
           // calculate Pix length of new Content

--- a/src/_P036_FrameOLED.ino
+++ b/src/_P036_FrameOLED.ino
@@ -1182,7 +1182,7 @@ boolean Plugin_036(uint8_t function, struct EventStruct *event, String& string)
           // content functions
           success = true;
           String *currentLine = &P036_data->LineContent->DisplayLinesV1[LineNo - 1].Content;
-          *currentLine = parseStringKeepCase(string, 3, ',', false);
+          *currentLine = parseStringKeepCaseNoTrim(string, 3);
           *currentLine = P036_data->P36_parseTemplate(*currentLine, LineNo - 1);
 
           // calculate Pix length of new Content

--- a/src/_P087_SerialProxy.ino
+++ b/src/_P087_SerialProxy.ino
@@ -241,7 +241,7 @@ boolean Plugin_087(uint8_t function, struct EventStruct *event, String& string) 
           static_cast<P087_data_struct *>(getPluginTaskData(event->TaskIndex));
 
         if ((nullptr != P087_data)) {
-          String param1 = parseStringKeepCase(string, 2, ',', false); // Don't trim off white-space
+          String param1 = parseStringKeepCaseNoTrim(string, 2); // Don't trim off white-space
           parseSystemVariables(param1, false);
           P087_data->sendString(param1);
           addLogMove(LOG_LEVEL_INFO, param1);

--- a/src/_P104_max7219_Dotmatrix.ino
+++ b/src/_P104_max7219_Dotmatrix.ino
@@ -68,6 +68,7 @@
 //                                The bar width is determined by the number of graph-strings
 //
 // History:
+// 2023-03-07 tonhuisman: Parse text to display without trimming off leading and trailing spaces
 // 2022-08-12 tonhuisman: Remove [DEVELOPMENT] tag
 // 2021-10-03 tonhuisman: Add Inverted option per zone
 // 2021-09    tonhuisman: Minor improvements, attempts to fix stack failures

--- a/src/_P131_NeoPixelMatrix.ino
+++ b/src/_P131_NeoPixelMatrix.ino
@@ -218,7 +218,7 @@ boolean Plugin_131(uint8_t function, struct EventStruct *event, String& string)
 
           html_TD(); // Text
           addTextBox(getPluginCustomArgName(varNr),
-                     parseStringKeepCase(strings[varNr], 1),
+                     parseStringKeepCaseNoTrim(strings[varNr], 1),
                      P131_Nchars,
                      false,
                      false,

--- a/src/src/ESPEasyCore/ESPEasyRules.cpp
+++ b/src/src/ESPEasyCore/ESPEasyRules.cpp
@@ -480,9 +480,9 @@ void parse_string_commands(String& line) {
     // Command without opening and closing brackets.
     const String fullCommand = line.substring(startIndex + 1, closingIndex);
     const String cmd_s_lower = parseString(fullCommand, 1, ':');
-    const String arg1        = parseStringKeepCase(fullCommand, 2, ':');
-    const String arg2        = parseStringKeepCase(fullCommand, 3, ':');
-    const String arg3        = parseStringKeepCase(fullCommand, 4, ':');
+    const String arg1        = parseStringKeepCaseNoTrim(fullCommand, 2, ':');
+    const String arg2        = parseStringKeepCaseNoTrim(fullCommand, 3, ':');
+    const String arg3        = parseStringKeepCaseNoTrim(fullCommand, 4, ':');
 
     if (cmd_s_lower.length() > 0) {
       String replacement; // maybe just replace with empty to avoid looping?

--- a/src/src/Helpers/AdafruitGFX_helper.cpp
+++ b/src/src/Helpers/AdafruitGFX_helper.cpp
@@ -869,7 +869,7 @@ bool AdafruitGFX_helper::processCommand(const String& string) {
 
   while (loop) { // Process all provided arguments
     // 0-offset + 1st and 2nd argument used by trigger/subcommand, don't trim off spaces
-    sParams.push_back(parseStringKeepCase(string, argCount + 3, ',', false));
+    sParams.push_back(parseStringKeepCaseNoTrim(string, argCount + 3));
     nParams.push_back(0);
     validIntFromString(sParams[argCount], nParams[argCount]);
 
@@ -917,7 +917,7 @@ bool AdafruitGFX_helper::processCommand(const String& string) {
 
   if (adagfx_commands_e::txt == subcmd)                           // txt: Print text at last cursor position, ends at next line!
   {
-    _display->println(parseStringToEndKeepCase(string, 3));       // Print entire rest of provided line
+    _display->println(parseStringToEndKeepCaseNoTrim(string, 3)); // Print entire rest of provided line
   }
   else if ((adagfx_commands_e::txp == subcmd) && (argCount == 2)) // txp: Text position
   {
@@ -949,10 +949,10 @@ bool AdafruitGFX_helper::processCommand(const String& string) {
       } else {
         _display->setCursor(nParams[0] + _xo, nParams[1] + _yo);
       }
-      _display->println(parseStringToEndKeepCase(string, 5));     // Print entire rest of provided line
+      _display->println(parseStringToEndKeepCaseNoTrim(string, 5)); // Print entire rest of provided line
     }
   }
-  else if ((adagfx_commands_e::txl == subcmd) && (argCount >= 2)) // txl: Text at line(s)
+  else if ((adagfx_commands_e::txl == subcmd) && (argCount >= 2))   // txl: Text at line(s)
   {
     uint8_t _line              = 0;
     uint8_t _column            = 0;
@@ -1851,7 +1851,7 @@ bool AdafruitGFX_helper::processCommand(const String& string) {
     #  if ADAGFX_ARGUMENT_VALIDATION
     const int16_t curWin = getWindow();
 
-    if (curWin != 0) { selectWindow(0); }           // Validate against raw window coordinates
+    if (curWin != 0) { selectWindow(0); } // Validate against raw window coordinates
 
     if (argCount == 6) { setRotation(nParams[5]); } // Use requested rotation
 
@@ -1984,7 +1984,7 @@ bool AdafruitGFX_helper::pluginGetConfigValue(String& string) {
     {
       int16_t  x1, y1;
       uint16_t w1, h1;
-      String   newString = AdaGFXparseTemplate(parseStringToEndKeepCase(string, 2), 0);
+      String   newString = AdaGFXparseTemplate(parseStringToEndKeepCaseNoTrim(string, 2), 0);
       _display->getTextBounds(newString, 0, 0, &x1, &y1, &w1, &h1); // Count length and height
 
       if (adagfx_getcommands_e::length == cmd) {

--- a/src/src/Helpers/StringConverter.cpp
+++ b/src/src/Helpers/StringConverter.cpp
@@ -731,6 +731,10 @@ String parseString(const String& string, uint8_t indexFind, char separator, bool
   return result;
 }
 
+String parseStringKeepCaseNoTrim(const String& string, uint8_t indexFind, char separator) {
+  return parseStringKeepCase(string, indexFind, separator, false);
+}
+
 String parseStringKeepCase(const String& string, uint8_t indexFind, char separator, bool trimResult) {
   String result;
 
@@ -748,6 +752,10 @@ String parseStringToEnd(const String& string, uint8_t indexFind, char separator,
 
   result.toLowerCase();
   return result;
+}
+
+String parseStringToEndKeepCaseNoTrim(const String& string, uint8_t indexFind, char separator) {
+  return parseStringToEndKeepCase(string, indexFind, separator, false);
 }
 
 String parseStringToEndKeepCase(const String& string, uint8_t indexFind, char separator, bool trimResult) {

--- a/src/src/Helpers/StringConverter.h
+++ b/src/src/Helpers/StringConverter.h
@@ -271,6 +271,10 @@ String parseStringKeepCase(const String& string,
                            char          separator = ',',
                            bool          trimResult = true);
 
+String parseStringKeepCaseNoTrim(const String& string,
+                                 uint8_t       indexFind,
+                                 char          separator = ',');
+
 String parseStringToEnd(const String& string,
                         uint8_t       indexFind,
                         char          separator = ',',
@@ -280,6 +284,10 @@ String parseStringToEndKeepCase(const String& string,
                                 uint8_t       indexFind,
                                 char          separator = ',',
                                 bool          trimResult = true);
+
+String parseStringToEndKeepCaseNoTrim(const String& string,
+                                      uint8_t       indexFind,
+                                      char          separator = ',');
 
 String tolerantParseStringKeepCase(const char * string,
                                    uint8_t      indexFind,

--- a/src/src/PluginStructs/P104_data_struct.cpp
+++ b/src/src/PluginStructs/P104_data_struct.cpp
@@ -938,7 +938,7 @@ bool P104_data_struct::handlePluginWrite(taskIndex_t   taskIndex,
     String sub = parseString(string, 2);
 
     int zoneIndex;
-    String string4 = parseStringKeepCase(string, 4);
+    String string4 = parseStringKeepCase(string, 4, ',', false);
     # ifdef P104_USE_COMMANDS
     int value4;
     validIntFromString(string4, value4);

--- a/src/src/PluginStructs/P104_data_struct.cpp
+++ b/src/src/PluginStructs/P104_data_struct.cpp
@@ -221,7 +221,7 @@ void P104_data_struct::loadSettings() {
           zones[zoneIndex].size = tmp_int;
         }
 
-        zones[zoneIndex].text = parseStringKeepCase(tmp, 1 + P104_OFFSET_TEXT, P104_FIELD_SEP);
+        zones[zoneIndex].text = parseStringKeepCaseNoTrim(tmp, 1 + P104_OFFSET_TEXT, P104_FIELD_SEP);
 
         if (validIntFromString(parseString(tmp, 1 + P104_OFFSET_ALIGNMENT, P104_FIELD_SEP), tmp_int)) {
           zones[zoneIndex].alignment = tmp_int;
@@ -938,7 +938,7 @@ bool P104_data_struct::handlePluginWrite(taskIndex_t   taskIndex,
     String sub = parseString(string, 2);
 
     int zoneIndex;
-    String string4 = parseStringKeepCase(string, 4, ',', false);
+    String string4 = parseStringKeepCaseNoTrim(string, 4);
     # ifdef P104_USE_COMMANDS
     int value4;
     validIntFromString(string4, value4);

--- a/src/src/PluginStructs/P131_data_struct.cpp
+++ b/src/src/PluginStructs/P131_data_struct.cpp
@@ -153,7 +153,7 @@ bool P131_data_struct::plugin_init(struct EventStruct *event) {
         content[x].pixelPos = 0;
 
         if (content[x].active) {
-          String   tmpString = parseStringKeepCase(strings[x], 1);
+          String   tmpString = parseStringKeepCaseNoTrim(strings[x], 1);
           String   newString = AdaGFXparseTemplate(tmpString, _textcols, gfxHelper);
           uint16_t h;
           content[x].length = gfxHelper->getTextSize(newString, h);
@@ -277,7 +277,7 @@ void P131_data_struct::display_content(struct EventStruct *event,
     for (; x < x_end; x++) {
       if (!scrollOnly ||
           (scrollOnly && content[x].active)) {
-        String   tmpString = parseStringKeepCase(strings[x], 1);
+        String   tmpString = parseStringKeepCaseNoTrim(strings[x], 1);
         String   newString = AdaGFXparseTemplate(tmpString, _textcols, gfxHelper);
         uint16_t h;
         content[x].length = gfxHelper->getTextSize(newString, h);

--- a/src/src/PluginStructs/P145_data_struct.cpp
+++ b/src/src/PluginStructs/P145_data_struct.cpp
@@ -447,6 +447,7 @@ float P145_data_struct::getAnalogValue()
 @param[in] ref     Reference level for calibration
 @note   These parameters must be set before the plugin can calculate the level
         They are determined by the plugin configuration
+*/
 /*****************************************************************************/
 void P145_data_struct::setSensorData(int stype, bool comp, bool cal, bool vcclow, float load, float zero, float ref)
 {
@@ -475,6 +476,7 @@ void P145_data_struct::setSensorData(int stype, bool comp, bool cal, bool vcclow
 @param[in] hPin   Ootput pin for heater control
 @note   These values must be set before the plugin can measure the level
         They are determined by the plugin configuration
+*/
 /*****************************************************************************/
 void P145_data_struct::setSensorPins(int aPin, int hPin)
 {
@@ -650,6 +652,7 @@ float P145_data_struct::getCalibrationValue() const
 @note   This is the internally corrected Rzero and will be unaltered when
         Autocalibration is switched off.
 */
+/**************************************************************************/
 float P145_data_struct::getAutoCalibrationValue() const
 {
   return rzero;


### PR DESCRIPTION
From a Forum request (second question in [this message](https://www.letscontrolit.com/forum/viewtopic.php?t=9562#p63492) about leading spaces)

Some display plugins trim off spaces from the text to display, even when quoted. That is now corrected, so leading and trailing spaces can be used.
Plugins:
- P012 - Display - LCD2004
- P023 - Display - OLED SSD1306
- P036 - Display - OLED SSD1306/SH1106 Framed
- P104 - Display - MAX7219 dot matrix
- P131 - Display - NeoPixel Matrix

Other:
- Plugins using `AdafruitGFX_helper` have already been corrected some time ago, but added some improvements there.
- Rules: string functions now handle/accept leading & trailing spaces

TODO:
- [ ] Testing
  - P012 [Confirmed](https://www.letscontrolit.com/forum/viewtopic.php?t=9562#p63514)