### PR TITLE
[ETH] Fix connect to LAN with internal clock

### DIFF
--- a/src/src/DataTypes/NetworkMedium.cpp
+++ b/src/src/DataTypes/NetworkMedium.cpp
@@ -1,10 +1,17 @@
+
 #include "../DataTypes/NetworkMedium.h"
 
 bool isValid(NetworkMedium_t medium) {
   switch (medium) {
     case NetworkMedium_t::WIFI:
     case NetworkMedium_t::Ethernet:
+#ifdef USES_ESPEASY_NOW
+    case NetworkMedium_t::ESPEasyNOW_only:
+#endif
       return true;
+
+    case NetworkMedium_t::NotSet:
+      return false;
 
       // Do not use default: as this allows the compiler to detect any missing cases.
   }
@@ -15,6 +22,10 @@ const __FlashStringHelper * toString(NetworkMedium_t medium) {
   switch (medium) {
     case NetworkMedium_t::WIFI:     return F("WiFi");
     case NetworkMedium_t::Ethernet: return F("Ethernet");
+#ifdef USES_ESPEASY_NOW
+    case NetworkMedium_t::ESPEasyNOW_only:  return F(ESPEASY_NOW_NAME " only");
+#endif
+    case NetworkMedium_t::NotSet:   return F("Not Set");
 
       // Do not use default: as this allows the compiler to detect any missing cases.
   }

--- a/src/src/DataTypes/NetworkMedium.h
+++ b/src/src/DataTypes/NetworkMedium.h
@@ -3,10 +3,16 @@
 
 #include <Arduino.h>
 
+#include "../../ESPEasy_common.h"
+
 // Is stored in settings
-enum class NetworkMedium_t : unsigned char {
-  WIFI     = 0,
-  Ethernet = 1
+enum class NetworkMedium_t : uint8_t {
+  WIFI            = 0,
+  Ethernet        = 1,
+#ifdef USES_ESPEASY_NOW
+  ESPEasyNOW_only = 2,
+#endif
+  NotSet          = 255
 };
 
 bool   isValid(NetworkMedium_t medium);

--- a/src/src/ESPEasyCore/ESPEasyEth_ProcessEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyEth_ProcessEvent.cpp
@@ -111,6 +111,7 @@ void processEthernetConnected() {
 
   // FIXME TD-er: Must differentiate among reconnects for WiFi and Ethernet.
   ++WiFiEventData.wifi_reconnects;
+  addLog(LOG_LEVEL_INFO, F("processEthernetConnected()"));
   EthEventData.setEthConnected();
   EthEventData.processedConnect = true;
 

--- a/src/src/ESPEasyCore/ESPEasyNetwork.cpp
+++ b/src/src/ESPEasyCore/ESPEasyNetwork.cpp
@@ -39,6 +39,8 @@ void setNetworkMedium(NetworkMedium_t new_medium) {
         WifiDisconnect();
       }
       break;
+    case NetworkMedium_t::NotSet:
+      return;
   }
   statusLED(true);
   active_network_medium = new_medium;

--- a/src/src/ESPEasyCore/ESPEasyWifi.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi.cpp
@@ -630,8 +630,10 @@ void initWiFi()
   // those WiFi connections will take a long time to make or sometimes will not work at all.
   WiFi.disconnect(false);
   delay(1);
-  setSTA(true);
-  WifiScan(false);
+  if (active_network_medium != NetworkMedium_t::NotSet) {
+    setSTA(true);
+    WifiScan(false);
+  }
   setWifiMode(WIFI_OFF);
 
 #if defined(ESP32)

--- a/src/src/ESPEasyCore/ESPEasy_setup.cpp
+++ b/src/src/ESPEasyCore/ESPEasy_setup.cpp
@@ -355,12 +355,7 @@ void ESPEasy_setup()
   #endif // if FEATURE_ETHERNET
 
   bool initWiFi = active_network_medium == NetworkMedium_t::WIFI;
-
-  #ifdef USES_ESPEASY_NOW
-  if (isESPEasy_now_only() || Settings.UseESPEasyNow()) {
-    initWiFi = true;
-  }
-  #endif
+  // FIXME TD-er: Must add another check for 'delayed start WiFi' for poorly designed ESP8266 nodes.
 
 
   if (initWiFi) {

--- a/src/src/Globals/NetworkState.cpp
+++ b/src/src/Globals/NetworkState.cpp
@@ -4,7 +4,7 @@
 
 
 // Ethernet Connection status
-NetworkMedium_t active_network_medium = DEFAULT_NETWORK_MEDIUM;
+NetworkMedium_t active_network_medium = NetworkMedium_t::NotSet;
 
 bool webserverRunning(false);
 bool webserver_init(false);

--- a/src/src/Helpers/Hardware.cpp
+++ b/src/src/Helpers/Hardware.cpp
@@ -86,7 +86,7 @@ void hardwareInit()
       if (getGpioPullResistor(gpio, hasPullUp, hasPullDown)) {
         PinBootState bootState = Settings.getPinBootState(gpio);
       #if FEATURE_ETHERNET
-
+/*
         if (Settings.ETH_Pin_power == gpio)
         {
           if (loglevelActiveFor(LOG_LEVEL_INFO)) {
@@ -96,7 +96,7 @@ void hardwareInit()
           }
           bootState = PinBootState::Output_low;
         }
-
+*/
       #endif // if FEATURE_ETHERNET
 
         #ifdef ESP32


### PR DESCRIPTION
Apparently with the latest SDKs, you need to start ETH before anything else or else you won't be able to allocate an interrupt for the internal generated 50 MHz clock.