### PR TITLE
[Eth] Fix restoring cached  DNS IPs

### DIFF
--- a/src/src/DataStructs/EthernetEventData.cpp
+++ b/src/src/DataStructs/EthernetEventData.cpp
@@ -3,6 +3,7 @@
 #if FEATURE_ETHERNET
 
 #include "../ESPEasyCore/ESPEasy_Log.h"
+#include "../Helpers/Networking.h"
 
 // Bit numbers for Eth status
 #define ESPEASY_ETH_CONNECTED               0
@@ -96,8 +97,12 @@ void EthernetEventData_t::setEthConnected() {
 bool EthernetEventData_t::setEthServicesInitialized() {
   if (!unprocessedEthEvents() && !EthServicesInitialized()) {
     if (EthGotIP() && EthConnected()) {
-      dns0_cache = WiFi.dnsIP(0);
-      dns1_cache = WiFi.dnsIP(1);
+      if (valid_DNS_address(WiFi.dnsIP(0))) {
+        dns0_cache = WiFi.dnsIP(0);
+      }
+      if (valid_DNS_address(WiFi.dnsIP(1))) {
+        dns1_cache = WiFi.dnsIP(1);
+      }
 
       #ifndef BUILD_NO_DEBUG
       addLog(LOG_LEVEL_DEBUG, F("Eth : Eth services initialized"));

--- a/src/src/DataStructs/WiFiEventData.cpp
+++ b/src/src/DataStructs/WiFiEventData.cpp
@@ -7,7 +7,7 @@
 #include "../Globals/WiFi_AP_Candidates.h"
 
 #include "../Helpers/ESPEasy_Storage.h"
-
+#include "../Helpers/Networking.h"
 
 // Bit numbers for WiFi status
 #define ESPEASY_WIFI_CONNECTED               0
@@ -145,8 +145,12 @@ void WiFiEventData_t::setWiFiDisconnected() {
 void WiFiEventData_t::setWiFiGotIP() {
   bitSet(wifiStatus, ESPEASY_WIFI_GOT_IP);
   processedGotIP = true;
-  dns0_cache = WiFi.dnsIP(0);
-  dns1_cache = WiFi.dnsIP(1);
+  if (valid_DNS_address(WiFi.dnsIP(0))) {
+    dns0_cache = WiFi.dnsIP(0);
+  }
+  if (valid_DNS_address(WiFi.dnsIP(1))) {
+    dns1_cache = WiFi.dnsIP(1);
+  }
 }
 
 void WiFiEventData_t::setWiFiConnected() {

--- a/src/src/ESPEasyCore/ESPEasyEth_ProcessEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyEth_ProcessEvent.cpp
@@ -85,13 +85,15 @@ void check_Eth_DNS_valid() {
       (active_network_medium == NetworkMedium_t::Ethernet) &&
       EthEventData.ethInitSuccess &&
       !ethUseStaticIP()) {
-    const bool has_cache = EthEventData.dns0_cache || EthEventData.dns1_cache;
+    const bool has_cache = 
+      valid_DNS_address(EthEventData.dns0_cache) || 
+      valid_DNS_address(EthEventData.dns1_cache);
 
     if (has_cache) {
       const IPAddress dns0 = ETH.dnsIP(0);
       const IPAddress dns1 = ETH.dnsIP(1);
 
-      if (!dns0 && !dns1) {
+      if (!valid_DNS_address(dns0) && !valid_DNS_address(dns1)) {
         static uint32_t lastLog = 0;
         if (timePassedSince(lastLog) > 1000) {
           addLogMove(LOG_LEVEL_ERROR, concat(

--- a/src/src/ESPEasyCore/ESPEasyGPIO.cpp
+++ b/src/src/ESPEasyCore/ESPEasyGPIO.cpp
@@ -429,7 +429,7 @@ void GPIO_Monitor10xSec()
       const uint16_t gpioPort = getPortFromKey(it->first);
       const uint16_t pluginID = getPluginFromKey(it->first);
       int8_t currentState = -1;
-      const __FlashStringHelper * eventString;
+      const __FlashStringHelper * eventString = F("");
       bool caseFound = true;
 
       switch (pluginID)

--- a/src/src/Helpers/Networking.cpp
+++ b/src/src/Helpers/Networking.cpp
@@ -1049,6 +1049,12 @@ void scrubDNS() {
   }
 }
 
+bool valid_DNS_address(const IPAddress& dns) {
+  return (dns.v4() != (uint32_t)0x00000000 && 
+          dns.v4() != (uint32_t)0xFD000000 && 
+          dns != INADDR_NONE);
+}
+
 bool setDNS(int index, const IPAddress& dns) {
   if (index >= 2) return false;
   #ifdef ESP8266
@@ -1066,7 +1072,7 @@ bool setDNS(int index, const IPAddress& dns) {
   ip_addr_t d;
   d.type = IPADDR_TYPE_V4;
 
-  if (dns.v4() != (uint32_t)0x00000000 && dns != INADDR_NONE) {
+  if (valid_DNS_address(dns)) {
     // Set DNS0-Server
     d.u_addr.ip4.addr = static_cast<uint32_t>(dns);
     const ip_addr_t* cur_dns = dns_getserver(index);

--- a/src/src/Helpers/Networking.h
+++ b/src/src/Helpers/Networking.h
@@ -156,6 +156,8 @@ bool connectClient(WiFiClient& client, IPAddress ip, uint16_t port, uint32_t tim
 
 void scrubDNS();
 
+bool valid_DNS_address(const IPAddress& dns);
+
 bool setDNS(int index, const IPAddress& dns);
 
 bool resolveHostByName(const char *aHostname, IPAddress& aResult, uint32_t timeout_ms = 1000);


### PR DESCRIPTION
DNS entries will be cleared when WiFi  is turned off.
However these DNS entries are shared between WiFi and Ethernet.

Also the DNS entries may sometimes be set to `253.0.0.0` thus checking for `0.0.0.0` cannot be used to check whether the DNS fields were cleared.