### PR TITLE
[Build] Add KEEP_RTTTL build-flag and apply to some builds

### DIFF
--- a/platformio_esp82xx_envs.ini
+++ b/platformio_esp82xx_envs.ini
@@ -520,6 +520,7 @@ build_flags               = ${normal_ir_extended_no_rx.build_flags}
                             ${esp8266_4M2M.build_flags}
                             ${limited_build_size.build_flags}
                             -DLIMIT_BUILD_SIZE
+                            -DKEEP_RTTTL
 extra_scripts             = ${esp8266_4M2M.extra_scripts}
                             pre:tools/pio/ir_build_check.py
 

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -2692,6 +2692,10 @@ To create/register a plugin, you have to :
 #ifndef FEATURE_RTTTL                         
 #define FEATURE_RTTTL                         0
 #endif
+#if defined(FEATURE_RTTTL) && !FEATURE_RTTTL && defined(KEEP_RTTTL)
+  #undef FEATURE_RTTTL
+  #define FEATURE_RTTTL 1
+#endif
 
 #ifndef FEATURE_SD                         
 #define FEATURE_SD                            0


### PR DESCRIPTION
From a request in a [comment](https://github.com/letscontrolit/ESPEasy/issues/3391#issuecomment-1462206479)

Allow to enable the RTTTL command for environments that have space available by adding a `KEEP_RTTTL` build-flag.
Environment(s):
- `normal_IRext_no_rx_ESP8266_4M2M`

This adds ca. 800 bytes to an ESP8266 build.