### PR TITLE
[P014] Disable I2C check to correct HTU21D read

### DIFF
--- a/src/_P014_SI70xx.ino
+++ b/src/_P014_SI70xx.ino
@@ -52,6 +52,7 @@ boolean Plugin_014(uint8_t function, struct EventStruct *event, String& string)
       Device[deviceCount].ValueCount         = 3;
       Device[deviceCount].SendDataOption     = true;
       Device[deviceCount].TimerOption        = true;
+      Device[deviceCount].I2CNoDeviceCheck   = true;
 
       // Device[deviceCount].GlobalSyncOption   = true;
       Device[deviceCount].PluginStats    = true;


### PR DESCRIPTION
Resolves #4556 

Features:
- Fix for I2C check interfering with normal read on HTU21D

TODO:
- [x] Confirmation by issue reporter ([confirmed](https://github.com/letscontrolit/ESPEasy/issues/4556#issuecomment-1478459934))