### PR TITLE
[Build] Add [P077] to Shelly_PLUG_S build environment

### DIFF
--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -752,6 +752,7 @@ To create/register a plugin, you have to :
     #define CONTROLLER_SET_STABLE
     #define NOTIFIER_SET_STABLE
     #define USES_P076   // HWL8012   in POW r1
+    #define USES_P077	  // CSE7766   in POW R2
     #define USES_P081   // Cron
 #endif
 


### PR DESCRIPTION
Feature:
- Add P077 - `Energy (AC) - CSE7766` to `hard_Shelly_PLUG_S_2M256` environment, to support newer power-monitoring plugs like Athom Smart Plug V2