### PR TITLE
[WiFi] APmodeEnabled event not generated when logging is disabled #4593

### DIFF
--- a/src/src/ESPEasyCore/ESPEasyWifi.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi.cpp
@@ -1196,8 +1196,8 @@ void setAPinternal(bool enable)
     }
 
     if (WiFi.softAP(softAPSSID.c_str(), pwd.c_str(), channel)) {
+      eventQueue.add(F("WiFi#APmodeEnabled"));
       if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-        eventQueue.add(F("WiFi#APmodeEnabled"));
         String log(F("WIFI : AP Mode ssid will be "));
         log += softAPSSID;
         log += F(" with address ");


### PR DESCRIPTION
Resolves #4593 

Event `WiFi#APmodeEnabled` was not generated when logging was below INFO level (ERROR or None).