### PR TITLE
[RTC TaskValues] Fix proper init of task values

### DIFF
--- a/src/src/DataStructs/UserVarStruct.cpp
+++ b/src/src/DataStructs/UserVarStruct.cpp
@@ -3,10 +3,18 @@
 #include "../ESPEasyCore/ESPEasy_Log.h"
 #include "../Globals/Plugins.h"
 #include "../Helpers/_Plugin_SensorTypeHelper.h"
+#include "../Helpers/CRC_functions.h"
 
 UserVarStruct::UserVarStruct()
 {
   _data.resize(TASKS_MAX);
+}
+
+void UserVarStruct::clear()
+{
+  for (size_t i = 0; i < _data.size(); ++i) {
+    _data.clear();
+  }
 }
 
 // Implementation of [] operator.  This function must return a
@@ -71,7 +79,8 @@ void UserVarStruct::setInt32(taskIndex_t taskIndex,
     _data[taskIndex].setInt32(varNr, value);
   }
 }
-#endif
+
+#endif // if FEATURE_EXTENDED_TASK_VALUE_TYPES
 
 uint32_t UserVarStruct::getUint32(taskIndex_t taskIndex, uint8_t varNr) const
 {
@@ -126,7 +135,7 @@ void UserVarStruct::setUint64(taskIndex_t taskIndex,
   }
 }
 
-#endif
+#endif // if FEATURE_EXTENDED_TASK_VALUE_TYPES
 
 float UserVarStruct::getFloat(taskIndex_t taskIndex,
                               uint8_t     varNr) const
@@ -166,7 +175,7 @@ void UserVarStruct::setDouble(taskIndex_t taskIndex,
   }
 }
 
-#endif
+#endif // if FEATURE_EXTENDED_TASK_VALUE_TYPES
 
 double UserVarStruct::getAsDouble(taskIndex_t  taskIndex,
                                   uint8_t      varNr,
@@ -194,8 +203,8 @@ void UserVarStruct::set(taskIndex_t taskIndex, uint8_t varNr, const double& valu
 }
 
 bool UserVarStruct::isValid(taskIndex_t  taskIndex,
-               uint8_t      varNr,
-               Sensor_VType sensorType) const
+                            uint8_t      varNr,
+                            Sensor_VType sensorType) const
 {
   if (taskIndex < _data.size()) {
     return _data[taskIndex].isValid(varNr, sensorType);
@@ -203,16 +212,9 @@ bool UserVarStruct::isValid(taskIndex_t  taskIndex,
   return false;
 }
 
-
-size_t UserVarStruct::getNrElements() const
+uint8_t * UserVarStruct::get(size_t& sizeInBytes)
 {
-  constexpr size_t factor = sizeof(TaskValues_Data_t) / sizeof(float);
-
-  return _data.size() * factor;
-}
-
-uint8_t * UserVarStruct::get()
-{
+  sizeInBytes = _data.size() * sizeof(TaskValues_Data_t);
   return reinterpret_cast<uint8_t *>(&_data[0]);
 }
 
@@ -230,4 +232,12 @@ TaskValues_Data_t * UserVarStruct::getTaskValues_Data(taskIndex_t taskIndex)
     return &_data[taskIndex];
   }
   return nullptr;
+}
+
+uint32_t UserVarStruct::compute_CRC32() const
+{
+  const uint8_t *buffer = reinterpret_cast<const uint8_t *>(&_data[0]);
+  const size_t   size   = _data.size() * sizeof(TaskValues_Data_t);
+
+  return calc_CRC32(buffer, size);
 }

--- a/src/src/DataStructs/UserVarStruct.h
+++ b/src/src/DataStructs/UserVarStruct.h
@@ -13,6 +13,8 @@
 struct UserVarStruct {
   UserVarStruct();
 
+  void          clear();
+
   // Overloading [] operator to access elements in array style
   float       & operator[](unsigned int index);
   const float & operator[](unsigned int index) const;
@@ -30,7 +32,7 @@ struct UserVarStruct {
   void    setInt32(taskIndex_t taskIndex,
                    uint8_t     varNr,
                    int32_t     value);
-#endif
+#endif // if FEATURE_EXTENDED_TASK_VALUE_TYPES
 
   // 32 bit unsigned int stored at the memory location of the float
   uint32_t getUint32(taskIndex_t taskIndex,
@@ -54,7 +56,7 @@ struct UserVarStruct {
   void     setUint64(taskIndex_t taskIndex,
                      uint8_t     varNr,
                      uint64_t    value);
-#endif
+#endif // if FEATURE_EXTENDED_TASK_VALUE_TYPES
 
   float getFloat(taskIndex_t taskIndex,
                  uint8_t     varNr) const;
@@ -70,7 +72,7 @@ struct UserVarStruct {
   void   setDouble(taskIndex_t taskIndex,
                    uint8_t     varNr,
                    double      value);
-#endif
+#endif // if FEATURE_EXTENDED_TASK_VALUE_TYPES
 
   double getAsDouble(taskIndex_t  taskIndex,
                      uint8_t      varNr,
@@ -91,14 +93,12 @@ struct UserVarStruct {
                uint8_t      varNr,
                Sensor_VType sensorType) const;
 
-
-
-  size_t                   getNrElements() const;
-
-  uint8_t                * get();
+  uint8_t                * get(size_t& sizeInBytes);
 
   const TaskValues_Data_t* getTaskValues_Data(taskIndex_t taskIndex) const;
-  TaskValues_Data_t* getTaskValues_Data(taskIndex_t taskIndex);
+  TaskValues_Data_t      * getTaskValues_Data(taskIndex_t taskIndex);
+
+  uint32_t                 compute_CRC32() const;
 
 private:
 

--- a/src/src/Helpers/ESPEasyRTC.cpp
+++ b/src/src/Helpers/ESPEasyRTC.cpp
@@ -52,11 +52,11 @@
     )
  */
 
-// RTC layout ESPeasy:
+// ESP8266 RTC layout ESPeasy:
 // these offsets are in blocks, bytes = blocks * 4
 // 64   RTCStruct  max 40 bytes: ( 74 - 64 ) * 4
 // 74   UserVar
-// 122  UserVar checksum:  RTC_BASE_USERVAR + UserVar.getNrElements()
+// 122  UserVar checksum:  RTC_BASE_USERVAR + (TASKS_MAX * VARS_PER_TASK)
 // 128  Cache (C016) metadata  4 blocks
 // 132  Cache (C016) data  6 blocks per sample => max 10 samples
 
@@ -133,9 +133,7 @@ void initRTC()
   RTC.init();
   saveToRTC();
 
-  for (size_t i = 0; i < UserVar.getNrElements(); ++i) {
-    UserVar[i] = 0.0f;
-  }
+  UserVar.clear();
   saveUserVarToRTC();
 }
 
@@ -174,15 +172,15 @@ bool saveUserVarToRTC()
       }
     }
   }
-  UserVar_checksum = calc_CRC32(reinterpret_cast<const uint8_t *>(&UserVar[0]), UserVar_nrelements * sizeof(float)); 
+  UserVar_checksum = UserVar.compute_CRC32();
   return true;
   #endif
 
   #ifdef ESP8266
   // addLog(LOG_LEVEL_DEBUG, F("RTCMEM: saveUserVarToRTC"));
-  uint8_t    *buffer = UserVar.get();
-  size_t   size   = UserVar.getNrElements() * sizeof(float);
-  uint32_t sum    = calc_CRC32(buffer, size);
+  size_t   size{};
+  uint8_t *buffer    = UserVar.get(size);
+  const uint32_t sum = UserVar.compute_CRC32();
   bool  ret    = system_rtc_mem_write(RTC_BASE_USERVAR, buffer, size);
   ret &= system_rtc_mem_write(RTC_BASE_USERVAR + (size >> 2), reinterpret_cast<const uint8_t *>(&sum), 4);
   return ret;
@@ -210,10 +208,10 @@ bool readUserVarFromRTC()
 
   #ifdef ESP8266
   // addLog(LOG_LEVEL_DEBUG, F("RTCMEM: readUserVarFromRTC"));
-  uint8_t    *buffer = UserVar.get();
-  size_t   size   = UserVar.getNrElements() * sizeof(float);
-  bool  ret    = system_rtc_mem_read(RTC_BASE_USERVAR, buffer, size);
-  uint32_t sumRAM = calc_CRC32(buffer, size);
+  size_t   size{};
+  uint8_t *buffer = UserVar.get(size);
+  bool ret        = system_rtc_mem_read(RTC_BASE_USERVAR, buffer, size);
+  uint32_t sumRAM = UserVar.compute_CRC32();
   uint32_t sumRTC = 0;
   ret &= system_rtc_mem_read(RTC_BASE_USERVAR + (size >> 2), reinterpret_cast<uint8_t *>(&sumRTC), 4);
 


### PR DESCRIPTION
The `UserVar` wasn't initialized properly since the latest changes to how UserVar was handled.