### PR TITLE
[Commands] Add PutToHTTP command

### DIFF
--- a/docs/source/Plugin/P000_commands.repl
+++ b/docs/source/Plugin/P000_commands.repl
@@ -386,6 +386,8 @@
     
     On completion of the command, the returned status code can be handled in a generated event, f.e. ``http#hostname=404`` for not found error, or ``http#hostname=200`` for success.
 
+    See also: ``PutToHTTP`` and ``SendToHTTP``
+
     Added: 2023-01-15
     "
     "
@@ -424,6 +426,65 @@
     Send command using MQTT broker service. Uses the first enabled MQTT Controller.
 
     ``Publish,<topic>[,<payload>]``"
+    "
+    PutToHTTP","
+    :green:`Rules`","
+    *Syntax format 1:*
+
+    ``PutToHTTP,[<user>:<password>@]<host>,<port>,<uri>,[<headers>][,<putdata>]``
+
+    Send a command to another network device via HTTP using the http ``PUT`` method.
+
+    ``<host>`` can be either a domain name or IP address.
+
+    ``<port>`` is the port to connect to, usually 80 for a HTTP site.
+
+    ``<uri>`` the path on the server to put the message to.
+
+    *Syntax format 2:*
+
+    ``PutToHTTP,http://[<user>:<password>@]<url>,[<headers>][,<putdata>]``
+
+    ``<url>`` is the full hostname (or IP address) and path on the server to put the content to.
+
+    *For both syntax formats:*
+
+    ``<user>`` is an optional user to supply for Basic authentication.
+
+    ``<password>`` is an optional password to supply for Basic authentication.
+
+    ``<headers>`` when provided will be added to the header of the ``PUT`` message, has to be in ``<name>:<value>`` format. Can be used to supply a ``Authorization: Bearer <token>`` and/or ``api-key:<key>`` (instead of a user/password Basic authentication) and a ``Content-Type: <content-type>``. Multiple entries have to be separated by a NewLine (``%LF%``) to be processed correctly. When not used (empty) and ``<putdata>`` *is used*, the comma should still be included!
+
+    ``<putdata>`` is the optional content to include in the ``PUT`` message. Can be anything, f.e. a JSON formatted string, like in the example below.
+
+    Syntax examples:
+
+    ``PutToHTTP,<host>,<Portnumber>,<uri>,[<headers>][,<putdata>]``
+
+    ``PutToHTTP,<user>:<pass>@<host>,<Portnumber>,<uri>,[<headers>][,<putdata>]``
+
+    ``PutToHTTP,http://<host>/<url>,[<headers>][,<putdata>]``
+
+    ``PutToHTTP,http://<user>:<pass>@<host>/<url>,[<headers>][,<putdata>]``
+
+    ``PutToHTTP,http://<host>:<Portnumber>/<url>,[<headers>][,<putdata>]``
+    
+    ``PutToHTTP,http://<user>:<pass>@<host>:<Portnumber>/<url>,[<headers>][,<putdata>]``
+
+    Example using syntax format 1:
+
+    ``PutToHTTP,user:password@192.168.1.100,8888,/someurl,'header1:value1%LF%header2:value2',`{'this':{'string':'can','be':'JSON','data':{'one':1,'two':2.0,'bool':true}}}```
+
+    Example using syntax format 2:
+
+    ``PutToHTTP,http://user:password@192.168.1.100:8888/someurl,'header1:value1%LF%header2:value2',`{'this':{'string':'can','be':'JSON','data':{'one':1,'two':2.0,'bool':true}}}```
+    
+    On completion of the command, the returned status code can be handled in a generated event, f.e. ``http#hostname=404`` for not found error, or ``http#hostname=200`` for success.
+
+    See also: ``PostToHTTP`` and ``SendToHTTP``
+
+    Added: 2023-04-17
+    "
     "
     Reboot","
     :red:`Internal`","

--- a/src/src/Commands/HTTP.cpp
+++ b/src/src/Commands/HTTP.cpp
@@ -17,7 +17,7 @@
 #include "../Helpers/Networking.h"
 #include "../Helpers/StringParser.h"
 
-#if FEATURE_SEND_TO_HTTP || FEATURE_POST_TO_HTTP
+#if FEATURE_SEND_TO_HTTP || FEATURE_POST_TO_HTTP || FEATURE_PUT_TO_HTTP
 const __FlashStringHelper* httpEmitToHTTP(struct EventStruct        *event,
                                           const __FlashStringHelper *logIdentifier,
                                           const __FlashStringHelper *HttpMethod,
@@ -125,7 +125,7 @@ const __FlashStringHelper* httpEmitToHTTP(struct EventStruct        *event,
   return return_command_failed();
 }
 
-#endif // if FEATURE_SEND_TO_HTTP || FEATURE_POST_TO_HTTP
+#endif // if FEATURE_SEND_TO_HTTP || FEATURE_POST_TO_HTTP || FEATURE_PUT_TO_HTTP
 
 #if FEATURE_SEND_TO_HTTP
 
@@ -160,3 +160,19 @@ const __FlashStringHelper* Command_HTTP_PostToHTTP(struct EventStruct *event, co
 }
 
 #endif // if FEATURE_POST_TO_HTTP
+
+#if FEATURE_PUT_TO_HTTP
+
+// syntax 1: PutToHttp,<[<user>:<password>@]<host>,<port>,<path>,<header>,<body>
+// syntax 2: PutToHttp,http://<[<user>:<password>@]<host>[:<port>]/<path>,<header>,<body>
+const __FlashStringHelper* Command_HTTP_PutToHTTP(struct EventStruct *event, const char *Line)
+{
+  // FIXME tonhuisman: Make putToHttp timeout a setting, now using a somewhat sensible default
+  const int timeout = CONTROLLER_CLIENTTIMEOUT_MAX;
+
+  // FIXME tonhuisman: make PutToHttp_ack a setting, using SendToHttp_ack for now...
+
+  return httpEmitToHTTP(event, F("PostToHTTP"), F("PUT"), Line, timeout, Settings.SendToHttp_ack(), true, true);
+}
+
+#endif // if FEATURE_PUT_TO_HTTP

--- a/src/src/Commands/HTTP.cpp
+++ b/src/src/Commands/HTTP.cpp
@@ -172,7 +172,7 @@ const __FlashStringHelper* Command_HTTP_PutToHTTP(struct EventStruct *event, con
 
   // FIXME tonhuisman: make PutToHttp_ack a setting, using SendToHttp_ack for now...
 
-  return httpEmitToHTTP(event, F("PostToHTTP"), F("PUT"), Line, timeout, Settings.SendToHttp_ack(), true, true);
+  return httpEmitToHTTP(event, F("PutToHTTP"), F("PUT"), Line, timeout, Settings.SendToHttp_ack(), true, true);
 }
 
 #endif // if FEATURE_PUT_TO_HTTP

--- a/src/src/Commands/HTTP.h
+++ b/src/src/Commands/HTTP.h
@@ -3,7 +3,7 @@
 
 #include <Arduino.h>
 
-#if FEATURE_SEND_TO_HTTP || FEATURE_POST_TO_HTTP
+#if FEATURE_SEND_TO_HTTP || FEATURE_POST_TO_HTTP || FEATURE_PUT_TO_HTTP
 const __FlashStringHelper* httpEmitToHTTP(struct EventStruct        *event,
                                           const __FlashStringHelper *logIdentifier,
                                           const __FlashStringHelper *HttpMethod,
@@ -12,7 +12,7 @@ const __FlashStringHelper* httpEmitToHTTP(struct EventStruct        *event,
                                           const bool                 waitForAck,
                                           const bool                 useHeader,
                                           const bool                 useBody);
-#endif // if FEATURE_SEND_TO_HTTP || FEATURE_POST_TO_HTTP
+#endif // if FEATURE_SEND_TO_HTTP || FEATURE_POST_TO_HTTP || FEATURE_PUT_TO_HTTP
 #if FEATURE_SEND_TO_HTTP
 const __FlashStringHelper* Command_HTTP_SendToHTTP(struct EventStruct *event,
                                                    const char         *Line);
@@ -21,5 +21,9 @@ const __FlashStringHelper* Command_HTTP_SendToHTTP(struct EventStruct *event,
 const __FlashStringHelper* Command_HTTP_PostToHTTP(struct EventStruct *event,
                                                    const char         *Line);
 #endif // if FEATURE_POST_TO_HTTP
+#if FEATURE_PUT_TO_HTTP
+const __FlashStringHelper* Command_HTTP_PutToHTTP(struct EventStruct *event,
+                                                  const char         *Line);
+#endif // if FEATURE_PUT_TO_HTTP
 
 #endif // COMMAND_HTTP_H

--- a/src/src/Commands/InternalCommands.cpp
+++ b/src/src/Commands/InternalCommands.cpp
@@ -413,6 +413,9 @@ bool executeInternalCommand(command_case_data & data)
 #if FEATURE_MQTT
       COMMAND_CASE_A( "publish", Command_MQTT_Publish,     -1); // MQTT.h
 #endif // if FEATURE_MQTT
+      #if FEATURE_PUT_TO_HTTP
+      COMMAND_CASE_A("puttohttp", Command_HTTP_PutToHTTP,  -1); // HTTP.h
+      #endif // if FEATURE_PUT_TO_HTTP
       COMMAND_CASE_A(     "pwm", Command_GPIO_PWM,          4); // GPIO.h
       break;
     }

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -443,6 +443,11 @@ To create/register a plugin, you have to :
     #endif
     #define FEATURE_POST_TO_HTTP  0 // Disabled
 
+    #ifdef FEATURE_PUT_TO_HTTP
+      #undef FEATURE_PUT_TO_HTTP
+    #endif
+    #define FEATURE_PUT_TO_HTTP  0 // Disabled
+
     #ifndef PLUGIN_SET_NONE
       #define PLUGIN_SET_NONE
     #endif
@@ -2245,6 +2250,10 @@ To create/register a plugin, you have to :
     #undef FEATURE_POST_TO_HTTP
   #endif
   #define FEATURE_POST_TO_HTTP  0 // Disabled
+  #ifdef FEATURE_PUT_TO_HTTP
+    #undef FEATURE_PUT_TO_HTTP
+  #endif
+  #define FEATURE_PUT_TO_HTTP  0 // Disabled
 #endif
 
 
@@ -2775,6 +2784,10 @@ To create/register a plugin, you have to :
   #define FEATURE_POST_TO_HTTP  1 // Enabled by default
 #endif
 
+#ifndef FEATURE_PUT_TO_HTTP
+  #define FEATURE_PUT_TO_HTTP   1 // Enabled by default
+#endif
+
 #ifndef FEATURE_HTTP_CLIENT
   #define FEATURE_HTTP_CLIENT   0 // Disable by default
 #endif
@@ -2804,7 +2817,7 @@ To create/register a plugin, you have to :
   #define FEATURE_I2C_GET_ADDRESS     1 // Needed by FEATURE_I2C_DEVICE_CHECK
 #endif
 
-#if !FEATURE_HTTP_CLIENT && (defined(USES_C001) || defined(USES_C008) || defined(USES_C009) || defined(USES_C011) || (defined(FEATURE_SEND_TO_HTTP) && FEATURE_SEND_TO_HTTP) || (defined(FEATURE_POST_TO_HTTP) && FEATURE_POST_TO_HTTP) || (defined(FEATURE_DOWNLOAD) && FEATURE_DOWNLOAD) || (defined(FEATURE_SETTINGS_ARCHIVE) && FEATURE_SETTINGS_ARCHIVE))
+#if !FEATURE_HTTP_CLIENT && (defined(USES_C001) || defined(USES_C008) || defined(USES_C009) || defined(USES_C011) || (defined(FEATURE_SEND_TO_HTTP) && FEATURE_SEND_TO_HTTP) || (defined(FEATURE_POST_TO_HTTP) && FEATURE_POST_TO_HTTP) || (defined(FEATURE_PUT_TO_HTTP) && FEATURE_PUT_TO_HTTP) || (defined(FEATURE_DOWNLOAD) && FEATURE_DOWNLOAD) || (defined(FEATURE_SETTINGS_ARCHIVE) && FEATURE_SETTINGS_ARCHIVE))
   #undef FEATURE_HTTP_CLIENT
   #define FEATURE_HTTP_CLIENT   1 // Enable because required for these controllers/features
 #endif


### PR DESCRIPTION
Resolves #4605 

Features:
- Add command `PutToHTTP`, very similar to `PostToHTTP`, but using the `PUT` http verb.
- Add documentation for `PutToHTTP`.

TODO:
- [x] Testing (by requester) ([confirmed](https://github.com/letscontrolit/ESPEasy/pull/4619#issuecomment-1515772736))