### PR TITLE
[LongPulse_ms] Fix end-state for inverted repeated pulse

### DIFF
--- a/src/src/Commands/GPIO.cpp
+++ b/src/src/Commands/GPIO.cpp
@@ -215,8 +215,14 @@ const __FlashStringHelper * Command_GPIO_LongPulse_Ms(struct EventStruct *event,
       }
       uint32_t runTimeUS = 0;
       if (event->Par5 > 0) {
-        // Must set slightly lower than expected duration as it will be rounded up.
-        runTimeUS = event->Par5 * (timeHighUS + timeLowUS) - ((timeHighUS + timeLowUS) / 2);
+        runTimeUS = event->Par5 * (timeHighUS + timeLowUS);
+        if (event->Par2 == 0) {
+          // When having an inverted state repeat-cycle, add some overshoot to return to the original state
+          runTimeUS += timeHighUS / 2;
+        } else {
+          // Must set slightly lower than expected duration as it will be rounded up.
+          runTimeUS -= ((timeHighUS + timeLowUS) / 2);
+        }
       }
 
       pinMode(event->Par1, OUTPUT);

--- a/src/src/Commands/GPIO.cpp
+++ b/src/src/Commands/GPIO.cpp
@@ -228,6 +228,17 @@ const __FlashStringHelper * Command_GPIO_LongPulse_Ms(struct EventStruct *event,
       pinMode(event->Par1, OUTPUT);
       usingWaveForm = startWaveform(
         pin, timeHighUS, timeLowUS, runTimeUS);
+
+      if (event->Par5 > 0 && event->Par2 == 0) {
+        // Schedule switching pin back to original state
+        Scheduler.setGPIOTimer(
+          (runTimeUS / 1000) + 1, // msecFromNow, rounded up
+          pluginID,    
+          event->Par1,            // Pin/port nr
+          !event->Par2,           // pin state
+          0,                      // repeatInterval
+          0);                     // repeatCount
+      }
     }
     #else
     // waveform function not available on ESP32


### PR DESCRIPTION
Resolves #4620 

Bugfix (only for ESP8266):
- When having an inverted, repeated, pulse sequence, ensure the duration is long enough to return the pin to the initial (high) state (see linked issue for an example)

TODO:
- [x] Testing by reporter ([confirmed](https://github.com/letscontrolit/ESPEasy/issues/4620#issuecomment-1517329073))