### PR TITLE
[P031][P105] Harmonize plugin names

### DIFF
--- a/docs/source/Plugin/P112.rst
+++ b/docs/source/Plugin/P112.rst
@@ -1,0 +1,52 @@
+.. include:: ../Plugin/_plugin_substitutions_p11x.repl
+.. _P112_page:
+
+|P112_typename|
+==================================================
+
+|P112_shortinfo|
+
+Plugin details
+--------------
+
+Type: |P112_type|
+
+Name: |P112_name|
+
+Status: |P112_status|
+
+GitHub: |P112_github|_
+
+Maintainer: |P112_maintainer|
+
+Used libraries: |P112_usedlibraries|
+
+Supported hardware
+------------------
+
+|P112_usedby|
+
+.. Commands available
+.. ^^^^^^^^^^^^^^^^^^
+
+.. .. include:: P112_commands.repl
+
+.. Events
+.. ~~~~~~
+
+.. .. include:: P112_events.repl
+
+Change log
+----------
+
+.. versionchanged:: 2.0
+  ...
+
+  |added|
+
+  Initial release version.
+
+
+
+
+

--- a/docs/source/Plugin/_Plugin.rst
+++ b/docs/source/Plugin/_Plugin.rst
@@ -342,6 +342,7 @@ There are different released versions of ESP Easy:
    ":ref:`P109_page`","|P109_status|","P109"
    ":ref:`P110_page`","|P110_status|","P110"
    ":ref:`P111_page`","|P111_status|","P111"
+   ":ref:`P112_page`","|P112_status|","P112"
    ":ref:`P113_page`","|P113_status|","P113"
    ":ref:`P114_page`","|P114_status|","P114"
    ":ref:`P115_page`","|P115_status|","P115"
@@ -390,6 +391,11 @@ Acceleration
 ------------
 
 Plugins: |Plugin_Acceleration|
+
+Color
+-----
+
+Plugins: |Plugin_Color|
 
 Communication
 -------------

--- a/docs/source/Plugin/_plugin_categories.repl
+++ b/docs/source/Plugin/_plugin_categories.repl
@@ -1,5 +1,6 @@
 .. |Plugin_Analog_input| replace:: :ref:`P002_page`, :ref:`P007_page`, :ref:`P025_page`, :ref:`P060_page`, :ref:`P097_page`
 .. |Plugin_Acceleration| replace:: :ref:`P120_page`, :ref:`P125_page`
+.. |Plugin_Color| replace:: :ref:`P112_page`
 .. |Plugin_Communication| replace:: :ref:`P016_page`, :ref:`P020_page`, :ref:`P035_page`, :ref:`P044_page`, :ref:`P054_page`, :ref:`P071_page`, :ref:`P087_page`, :ref:`P089_page`, :ref:`P094_page`, :ref:`P101_page`, :ref:`P118_page`
 .. |Plugin_Display| replace:: :ref:`P012_page`, :ref:`P023_page`, :ref:`P036_page`, :ref:`P057_page`, :ref:`P073_page`, :ref:`P075_page`, :ref:`P095_page`, :ref:`P104_page`, :ref:`P116_page`, :ref:`P131_page`, :ref:`P148_page`
 .. |Plugin_Distance| replace:: :ref:`P110_page`, :ref:`P113_page`

--- a/docs/source/Plugin/_plugin_substitutions_p03x.repl
+++ b/docs/source/Plugin/_plugin_substitutions_p03x.repl
@@ -4,9 +4,9 @@
 .. |P030_porttype| replace:: `.`
 .. |P030_status| replace:: :gray:`RETIRED`
 
-.. |P031_name| replace:: :cyan:`SHT1X`
+.. |P031_name| replace:: :cyan:`SHT1x`
 .. |P031_type| replace:: :cyan:`Environment`
-.. |P031_typename| replace:: :cyan:`Environment - SHT1X`
+.. |P031_typename| replace:: :cyan:`Environment - SHT1x`
 .. |P031_porttype| replace:: `.`
 .. |P031_status| replace:: :green:`NORMAL` :yellow:`CLIMATE`
 .. |P031_github| replace:: P031_SHT1X.ino

--- a/docs/source/Plugin/_plugin_substitutions_p09x.repl
+++ b/docs/source/Plugin/_plugin_substitutions_p09x.repl
@@ -47,9 +47,9 @@
 .. |P093_compileinfo| replace:: `.`
 .. |P093_usedlibraries| replace:: `.`
 
-.. |P094_name| replace:: :cyan:`Communication - CUL Reader`
+.. |P094_name| replace:: :cyan:`CUL Reader`
 .. |P094_type| replace:: :cyan:`Communication`
-.. |P094_typename| replace:: :cyan:`CUL Reader`
+.. |P094_typename| replace:: :cyan:`Communication - CUL Reader`
 .. |P094_status| replace:: :yellow:`COLLECTION D`
 .. |P094_github| replace:: P094_CULReader.ino
 .. _P094_github: https://github.com/letscontrolit/ESPEasy/blob/mega/src/_P094_CULReader.ino

--- a/docs/source/Plugin/_plugin_substitutions_p10x.repl
+++ b/docs/source/Plugin/_plugin_substitutions_p10x.repl
@@ -75,9 +75,9 @@
 .. |P104-Font-Katakana_typename| replace:: `Katakana font characters`
 
 
-.. |P105_name| replace:: :cyan:`AHT10/20/21`
+.. |P105_name| replace:: :cyan:`AHT10/AHT2x`
 .. |P105_type| replace:: :cyan:`Environment`
-.. |P105_typename| replace:: :cyan:`Environment - AHT10/20/21`
+.. |P105_typename| replace:: :cyan:`Environment - AHT10/AHT2x`
 .. |P105_porttype| replace:: `.`
 .. |P105_status| replace:: :yellow:`COLLECTION A` :yellow:`CLIMATE`
 .. |P105_github| replace:: P105_AHT.ino

--- a/docs/source/Plugin/_plugin_substitutions_p11x.repl
+++ b/docs/source/Plugin/_plugin_substitutions_p11x.repl
@@ -24,6 +24,19 @@
 .. |P111_compileinfo| replace:: `.`
 .. |P111_usedlibraries| replace:: `https://github.com/miguelbalboa/rfid (local copy)`
 
+.. |P112_name| replace:: :cyan:`AS7265X`
+.. |P112_type| replace:: :cyan:`Color`
+.. |P112_typename| replace:: :cyan:`Color - AS7265X`
+.. |P112_porttype| replace:: `.`
+.. |P112_status| replace:: :yellow:`COLLECTION F`
+.. |P112_github| replace:: P112_AS7265x.ino
+.. _P112_github: https://github.com/letscontrolit/ESPEasy/blob/mega/src/_P112_AS7265x.ino
+.. |P112_usedby| replace:: `.`
+.. |P112_shortinfo| replace:: `Color sensor`
+.. |P112_maintainer| replace:: `heinemannj`
+.. |P112_compileinfo| replace:: `.`
+.. |P112_usedlibraries| replace:: `https://github.com/sparkfun/SparkFun_AS7265X_Arduino_Library (local copy)`
+
 .. |P113_name| replace:: :cyan:`VL53L1X`
 .. |P113_type| replace:: :cyan:`Distance`
 .. |P113_typename| replace:: :cyan:`Distance - VL53L1X (400cm)`

--- a/src/_P031_SHT1X.ino
+++ b/src/_P031_SHT1X.ino
@@ -10,7 +10,7 @@
 
 # define PLUGIN_031
 # define PLUGIN_ID_031         31
-# define PLUGIN_NAME_031       "Environment - SHT1X"
+# define PLUGIN_NAME_031       "Environment - SHT1x"
 # define PLUGIN_VALUENAME1_031 "Temperature"
 # define PLUGIN_VALUENAME2_031 "Humidity"
 
@@ -92,7 +92,7 @@ boolean Plugin_031(uint8_t function, struct EventStruct *event, String& string)
         # ifndef BUILD_NO_DEBUG
 
       if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
-        String log = F("SHT1X : Status uint8_t: ");
+        String log = F("SHT1x : Status uint8_t: ");
         log += String(status, HEX);
         log += F(" - resolution: ");
         log += ((status & 1) ? F("low") : F("high"));
@@ -140,10 +140,10 @@ boolean Plugin_031(uint8_t function, struct EventStruct *event, String& string)
           if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
             switch (P031_data->state) {
               case P031_COMMAND_NO_ACK:
-                addLog(LOG_LEVEL_ERROR, F("SHT1X : Sensor did not ACK command"));
+                addLog(LOG_LEVEL_ERROR, F("SHT1x : Sensor did not ACK command"));
                 break;
               case P031_NO_DATA:
-                addLog(LOG_LEVEL_ERROR, F("SHT1X : Data not ready"));
+                addLog(LOG_LEVEL_ERROR, F("SHT1x : Data not ready"));
                 break;
               default:
                 break;

--- a/src/_P105_AHT.ino
+++ b/src/_P105_AHT.ino
@@ -37,7 +37,7 @@
 
 # define PLUGIN_105
 # define PLUGIN_ID_105         105
-# define PLUGIN_NAME_105       "Environment - AHT10/20/21"
+# define PLUGIN_NAME_105       "Environment - AHT10/AHT2x"
 # define PLUGIN_VALUENAME1_105 "Temperature"
 # define PLUGIN_VALUENAME2_105 "Humidity"
 

--- a/src/_P112_AS7265x.ino
+++ b/src/_P112_AS7265x.ino
@@ -10,6 +10,7 @@
 // based on this library: https://github.com/sparkfun/SparkFun_AS7265x_Arduino_Library
 // this code is based on 29 Mar 2019-03-29 version of the above library
 //
+// 2023-04-28 tonhuisman: Remove [Development] tag
 // 2021-03-29 heinemannj: Initial commit
 //
 
@@ -17,7 +18,7 @@
 
 # define PLUGIN_112
 # define PLUGIN_ID_112         112
-# define PLUGIN_NAME_112       "Color - AS7265X [DEVELOPMENT]"
+# define PLUGIN_NAME_112       "Color - AS7265X"
 # define PLUGIN_VALUENAME1_112 "TempMaster"
 # define PLUGIN_VALUENAME2_112 "TempAverage"
 # define PLUGIN_VALUENAME3_112 "State"

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -1518,6 +1518,9 @@ To create/register a plugin, you have to :
 #endif
 
 #ifdef PLUGIN_SET_COLLECTION_F
+  #ifndef USES_P112
+    #define USES_P112   // AS7265x 
+  #endif
   #ifndef USES_P122
     #define USES_P122   // SHT2x 
   #endif


### PR DESCRIPTION
Features:
- Adjust plugin names to align with other plugins when supporting a range of sensor models (incl. documentation)
  - P031 - Environment - SHT1x
  - P105 - Environment - AHT10/AHT2x
- P094 Correct plugin name in documentation
- P112 Add missing documentation template, and include in `Collection F`