### PR TITLE
[UI] Bugfix: `/dashboard.esp` url was not working anymore

### DIFF
--- a/src/src/WebServer/LoadFromFS.cpp
+++ b/src/src/WebServer/LoadFromFS.cpp
@@ -234,18 +234,18 @@ bool loadFromFS(String path) {
     addLog(LOG_LEVEL_INFO, concat(F("static_file: "), path));
   }
 #endif // ifndef BUILD_NO_DEBUG
-  const bool fileEmbedded = fileIsEmbedded(path);
-
-  if (!fileExists(path) && !fileEmbedded) {
-    return false;
-  }
-
 #ifdef WEBSERVER_CUSTOM
 
   if (path.endsWith(F(".esp"))) {
     return handle_custom(path);
   }
 #endif // ifdef WEBSERVER_CUSTOM
+
+  const bool fileEmbedded = fileIsEmbedded(path);
+
+  if (!fileExists(path) && !fileEmbedded) {
+    return false;
+  }
 
   bool mustCheckCredentials = false;
   const __FlashStringHelper* contentType  = get_ContentType(path, mustCheckCredentials);


### PR DESCRIPTION
From a [Forum reported bug](https://www.letscontrolit.com/forum/viewtopic.php?t=9336)

Bugfix:
- `/dashboard.esp` url wasn't working anymore (issue with the order of checks performed).

TODO:
- [x] Testing by reporter (tested locally: ✅)