### PR TITLE
[UI/UX] Setup page doesn't serve css

### DIFF
--- a/src/src/WebServer/WebTemplateParser.cpp
+++ b/src/src/WebServer/WebTemplateParser.cpp
@@ -325,12 +325,12 @@ void WebTemplateParser::getWebPageTemplateVar(const String& varName)
   else if (equals(varName, F("css")))
   {
     serve_favicon();
-    if (MENU_INDEX_SETUP == navMenuIndex) {
-      // Serve embedded CSS
-      serve_CSS_inline();
-    } else {
+    // if (MENU_INDEX_SETUP == navMenuIndex) {
+    //  // Serve embedded CSS
+    //  serve_CSS_inline();
+    // } else {
       serve_CSS(CSSfiles_e::ESPEasy_default);
-    }
+    // }
     #if FEATURE_RULES_EASY_COLOR_CODE
     if (MENU_INDEX_RULES == navMenuIndex ||
         MENU_INDEX_CUSTOM_PAGE == navMenuIndex) {


### PR DESCRIPTION
Resolves #4584 

Bugfix:
- On the `/setup` page no css was served, giving a rather poor user experience. Now css is served if possible/available (may require access to the internet from the browser or the css already in browser-cache).