### PR TITLE
[Bugfixes] Some small corrections

### DIFF
--- a/src/Custom-sample.h
+++ b/src/Custom-sample.h
@@ -225,6 +225,7 @@
 // #define FEATURE_POST_TO_HTTP 1 // Enable availability of the PostToHTTP command
 // #define FEATURE_I2C_DEVICE_CHECK 0 // Disable the I2C Device check feature
 // #define FEATURE_I2C_GET_ADDRESS 0 // Disable fetching the I2C address from I2C plugins. Will be enabled when FEATURE_I2C_DEVICE_CHECK is enabled
+// #define FEATURE_RTTTL 1   // Enable rtttl command
 
 
 #if FEATURE_CUSTOM_PROVISIONING

--- a/src/Custom-sample.h
+++ b/src/Custom-sample.h
@@ -223,6 +223,7 @@
 // #define ADAGFX_SUPPORT_7COLOR  0 // Disable the support of 7-color eInk displays by AdafruitGFX_helper
 // #define FEATURE_SEND_TO_HTTP 1 // Enable availability of the SendToHTTP command
 // #define FEATURE_POST_TO_HTTP 1 // Enable availability of the PostToHTTP command
+// #define FEATURE_PUT_TO_HTTP 1 // Enable availability of the PutToHTTP command
 // #define FEATURE_I2C_DEVICE_CHECK 0 // Disable the I2C Device check feature
 // #define FEATURE_I2C_GET_ADDRESS 0 // Disable fetching the I2C address from I2C plugins. Will be enabled when FEATURE_I2C_DEVICE_CHECK is enabled
 // #define FEATURE_RTTTL 1   // Enable rtttl command

--- a/src/_P080_DallasIButton.ino
+++ b/src/_P080_DallasIButton.ino
@@ -117,12 +117,12 @@ boolean Plugin_080(uint8_t function, struct EventStruct *event, String& string)
 
         if (Dallas_readiButton(addr, Plugin_080_DallasPin, Plugin_080_DallasPin))
         {
-          UserVar[event->BaseVarIndex] = 1;
-          success                      = true;
+          UserVar.setUint32(event->TaskIndex, 0, 1);
+          success = true;
         }
         else
         {
-          UserVar[event->BaseVarIndex] = 0;
+          UserVar.setUint32(event->TaskIndex, 0, 0);
         }
         Dallas_startConversion(addr, Plugin_080_DallasPin, Plugin_080_DallasPin);
 
@@ -144,10 +144,10 @@ boolean Plugin_080(uint8_t function, struct EventStruct *event, String& string)
     }
     case PLUGIN_READ:
     {
-      success = UserVar[event->BaseVarIndex] != UserVar[event->BaseVarIndex + 1]; // Changed?
+      success = UserVar.getUint32(event->TaskIndex, 0) != UserVar.getUint32(event->TaskIndex, 2); // Changed?
 
       // Keep previous state
-      UserVar[event->BaseVarIndex + 1] = UserVar[event->BaseVarIndex];
+      UserVar.setUint32(event->TaskIndex, 2, UserVar.getUint32(event->TaskIndex, 0));
       break;
     }
   }

--- a/src/_P080_DallasIButton.ino
+++ b/src/_P080_DallasIButton.ino
@@ -126,7 +126,8 @@ boolean Plugin_080(uint8_t function, struct EventStruct *event, String& string)
         }
         Dallas_startConversion(addr, Plugin_080_DallasPin, Plugin_080_DallasPin);
 
-        #ifndef BUILD_NO_DEBUG
+        # ifndef BUILD_NO_DEBUG
+
         if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
           String log = F("DS   : iButton: ");
 
@@ -137,13 +138,17 @@ boolean Plugin_080(uint8_t function, struct EventStruct *event, String& string)
           }
           addLogMove(LOG_LEVEL_DEBUG, log);
         }
-        #endif
+        # endif // ifndef BUILD_NO_DEBUG
       }
+      break;
+    }
+    case PLUGIN_READ:
+    {
+      success = true;
       break;
     }
   }
   return success;
 }
-
 
 #endif // USES_P080

--- a/src/_P080_DallasIButton.ino
+++ b/src/_P080_DallasIButton.ino
@@ -144,7 +144,10 @@ boolean Plugin_080(uint8_t function, struct EventStruct *event, String& string)
     }
     case PLUGIN_READ:
     {
-      success = true;
+      success = UserVar[event->BaseVarIndex] != UserVar[event->BaseVarIndex + 1]; // Changed?
+
+      // Keep previous state
+      UserVar[event->BaseVarIndex + 1] = UserVar[event->BaseVarIndex];
       break;
     }
   }

--- a/src/src/Commands/i2c.cpp
+++ b/src/src/Commands/i2c.cpp
@@ -4,22 +4,29 @@
 #include "../ESPEasyCore/Serial.h"
 
 #include "../Globals/I2Cdev.h"
+#include "../Globals/Settings.h"
 
 #include "../../ESPEasy_common.h"
 
-const __FlashStringHelper * Command_i2c_Scanner(struct EventStruct *event, const char* Line)
+const __FlashStringHelper* Command_i2c_Scanner(struct EventStruct *event, const char *Line)
 {
-	uint8_t error, address;
-	for (address = 1; address <= 127; address++) {
-		Wire.beginTransmission(address);
-		error = Wire.endTransmission();
-		if (error == 0) {
-			serialPrint(F("I2C  : Found 0x"));
-			serialPrintln(String(address, HEX));
-		}else if (error == 4) {
-			serialPrint(F("I2C  : Error at 0x"));
-			serialPrintln(String(address, HEX));
-		}
-	}
-	return return_see_serial(event);
+  uint8_t error, address;
+
+  if (Settings.isI2CEnabled()) {
+    for (address = 1; address <= 127; address++) {
+      Wire.beginTransmission(address);
+      error = Wire.endTransmission();
+
+      if (error == 0) {
+        serialPrint(F("I2C  : Found 0x"));
+        serialPrintln(String(address, HEX));
+      } else if (error == 4) {
+        serialPrint(F("I2C  : Error at 0x"));
+        serialPrintln(String(address, HEX));
+      }
+    }
+  } else {
+    serialPrintln(F("I2C  : Not enabled."));
+  }
+  return return_see_serial(event);
 }

--- a/src/src/Helpers/AdafruitGFX_helper.cpp
+++ b/src/src/Helpers/AdafruitGFX_helper.cpp
@@ -803,8 +803,8 @@ enum class adagfx_fonts_e : int8_t {
   sevenseg24,
   sevenseg18,
   freesans,
-  angelina8prop,
   # ifdef ADAGFX_FONTS_EXTRA_8PT_INCLUDED
+  angelina8prop,
   novamono8pt, // 8pt
   unispace8pt,
   unispaceitalic8pt,


### PR DESCRIPTION
Fix a few small issues:
- `I2Cscanner` command didn't check if I2C was enabled, resulting in 127 error messages
- Add missing `#define FEATURE_RTTTL 1` to `Custom-sample.h`
- Add missing `#define FEATURE_PUT_TO_HTTP 1` to `Custom-sample.h`
- Correct AdafruitGFX_helper #define error ([reported in the forum](https://www.letscontrolit.com/forum/viewtopic.php?t=9638#p64352))
- [P080] Add missing `PLUGIN_READ` function-handler, so value is sent out to controllers

Resolves #4644
Resolves #4646
