### PR TITLE
[Commands] Add internal command AppendUnitToHostname

### DIFF
--- a/docs/source/Plugin/P000_commands.repl
+++ b/docs/source/Plugin/P000_commands.repl
@@ -7,6 +7,15 @@
     :widths: 8, 5, 30
 
     "
+    AppendUnitToHostname","
+    :red:`Internal`","
+    Get or set the Append Unit to Hostname option in the Config page.
+
+    ``AppendUnitToHostname``
+
+    ``AppendUnitToHostname,true`` (can use ``1``, ``true`` or ``on`` to enable, and ``0``, ``false`` or ``off`` to disable)
+    "
+    "
     AsyncEvent","
     :blue:`Special`","
     Schedule an event, it's possible to send a float value along as well.

--- a/src/src/Commands/Common.cpp
+++ b/src/src/Commands/Common.cpp
@@ -158,11 +158,10 @@ String Command_GetORSetBool(struct EventStruct *event,
       if (validIntFromString(TmpStr1, tmp_int)) {
         *value = tmp_int > 0;
       }
-      else if (TmpStr1.isEmpty()) {} // Empty string not always handled nicely by strcmp_P
-      else if (strcmp_P(PSTR("on"), TmpStr1.c_str()) == 0) { *value = true; }
-      else if (strcmp_P(PSTR("true"), TmpStr1.c_str()) == 0) { *value = true; }
-      else if (strcmp_P(PSTR("off"), TmpStr1.c_str()) == 0) { *value = false; }
-      else if (strcmp_P(PSTR("false"), TmpStr1.c_str()) == 0) { *value = false; }
+      else if (equals(TmpStr1, F("on"))) { *value = true; }
+      else if (equals(TmpStr1, F("true"))) { *value = true; }
+      else if (equals(TmpStr1, F("off"))) { *value = false; }
+      else if (equals(TmpStr1, F("false"))) { *value = false; }
     }
   }
 

--- a/src/src/Commands/InternalCommands.cpp
+++ b/src/src/Commands/InternalCommands.cpp
@@ -254,8 +254,9 @@ bool executeInternalCommand(command_case_data & data)
   // FIXME TD-er: must determine nr arguments where NARGS is set to -1
   switch (data.cmd_lc[0]) {
     case 'a': {
-      COMMAND_CASE_A("accessinfo", Command_AccessInfo_Ls,       0); // Network Command
-      COMMAND_CASE_A("asyncevent", Command_Rules_Async_Events, -1); // Rule.h
+      COMMAND_CASE_A(          "accessinfo", Command_AccessInfo_Ls,         0); // Network Command
+      COMMAND_CASE_R("appendunittohostname", Command_AppendUnitToHostname, -1); // Settings.h
+      COMMAND_CASE_A(          "asyncevent", Command_Rules_Async_Events,   -1); // Rule.h
       break;
     }
     case 'b': {

--- a/src/src/Commands/Settings.cpp
+++ b/src/src/Commands/Settings.cpp
@@ -42,6 +42,20 @@ String Command_Settings_Unit(struct EventStruct *event, const char* Line)
 	return return_command_success_str();
 }
 
+String Command_AppendUnitToHostname(struct EventStruct *event, const char *Line)
+{
+  bool   appendUnitToHostname = Settings.appendUnitToHostname();
+  String result            		= Command_GetORSetBool(event, F("Append Unit to Hostname:"),
+                              	                     Line,
+                              	                     (bool *)&appendUnitToHostname,
+                              	                     1);
+
+  if (Settings.appendUnitToHostname() != appendUnitToHostname) { // Update if changed
+    Settings.appendUnitToHostname(appendUnitToHostname);
+  }
+  return result;
+}
+
 String Command_Settings_Name(struct EventStruct *event, const char* Line)
 {
 	return Command_GetORSetString(event, F("Name:"),

--- a/src/src/Commands/Settings.h
+++ b/src/src/Commands/Settings.h
@@ -5,6 +5,7 @@
 
 String Command_Settings_Build(struct EventStruct *event, const char* Line);
 String Command_Settings_Unit(struct EventStruct *event, const char* Line);
+String Command_AppendUnitToHostname(struct EventStruct *event, const char *Line);
 String Command_Settings_Name(struct EventStruct *event, const char* Line);
 String Command_Settings_Password(struct EventStruct *event, const char* Line);
 const __FlashStringHelper * Command_Settings_Password_Clear(struct EventStruct *event, const char* Line);


### PR DESCRIPTION
As suggested in [this comment](https://github.com/letscontrolit/ESPEasy/issues/4609#issuecomment-1537122224)

Features:
- Add internal command `AppendUnitToHostname[,<on|off>]` to change the Config page setting 'Append Unit to Hostname'.
- Update documentation.
- Fix internal on/off/true/false command handling.