### PR TITLE
[UserVar] Bugfix: Clear element only

### DIFF
--- a/src/src/DataStructs/UserVarStruct.cpp
+++ b/src/src/DataStructs/UserVarStruct.cpp
@@ -13,7 +13,7 @@ UserVarStruct::UserVarStruct()
 void UserVarStruct::clear()
 {
   for (size_t i = 0; i < _data.size(); ++i) {
-    _data.clear();
+    _data[i].clear();
   }
 }
 


### PR DESCRIPTION
Resolves #4652 

Bugfix:
- UserVar data element should be cleared, not entire list. (Only found to fail on ESP8266)

TODO:
- [x] Testing by reporter