### PR TITLE
[Cleanup] Fix IP address formatting

### DIFF
--- a/src/_C009.cpp
+++ b/src/_C009.cpp
@@ -157,7 +157,7 @@ bool do_process_c009_delay_queue(int controller_number, const Queue_element_base
           // IPAddress ip = NetworkLocalIP();
           // sprintf_P(ipStr, PSTR("%u.%u.%u.%u"), ip[0], ip[1], ip[2], ip[3]);
           jsonString += ',';
-          jsonString += to_json_object_value(F("ip"), NetworkLocalIP().toString());
+          jsonString += to_json_object_value(F("ip"), formatIP(NetworkLocalIP()));
         }
         jsonString += '}'; // End "ESP"
 

--- a/src/src/Commands/Settings.cpp
+++ b/src/src/Commands/Settings.cpp
@@ -92,7 +92,7 @@ const __FlashStringHelper * Command_Settings_Print(struct EventStruct *event, co
 	serialPrintln();
 
 	serialPrintln(F("System Info"));
-	serialPrint(F("  IP Address    : ")); serialPrintln(NetworkLocalIP().toString());
+	serialPrint(F("  IP Address    : ")); serialPrintln(formatIP(NetworkLocalIP()));
 	serialPrint(F("  Build         : ")); serialPrintln(String(get_build_nr()) + '/' + getSystemBuildString());
 	serialPrint(F("  Name          : ")); serialPrintln(Settings.getName());
 	serialPrint(F("  Unit          : ")); serialPrintln(String(static_cast<int>(Settings.Unit)));

--- a/src/src/DataStructs/ControllerSettingsStruct.cpp
+++ b/src/src/DataStructs/ControllerSettingsStruct.cpp
@@ -91,7 +91,7 @@ String ControllerSettingsStruct::getHost() const {
   if (UseDNS) {
     return HostName;
   }
-  return getIP().toString();
+  return formatIP(getIP());
 }
 
 void ControllerSettingsStruct::setHostname(const String& controllerhostname) {

--- a/src/src/ESPEasyCore/ESPEasyEth_ProcessEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyEth_ProcessEvent.cpp
@@ -98,7 +98,7 @@ void check_Eth_DNS_valid() {
         if (timePassedSince(lastLog) > 1000) {
           addLogMove(LOG_LEVEL_ERROR, concat(
             F("ETH  : DNS server was cleared, use cached DNS IP: "), 
-            EthEventData.dns0_cache.toString()));
+            formatIP(EthEventData.dns0_cache)));
           lastLog = millis();
         }
         setDNS(0, EthEventData.dns0_cache);
@@ -183,17 +183,17 @@ void processEthernetGotIP() {
         log += F("DHCP");
       }
       log += F(" IP: ");
-      log += ip.toString();
+      log += formatIP(ip);
       log += ' ';
       log += wrap_braces(NetworkGetHostname());
       log += F(" GW: ");
-      log += gw.toString();
+      log += formatIP(gw);
       log += F(" SN: ");
-      log += subnet.toString();
+      log += formatIP(subnet);
       log += F(" DNS: ");
-      log += dns0.toString();
+      log += formatIP(dns0);
       log += '/';
-      log += dns1.toString();
+      log += formatIP(dns1);
 
       if (EthLinkUp()) {
         if (EthFullDuplex()) {

--- a/src/src/ESPEasyCore/ESPEasyWifi.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi.cpp
@@ -1207,7 +1207,9 @@ void setAPinternal(bool enable)
         String log(F("WIFI : AP Mode ssid will be "));
         log += softAPSSID;
         log += F(" with address ");
-        log += WiFi.softAPIP().toString();
+        log += formatIP(WiFi.softAPIP());
+        log += F(" ch: ");
+        log += channel;
         addLogMove(LOG_LEVEL_INFO, log);
       }
     } else {
@@ -1215,7 +1217,7 @@ void setAPinternal(bool enable)
         String log(F("WIFI : Error while starting AP Mode with SSID: "));
         log += softAPSSID;
         log += F(" IP: ");
-        log += apIP.toString();
+        log += formatIP(apIP);
         addLogMove(LOG_LEVEL_ERROR, log);
       }
     }

--- a/src/src/Helpers/ESPEasy_time.cpp
+++ b/src/src/Helpers/ESPEasy_time.cpp
@@ -394,7 +394,7 @@ bool ESPEasy_time::getNtpTime(double& unixTime_d)
   }
 
   log += F(" (");
-  log += timeServerIP.toString();
+  log += formatIP(timeServerIP);
   log += ')';
 
   if (!hostReachable(timeServerIP)) {
@@ -456,7 +456,7 @@ bool ESPEasy_time::getNtpTime(double& unixTime_d)
         // See: https://github.com/letscontrolit/ESPEasy/issues/2886#issuecomment-586656384
         if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
           String log = F("NTP  : NTP host (");
-          log += timeServerIP.toString();
+          log += formatIP(timeServerIP);
           log += F(") unsynchronized");
           addLogMove(LOG_LEVEL_ERROR, log);
         }

--- a/src/src/Helpers/Networking.cpp
+++ b/src/src/Helpers/Networking.cpp
@@ -350,7 +350,7 @@ void checkUDP()
                     log  = F("UDP  : ");
                     log += received.STA_MAC().toString();
                     log += ',';
-                    log += received.IP().toString();
+                    log += formatIP(received.IP());
                     log += ',';
                     log += received.unit;
                     addLog(LOG_LEVEL_DEBUG_MORE, log);
@@ -406,7 +406,7 @@ String formatUnitToIPAddress(uint8_t unit, uint8_t formatCode) {
       }
     }
   }
-  return unitIPAddress.toString();
+  return formatIP(unitIPAddress);
 }
 
 /*********************************************************************************************\
@@ -1473,7 +1473,7 @@ int http_authenticate(const String& logIdentifier,
   http.addHeader(F("Accept"), F("*/*;q=0.1"));
 
   // Add client IP
-  http.addHeader(F("X-Forwarded-For"), NetworkLocalIP().toString());
+  http.addHeader(F("X-Forwarded-For"), formatIP(NetworkLocalIP()));
 
   delay(0);
   scrubDNS();

--- a/src/src/Helpers/StringConverter.cpp
+++ b/src/src/Helpers/StringConverter.cpp
@@ -72,12 +72,24 @@ bool str2ip(const char *string, uint8_t *IP)
 }
 
 String formatIP(const IPAddress& ip) {
+#ifdef ESP8266
 #if defined(ARDUINO_ESP8266_RELEASE_2_3_0)
   IPAddress tmp(ip);
   return tmp.toString();
 #else // if defined(ARDUINO_ESP8266_RELEASE_2_3_0)
   return ip.toString();
 #endif // if defined(ARDUINO_ESP8266_RELEASE_2_3_0)
+#endif
+#ifdef ESP32
+  #if LWIP_IPV6
+  if (ip.isAny()) {
+    IPAddress tmp;
+    tmp.setV4();
+    return tmp.toString();
+  }
+  #endif
+  return ip.toString();
+#endif
 }
 
 

--- a/src/src/Helpers/StringProvider.cpp
+++ b/src/src/Helpers/StringProvider.cpp
@@ -378,18 +378,18 @@ String getValue(LabelType::Enum label) {
                                                             LabelType::IP_CONFIG_DYNAMIC));
     case LabelType::IP_CONFIG_STATIC:       break;
     case LabelType::IP_CONFIG_DYNAMIC:      break;
-    case LabelType::IP_ADDRESS:             return NetworkLocalIP().toString();
-    case LabelType::IP_SUBNET:              return NetworkSubnetMask().toString();
+    case LabelType::IP_ADDRESS:             return formatIP(NetworkLocalIP());
+    case LabelType::IP_SUBNET:              return formatIP(NetworkSubnetMask());
     case LabelType::IP_ADDRESS_SUBNET:      return getValue(LabelType::IP_ADDRESS) + F(" / ") + getValue(LabelType::IP_SUBNET);
-    case LabelType::GATEWAY:                return NetworkGatewayIP().toString();
+    case LabelType::GATEWAY:                return formatIP(NetworkGatewayIP());
     case LabelType::CLIENT_IP:              return formatIP(web_server.client().remoteIP());
 
     #if FEATURE_MDNS
     case LabelType::M_DNS:                  return NetworkGetHostname() + F(".local");
     #endif // if FEATURE_MDNS
     case LabelType::DNS:                    return getValue(LabelType::DNS_1) + F(" / ") + getValue(LabelType::DNS_2);
-    case LabelType::DNS_1:                  return NetworkDnsIP(0).toString();
-    case LabelType::DNS_2:                  return NetworkDnsIP(1).toString();
+    case LabelType::DNS_1:                  return formatIP(NetworkDnsIP(0));
+    case LabelType::DNS_2:                  return formatIP(NetworkDnsIP(1));
     case LabelType::ALLOWED_IP_RANGE:       return describeAllowedIPrange();
     case LabelType::STA_MAC:                return WifiSTAmacAddress().toString();
     case LabelType::AP_MAC:                 return WifiSoftAPmacAddress().toString();
@@ -485,12 +485,12 @@ String getValue(LabelType::Enum label) {
     case LabelType::OTA_2STEP:              break;
     case LabelType::OTA_POSSIBLE:           break;
 #if FEATURE_ETHERNET
-    case LabelType::ETH_IP_ADDRESS:         return NetworkLocalIP().toString();
-    case LabelType::ETH_IP_SUBNET:          return NetworkSubnetMask().toString();
+    case LabelType::ETH_IP_ADDRESS:         return formatIP(NetworkLocalIP());
+    case LabelType::ETH_IP_SUBNET:          return formatIP(NetworkSubnetMask());
     case LabelType::ETH_IP_ADDRESS_SUBNET:  return String(getValue(LabelType::ETH_IP_ADDRESS) + F(" / ") +
                                                           getValue(LabelType::ETH_IP_SUBNET));
-    case LabelType::ETH_IP_GATEWAY:         return NetworkGatewayIP().toString();
-    case LabelType::ETH_IP_DNS:             return NetworkDnsIP(0).toString();
+    case LabelType::ETH_IP_GATEWAY:         return formatIP(NetworkGatewayIP());
+    case LabelType::ETH_IP_DNS:             return formatIP(NetworkDnsIP(0));
     case LabelType::ETH_MAC:                return NetworkMacAddress().toString();
     case LabelType::ETH_DUPLEX:             return EthLinkUp() ? (EthFullDuplex() ? F("Full Duplex") : F("Half Duplex")) : F("Link Down");
     case LabelType::ETH_SPEED:              return EthLinkUp() ? getEthSpeed() : F("Link Down");

--- a/src/src/WebServer/CustomPage.cpp
+++ b/src/src/WebServer/CustomPage.cpp
@@ -56,7 +56,7 @@ bool handle_custom(const String& path) {
         TXBuffer.startStream();
         sendHeadandTail(F("TmplDsh"), _HEAD);
         addHtml(F("<meta http-equiv=\"refresh\" content=\"0; URL=http://"));
-        addHtml(it->second.IP().toString());
+        addHtml(formatIP(it->second.IP()));
         addHtml(F("/dashboard.esp\">"));
         sendHeadandTail(F("TmplDsh"), _TAIL);
         TXBuffer.endStream();

--- a/src/src/WebServer/ESPEasy_WebServer.cpp
+++ b/src/src/WebServer/ESPEasy_WebServer.cpp
@@ -167,7 +167,7 @@ bool captivePortal() {
   }
   if (!isIP(web_server.hostHeader()) && web_server.hostHeader() != (NetworkGetHostname() + F(".local"))) {
     String redirectURL = F("http://");
-    redirectURL += web_server.client().localIP().toString();
+    redirectURL += formatIP(web_server.client().localIP());
     #ifdef WEBSERVER_SETUP
     if (fromAP && !hasWiFiCredentials) {
       redirectURL += F("/setup");

--- a/src/src/WebServer/JSON.cpp
+++ b/src/src/WebServer/JSON.cpp
@@ -337,7 +337,7 @@ void handle_json()
           if (rssi < 0) {
             stream_next_json_object_value(F("rssi"), rssi);
           }
-          stream_next_json_object_value(F("ip"), it->second.IP().toString());
+          stream_next_json_object_value(F("ip"), formatIP(it->second.IP()));
           stream_last_json_object_value(F("age"), it->second.getAge());
         } // if node info exists
       }   // for loop
@@ -545,7 +545,7 @@ void handle_nodes_list_json() {
 
       if (it->second.build) { json_prop(F("build"), formatSystemBuildNr(it->second.build)); }
       json_prop(F("type"), it->second.getNodeTypeDisplayString());
-      json_prop(F("ip"),   it->second.ip.toString());
+      json_prop(F("ip"),   formatIP(it->second.ip));
       json_number(F("age"), String(it->second.getAge() / 1000)); // time in seconds
       json_close();
     }

--- a/src/src/WebServer/RootPage.cpp
+++ b/src/src/WebServer/RootPage.cpp
@@ -329,7 +329,7 @@ void handle_root() {
           html_add_wide_button_prefix();
 
           addHtml(F("http://"));
-          addHtml(it->second.IP().toString());
+          addHtml(formatIP(it->second.IP()));
           uint16_t port = it->second.webgui_portnumber;
 
           if ((port != 0) && (port != 80)) {
@@ -337,7 +337,7 @@ void handle_root() {
             addHtmlInt(port);
           }
           addHtml('\'', '>');
-          addHtml(it->second.IP().toString());
+          addHtml(formatIP(it->second.IP()));
           addHtml(F("</a>"));
         }
         html_TD();


### PR DESCRIPTION
Now ESP32 SDK code has support for IPv6, some uninitialized IPs were shown as `::` This was confusing to say the least and may have broken some other tools that may read IP info from JSON for example.