### PR TITLE
[P153] [Bugfix] Using Startup config with Heater enabled causes checksum errors

### DIFF
--- a/src/_P153_SHT4x.ino
+++ b/src/_P153_SHT4x.ino
@@ -6,6 +6,7 @@
 // #######################################################################################################
 
 /**
+ * 2023-06-10 tonhuisman: BUGFIX: The switch to Normal configuration wasn't working, resulting in checksum errors
  * 2023-04-24 tonhuisman: Rename Boot configuration to Startup configuration, add PLUGIN_WRITE support for commands
  *                        Minor improvements
  * 2023-04-23 tonhuisman: Add Boot Configuration and Normal Configuration options, to allow evaporating condensation

--- a/src/_P153_SHT4x.ino
+++ b/src/_P153_SHT4x.ino
@@ -6,6 +6,7 @@
 // #######################################################################################################
 
 /**
+ * 2023-06-10 tonhuisman: Return NaN values if there is an error connecting to the sensor, or a checksum error is reported
  * 2023-06-10 tonhuisman: BUGFIX: The switch to Normal configuration wasn't working, resulting in checksum errors
  * 2023-04-24 tonhuisman: Rename Boot configuration to Startup configuration, add PLUGIN_WRITE support for commands
  *                        Minor improvements

--- a/src/src/PluginStructs/P153_data_struct.cpp
+++ b/src/src/PluginStructs/P153_data_struct.cpp
@@ -88,7 +88,7 @@ bool P153_data_struct::plugin_read(struct EventStruct *event)           {
       }
 
       // Start measurement
-      if (!I2C_write8(_address, static_cast<uint8_t>(_startupConfiguration))) {
+      if (!I2C_write8(_address, static_cast<uint8_t>((_intervalLoops > 0) ? _startupConfiguration : _normalConfiguration))) {
         timeDelay = -1; // Don't continue if writing command fails
       }
       # ifndef BUILD_NO_DEBUG
@@ -142,7 +142,7 @@ bool P153_data_struct::plugin_read(struct EventStruct *event)           {
           _intervalLoops--;
 
           if ((_intervalLoops == 0) && (_startupConfiguration != _normalConfiguration)) {
-            addLog(LOG_LEVEL_INFO, F("SHT4x: Switching from Boot to Normal Configuration."));
+            addLog(LOG_LEVEL_INFO, F("SHT4x: Switching from Startup to Normal Configuration."));
           }
         }
 


### PR DESCRIPTION
BUGFIX: After the Interval runs had passed, the sensor reading mode wasn't switched to Normal, causing checksum errors (probably the sensor was overheating 😞).
Feature: Return `NaN` when an error occurs during command-write, data-read or on checksum error.

As reported in [this comment](https://github.com/letscontrolit/ESPEasy/issues/4590#issuecomment-1565957102).

TODO:
- [x] Testing by reporter ([confirmed](https://github.com/letscontrolit/ESPEasy/issues/4590#issuecomment-1585631003))
- [x] Investigate if reporting `NaN` can be added.