### PR TITLE
[ESP32 IDF] Update to IDF 4.4.5 (2023-06-14)

### DIFF
--- a/platformio_core_defs.ini
+++ b/platformio_core_defs.ini
@@ -235,7 +235,8 @@ build_flags               = ${esp82xx_3_0_x.build_flags}
 ;platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2023.02.00/platform-espressif32.zip
 ;platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/1243/framework-arduinoespressif32-lwip_timeout-ed6742e7f0.zip
 
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2023.05.03/platform-espressif32.zip
+;platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2023.05.03/platform-espressif32.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2023.06.04/platform-espressif32.zip
 platform_packages           =
 build_flags                 = -DESP32_STAGE
                               -DESP_IDF_VERSION_MAJOR=4


### PR DESCRIPTION
Lots and lots of bugfixes in ESP32 IDF SDK.
https://github.com/espressif/esp-idf/tree/release/v4.4

Including commits upto 2023-06-14.