### PR TITLE
[Build] Add Configuration code on System Info page

### DIFF
--- a/src/_C015.cpp
+++ b/src/_C015.cpp
@@ -120,7 +120,7 @@ bool CPlugin_015(CPlugin::Function function, struct EventStruct *event, String& 
     case CPlugin::Function::CPLUGIN_WEBFORM_LOAD:
     {
       char thumbprint[60] = {0};
-      LoadCustomControllerSettings(event->ControllerIndex, reinterpret_cast<const uint8_t *>(&thumbprint), sizeof(thumbprint));
+      LoadCustomControllerSettings(event->ControllerIndex, reinterpret_cast<uint8_t *>(&thumbprint), sizeof(thumbprint));
 
       if (strlen(thumbprint) != 59) {
         strcpy(thumbprint, CPLUGIN_015_DEFAULT_THUMBPRINT);

--- a/src/src/CustomBuild/CompiletimeDefines.cpp
+++ b/src/src/CustomBuild/CompiletimeDefines.cpp
@@ -116,3 +116,11 @@ const __FlashStringHelper * get_CDN_url_prefix() {
     //return F("https://cdn.jsdelivr.net/gh/letscontrolit/ESPEasy/static/");
   #endif
 }
+
+const __FlashStringHelper * getConfigurationCode() {
+  #ifndef CONFIGURATION_CODE
+    return F("");
+  #else // ifndef CONFIGURATION_CODE
+    return F(CONFIGURATION_CODE);
+  #endif // ifndef CONFIGURATION_CODE
+}

--- a/src/src/CustomBuild/CompiletimeDefines.h
+++ b/src/src/CustomBuild/CompiletimeDefines.h
@@ -21,6 +21,7 @@ const __FlashStringHelper * get_build_platform();
 const __FlashStringHelper * get_git_head();
 const __FlashStringHelper * get_board_name();
 const __FlashStringHelper * get_CDN_url_prefix();
+const __FlashStringHelper * getConfigurationCode();
 
 
 #endif // CUSTOMBUILD_COMPILETIMEDEFINES_H

--- a/src/src/Helpers/StringProvider.cpp
+++ b/src/src/Helpers/StringProvider.cpp
@@ -184,6 +184,9 @@ const __FlashStringHelper * getLabel(LabelType::Enum label) {
     case LabelType::BINARY_FILENAME:        return F("Binary Filename");
     case LabelType::BUILD_PLATFORM:         return F("Build Platform");
     case LabelType::GIT_HEAD:               return F("Git HEAD");
+    #ifdef CONFIGURATION_CODE
+    case LabelType::CONFIGURATION_CODE_LBL: return F("Configuration code");
+    #endif // ifdef CONFIGURATION_CODE
 
     case LabelType::I2C_BUS_STATE:          return F("I2C Bus State");
     case LabelType::I2C_BUS_CLEARED_COUNT:  return F("I2C bus cleared count");
@@ -457,6 +460,9 @@ String getValue(LabelType::Enum label) {
     case LabelType::BINARY_FILENAME:        return get_binary_filename();
     case LabelType::BUILD_PLATFORM:         return get_build_platform();
     case LabelType::GIT_HEAD:               return get_git_head();
+    #ifdef CONFIGURATION_CODE
+    case LabelType::CONFIGURATION_CODE_LBL: return getConfigurationCode();
+    #endif // ifdef CONFIGURATION_CODE
     case LabelType::I2C_BUS_STATE:          return toString(I2C_state);
     case LabelType::I2C_BUS_CLEARED_COUNT:  return String(I2C_bus_cleared_count);
     case LabelType::SYSLOG_LOG_LEVEL:       return getLogLevelDisplayString(Settings.SyslogLevel);

--- a/src/src/Helpers/StringProvider.h
+++ b/src/src/Helpers/StringProvider.h
@@ -136,6 +136,9 @@ struct LabelType {
     BINARY_FILENAME,
     BUILD_PLATFORM,
     GIT_HEAD,
+    #ifdef CONFIGURATION_CODE
+    CONFIGURATION_CODE_LBL,
+    #endif // ifdef CONFIGURATION_CODE
 
 
     I2C_BUS_STATE,

--- a/src/src/WebServer/SysInfoPage.cpp
+++ b/src/src/WebServer/SysInfoPage.cpp
@@ -161,6 +161,9 @@ void handle_sysinfo_json() {
   json_prop(F("filename"),       getValue(LabelType::BINARY_FILENAME));
   json_prop(F("build_platform"), getValue(LabelType::BUILD_PLATFORM));
   json_prop(F("git_head"),       getValue(LabelType::GIT_HEAD));
+  #ifdef CONFIGURATION_CODE
+  json_prop(F("configuration_code"), getValue(LabelType::CONFIGURATION_CODE));
+  #endif // ifdef CONFIGURATION_CODE
   json_close();
 
   json_open(false, F("esp"));
@@ -514,6 +517,9 @@ void handle_sysinfo_Firmware() {
   addRowLabelValue_copy(LabelType::BINARY_FILENAME);
   addRowLabelValue_copy(LabelType::BUILD_PLATFORM);
   addRowLabelValue_copy(LabelType::GIT_HEAD);
+  #ifdef CONFIGURATION_CODE
+  addRowLabelValue_copy(LabelType::CONFIGURATION_CODE_LBL);
+  #endif  // ifdef CONFIGURATION_CODE
 }
 
 #ifndef WEBSERVER_SYSINFO_MINIMAL


### PR DESCRIPTION
Feature:
- Add Configuration code field on the System Info page, can be set from external tools via `Custom.h` variable `CONFIGURATION_CODE`.
- [C015] Blynk: Fix compile-error when the SSL option is enabled