### PR TITLE
[ETH] Allow Ethernet Power GPIO pin unset (#4724)

### DIFF
--- a/src/src/ESPEasyCore/ESPEasyEth.cpp
+++ b/src/src/ESPEasyCore/ESPEasyEth.cpp
@@ -68,7 +68,7 @@ bool ethCheckSettings() {
       && isValid(Settings.NetworkMedium)
       && validGpio(Settings.ETH_Pin_mdc)
       && validGpio(Settings.ETH_Pin_mdio)
-      && validGpio(Settings.ETH_Pin_power);
+      && (validGpio(Settings.ETH_Pin_power) || (Settings.ETH_Pin_power == -1)); // Some boards have fixed power
 }
 
 bool ethPrepare() {


### PR DESCRIPTION
Resolves #4724 

Feature:
- Allow Ethernet Power GPIO pin to be set to None, as some boards don't have that wired that way (fixed power connection)