### PR TITLE
[P014] Set default output values to Temp/Hum

### DIFF
--- a/src/_P014_SI70xx.ino
+++ b/src/_P014_SI70xx.ino
@@ -4,8 +4,10 @@
 // #######################################################################################################
 // ######################## Plugin 014 SI70xx I2C Temperature Humidity Sensor  ###########################
 // #######################################################################################################
-// 12-10-2015 Charles-Henri Hallard, see my projects and blog at https://hallard.me
-// 07-22-2022 MFD, Adding support for SI7013 with ADC and lots of refactoring
+// 2015-10-12 Charles-Henri Hallard, see my projects and blog at https://hallard.me
+// 2022-07-22 MFD, Adding support for SI7013 with ADC and lots of refactoring
+// 2023-07-11 tonhuisman, Add missing PLUGIN_SET_DEFAULTS handling, to set default Temperature/Humidity output values
+//                        Use internationally usable dates for changelog
 
 
 /*
@@ -71,6 +73,12 @@ boolean Plugin_014(uint8_t function, struct EventStruct *event, String& string)
       strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[0], PSTR(PLUGIN_VALUENAME1_014));
       strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[1], PSTR(PLUGIN_VALUENAME2_014));
       strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[2], PSTR(PLUGIN_VALUENAME3_014));
+      break;
+    }
+
+    case PLUGIN_SET_DEFAULTS:
+    {
+      P014_VALUES_COUNT = static_cast<int>(Sensor_VType::SENSOR_TYPE_TEMP_HUM);
       break;
     }
 

--- a/src/_P014_SI70xx.ino
+++ b/src/_P014_SI70xx.ino
@@ -78,7 +78,7 @@ boolean Plugin_014(uint8_t function, struct EventStruct *event, String& string)
 
     case PLUGIN_SET_DEFAULTS:
     {
-      P014_VALUES_COUNT = static_cast<int>(Sensor_VType::SENSOR_TYPE_TEMP_HUM);
+      P014_VALUES_COUNT = getValueCountFromSensorType(Sensor_VType::SENSOR_TYPE_TEMP_HUM);
       break;
     }
 


### PR DESCRIPTION
Resolves #4728 

Feature:
- Set default for Output values to Temp/Hum (instead of Single)