### PR TITLE
[P118] Fix compilation when included in Custom builds

### DIFF
--- a/src/src/PluginStructs/P118_data_struct.h
+++ b/src/src/PluginStructs/P118_data_struct.h
@@ -12,7 +12,7 @@
 # define P118_DEBUG_LOG         // Enable for some (extra) logging
 # define P118_FEATURE_ORCON   1 // Enable use of Orcon commands
 
-# if defined(LIMIT_BUILD_SIZE) && defined(P118_DEBUG_LOG)
+# if (defined(LIMIT_BUILD_SIZE) || defined(BUILD_NO_DEBUG)) && defined(P118_DEBUG_LOG)
 #  undef P118_DEBUG_LOG
 # endif // if defined(LIMIT_BUILD_SIZE) && defined(P118_DEBUG_LOG)
 # ifdef LIMIT_BUILD_SIZE


### PR DESCRIPTION
Bugfix to allow correct compilation when using the plugin in a Custom build