### PR TITLE
[Rules] Add minHexDigits to toHex function

### DIFF
--- a/docs/source/Rules/Rules.rst
+++ b/docs/source/Rules/Rules.rst
@@ -1121,9 +1121,10 @@ Convert an integer value into a binary or hexadecimal representation.
 Usage: 
 
 * ``{toBin:<value>}`` Convert the number into binary representation.
-* ``{toHex:<value>}`` Convert the number into hexadecimal representation.
+* ``{toHex:<value>[:<minHexDigits>]}`` Convert the number into hexadecimal representation.
 
 * ``<value>`` The number to convert, if it is representing a valid unsigned integer value.
+* ``<minHexDigits>`` Optional. The minimal number to digits to output the hex value in
 
 
 For example:
@@ -1134,7 +1135,7 @@ For example:
    let,1,%eventvalue1%
    let,2,{bitset:9:%eventvalue1%}
    LogEntry,'Values {tobin:[int#1]} {tohex:[int#1]}'
-   LogEntry,'Values {tobin:[int#2]} {tohex:[int#2]}'
+   LogEntry,'Values {tobin:[int#2]} {tohex:[int#2]:4}'
  endon
 
 
@@ -1146,8 +1147,8 @@ For example:
  320603: ACT : let,2,635
  320612: ACT : LogEntry,'Values 1111011 7b'
  320618: Values 1111011 7b
- 320631: ACT : LogEntry,'Values 1001111011 27b'
- 320635: Values 1001111011 27b
+ 320631: ACT : LogEntry,'Values 1001111011 027b'
+ 320635: Values 1001111011 027b
 
 ord
 ^^^

--- a/src/src/ESPEasyCore/ESPEasyRules.cpp
+++ b/src/src/ESPEasyCore/ESPEasyRules.cpp
@@ -593,9 +593,12 @@ void parse_string_commands(String& line) {
               break;
             case string_commands_e::tohex:
               // Convert to HEX string
-              // Syntax like 1234{tohex:15}7890
+              // Syntax like 1234{tohex:15[,minHexDigits]}7890
               if (validUInt64FromString(arg1, iarg1)) {
-                replacement = ull2String(iarg1, HEX);
+                if (!validUInt64FromString(arg2, iarg2)) {
+                  iarg2 = 0;
+                }
+                replacement = formatToHex_no_prefix(iarg1, iarg2);
               }
               break;
             case string_commands_e::ord:


### PR DESCRIPTION
From a [Forum request](https://www.letscontrolit.com/forum/viewtopic.php?t=9743)

Features:
- Add optional `minHexDigits` argument to `toHex` function
- Update documentation

Example:
```
on myevent do
  let,2,{bitset:9:%eventvalue1%}
  LogEntry,'Values {tobin:[int#2]} {tohex:[int#2]:4}'
endon
```
will output:
```
 320528: HTTP: Event,eventname=123
 320586: EVENT: eventname=123
 320603: ACT : let,2,635
 320631: ACT : LogEntry,'Values 1001111011 027b'
 320635: Values 1001111011 027b
```
(partial copy from toBin/toHex documentation)