### PR TITLE
[P128] Revert changes after library update (not working with ESP8266)

### DIFF
--- a/src/_P128_NeoPixelBusFX.ino
+++ b/src/_P128_NeoPixelBusFX.ino
@@ -7,6 +7,7 @@
 // #######################################################################################################
 
 // Changelog:
+// 2023-07-20, tonhuisman Revert change to NeoWs2812xMethod, as this doesn't properly work on ESP8266 (yet)
 // 2023-05-13, tonhuisman Add P128_USES_BGR / BGR definitions and support (compile-time)
 //                        Use more global NeoWs2812xMethod, as the library uses best matching hardware features per CPU type
 // 2023-05-12, tonhuisman Update for latest NeoPixelBusFx changes (NeoPixelBusLg class, (S/G)etLuminance method)

--- a/src/src/PluginStructs/P128_data_struct.cpp
+++ b/src/src/PluginStructs/P128_data_struct.cpp
@@ -21,7 +21,7 @@ P128_data_struct::P128_data_struct(int8_t   _gpioPin,
   
   if (nullptr != Plugin_128_pixels) {
     Plugin_128_pixels->Begin(); // This initializes the NeoPixelBus library.
-    Plugin_128_pixels->SetLuminance(maxBright);
+    Plugin_128_pixels->SetBrightness(maxBright);
   }
 }
 
@@ -146,7 +146,7 @@ bool P128_data_struct::plugin_write(struct EventStruct *event,
     else if (equals(subCommand, F("dim"))) {
       if ((str3i >= 0) && (str3i <= maxBright)) { // Safety check
         success = true;
-        Plugin_128_pixels->SetLuminance(str3i);
+        Plugin_128_pixels->SetBrightness(str3i);
       }
     }
 
@@ -987,7 +987,7 @@ void P128_data_struct::rainbow(void) {
   float progress = (float)counter / (float)fadetime;
 
   if (fadeIn == true) {
-    Plugin_128_pixels->SetLuminance(progress * maxBright); // Safety check
+    Plugin_128_pixels->SetBrightness(progress * maxBright); // Safety check
     fadeIn = (progress == 1) ? false : true;
   }
 
@@ -1521,7 +1521,7 @@ void P128_data_struct::NeoPixelSendStatus(struct EventStruct *eventSource) {
   json += ','; json += '\n';
   json += to_json_object_value(F("fadedelay"), toString(fadedelay, 0));                   // 15..19
   json += ','; json += '\n';
-  json += to_json_object_value(F("dim"), toString(Plugin_128_pixels->GetLuminance(), 0)); // 8..10
+  json += to_json_object_value(F("dim"), toString(Plugin_128_pixels->GetBrightness(), 0)); // 8..10
   json += ','; json += '\n';
   json += to_json_object_value(F("rgb"), colorStr, true);                                 // 15..17
   json += ','; json += '\n';

--- a/src/src/PluginStructs/P128_data_struct.h
+++ b/src/src/PluginStructs/P128_data_struct.h
@@ -2209,8 +2209,7 @@ const uint8_t PROGMEM ftv_colors[] = {
   0X20, 0XE4, 0X21, 0XA6, 0X29, 0XE7, 0X32, 0X28 };
 # endif // if P128_ENABLE_FAKETV
 
-# include <NeoPixelBusLg.h>
-# include <NeoPixelBus.h>
+# include <NeoPixelBrightnessBus.h>
 # include "../../ESPEasy-Globals.h"
 
 # define P128_CONFIG_LED_COUNT  PCONFIG(0)
@@ -2247,9 +2246,9 @@ const uint8_t PROGMEM ftv_colors[] = {
 // # define BRG   //A three element color in the order of Blue, Red, and then Green.
 // # define RBG   //A three element color in the order of Red, Blue, and then Green.
 
-# define NEOPIXEL_LIB NeoPixelBusLg           // Neopixel library type
+# define NEOPIXEL_LIB NeoPixelBrightnessBus   // Neopixel library type
 # if defined(ESP32)
-#  define METHOD NeoWs2812xMethod             // RMT, user selected pin - use NeoEsp32RmtMethod (CPU dependent)
+#  define METHOD NeoEsp32Rmt1800KbpsMethod    // RMT, user selected pin - use NeoEsp32RmtMethod (CPU dependent)
 # endif // if defined(ESP32)
 # if defined(ESP8266)
 #  define METHOD NeoEsp8266Uart1800KbpsMethod // GPIO2 - use NeoEsp8266Uart0800KbpsMethod for GPIO1(TX)
@@ -2342,7 +2341,7 @@ private:
   const uint8_t  maxBright  = 0;
 
   int16_t fadedelay = 20;
-  
+
   uint16_t ledi = 0;
   uint16_t ledf = 0;
 


### PR DESCRIPTION
Resolves #4739 

Bugfix for ESP8266, as the changes after a library update don't work as intended. (To be corrected later)