### PR TITLE
[UI] Add option for disabling Rules auto-completion

### DIFF
--- a/docs/source/Tools/Tools.rst
+++ b/docs/source/Tools/Tools.rst
@@ -462,6 +462,13 @@ When using Dark-mode as an Operating System or Web-browser setting, the ESPEasy 
 
 NB: If this option is not available, the regular non-dark mode will be used.
 
+Disable Rules auto-completion
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Added: 2023-07-20
+
+When Rules auto-completion, also including syntax highlighting, is available in the build, some users have difficulty working with the auto-completion. This option disables the auto-completion, and that also inhibits the syntax highlighting as these 2 features are closely integrated.
+
 Deep Sleep Alternative
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/src/DataStructs/SettingsStruct.h
+++ b/src/src/DataStructs/SettingsStruct.h
@@ -158,6 +158,12 @@ class SettingsStruct_tmpl
   bool SDK_WiFi_autoreconnect() const;
   void SDK_WiFi_autoreconnect(bool value);
 
+  #if FEATURE_RULES_EASY_COLOR_CODE
+  // Inhibit RulesCodeCompletion
+  bool DisableRulesCodeCompletion() const;
+  void DisableRulesCodeCompletion(bool value);
+  #endif // if FEATURE_RULES_EASY_COLOR_CODE
+
 
   // Flag indicating whether all task values should be sent in a single event or one event per task value (default behavior)
   bool CombineTaskValues_SingleEvent(taskIndex_t taskIndex) const;

--- a/src/src/DataStructs_templ/SettingsStruct.cpp
+++ b/src/src/DataStructs_templ/SettingsStruct.cpp
@@ -351,6 +351,19 @@ void SettingsStruct_tmpl<N_TASKS>::SDK_WiFi_autoreconnect(bool value) {
 }
 
 
+#if FEATURE_RULES_EASY_COLOR_CODE
+template<unsigned int N_TASKS>
+bool SettingsStruct_tmpl<N_TASKS>::DisableRulesCodeCompletion() const { 
+  return bitRead(VariousBits2, 2);
+}
+
+template<unsigned int N_TASKS>
+void SettingsStruct_tmpl<N_TASKS>::DisableRulesCodeCompletion(bool value) { 
+  bitWrite(VariousBits2, 2, value);
+}
+#endif // if FEATURE_RULES_EASY_COLOR_CODE
+
+
 
 template<unsigned int N_TASKS>
 bool SettingsStruct_tmpl<N_TASKS>::isTaskEnableReadonly(taskIndex_t taskIndex) const {

--- a/src/src/Helpers/StringProvider.cpp
+++ b/src/src/Helpers/StringProvider.cpp
@@ -126,6 +126,9 @@ const __FlashStringHelper * getLabel(LabelType::Enum label) {
 #if FEATURE_AUTO_DARK_MODE
     case LabelType::ENABLE_AUTO_DARK_MODE:  return F("Web light/dark mode");
 #endif // FEATURE_AUTO_DARK_MODE
+#if FEATURE_RULES_EASY_COLOR_CODE
+    case LabelType::DISABLE_RULES_AUTOCOMPLETE:  return F("Disable Rules auto-completion");
+#endif // if FEATURE_RULES_EASY_COLOR_CODE
 
     case LabelType::BOOT_TYPE:              return F("Last Boot Cause");
     case LabelType::BOOT_COUNT:             return F("Boot Count");
@@ -380,6 +383,9 @@ String getValue(LabelType::Enum label) {
 #if FEATURE_AUTO_DARK_MODE
     case LabelType::ENABLE_AUTO_DARK_MODE:      return toString(Settings.getCssMode());
 #endif // FEATURE_AUTO_DARK_MODE
+#if FEATURE_RULES_EASY_COLOR_CODE
+    case LabelType::DISABLE_RULES_AUTOCOMPLETE: return jsonBool(Settings.DisableRulesCodeCompletion());
+#endif // if FEATURE_RULES_EASY_COLOR_CODE
 
     case LabelType::BOOT_TYPE:              return getLastBootCauseString();
     case LabelType::BOOT_COUNT:             break;

--- a/src/src/Helpers/StringProvider.h
+++ b/src/src/Helpers/StringProvider.h
@@ -80,6 +80,9 @@ struct LabelType {
 #if FEATURE_AUTO_DARK_MODE
     ENABLE_AUTO_DARK_MODE,
 #endif
+#if FEATURE_RULES_EASY_COLOR_CODE
+    DISABLE_RULES_AUTOCOMPLETE,
+#endif // if FEATURE_RULES_EASY_COLOR_CODE
 
     BOOT_TYPE,               // Cold boot
     BOOT_COUNT,              // 0

--- a/src/src/WebServer/AdvancedConfigPage.cpp
+++ b/src/src/WebServer/AdvancedConfigPage.cpp
@@ -149,6 +149,9 @@ void handle_advanced() {
 #if FEATURE_AUTO_DARK_MODE
     Settings.setCssMode(getFormItemInt(getInternalLabel(LabelType::ENABLE_AUTO_DARK_MODE)));
 #endif // FEATURE_AUTO_DARK_MODE
+#if FEATURE_RULES_EASY_COLOR_CODE
+    Settings.DisableRulesCodeCompletion(isFormItemChecked(LabelType::DISABLE_RULES_AUTOCOMPLETE));
+#endif // if FEATURE_RULES_EASY_COLOR_CODE
 
     addHtmlError(SaveSettings());
 
@@ -323,6 +326,11 @@ void handle_advanced() {
                     cssModeOptions,
                     Settings.getCssMode());
   #endif // FEATURE_AUTO_DARK_MODE
+
+  #if FEATURE_RULES_EASY_COLOR_CODE
+  addFormCheckBox(LabelType::DISABLE_RULES_AUTOCOMPLETE, Settings.DisableRulesCodeCompletion());
+  addFormNote(F("Also disables Rules syntax highlighting!"));
+  #endif // if FEATURE_RULES_EASY_COLOR_CODE
 
   #ifdef ESP8266
   addFormCheckBox(LabelType::DEEP_SLEEP_ALTERNATIVE_CALL, Settings.UseAlternativeDeepSleep());

--- a/src/src/WebServer/WebTemplateParser.cpp
+++ b/src/src/WebServer/WebTemplateParser.cpp
@@ -332,8 +332,9 @@ void WebTemplateParser::getWebPageTemplateVar(const String& varName)
       serve_CSS(CSSfiles_e::ESPEasy_default);
     // }
     #if FEATURE_RULES_EASY_COLOR_CODE
-    if (MENU_INDEX_RULES == navMenuIndex ||
-        MENU_INDEX_CUSTOM_PAGE == navMenuIndex) {
+    if (!Settings.DisableRulesCodeCompletion() &&
+       (MENU_INDEX_RULES == navMenuIndex ||
+        MENU_INDEX_CUSTOM_PAGE == navMenuIndex)) {
       serve_CSS(CSSfiles_e::EasyColorCode_codemirror);
     }
     #endif
@@ -349,8 +350,9 @@ void WebTemplateParser::getWebPageTemplateVar(const String& varName)
     #endif // if FEATURE_CHART_JS
 
     #if FEATURE_RULES_EASY_COLOR_CODE
-    if (MENU_INDEX_RULES == navMenuIndex ||
-        MENU_INDEX_CUSTOM_PAGE == navMenuIndex) {
+    if (!Settings.DisableRulesCodeCompletion() &&
+       (MENU_INDEX_RULES == navMenuIndex ||
+        MENU_INDEX_CUSTOM_PAGE == navMenuIndex)) {
       html_add_Easy_color_code_script();
     }
     #endif


### PR DESCRIPTION
Resolves #4740 

Features:
- Add Tools/Advanced setting to optionally disable the Rules auto-completion (when available). Will also disable Rules syntax highlighting!
Settings screenshot (in dark mode):
![Screenshot - 20-07-2023 , 22_23_18](https://github.com/letscontrolit/ESPEasy/assets/1922393/d9199a2b-4a1d-4955-b3b3-b061ff7877e6)

- Update documentation