### PR TITLE
[CSE7766] Fix crash when not all stats are enabled

### DIFF
--- a/src/src/PluginStructs/P002_data_struct.cpp
+++ b/src/src/PluginStructs/P002_data_struct.cpp
@@ -10,8 +10,6 @@
 # endif // ifndef DEFAULT_VREF
 
 
-
-
 void P002_data_struct::init(struct EventStruct *event)
 {
   _sampleMode = P002_OVERSAMPLING;
@@ -38,7 +36,7 @@ void P002_data_struct::init(struct EventStruct *event)
     _calib_out1           = P002_CALIBRATION_VALUE1;
     _calib_out2           = P002_CALIBRATION_VALUE2;
   }
-  _nrDecimals        = Cache.getTaskDeviceValueDecimals(event->TaskIndex, 0);
+  _nrDecimals = Cache.getTaskDeviceValueDecimals(event->TaskIndex, 0);
 # ifndef LIMIT_BUILD_SIZE
   _nrMultiPointItems = P002_NR_MULTIPOINT_ITEMS;
   _useMultipoint     = P002_MULTIPOINT_ENABLED;
@@ -85,11 +83,12 @@ void P002_data_struct::webformLoad_2p_calibPoint(
   addRowLabel_tr_id(label, id_point);
   addTextBox(id_point, String(point), 10, false, false, EMPTY_STRING, F("number"));
 
-#ifdef ESP32
+# ifdef ESP32
+
   if (_useFactoryCalibration) {
     addUnit(F("mV"));
   }
-#endif
+# endif // ifdef ESP32
 
   html_add_estimate_symbol();
   const unsigned int display_nrDecimals = _nrDecimals > 3 ? _nrDecimals : 3;
@@ -104,9 +103,10 @@ void P002_data_struct::webformLoad(struct EventStruct *event)
   const float currentValue = P002_data_struct::getCurrentValue(event, raw_value);
 
 # if FEATURE_PLUGIN_STATS
+  PluginStats *stats = getPluginStats(0);
 
-  if (getPluginStats(0) != nullptr) {
-    getPluginStats(0)->trackPeak(raw_value);
+  if (stats != nullptr) {
+    stats->trackPeak(raw_value);
   }
 # endif // if FEATURE_PLUGIN_STATS
 
@@ -192,11 +192,11 @@ void P002_data_struct::webformLoad(struct EventStruct *event)
 
   addFormCheckBox(F("Calibration Enabled"), F("cal"), P002_CALIBRATION_ENABLED);
 
-#ifdef ESP8266
-#if FEATURE_ADC_VCC
+# ifdef ESP8266
+#  if FEATURE_ADC_VCC
   addFormNote(F("Measuring ESP VCC, not A0. Unit is 1/1024 V. See documentation."));
-#endif
-#endif
+#  endif // if FEATURE_ADC_VCC
+# endif // ifdef ESP8266
 
 
   webformLoad_2p_calibPoint(
@@ -270,27 +270,27 @@ void P002_data_struct::webformLoad(struct EventStruct *event)
                    label,
                    getPluginCustomArgName(varNr),
 
-                   _multipoint.size() > line_nr ? 
-#if FEATURE_USE_DOUBLE_AS_ESPEASY_RULES_FLOAT_TYPE
+                   _multipoint.size() > line_nr ?
+#  if FEATURE_USE_DOUBLE_AS_ESPEASY_RULES_FLOAT_TYPE
                    doubleToString
-#else
+#  else // if FEATURE_USE_DOUBLE_AS_ESPEASY_RULES_FLOAT_TYPE
                    floatToString
-#endif
-                    (static_cast<ESPEASY_RULES_FLOAT_TYPE>(_multipoint[line_nr]._adc), 
-                    _nrDecimals,
-                    true) : EMPTY_STRING,
+#  endif // if FEATURE_USE_DOUBLE_AS_ESPEASY_RULES_FLOAT_TYPE
+                     (static_cast<ESPEASY_RULES_FLOAT_TYPE>(_multipoint[line_nr]._adc),
+                     _nrDecimals,
+                     true) : EMPTY_STRING,
                    0);
     html_add_estimate_symbol();
     addTextBox(getPluginCustomArgName(varNr + 1),
-               _multipoint.size() > line_nr ?  
-#if FEATURE_USE_DOUBLE_AS_ESPEASY_RULES_FLOAT_TYPE
-                   doubleToString
-#else
-                   floatToString
-#endif
-               (static_cast<ESPEASY_RULES_FLOAT_TYPE>(_multipoint[line_nr]._value), 
-               _nrDecimals,
-               true) : EMPTY_STRING,
+               _multipoint.size() > line_nr ?
+#  if FEATURE_USE_DOUBLE_AS_ESPEASY_RULES_FLOAT_TYPE
+               doubleToString
+#  else // if FEATURE_USE_DOUBLE_AS_ESPEASY_RULES_FLOAT_TYPE
+               floatToString
+#  endif // if FEATURE_USE_DOUBLE_AS_ESPEASY_RULES_FLOAT_TYPE
+                 (static_cast<ESPEASY_RULES_FLOAT_TYPE>(_multipoint[line_nr]._value),
+                 _nrDecimals,
+                 true) : EMPTY_STRING,
                0,
                false,
                false,
@@ -310,7 +310,7 @@ bool P002_data_struct::webformLoad_show_stats(struct EventStruct *event)
 {
   bool somethingAdded = false;
 
-  const PluginStats* stats = getPluginStats(0);
+  const PluginStats *stats = getPluginStats(0);
 
   if (stats != nullptr) {
     if (stats->webformLoad_show_avg(event)) { somethingAdded = true; }
@@ -745,9 +745,10 @@ void P002_data_struct::takeSample()
   int raw = espeasy_analogRead(_pin_analogRead);
 
 # if FEATURE_PLUGIN_STATS
+  PluginStats *stats = getPluginStats(0);
 
-  if (getPluginStats(0) != nullptr) {
-    getPluginStats(0)->trackPeak(raw);
+  if (stats != nullptr) {
+    stats->trackPeak(raw);
   }
 # endif // if FEATURE_PLUGIN_STATS
 
@@ -797,8 +798,10 @@ bool P002_data_struct::getValue(float& float_value,
   raw_value = espeasy_analogRead(_pin_analogRead);
 # if FEATURE_PLUGIN_STATS
 
-  if (getPluginStats(0) != nullptr) {
-    getPluginStats(0)->trackPeak(raw_value);
+  PluginStats *stats = getPluginStats(0);
+
+  if (stats != nullptr) {
+    stats->trackPeak(raw_value);
   }
 # endif // if FEATURE_PLUGIN_STATS
   float_value = raw_value;
@@ -866,12 +869,11 @@ void P002_data_struct::resetOversampling() {
 
 void P002_data_struct::addOversamplingValue(int currentValue) {
   OverSampling.add(currentValue);
-
 }
 
 bool P002_data_struct::getOversamplingValue(float& float_value, int& raw_value) const {
   if (OverSampling.peek(float_value)) {
-    raw_value   = static_cast<int>(float_value);
+    raw_value = static_cast<int>(float_value);
 
 # ifdef ESP32
 
@@ -983,11 +985,11 @@ bool P002_data_struct::getBinnedValue(float& float_value, int& raw_value) const
   #  ifndef BUILD_NO_DEBUG
 
   if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
-    addLogMove(LOG_LEVEL_DEBUG, 
-      strformat(F("ADC getBinnedValue: bin cnt: %u  Value: %f RAW: %d"), 
-        highest_bin_count, 
-        float_value, 
-        raw_value));
+    addLogMove(LOG_LEVEL_DEBUG,
+               strformat(F("ADC getBinnedValue: bin cnt: %u  Value: %f RAW: %d"),
+                         highest_bin_count,
+                         float_value,
+                         raw_value));
   }
   #  endif // ifndef BUILD_NO_DEBUG
 
@@ -1173,34 +1175,34 @@ float P002_data_struct::mapADCtoFloat(float float_value,
 
 void P002_data_struct::setTwoPointCalibration(
   struct EventStruct *event,
-  float adc1,
-  float adc2,
-  float out1,
-  float out2)
+  float               adc1,
+  float               adc2,
+  float               out1,
+  float               out2)
 {
-    P002_CALIBRATION_POINT1 = lround(adc1);
-    P002_CALIBRATION_POINT2 = lround(adc2);
-    P002_CALIBRATION_VALUE1 = mapADCtoFloat(
-      P002_CALIBRATION_POINT1,
-      adc1, adc2,
-      out1, out2);
-    P002_CALIBRATION_VALUE2 = mapADCtoFloat(
-      P002_CALIBRATION_POINT2,
-      adc1, adc2,
-      out1, out2);
+  P002_CALIBRATION_POINT1 = lround(adc1);
+  P002_CALIBRATION_POINT2 = lround(adc2);
+  P002_CALIBRATION_VALUE1 = mapADCtoFloat(
+    P002_CALIBRATION_POINT1,
+    adc1, adc2,
+    out1, out2);
+  P002_CALIBRATION_VALUE2 = mapADCtoFloat(
+    P002_CALIBRATION_POINT2,
+    adc1, adc2,
+    out1, out2);
 }
-
 
 /*****************************************************
  * plugin_set_config
  ****************************************************/
 bool P002_data_struct::plugin_set_config(struct EventStruct *event,
-                                    String            & string) {
+                                         String            & string) {
   bool success     = false;
   const String cmd = parseString(string, 1);
 
   if (equals(cmd, F("setcalib"))) {
     const String sub = parseString(string, 2);
+
     if (equals(sub, F("twopoint"))) {
       // Command:
       // 1 point : adcsetcalib,twopoint,ADC1,out1
@@ -1211,17 +1213,19 @@ bool P002_data_struct::plugin_set_config(struct EventStruct *event,
       float out2{};
 
       if (validFloatFromString(parseString(string, 3), adc1) &&
-          validFloatFromString(parseString(string, 4), out1)) 
+          validFloatFromString(parseString(string, 4), out1))
       {
         success = true;
       }
+
       if (!validFloatFromString(parseString(string, 5), adc2) ||
-          !validFloatFromString(parseString(string, 6), out2)) 
+          !validFloatFromString(parseString(string, 6), out2))
       {
         // Not a complete 2nd calibration point, so make sure to set both values to 0.
         adc2 = 0;
         out2 = 0;
       }
+
       if (success) {
         setTwoPointCalibration(event, adc1, adc2, out1, out2);
       }
@@ -1230,6 +1234,5 @@ bool P002_data_struct::plugin_set_config(struct EventStruct *event,
 
   return success;
 }
-
 
 #endif // ifdef USES_P002

--- a/src/src/PluginStructs/P078_data_struct.cpp
+++ b/src/src/PluginStructs/P078_data_struct.cpp
@@ -472,8 +472,10 @@ void SDM_loopRegisterReadQueue(SDM *sdm)
       PluginTaskData_base *taskdata = getPluginTaskDataBaseClassOnly(it->taskIndex);
 
       if (taskdata != nullptr) {
-        if (taskdata->getPluginStats(it->taskVarIndex) != nullptr) {
-          taskdata->getPluginStats(it->taskVarIndex)->trackPeak(value);
+        PluginStats *stats = taskdata->getPluginStats(it->taskVarIndex);
+
+        if (stats != nullptr) {
+          stats->trackPeak(value);
         }
       }
 # endif // if FEATURE_PLUGIN_STATS


### PR DESCRIPTION
When not all stats are enabled for all task values of a CSE7766 task, ESPEasy would crash reboot till the task is disabled.