### PR TITLE
[Converters] Add toStringNoZero() function

### DIFF
--- a/src/src/Helpers/StringConverter_Numerical.cpp
+++ b/src/src/Helpers/StringConverter_Numerical.cpp
@@ -121,7 +121,7 @@ String trimTrailingZeros(const String& value) {
  */
 String toStringNoZero(int64_t value) {
   if (value != 0) {
-    return toString(value, 0);
+    return ll2String(value);
   } else {
     return EMPTY_STRING;
   }

--- a/src/src/Helpers/StringConverter_Numerical.cpp
+++ b/src/src/Helpers/StringConverter_Numerical.cpp
@@ -116,6 +116,17 @@ String trimTrailingZeros(const String& value) {
 
 }
 
+/**
+ * Helper: Convert an integer to string, but return an empty string for 0, to save a little space in settings
+ */
+String toStringNoZero(int64_t value) {
+  if (value != 0) {
+    return toString(value, 0);
+  } else {
+    return EMPTY_STRING;
+  }
+}
+
 #if FEATURE_USE_DOUBLE_AS_ESPEASY_RULES_FLOAT_TYPE
 String doubleToString(const double& value, unsigned int decimalPlaces, bool trimTrailingZeros_b) {
   // This has been fixed in ESP32 code, not (yet) in ESP8266 code

--- a/src/src/Helpers/StringConverter_Numerical.h
+++ b/src/src/Helpers/StringConverter_Numerical.h
@@ -30,6 +30,8 @@ String ll2String(int64_t value,
 
 String trimTrailingZeros(const String& value);
 
+String toStringNoZero(int64_t value);
+
 #if FEATURE_USE_DOUBLE_AS_ESPEASY_RULES_FLOAT_TYPE
 String doubleToString(const double& value,
                       unsigned int  decimalPlaces     = 2,


### PR DESCRIPTION
Feature:
- Add function `toStringNoZero(int64_t value)` that will return an empty string for value 0, and for all other values the stringified value.
  To be used for adding a value to a comma-separated string but avoiding to add unneeded zeroes, to keep the string as short as possible (like when storing in custom task-settings)