### PR TITLE
[SD-card] Bugfix: Opening a file from SD-card doesn't always work

### DIFF
--- a/src/src/Helpers/ESPEasy_Storage.cpp
+++ b/src/src/Helpers/ESPEasy_Storage.cpp
@@ -184,8 +184,7 @@ fs::File tryOpenFile(const String& fname, const String& mode, FileDestination_e 
   #  if FEATURE_SD
 
   if (!f && ((destination == FileDestination_e::ANY) || (destination == FileDestination_e::SD))) {
-    // FIXME TD-er: Should this fallback to SD only be done on "r" mode?
-    f = SD.open(fname.c_str(), mode.c_str());
+    f = SD.open(patch_fname(fname).c_str(), mode.c_str());
   }
   #  endif // if FEATURE_SD
 

--- a/src/src/WebServer/FileList.cpp
+++ b/src/src/WebServer/FileList.cpp
@@ -413,12 +413,9 @@ void handle_SDfilelist() {
     // size_t entrynameLength = strlen(entry.name());
     if (entry.isDirectory())
     {
-      char SDcardChildDir[80];
-
       // take a look in the directory for entries
       String child_dir = current_dir + entry.name();
-      child_dir.toCharArray(SDcardChildDir, child_dir.length() + 1);
-      fs::File child         = SD.open(SDcardChildDir);
+      fs::File child         = SD.open(child_dir.c_str());
       fs::File dir_has_entry = child.openNextFile();
 
       // when the directory is empty, display the button to delete them


### PR DESCRIPTION
Bugfix:
- Opening a file from SD-card didn't always work on ESP32, where `fileExists()` returns true.

Feature:
- Removed a `FIXME` that's been solved (files can be created on SD-card explicitly)