### PR TITLE
[SD-Card] Show SD-card CS GPIO pin in pin-selection

### DIFF
--- a/src/src/Helpers/StringGenerator_GPIO.cpp
+++ b/src/src/Helpers/StringGenerator_GPIO.cpp
@@ -207,6 +207,9 @@ const __FlashStringHelper* getConflictingUse(int gpio, PinSelectPurpose purpose)
 
   bool includeI2C = true;
   bool includeSPI = true;
+  #if FEATURE_SD
+  bool includeSDCard = true;
+  #endif
   #if FEATURE_DEFINE_SERIAL_CONSOLE_PORT
   // FIXME TD-er: Must check whether this can be a conflict.
   bool includeSerial = false;
@@ -241,6 +244,11 @@ const __FlashStringHelper* getConflictingUse(int gpio, PinSelectPurpose purpose)
     case PinSelectPurpose::Generic_bidir:
     case PinSelectPurpose::DAC:
       break;
+    #if FEATURE_SD
+    case PinSelectPurpose::SD_Card:
+      includeSDCard = false;
+      break;
+    #endif
   }
 
   if (includeI2C && Settings.isI2C_pin(gpio)) {
@@ -264,6 +272,10 @@ const __FlashStringHelper* getConflictingUse(int gpio, PinSelectPurpose purpose)
       if (gpio == SOC_RX0) { return F("RX0"); }
     }
   }
+
+  #if FEATURE_SD
+  if (Settings.Pin_sd_cs == gpio && includeSDCard) { return F("SD-Card CS"); }
+  #endif // if FEATURE_SD
 
 
   #if FEATURE_ETHERNET

--- a/src/src/Helpers/StringGenerator_GPIO.h
+++ b/src/src/Helpers/StringGenerator_GPIO.h
@@ -27,7 +27,10 @@ enum class PinSelectPurpose : uint8_t {
   Ethernet,
   Serial_input,
   Serial_output,
-  DAC
+  DAC,
+  #if FEATURE_SD
+  SD_Card,
+  #endif
 
 };
 

--- a/src/src/WebServer/HardwarePage.cpp
+++ b/src/src/WebServer/HardwarePage.cpp
@@ -227,7 +227,7 @@ void handle_hardware() {
   
 #if FEATURE_SD
   addFormSubHeader(F("SD Card"));
-  addFormPinSelect(PinSelectPurpose::Generic_output, formatGpioName_output(F("SD Card CS")), F("sd"), Settings.Pin_sd_cs);
+  addFormPinSelect(PinSelectPurpose::SD_Card, formatGpioName_output(F("SD Card CS")), F("sd"), Settings.Pin_sd_cs);
 #endif // if FEATURE_SD
   
 #if FEATURE_ETHERNET

--- a/src/src/WebServer/Markup.cpp
+++ b/src/src/WebServer/Markup.cpp
@@ -280,6 +280,9 @@ void addPinSelector_Item(PinSelectPurpose purpose, const String& gpio_label, int
       #if FEATURE_ETHERNET
       bool includeEthernet = true;
       #endif // if FEATURE_ETHERNET
+      #if FEATURE_SD
+      bool includeSDCard = true;
+      #endif // if FEATURE_SD
 
       switch (purpose) {
         case PinSelectPurpose::SPI:
@@ -341,6 +344,14 @@ void addPinSelector_Item(PinSelectPurpose purpose, const String& gpio_label, int
             return;
           }
           break;
+        #if FEATURE_SD
+        case PinSelectPurpose::SD_Card:
+          includeSDCard = false;
+          if (!output) {
+            return;
+          }
+          break;
+        #endif
       }
 
       if (includeI2C && Settings.isI2C_pin(gpio)) {
@@ -361,6 +372,12 @@ void addPinSelector_Item(PinSelectPurpose purpose, const String& gpio_label, int
         disabled = true;
       }
   #endif // if FEATURE_ETHERNET
+
+      #if FEATURE_SD
+      if (includeSDCard && (Settings.Pin_sd_cs == gpio)) {
+        disabled = true;
+      }
+      #endif
     }
   }
 


### PR DESCRIPTION
Feature:
- Show configured SD-Card CS pin in GPIO pin selection (disabled for other uses when configured)