### PR TITLE
[Build] Restore RTTTL feature in ESP8266 Climate build

### DIFF
--- a/platformio_esp82xx_envs.ini
+++ b/platformio_esp82xx_envs.ini
@@ -817,6 +817,7 @@ platform_packages         = ${regular_platform.platform_packages}
 build_flags               = ${regular_platform.build_flags}
                             ${esp8266_4M1M.build_flags}
                             -D PLUGIN_CLIMATE_COLLECTION
+                            -D KEEP_RTTTL
                             -D WEBSERVER_USE_CDN_JS_CSS
 
 ; neopixel : 4096k version ----------------------------


### PR DESCRIPTION
Resolves #4797 

Bugfix:
- Restore the RTTTL feature in the ESP8266 `Climate` build, that went missing when we applied `LIMIT_BUILD_SIZE` to it.

- [x] Testing [Confirmed](https://github.com/letscontrolit/ESPEasy/issues/4797#issuecomment-1717645228)