### PR TITLE
[Build] Add Collection G builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ collection_C | Normal + plugin collection C              | Stable + Collection b
 collection_D | Normal + plugin collection D              | Stable + Collection base + set D |
 collection_E | Normal + plugin collection E              | Stable + Collection base + set E |
 collection_F | Normal + plugin collection F              | Stable + Collection base + set F |
+collection_G | Normal + plugin collection G              | Stable + Collection base + set G |
 max          | All available plugins                     | All available                    |
 energy       | All plugins related to energy measurement | Stable + Energy measurement      |
 display      | All plugins related to displays           | Stable + Displays                |
@@ -76,6 +77,7 @@ Hardware type    | Description                                 |
 ESP8266          | Espressif ESP8266/ESP8285 generic boards    |
 WROOM02          | Espressif ESP8266 WRoom02 boards            |
 ESP32            | Espressif ESP32 generic boards              |
+ESP32solo1       | Espressif ESP32-Solo1 generic boards        |
 ESP32s2          | Espressif ESP32-S2 generic boards           |
 ESP32c3          | Espressif ESP32-C3 generic boards           |
 ESP32s3          | Espressif ESP32-S3 generic boards           |
@@ -114,20 +116,22 @@ OTA             | Arduino OTA (Over The Air) update feature enabled             
 Domoticz        | Only Domoticz controllers (HTTP+MQTT) and plugins included                 |
 FHEM_HA         | Only FHEM/OpenHAB/Home Assistant (MQTT) controllers and plugins included   |
 ETH             | Ethernet interface enabled (ESP32 only)                                    |
-PSRAM           | Specific configuration to enable PSRAM detection, ESP32-S3 only            |
+OPI_PSRAM       | Specific configuration to enable PSRAM detection, ESP32-S3 only            |
 CDC             | Support USBCDC/HWCDC-serial console on ESP32-C3, ESP32-S2 and ESP32-S3     |
 
 Some example firmware names:
-Firmware name                                       | Hardware                       | Included plugins                 |
-----------------------------------------------------|--------------------------------|----------------------------------|
-ESPEasy_mega-20230623_normal_ESP8266_1M.bin         | ESP8266/ESP8285 with 1MB flash | Stable                           |
-ESPEasy_mega-20230623_normal_ESP8266_4M1M.bin       | ESP8266 with 4MB flash         | Stable                           |
-ESPEasy_mega-20230623_collection_A_ESP8266_4M1M.bin | ESP8266 with 4MB flash         | Stable + Collection base + set A |
-ESPEasy_mega-20230623_normal_ESP32_4M316k.bin       | ESP32 with 4MB flash           | Stable                           |
-ESPEasy_mega-20230623_collection_A_ESP32_4M316k.bin | ESP32 with 4MB flash           | Stable + Collection base + set A |
-ESPEasy_mega-20230623_collection_B_ESP32_4M316k.bin | ESP32 with 4MB flash           | Stable + Collection base + set B |
-ESPEasy_mega-20230623_max_ESP32_16M1M.bin           | ESP32 with 16MB flash          | All available plugins            |
-ESPEasy_mega-20230623_max_ESP32_16M8M_LittleFS.bin  | ESP32 with 16MB flash          | All available plugins            |
+Firmware name                                                     | Hardware                              | Included plugins                 |
+------------------------------------------------------------------|---------------------------------------|----------------------------------|
+ESPEasy_mega-20230822_normal_ESP8266_1M.bin                       | ESP8266/ESP8285 with 1MB flash        | Stable                           |
+ESPEasy_mega-20230822_normal_ESP8266_4M1M.bin                     | ESP8266 with 4MB flash                | Stable                           |
+ESPEasy_mega-20230822_collection_A_ESP8266_4M1M.bin               | ESP8266 with 4MB flash                | Stable + Collection base + set A |
+ESPEasy_mega-20230822_normal_ESP32_4M316k.bin                     | ESP32 with 4MB flash                  | Stable                           |
+ESPEasy_mega-20230822_collection_A_ESP32_4M316k.bin               | ESP32 with 4MB flash                  | Stable + Collection base + set A |
+ESPEasy_mega-20230822_collection_B_ESP32_4M316k.bin               | ESP32 with 4MB flash                  | Stable + Collection base + set B |
+ESPEasy_mega-20230822_max_ESP32s3_8M1M_LittleFS_CDC.bin           | ESP32-S3 with 8MB flash, CDC-serial   | All available plugins            |
+ESPEasy_mega-20230822_max_ESP32s3_8M1M_LittleFS_OPI_PSRAM_CDC.bin | ESP32-S3 8MB flash, PSRAM, CDC-serial | All available plugins            |
+ESPEasy_mega-20230822_max_ESP32_16M1M.bin                         | ESP32 with 16MB flash                 | All available plugins            |
+ESPEasy_mega-20230822_max_ESP32_16M8M_LittleFS.bin                | ESP32 with 16MB flash                 | All available plugins            |
 
 NB: Since 2023-05-10 the binary files for the different ESP32 variants (S2, C3, S3, 'Classic') are available in separate archives.
 

--- a/docs/source/Plugin/_Plugin.rst
+++ b/docs/source/Plugin/_Plugin.rst
@@ -219,13 +219,13 @@ There are different released versions of ESP Easy:
 
 :green:`NORMAL` is the regular set of plugins, this is the base set of plugins, and with all secondary features enabled, like I2C multiplexer, RTTTL, DEBUG logging, etc.
 
-:yellow:`COLLECTION` (split into sets A..x) with plugins that don't fit into the NORMAL builds. Because of space limitations, this collection is split into a number of sets. When only :yellow:`COLLECTION` is mentioned, the plugin is available in **all** :yellow:`COLLECTION` builds. Also, some features are disabled to save space in the .bin files, like RTTTL, tooltips, and some DEBUG logging.
+:yellow:`COLLECTION` (split into sets A..x) with plugins that don't fit into the NORMAL builds. Because of space limitations, this collection is split into a number of sets. When only :yellow:`COLLECTION` is mentioned, the plugin is available in **all** :yellow:`COLLECTION` builds. Also, some features are disabled to save space in the .bin files, like RTTTL, tooltips, and DEBUG-level logging.
 
 :red:`DEVELOPMENT` is used for plugins that are still being developed and are not considered stable at all. Currently there are no DEVELOPMENT builds available.
 
 :yellow:`ENERGY` :yellow:`DISPLAY` :yellow:`IR` :yellow:`IRext` :yellow:`NEOPIXEL` :yellow:`CLIMATE` are specialized builds holding all Energy-, Display-, Infra Red- (extended), NeoPixel- and Climate- related plugins.
 
-:yellow:`MAX` is the build that has all plugins that are available in the ESPEasy repository. Only available for ESP32 16MB Flash units.
+:yellow:`MAX` is the build that has all plugins that are available in the ESPEasy repository. Available for ESP32 16MB and ESP32-s3 8MB Flash units.
 
 :gray:`RETIRED` plugin has been retired and removed from ESPEasy.
 

--- a/docs/source/Plugin/_plugin_substitutions_p15x.repl
+++ b/docs/source/Plugin/_plugin_substitutions_p15x.repl
@@ -54,7 +54,7 @@
 .. |P154_type| replace:: :cyan:`Environment`
 .. |P154_typename| replace:: :cyan:`Environment - BMP3xx`
 .. |P154_porttype| replace:: `.`
-.. |P154_status| replace:: :yellow:`COLLECTION F` :yellow:`CLIMATE`
+.. |P154_status| replace:: :yellow:`COLLECTION G` :yellow:`CLIMATE`
 .. |P154_github| replace:: P154_BMP3xx.ino
 .. _P154_github: https://github.com/letscontrolit/ESPEasy/blob/mega/src/_P154_BMP3xx.ino
 .. |P154_usedby| replace:: `.`

--- a/platformio_esp32_envs.ini
+++ b/platformio_esp32_envs.ini
@@ -190,6 +190,14 @@ build_flags               = ${esp32_common.build_flags}
                             -DPLUGIN_SET_COLLECTION_F_ESP32
                             -DCOLLECTION_USE_RTTTL
 
+[env:collection_G_ESP32_4M316k]
+extends                   = esp32_common
+board                     = esp32_4M
+build_flags               = ${esp32_common.build_flags}  
+                            -DFEATURE_ARDUINO_OTA=1
+                            -DPLUGIN_SET_COLLECTION_G_ESP32
+                            -DCOLLECTION_USE_RTTTL
+
 
 [env:collection_A_ESP32_IRExt_4M316k]
 extends                   = esp32_IRExt
@@ -226,6 +234,12 @@ extends                   = esp32_IRExt
 board                     = esp32_4M
 build_flags               = ${esp32_IRExt.build_flags}
                             -DPLUGIN_SET_COLLECTION_F_ESP32
+
+[env:collection_G_ESP32_IRExt_4M316k]
+extends                   = esp32_IRExt
+board                     = esp32_4M
+build_flags               = ${esp32_IRExt.build_flags}
+                            -DPLUGIN_SET_COLLECTION_G_ESP32
 
 [env:energy_ESP32_4M316k]
 extends                   = esp32_common
@@ -329,6 +343,12 @@ build_flags               = ${env:collection_F_ESP32_4M316k.build_flags}
                             -DFEATURE_ETHERNET=1
                             -DCOLLECTION_USE_RTTTL
 
+[env:collection_G_ESP32_4M316k_ETH]
+extends                   = env:collection_G_ESP32_4M316k
+build_flags               = ${env:collection_G_ESP32_4M316k.build_flags}
+                            -DFEATURE_ETHERNET=1
+                            -DCOLLECTION_USE_RTTTL
+
 [env:energy_ESP32_4M316k_ETH]
 extends                   = env:energy_ESP32_4M316k
 build_flags               = ${env:energy_ESP32_4M316k.build_flags}
@@ -389,6 +409,13 @@ build_flags               = ${env:neopixel_ESP32_4M316k.build_flags}
 ; board                     = esp32_4M
 ; build_flags               = ${esp32_IRExt.build_flags}
 ;                             -DPLUGIN_SET_COLLECTION_F_ESP32
+;                             -DFEATURE_ETHERNET=1
+
+; [env:collection_G_ESP32_IRExt_4M316k_ETH]
+; extends                   = esp32_IRExt
+; board                     = esp32_4M
+; build_flags               = ${esp32_IRExt.build_flags}
+;                             -DPLUGIN_SET_COLLECTION_G_ESP32
 ;                             -DFEATURE_ETHERNET=1
 
 ; [env:energy_ESP32_IRExt_4M316k_ETH]

--- a/platformio_esp32c3_envs.ini
+++ b/platformio_esp32c3_envs.ini
@@ -92,6 +92,13 @@ build_flags               = ${esp32c3_common.build_flags}
                             -DPLUGIN_SET_COLLECTION_F_ESP32
                             -DCOLLECTION_USE_RTTTL
 
+[env:collection_G_ESP32c3_4M316k_CDC]
+extends                   = esp32c3_common
+board                     = esp32c3cdc
+build_flags               = ${esp32c3_common.build_flags}  
+                            -DPLUGIN_SET_COLLECTION_G_ESP32
+                            -DCOLLECTION_USE_RTTTL
+
 
 [env:energy_ESP32c3_4M316k_CDC]
 extends                   = esp32c3_common

--- a/platformio_esp32s2_envs.ini
+++ b/platformio_esp32s2_envs.ini
@@ -101,6 +101,13 @@ build_flags               = ${esp32s2_common.build_flags}
                             -DPLUGIN_SET_COLLECTION_F_ESP32
                             -DCOLLECTION_USE_RTTTL
 
+[env:collection_G_ESP32s2_4M316k_CDC]
+extends                   = esp32s2_common
+board                     = esp32s2_cdc
+build_flags               = ${esp32s2_common.build_flags}  
+                            -DPLUGIN_SET_COLLECTION_G_ESP32
+                            -DCOLLECTION_USE_RTTTL
+
 
 [env:energy_ESP32s2_4M316k_CDC]
 extends                   = esp32s2_common

--- a/platformio_esp32s3_envs.ini
+++ b/platformio_esp32s3_envs.ini
@@ -92,6 +92,13 @@ build_flags               = ${esp32s3_common.build_flags}
                             -DPLUGIN_SET_COLLECTION_F_ESP32
                             -DCOLLECTION_USE_RTTTL
 
+[env:collection_G_ESP32s3_4M316k_CDC]
+extends                   = esp32s3_common
+board                     = esp32s3cdc-qio_qspi
+build_flags               = ${esp32s3_common.build_flags}  
+                            -DPLUGIN_SET_COLLECTION_G_ESP32
+                            -DCOLLECTION_USE_RTTTL
+
 
 [env:energy_ESP32s3_4M316k_CDC]
 extends                   = esp32s3_common

--- a/platformio_esp82xx_envs.ini
+++ b/platformio_esp82xx_envs.ini
@@ -609,6 +609,12 @@ build_flags               = ${collection_ESP8266_4M1M.build_flags}
                             -DPLUGIN_BUILD_COLLECTION_F
                             -DCOLLECTION_USE_RTTTL
 
+[env:collection_G_ESP8266_4M1M]
+extends                   = collection_ESP8266_4M1M
+build_flags               = ${collection_ESP8266_4M1M.build_flags}
+                            -DPLUGIN_BUILD_COLLECTION_G
+                            -DCOLLECTION_USE_RTTTL
+
 
 ; COLL: 4096k version + FEATURE_ADC_VCC ----------
 [env:collection_A_ESP8266_4M1M_VCC]
@@ -651,6 +657,13 @@ build_flags               = ${collection_ESP8266_4M1M.build_flags}
                             -DPLUGIN_BUILD_COLLECTION_F
                             -DCOLLECTION_USE_RTTTL
 
+[env:collection_G_ESP8266_4M1M_VCC]
+extends                   = collection_ESP8266_4M1M
+build_flags               = ${collection_ESP8266_4M1M.build_flags}
+                            -DFEATURE_ADC_VCC=1
+                            -DPLUGIN_BUILD_COLLECTION_G
+                            -DCOLLECTION_USE_RTTTL
+
 ;[env:collection_A_alt_wifi_ESP8266_4M1M_VCC]
 ;extends                   = collection_alt_wifi_ESP8266_4M1M
 ;build_flags               = ${collection_alt_wifi_ESP8266_4M1M.build_flags}
@@ -685,6 +698,12 @@ build_flags               = ${collection_ESP8266_4M1M.build_flags}
 ;build_flags               = ${collection_alt_wifi_ESP8266_4M1M.build_flags}
 ;                            -DFEATURE_ADC_VCC=1
 ;                            -DPLUGIN_BUILD_COLLECTION_F
+
+;[env:collection_G_alt_wifi_ESP8266_4M1M_VCC]
+;extends                   = collection_alt_wifi_ESP8266_4M1M
+;build_flags               = ${collection_alt_wifi_ESP8266_4M1M.build_flags}
+;                            -DFEATURE_ADC_VCC=1
+;                            -DPLUGIN_BUILD_COLLECTION_G
 
 
 ; COLL: 4096k version + FEATURE_ADC_VCC + FEATURE_MDNS + FEATURE_SD ----------
@@ -747,6 +766,13 @@ build_flags               = ${collection_ESP8266_4M1M.build_flags}
 ;                            -DPLUGIN_BUILD_COLLECTION_F
 ;                            -DCOLLECTION_USE_RTTTL
 
+;[env:collection_G_beta_ESP8266_4M1M]
+;extends                   = collection_beta_ESP8266_4M1M
+;build_flags               = ${collection_beta_ESP8266_4M1M.build_flags}
+;                            -DLIMIT_BUILD_SIZE
+;                            -DPLUGIN_BUILD_COLLECTION_G
+;                            -DCOLLECTION_USE_RTTTL
+
 ; COLL: 16M version -- LittleFS --------------
 ; LittleFS is determined by using "LittleFS" in the pio env name
 ;[env:collection_A_beta_ESP8266_16M_LittleFS]
@@ -780,6 +806,12 @@ build_flags               = ${collection_ESP8266_4M1M.build_flags}
 ;extends                   = collection_beta_ESP8266_16M_LittleFS
 ;build_flags               = ${collection_beta_ESP8266_16M_LittleFS.build_flags}
 ;                            -DPLUGIN_BUILD_COLLECTION_F
+;                            -DCOLLECTION_USE_RTTTL
+
+;[env:collection_G_beta_ESP8266_16M_LittleFS]
+;extends                   = collection_beta_ESP8266_16M_LittleFS
+;build_flags               = ${collection_beta_ESP8266_16M_LittleFS.build_flags}
+;                            -DPLUGIN_BUILD_COLLECTION_G
 ;                            -DCOLLECTION_USE_RTTTL
 
 

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -249,6 +249,8 @@ To create/register a plugin, you have to :
     #define PLUGIN_DESCR  "Collection_E, IR with AC"
   #elif defined(PLUGIN_SET_COLLECTION_F_ESP32)
     #define PLUGIN_DESCR  "Collection_F, IR with AC"
+  #elif defined(PLUGIN_SET_COLLECTION_G_ESP32)
+    #define PLUGIN_DESCR  "Collection_G, IR with AC"
   #else
     #define PLUGIN_DESCR  "Normal, IR with AC"
   #endif
@@ -263,7 +265,7 @@ To create/register a plugin, you have to :
 #endif
 
 #ifdef PLUGIN_BUILD_COLLECTION
-  #if !defined(PLUGIN_BUILD_COLLECTION_B) && !defined(PLUGIN_BUILD_COLLECTION_C) && !defined(PLUGIN_BUILD_COLLECTION_D) && !defined(PLUGIN_BUILD_COLLECTION_E) && !defined(PLUGIN_BUILD_COLLECTION_F)
+  #if !defined(PLUGIN_BUILD_COLLECTION_B) && !defined(PLUGIN_BUILD_COLLECTION_C) && !defined(PLUGIN_BUILD_COLLECTION_D) && !defined(PLUGIN_BUILD_COLLECTION_E) && !defined(PLUGIN_BUILD_COLLECTION_F) && !defined(PLUGIN_BUILD_COLLECTION_G)
     #define PLUGIN_DESCR  "Collection_A"
     #define PLUGIN_SET_COLLECTION_A
   #endif
@@ -313,6 +315,15 @@ To create/register a plugin, you have to :
   #define PLUGIN_DESCR  "Collection_F"
   #define PLUGIN_SET_COLLECTION
   #define PLUGIN_SET_COLLECTION_F
+  #define CONTROLLER_SET_COLLECTION
+  #define NOTIFIER_SET_COLLECTION
+  #define PLUGIN_BUILD_NORMAL     // add stable
+#endif
+
+#ifdef PLUGIN_BUILD_COLLECTION_G
+  #define PLUGIN_DESCR  "Collection_G"
+  #define PLUGIN_SET_COLLECTION
+  #define PLUGIN_SET_COLLECTION_G
   #define CONTROLLER_SET_COLLECTION
   #define NOTIFIER_SET_COLLECTION
   #define PLUGIN_BUILD_NORMAL     // add stable
@@ -836,7 +847,7 @@ To create/register a plugin, you have to :
 #endif
 
 #ifdef PLUGIN_SET_COLLECTION_ESP32
-  #if !defined(PLUGIN_SET_COLLECTION_B_ESP32) && !defined(PLUGIN_SET_COLLECTION_C_ESP32) && !defined(PLUGIN_SET_COLLECTION_D_ESP32) && !defined(PLUGIN_SET_COLLECTION_E_ESP32) && !defined(PLUGIN_SET_COLLECTION_F_ESP32)
+  #if !defined(PLUGIN_SET_COLLECTION_B_ESP32) && !defined(PLUGIN_SET_COLLECTION_C_ESP32) && !defined(PLUGIN_SET_COLLECTION_D_ESP32) && !defined(PLUGIN_SET_COLLECTION_E_ESP32) && !defined(PLUGIN_SET_COLLECTION_F_ESP32) && !defined(PLUGIN_SET_COLLECTION_G_ESP32)
     #ifndef PLUGIN_DESCR // COLLECTION_A_ESP32_IRExt also passes here
       #define PLUGIN_DESCR  "Collection_A ESP32"
     #endif
@@ -1023,6 +1034,37 @@ To create/register a plugin, you have to :
   // TODO : Check compatibility of plugins for ESP32 board.
 #endif
 
+#ifdef PLUGIN_SET_COLLECTION_G_ESP32
+  #ifndef PLUGIN_DESCR // COLLECTION_G_ESP32_IRExt also passes here
+    #define PLUGIN_DESCR  "Collection_G ESP32"
+  #endif
+  #ifndef ESP32
+    #define ESP32
+  #endif
+  #ifdef ESP8266
+    #undef ESP8266
+  #endif
+  // Undefine contradictionary defines
+  #ifdef PLUGIN_SET_NONE
+    #undef PLUGIN_SET_NONE
+  #endif
+  #ifdef PLUGIN_SET_ONLY_SWITCH
+    #undef PLUGIN_SET_ONLY_SWITCH
+  #endif
+  #ifdef PLUGIN_SET_ONLY_TEMP_HUM
+    #undef PLUGIN_SET_ONLY_TEMP_HUM
+  #endif
+  #define  PLUGIN_SET_COLLECTION
+  #define  PLUGIN_SET_COLLECTION_G
+  #define  CONTROLLER_SET_STABLE
+  #define  CONTROLLER_SET_COLLECTION
+  #define  NOTIFIER_SET_STABLE
+  #define  PLUGIN_SET_STABLE     // add stable
+  // See also PLUGIN_SET_COLLECTION_ESP32 section at end,
+  // where incompatible plugins will be disabled.
+  // TODO : Check compatibility of plugins for ESP32 board.
+#endif
+
 #ifdef PLUGIN_BUILD_MAX_ESP32
     #ifndef PLUGIN_DESCR
       #define PLUGIN_DESCR  "MAX ESP32"
@@ -1188,6 +1230,9 @@ To create/register a plugin, you have to :
   #ifdef PLUGIN_SET_COLLECTION_F
     #undef PLUGIN_SET_COLLECTION_F
   #endif
+  #ifdef PLUGIN_SET_COLLECTION_G
+    #undef PLUGIN_SET_COLLECTION_G
+  #endif
   #ifdef PLUGIN_SET_EXPERIMENTAL
     #undef PLUGIN_SET_EXPERIMENTAL
   #endif
@@ -1283,6 +1328,9 @@ To create/register a plugin, you have to :
   #endif
   #ifndef PLUGIN_SET_COLLECTION_F
     #define PLUGIN_SET_COLLECTION_F
+  #endif
+  #ifndef PLUGIN_SET_COLLECTION_G
+    #define PLUGIN_SET_COLLECTION_G
   #endif
 #endif
 
@@ -1391,7 +1439,7 @@ To create/register a plugin, you have to :
     #endif
 #endif
 
-#if defined(PLUGIN_SET_COLLECTION) || defined(PLUGIN_SET_COLLECTION_A) || defined(PLUGIN_SET_COLLECTION_B) || defined(PLUGIN_SET_COLLECTION_C) || defined(PLUGIN_SET_COLLECTION_D) || defined(PLUGIN_SET_COLLECTION_E) || defined(PLUGIN_SET_COLLECTION_F)
+#if defined(PLUGIN_SET_COLLECTION) || defined(PLUGIN_SET_COLLECTION_A) || defined(PLUGIN_SET_COLLECTION_B) || defined(PLUGIN_SET_COLLECTION_C) || defined(PLUGIN_SET_COLLECTION_D) || defined(PLUGIN_SET_COLLECTION_E) || defined(PLUGIN_SET_COLLECTION_F) || defined(PLUGIN_SET_COLLECTION_G)
   #if !defined(PLUGIN_SET_MAX) && !defined(ESP32)
     #ifndef LIMIT_BUILD_SIZE
       #define LIMIT_BUILD_SIZE
@@ -1551,6 +1599,10 @@ To create/register a plugin, you have to :
   #ifndef USES_P154
     #define USES_P154   // Environment - BMP3xx
   #endif
+
+#endif
+
+#ifdef PLUGIN_SET_COLLECTION_G
 
 #endif
 
@@ -2683,7 +2735,7 @@ To create/register a plugin, you have to :
 #endif
 
 // Here we can re-enable specific features in the COLLECTION sets as we have created some space there by splitting them up
-#if defined(COLLECTION_FEATURE_RTTTL) && (defined(PLUGIN_SET_COLLECTION_A) || defined(PLUGIN_SET_COLLECTION_B) || defined(PLUGIN_SET_COLLECTION_C) || defined(PLUGIN_SET_COLLECTION_D) || defined(PLUGIN_SET_COLLECTION_E) || defined(PLUGIN_SET_COLLECTION_F))
+#if defined(COLLECTION_FEATURE_RTTTL) && (defined(PLUGIN_SET_COLLECTION_A) || defined(PLUGIN_SET_COLLECTION_B) || defined(PLUGIN_SET_COLLECTION_C) || defined(PLUGIN_SET_COLLECTION_D) || defined(PLUGIN_SET_COLLECTION_E) || defined(PLUGIN_SET_COLLECTION_F) || defined(PLUGIN_SET_COLLECTION_G))
   #ifndef FEATURE_RTTTL
     #define FEATURE_RTTTL 1
   #endif

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -1596,13 +1596,13 @@ To create/register a plugin, you have to :
   #ifndef USES_P153
     #define USES_P153   // Environment - SHT4x
   #endif
-  #ifndef USES_P154
-    #define USES_P154   // Environment - BMP3xx
-  #endif
 
 #endif
 
 #ifdef PLUGIN_SET_COLLECTION_G
+  #ifndef USES_P154
+    #define USES_P154   // Environment - BMP3xx
+  #endif
 
 #endif
 

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -1342,6 +1342,9 @@ To create/register a plugin, you have to :
     #ifndef FEATURE_SERVO
       #define FEATURE_SERVO 1
     #endif
+    #ifdef FEATURE_RTTTL
+      #undef FEATURE_RTTTL
+    #endif
     #define FEATURE_RTTTL 1
 
     #define USES_P001   // Switch
@@ -1759,7 +1762,9 @@ To create/register a plugin, you have to :
   #ifndef FEATURE_SERVO
     #define FEATURE_SERVO 1
   #endif
-  #define FEATURE_RTTTL 1
+  #ifndef FEATURE_RTTTL
+    #define FEATURE_RTTTL 1
+  #endif
 
   #define USES_P001   // Switch
   #define USES_P002   // ADC
@@ -2349,6 +2354,9 @@ To create/register a plugin, you have to :
 #endif
 
 #if defined(USES_C018)
+  #ifdef FEATURE_PACKED_RAW_DATA
+    #undef FEATURE_PACKED_RAW_DATA
+  #endif
   #define FEATURE_PACKED_RAW_DATA 1
 #endif
 
@@ -2360,6 +2368,9 @@ To create/register a plugin, you have to :
 
 #if defined(USES_P085) || defined (USES_P052) || defined(USES_P078) || defined(USES_P108)
   // FIXME TD-er: Is this correct? Those plugins use Modbus_RTU.
+  #ifdef FEATURE_MODBUS
+    #undef FEATURE_MODBUS
+  #endif
   #define FEATURE_MODBUS  1
 #endif
 
@@ -2647,10 +2658,16 @@ To create/register a plugin, you have to :
 #endif
 
 #if defined(USES_C002) || defined (USES_C005) || defined(USES_C006) || defined(USES_C014) || defined(USES_P037)
+  #ifdef FEATURE_MQTT
+    #undef FEATURE_MQTT
+  #endif
   #define FEATURE_MQTT  1
 #endif
 
 #if defined(USES_C012) || defined (USES_C015)
+  #ifdef FEATURE_BLYNK
+    #undef FEATURE_BLYNK
+  #endif
   #define FEATURE_BLYNK 1
 #endif
 


### PR DESCRIPTION
Features:
- Add `Collection G` builds as the other collections are getting too large to add more plugins
- Move plugin [P154] `Environment - BMP3xx` to Collection G (from F)
- Update documentation
- Fix some `#define` settings when using `Custom.h` compilation
