### PR TITLE
[P073] Reduce logging for BUILD_NO_DEBUG builds to reduce size

### DIFF
--- a/src/_P073_7DGT.ino
+++ b/src/_P073_7DGT.ino
@@ -422,14 +422,18 @@ bool p073_plugin_write(struct EventStruct *event,
       # ifdef P073_SCROLL_TEXT
       newScroll = currentScroll; // Restore state
       # endif // ifdef P073_SCROLL_TEXT
+      # ifndef BUILD_NO_DEBUG
       addLog(LOG_LEVEL_INFO, F("7DGT : Display ON"));
+      # endif // ifndef BUILD_NO_DEBUG
       p073_displayon = true;
       p073_validcmd  = true;
     } else if (equals(cmd, F("7doff"))) {
       # ifdef P073_SCROLL_TEXT
       newScroll = currentScroll; // Restore state
       # endif // ifdef P073_SCROLL_TEXT
+      # ifndef BUILD_NO_DEBUG
       addLog(LOG_LEVEL_INFO, F("7DGT : Display OFF"));
+      # endif // ifndef BUILD_NO_DEBUG
       p073_displayon = false;
       p073_validcmd  = true;
     } else if (equals(cmd, F("7db"))) {
@@ -438,11 +442,12 @@ bool p073_plugin_write(struct EventStruct *event,
       # endif // ifdef P073_SCROLL_TEXT
 
       if ((event->Par1 >= 0) && (event->Par1 < 16)) {
+        # ifndef BUILD_NO_DEBUG
+
         if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-          String log = F("7DGT : Brightness=");
-          log += event->Par1;
-          addLogMove(LOG_LEVEL_INFO, log);
+          addLog(LOG_LEVEL_INFO, concat(F("7DGT : Brightness="), event->Par1));
         }
+        # endif // ifndef BUILD_NO_DEBUG
         P073_data->brightness = event->Par1;
         PCONFIG(2)            = event->Par1;
         p073_displayon        = true;
@@ -451,11 +456,12 @@ bool p073_plugin_write(struct EventStruct *event,
     } else if (equals(cmd, F("7output"))) {
       if ((event->Par1 >= 0) && (event->Par1 < 6)) { // 0:"Manual",1:"Clock 24h - Blink",2:"Clock 24h - No Blink",
                                                      // 3:"Clock 12h - Blink",4:"Clock 12h - No Blink",5:"Date"
+        # ifndef BUILD_NO_DEBUG
+
         if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-          String log = F("7DGT : Display output=");
-          log += event->Par1;
-          addLogMove(LOG_LEVEL_INFO, log);
+          addLog(LOG_LEVEL_INFO, concat(F("7DGT : Display output="), event->Par1));
         }
+        # endif // ifndef BUILD_NO_DEBUG
         P073_data->output = event->Par1;
         PCONFIG(1)        = event->Par1;
         p073_displayon    = true;
@@ -504,11 +510,12 @@ bool p073_plugin_write_7dn(struct EventStruct *event,
     return false;
   }
 
+  # ifndef BUILD_NO_DEBUG
+
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-    String log = F("7DGT : Show Number=");
-    log += event->Par1;
-    addLogMove(LOG_LEVEL_INFO, log);
+    addLog(LOG_LEVEL_INFO, concat(F("7DGT : Show Number="), event->Par1));
   }
+  # endif // ifndef BUILD_NO_DEBUG
 
   switch (P073_data->displayModel) {
     case P073_TM1637_4DGTCOLON:
@@ -566,11 +573,12 @@ bool p073_plugin_write_7dt(struct EventStruct *event,
     validFloatFromString(text, p073_temptemp);
   }
 
+  # ifndef BUILD_NO_DEBUG
+
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-    String log = F("7DGT : Show Temperature=");
-    log += p073_temptemp;
-    addLogMove(LOG_LEVEL_INFO, log);
+    addLog(LOG_LEVEL_INFO, concat(F("7DGT : Show Temperature="), p073_temptemp));
   }
+  # endif // ifndef BUILD_NO_DEBUG
 
   switch (P073_data->displayModel) {
     case P073_TM1637_4DGTCOLON:
@@ -606,9 +614,7 @@ bool p073_plugin_write_7dt(struct EventStruct *event,
       # ifdef P073_DEBUG
 
       if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-        String log = F("7DGT : 7dt preprocessed =");
-        log += p073_temptemp;
-        addLogMove(LOG_LEVEL_INFO, log);
+        addLogMove(LOG_LEVEL_INFO, concat(F("7DGT : 7dt preprocessed ="), p073_temptemp));
       }
       # endif // ifdef P073_DEBUG
 
@@ -645,11 +651,7 @@ bool p073_plugin_write_7ddt(struct EventStruct *event,
   }
 
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-    String log = F("7DGT : Show Temperature 1st=");
-    log += p073_lefttemp;
-    log += F(" 2nd=");
-    log += p073_righttemp;
-    addLogMove(LOG_LEVEL_INFO, log);
+    addLog(LOG_LEVEL_INFO, strformat(F("7DGT : Show Temperature 1st=%.2f 2nd=%.2f"), p073_lefttemp, p073_righttemp));
   }
 
   switch (P073_data->displayModel) {
@@ -697,11 +699,7 @@ bool p073_plugin_write_7ddt(struct EventStruct *event,
       #  ifdef P073_DEBUG
 
       if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-        String log = F("7DGT : 7ddt preprocessed 1st=");
-        log += p073_lefttemp;
-        log += F(" 2nd=");
-        log += p073_righttemp;
-        addLogMove(LOG_LEVEL_INFO, log);
+        addLog(LOG_LEVEL_INFO, strformat(F("7DGT : 7ddt preprocessed 1st=%.2f 2nd=%.2f"), p073_lefttemp, p073_righttemp));
       }
       #  endif // ifdef P073_DEBUG
 
@@ -733,15 +731,12 @@ bool p073_plugin_write_7dst(struct EventStruct *event) {
     return false;
   }
 
+  # ifndef BUILD_NO_DEBUG
+
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-    String log = F("7DGT : Show Time=");
-    log += event->Par1;
-    log += ':';
-    log += event->Par2;
-    log += ':';
-    log += event->Par3;
-    addLogMove(LOG_LEVEL_INFO, log);
+    addLog(LOG_LEVEL_INFO, strformat(F("7DGT : Show Time=%02d:%02d:%02d"), event->Par1, event->Par2, event->Par3));
   }
+  # endif // ifndef BUILD_NO_DEBUG
   P073_data->timesep = true;
   P073_data->FillBufferWithTime(false, event->Par1, event->Par2, event->Par3, false,
                                 # ifdef P073_SUPPRESS_ZERO
@@ -781,13 +776,7 @@ bool p073_plugin_write_7dsd(struct EventStruct *event) {
   }
 
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-    String log = F("7DGT : Show Date=");
-    log += event->Par1;
-    log += '-';
-    log += event->Par2;
-    log += '-';
-    log += event->Par3;
-    addLogMove(LOG_LEVEL_INFO, log);
+    addLog(LOG_LEVEL_INFO, strformat(F("7DGT : Show Date=%02d:%02d:%02d"), event->Par1, event->Par2, event->Par3));
   }
   P073_data->FillBufferWithDate(false, event->Par1, event->Par2, event->Par3,
                                 # ifdef P073_SUPPRESS_ZERO
@@ -827,11 +816,12 @@ bool p073_plugin_write_7dtext(struct EventStruct *event,
     return false;
   }
 
+  # ifndef BUILD_NO_DEBUG
+
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-    String log = F("7DGT : Show Text=");
-    log += text;
-    addLogMove(LOG_LEVEL_INFO, log);
+    addLogMove(LOG_LEVEL_INFO, concat(F("7DGT : Show Text="), text));
   }
+  # endif // ifndef BUILD_NO_DEBUG
   # ifdef P073_SCROLL_TEXT
   P073_data->setTextToScroll("");
   uint8_t bufLen = P073_data->getBufferLength(P073_data->displayModel);
@@ -896,11 +886,7 @@ bool p073_plugin_write_7dfont(struct EventStruct *event,
     #  ifdef P073_DEBUG
 
     if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-      String info = F("P037 7dfont,");
-      info += fontArg;
-      info += F(" -> ");
-      info += fontNr;
-      addLogMove(LOG_LEVEL_INFO, info);
+      addLog(LOG_LEVEL_INFO, strformat(F("P037 7dfont,%s -> %d"), fontArg.c_str(), fontNr));
     }
     #  endif // P073_DEBUG
 

--- a/src/src/PluginStructs/P073_data_struct.cpp
+++ b/src/src/PluginStructs/P073_data_struct.cpp
@@ -415,8 +415,7 @@ void P073_data_struct::LogBufferContent(String prefix) {
 
     for (uint8_t i = 0; i < 8; i++) {
       if (i > 0) { log += ','; }
-      log += F("0x");
-      log += String(showbuffer[i], HEX);
+      log += formatToHex(showbuffer[i]);
       log += ',';
       log += showperiods[i] ? F(".") : F("");
     }


### PR DESCRIPTION
Feature:
- Disable some logging for builds with `BUILD_NO_DEBUG` enabled to further reduce .bin size