### PR TITLE
[GPIO] Fix check for valid GPIO

### DIFF
--- a/src/src/DataStructs/SettingsStruct.h
+++ b/src/src/DataStructs/SettingsStruct.h
@@ -259,7 +259,7 @@ private:
   // - PinBootStates_ESP32 (index_high)
   // Returns whether it is a valid index
   bool getPinBootStateIndex(
-    uint8_t gpio_pin, 
+    int8_t gpio_pin, 
     int8_t& index_low
     #ifdef ESP32
     , int8_t& index_high
@@ -268,8 +268,8 @@ private:
   
 public:
 
-  PinBootState getPinBootState(uint8_t gpio_pin) const;
-  void setPinBootState(uint8_t gpio_pin, PinBootState state);
+  PinBootState getPinBootState(int8_t gpio_pin) const;
+  void setPinBootState(int8_t gpio_pin, PinBootState state);
 
   bool getSPI_pins(int8_t spi_gpios[3]) const;
 

--- a/src/src/DataStructs_templ/SettingsStruct.cpp
+++ b/src/src/DataStructs_templ/SettingsStruct.cpp
@@ -694,7 +694,7 @@ String SettingsStruct_tmpl<N_TASKS>::getName() const {
 
 template<unsigned int N_TASKS>
 bool SettingsStruct_tmpl<N_TASKS>::getPinBootStateIndex(
-  uint8_t   gpio_pin,
+  int8_t  gpio_pin,
   int8_t& index_low
     # ifdef ESP32
   , int8_t& index_high
@@ -703,17 +703,16 @@ bool SettingsStruct_tmpl<N_TASKS>::getPinBootStateIndex(
   index_low = -1;
 # ifdef ESP32
   index_high = -1;
-
-  if (!GPIO_IS_VALID_GPIO(gpio_pin)) { return false; }
+  if ((gpio_pin < 0) || !(GPIO_IS_VALID_GPIO(gpio_pin))) { return false; }
 # endif // ifdef ESP32
-  constexpr uint8_t maxStates = NR_ELEMENTS(PinBootStates);
+  constexpr int maxStates = NR_ELEMENTS(PinBootStates);
 
   if (gpio_pin < maxStates) {
     index_low = gpio_pin;
     return true;
   }
 # ifdef ESP32
-  constexpr uint8_t maxStatesesp32 = NR_ELEMENTS(PinBootStates_ESP32);
+  constexpr int maxStatesesp32 = NR_ELEMENTS(PinBootStates_ESP32);
 
   index_high = gpio_pin - maxStates;
 
@@ -768,7 +767,8 @@ bool SettingsStruct_tmpl<N_TASKS>::getPinBootStateIndex(
 }
 
 template<unsigned int N_TASKS>
-PinBootState SettingsStruct_tmpl<N_TASKS>::getPinBootState(uint8_t gpio_pin) const {
+PinBootState SettingsStruct_tmpl<N_TASKS>::getPinBootState(int8_t gpio_pin) const {
+  if (gpio_pin < 0) return PinBootState::Default_state;
 # ifdef ESP8266
   int8_t index_low{};
 
@@ -795,7 +795,8 @@ PinBootState SettingsStruct_tmpl<N_TASKS>::getPinBootState(uint8_t gpio_pin) con
 }
 
 template<unsigned int N_TASKS>
-void SettingsStruct_tmpl<N_TASKS>::setPinBootState(uint8_t gpio_pin, PinBootState state) {
+void SettingsStruct_tmpl<N_TASKS>::setPinBootState(int8_t gpio_pin, PinBootState state) {
+  if (gpio_pin < 0) return;
 # ifdef ESP8266
   int8_t index_low{};
 

--- a/src/src/Helpers/Hardware.cpp
+++ b/src/src/Helpers/Hardware.cpp
@@ -1660,7 +1660,7 @@ bool getGpioInfo(int gpio, int& pinnr, bool& input, bool& output, bool& warning)
   output = GPIO_IS_VALID_OUTPUT_GPIO(gpio);
   warning = false;
 
-  if (!GPIO_IS_VALID_GPIO(gpio)) return false;
+  if ((gpio < 0) || !(GPIO_IS_VALID_GPIO(gpio))) { return false; }
 
 # ifdef ESP32S2
 
@@ -2041,11 +2041,12 @@ bool getGpioPullResistor(int gpio, bool& hasPullUp, bool& hasPullDown) {
 #endif // ifdef ESP8266
 
 bool validGpio(int gpio) {
+  if (gpio < 0) { return false; }
   #ifdef ESP32
   if (!GPIO_IS_VALID_GPIO(gpio)) { return false; }
   #endif
   #ifdef ESP8266
-  if ((gpio < 0) || (gpio > MAX_GPIO)) { return false; }
+  if (gpio > MAX_GPIO) { return false; }
   #endif
   int pinnr;
   bool input;


### PR DESCRIPTION
The ESP32 macro `GPIO_IS_VALID_GPIO` does not check for negative gpio index. We use a negative value as "invalid".