### PR TITLE
[P131] Optimization for build size

### DIFF
--- a/src/_P131_NeoPixelMatrix.ino
+++ b/src/_P131_NeoPixelMatrix.ino
@@ -7,6 +7,7 @@
 // #######################################################################################################
 
 /** Changelog:
+ * 2023-10-03 tonhuisman: Optimizate alignment of settings struct, exclude some logging if BUILD_NO_DEBUG is defined
  * 2023-02-27 tonhuisman: Implement support for getting config values, see AdafruitGFX_Helper.h changelog for details
  * 2022-07-30 tonhuisman: Add commands to set scroll-options (settext, setscroll, setstep, setspeed, setempty, setright)
  *                        Fix issue that on startup the display wasn't cleared (unit reset should turn off the display)
@@ -385,8 +386,10 @@ boolean Plugin_131(uint8_t function, struct EventStruct *event, String& string)
         P131_data_struct *P131_data = static_cast<P131_data_struct *>(getPluginTaskData(event->TaskIndex));
 
         success = (nullptr != P131_data) && P131_data->plugin_init(event); // Start the display
+      # ifndef BUILD_NO_DEBUG
       } else {
         addLog(LOG_LEVEL_ERROR, F("NEOMATRIX: No GPIO pin configured, init cancelled."));
+      # endif // ifndef BUILD_NO_DEBUG
       }
 
       break;

--- a/src/src/PluginStructs/P131_data_struct.cpp
+++ b/src/src/PluginStructs/P131_data_struct.cpp
@@ -59,7 +59,9 @@ bool P131_data_struct::plugin_init(struct EventStruct *event) {
   bool success = false;
 
   if (!isInitialized()) {
+    # ifndef BUILD_NO_DEBUG
     addLog(LOG_LEVEL_INFO, F("NEOMATRIX: Init start."));
+    # endif // ifndef BUILD_NO_DEBUG
     matrix = new (std::nothrow) Adafruit_NeoMatrix(_matrixWidth,
                                                    _matrixHeight,
                                                    _tileWidth,
@@ -94,9 +96,9 @@ bool P131_data_struct::plugin_init(struct EventStruct *event) {
       log += _ypix;
       addLogMove(LOG_LEVEL_INFO, log);
     }
-    # endif // ifndef BUILD_NO_DEBUG
   } else {
     addLog(LOG_LEVEL_INFO, F("NEOMATRIX: Init failed."));
+    # endif // ifndef BUILD_NO_DEBUG
   }
 
   if (isInitialized()) {

--- a/src/src/PluginStructs/P131_data_struct.h
+++ b/src/src/PluginStructs/P131_data_struct.h
@@ -84,6 +84,7 @@ struct P131_content_struct {
   int16_t pixelPos    = 0;  // current left-offset on display
   int16_t speed       = 0;  // 0.1 sec. steps
   int16_t loop        = -1; // steps before we go, -1 = restart from speed
+  int16_t _filler1    = 0;  // Filler added to achieve better instance/memory alignment
   int8_t  stepWidth   = 0;  // Nr. of pixels to scroll - 1
   bool    active      = false;
   bool    rightScroll = false;


### PR DESCRIPTION
Features:
- Improve `struct` alignment to reduce build-size 
- Exclude some log messages for builds with `BUILD_NO_DEBUG` set

(Size reduction: ESP8266 ~200 bytes, ESP32 ~80 bytes)