### PR TITLE
Gpio fixes

### DIFF
--- a/src/src/Commands/GPIO.cpp
+++ b/src/src/Commands/GPIO.cpp
@@ -288,6 +288,7 @@ const __FlashStringHelper * Command_GPIO_Status(struct EventStruct *event, const
 {
   bool sendStatusFlag;
   pluginID_t pluginID;
+  int8_t value = -1;
 
   switch (tolower(parseString(Line, 2).charAt(0)))
   {
@@ -298,13 +299,15 @@ const __FlashStringHelper * Command_GPIO_Status(struct EventStruct *event, const
 #ifdef USES_P009
     case 'm': // mcp
       pluginID       = PLUGIN_MCP;
-      sendStatusFlag = GPIO_MCP_Read(event->Par2) == -1;
+      value          = GPIO_MCP_Read(event->Par2);
+      sendStatusFlag = value == -1;
       break;
 #endif
 #ifdef USES_P019
     case 'p': // pcf
       pluginID       = PLUGIN_PCF;
-      sendStatusFlag = GPIO_PCF_Read(event->Par2) == -1;
+      value          = GPIO_PCF_Read(event->Par2);
+      sendStatusFlag = value == -1;
       break;
 #endif
     default:
@@ -318,7 +321,7 @@ const __FlashStringHelper * Command_GPIO_Status(struct EventStruct *event, const
   }
   const uint32_t key = createKey(pluginID, event->Par2); // WARNING: 'status' uses Par2 instead of Par1
   String dummy;
-  SendStatusOnlyIfNeeded(event, sendStatusFlag, key, dummy, 0);
+  SendStatusOnlyIfNeeded(event, sendStatusFlag, key, dummy, value);
   return return_command_success_flashstr();
 }
 

--- a/src/src/ESPEasyCore/ESPEasyGPIO.cpp
+++ b/src/src/ESPEasyCore/ESPEasyGPIO.cpp
@@ -426,18 +426,18 @@ void GPIO_Monitor10xSec()
           currentState = GPIO_Read_Switch_State(gpioPort, it->second.mode);
           eventString = F("GPIO");
           break;
-        case PLUGIN_MCP_INT:
 #ifdef USES_P009
+        case PLUGIN_MCP_INT:
           currentState = GPIO_MCP_Read(gpioPort);
           eventString = F("MCP");
-#endif
           break;
-        case PLUGIN_PCF_INT:
+#endif
 #ifdef USES_P019
+        case PLUGIN_PCF_INT:
           currentState = GPIO_PCF_Read(gpioPort);
           eventString = F("PCF");
-#endif
           break;
+#endif
         default:
           caseFound=false;
         break;


### PR DESCRIPTION
### [[GPIO] Fix taking wrong branch in GPIO_Monitor10xSec when MCP/PCF plu…](https://github.com/letscontrolit/ESPEasy/commit/e4e846906d342e0ffdb3fcd8815ed01596f0f215)

I think the intention was to have the whole `case  ... break` statement inside the `#ifdef .. #endif`.

### [[GPIO] Fix response to Status command](https://github.com/letscontrolit/ESPEasy/commit/25b10d76ca11d121ce062556d0390d63377f9aba)

Submitting command `status, mcp, 9` gives always the same response in the widget on http://esp-easy.local/tools:

```
{
"log": "",
"plugin": 9,
"pin": 9,
"mode": "input",
"state": 0
}
```

In my case the expected answer is:
```
{
"log": "",
"plugin": 9,
"pin": 9,
"mode": "output",
"state": 1
}
```

The reported state is wrong because `getPinStateJSON` is called with "search = false" and "noSearchValue = 0".
`String getPinStateJSON(bool search, uint32_t key, const String& log, int16_t noSearchValue)`

My commit passes correct pin value in noSearchValue but does nothing to fix reported `mode`.