### PR TITLE
[GPIO] Fix mode reported in response to Status command

### DIFF
--- a/src/src/Helpers/PortStatus.cpp
+++ b/src/src/Helpers/PortStatus.cpp
@@ -195,13 +195,14 @@ String getPinStateJSON(bool search, uint32_t key, const String& log, int16_t noS
   int16_t value = noSearchValue;
   bool    found = false;
 
-  if (search) {
-    const auto it = globalMapPortStatus.find(key);
-    if (it != globalMapPortStatus.end()) {
-      mode  = it->second.mode;
+  const auto it = globalMapPortStatus.find(key);
+  if (it != globalMapPortStatus.end()) {
+    found = true;
+    // update mode even if search = false, otherwise it will print mode assigned above
+    mode  = it->second.mode;
+    // update value only if search = true, otherwise use noSearchValue
+    if(search)
       value = it->second.getValue();
-      found = true;
-    }
   }
 
   if (!search || found)


### PR DESCRIPTION
Response to `status, mcp, 9` always reports the same "mode": "input":
{
"log": "",
"plugin": 9,
"pin": 9,
"mode": "input",
"state": 1
}

This commit fixes reported mode if the pin is initialized.
Now I see expected response in the widget on http://esp-easy.local/tools and via MQTT:
{
"log": "",
"plugin": 9,
"pin": 9,
"mode": "output",
"state": 1
}

If the pin is not initialized it will print the default "mode": "input" as before.