### PR TITLE
[P023] Bugfix: Template parsing was overwriting the template

### DIFF
--- a/src/_P023_OLED.ino
+++ b/src/_P023_OLED.ino
@@ -7,6 +7,7 @@
 // #######################################################################################################
 
 /** Changelog:
+ * 2023-10-16 tonhuisman: Bugfix: Template parsing stopped after initial display since previous updates :-(
  * 2023-03-18 tonhuisman: Show current on-display content on Devices page (75% size, omits trailing empty lines)
  *                        Manually set content via command: oled,x,y,<content> is included in the Devices page content
  *                        Make Interval optional

--- a/src/src/PluginStructs/P023_data_struct.cpp
+++ b/src/src/PluginStructs/P023_data_struct.cpp
@@ -262,10 +262,10 @@ void P023_data_struct::StartUp_OLED(struct EventStruct *event) {
 
 bool P023_data_struct::plugin_read(struct EventStruct *event) {
   for (uint8_t x = 0; x < 8; x++) {
-    String tmp             = strings[x];
-    const String newString = parseTemplate(tmp, 16);
-
     if (strings[x].length()) {
+      String tmp             = strings[x];
+      const String newString = parseTemplate(tmp, 16);
+
       sendStrXY(newString.c_str(), x, 0);
       currentLines[x] = newString;
     }

--- a/src/src/PluginStructs/P023_data_struct.cpp
+++ b/src/src/PluginStructs/P023_data_struct.cpp
@@ -262,7 +262,8 @@ void P023_data_struct::StartUp_OLED(struct EventStruct *event) {
 
 bool P023_data_struct::plugin_read(struct EventStruct *event) {
   for (uint8_t x = 0; x < 8; x++) {
-    String newString = parseTemplate(strings[x], 16);
+    String tmp             = strings[x];
+    const String newString = parseTemplate(tmp, 16);
 
     if (strings[x].length()) {
       sendStrXY(newString.c_str(), x, 0);


### PR DESCRIPTION
Resolves #4842 

Bugfix:
- Template parsing was overwriting the template

TODO:
- [x] Testing ([confirmed](https://github.com/letscontrolit/ESPEasy/issues/4842#issuecomment-1767154577))