### PR TITLE
[Build] Freeze Python version on 3.11 so pygit2 will run as intended

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
       - uses: actions/cache@v3
         with:
           path: ~/.cache/pip


### PR DESCRIPTION
Fix build issue for pygit2 not working with Python 3,12 yet...