### PR TITLE
[CDN URL] Add default CDN url with latest tag when no pygit2 installed

### DIFF
--- a/tools/pio/generate-compiletime-defines.py
+++ b/tools/pio/generate-compiletime-defines.py
@@ -62,9 +62,10 @@ def get_cdn_url_prefix():
                 tag = tag.replace('refs/tags/','@')
                 return "https://cdn.jsdelivr.net/gh/letscontrolit/ESPEasy{0}/static/".format(tag)
         except:
-            return 'https://cdn.jsdelivr.net/gh/letscontrolit/ESPEasy/static/'
+            return 'https://cdn.jsdelivr.net/gh/letscontrolit/ESPEasy@mega-20231013/static/'
     except ImportError:
-        return 'https://cdn.jsdelivr.net/gh/letscontrolit/ESPEasy/static/'
+        return 'https://cdn.jsdelivr.net/gh/letscontrolit/ESPEasy@mega-20231013/static/'
+
 
 
 def get_git_description():


### PR DESCRIPTION
For a build without pygit2 installed, the default CDN url didn't have a tag in the URL. This used to work, but not anymore.

See: 
- https://www.letscontrolit.com/forum/viewtopic.php?t=9902
- https://www.letscontrolit.com/forum/viewtopic.php?p=66828#p66828
