### PR TITLE
[WiFi] Bugfix: AP wasn't consistently started on WiFi connection failure

### DIFF
--- a/src/src/ESPEasyCore/ESPEasyWifi.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi.cpp
@@ -109,7 +109,7 @@ void ESPEasyWiFi_t::startScanning() {
 
 
 bool ESPEasyWiFi_t::connectSTA() {
-  if (!WiFi_AP_Candidates.hasKnownCredentials()) {
+  if (!WiFi_AP_Candidates.hasCandidateCredentials()) {
     if (!WiFiEventData.warnedNoValidWiFiSettings) {
       addLog(LOG_LEVEL_ERROR, F("WIFI : No valid wifi settings"));
       WiFiEventData.warnedNoValidWiFiSettings = true;
@@ -505,7 +505,7 @@ void AttemptWiFiConnect() {
 // Set Wifi config
 // ********************************************************************************
 bool prepareWiFi() {
-  if (!WiFi_AP_Candidates.hasKnownCredentials()) {
+  if (!WiFi_AP_Candidates.hasCandidateCredentials()) {
     if (!WiFiEventData.warnedNoValidWiFiSettings) {
       addLog(LOG_LEVEL_ERROR, F("WIFI : No valid wifi settings"));
       WiFiEventData.warnedNoValidWiFiSettings = true;

--- a/src/src/ESPEasyCore/ESPEasy_Console.cpp
+++ b/src/src/ESPEasyCore/ESPEasy_Console.cpp
@@ -76,6 +76,7 @@ EspEasy_Console_t::EspEasy_Console_t()
 void EspEasy_Console_t::reInit()
 {
   updateActiveTaskUseSerial0();
+  bool somethingChanged = false;
 #if FEATURE_DEFINE_SERIAL_CONSOLE_PORT
   const ESPEasySerialPort port = static_cast<ESPEasySerialPort>(Settings.console_serial_port);
 
@@ -114,6 +115,7 @@ void EspEasy_Console_t::reInit()
       _fallbackSerial._serial->end();
       delete _fallbackSerial._serial;
       _fallbackSerial._serial = nullptr;
+      somethingChanged = true;
     }
   }
 # endif // if USES_ESPEASY_CONSOLE_FALLBACK_PORT
@@ -128,6 +130,7 @@ void EspEasy_Console_t::reInit()
       _mainSerial._serial->end();
       delete _mainSerial._serial;
       _mainSerial._serial = nullptr;
+      somethingChanged = true;
     }
 
     _console_serial_port  = Settings.console_serial_port;
@@ -140,6 +143,7 @@ void EspEasy_Console_t::reInit()
       static_cast<ESPEasySerialPort>(_console_serial_port),
       _console_serial_rxpin,
       _console_serial_txpin);
+    somethingChanged = true;
   }
 # if USES_ESPEASY_CONSOLE_FALLBACK_PORT
 
@@ -148,6 +152,7 @@ void EspEasy_Console_t::reInit()
       ESPEasySerialPort::serial0,
       SOC_RX0,
       SOC_TX0);
+    somethingChanged = true;
   }
 # endif // if USES_ESPEASY_CONSOLE_FALLBACK_PORT
 
@@ -164,7 +169,9 @@ void EspEasy_Console_t::reInit()
     _mainSerial._serialWriteBuffer.clear();
   }
 #endif // if FEATURE_DEFINE_SERIAL_CONSOLE_PORT
-  begin(Settings.BaudRate);
+  if (somethingChanged) {
+    begin(Settings.BaudRate);
+  }
 }
 
 void EspEasy_Console_t::begin(uint32_t baudrate)

--- a/src/src/ESPEasyCore/ESPEasy_setup.cpp
+++ b/src/src/ESPEasyCore/ESPEasy_setup.cpp
@@ -392,7 +392,7 @@ void ESPEasy_setup()
     WiFi_AP_Candidates.clearCache();
     WiFi_AP_Candidates.load_knownCredentials();
     setSTA(true);
-    if (!WiFi_AP_Candidates.hasCandidateCredentials()) {
+    if (!WiFi_AP_Candidates.hasCandidates()) {
       WiFiEventData.wifiSetup = true;
       RTC.clearLastWiFi(); // Must scan all channels
       // Wait until scan has finished to make sure as many as possible are found

--- a/src/src/ESPEasyCore/ESPEasy_setup.cpp
+++ b/src/src/ESPEasyCore/ESPEasy_setup.cpp
@@ -392,7 +392,7 @@ void ESPEasy_setup()
     WiFi_AP_Candidates.clearCache();
     WiFi_AP_Candidates.load_knownCredentials();
     setSTA(true);
-    if (!WiFi_AP_Candidates.hasKnownCredentials()) {
+    if (!WiFi_AP_Candidates.hasCandidateCredentials()) {
       WiFiEventData.wifiSetup = true;
       RTC.clearLastWiFi(); // Must scan all channels
       // Wait until scan has finished to make sure as many as possible are found

--- a/src/src/Helpers/WiFi_AP_CandidatesList.cpp
+++ b/src/src/Helpers/WiFi_AP_CandidatesList.cpp
@@ -197,9 +197,9 @@ WiFi_AP_Candidate WiFi_AP_CandidatesList::getBestCandidate() const {
   return WiFi_AP_Candidate();
 }
 
-bool WiFi_AP_CandidatesList::hasKnownCredentials() {
+bool WiFi_AP_CandidatesList::hasCandidateCredentials() {
   load_knownCredentials();
-  return !known.empty();
+  return !candidates.empty();
 }
 
 bool WiFi_AP_CandidatesList::hasCandidates() const {

--- a/src/src/Helpers/WiFi_AP_CandidatesList.h
+++ b/src/src/Helpers/WiFi_AP_CandidatesList.h
@@ -50,7 +50,7 @@ struct WiFi_AP_CandidatesList {
 
   WiFi_AP_Candidate        getBestCandidate() const;
 
-  bool                     hasKnownCredentials();
+  bool                     hasCandidateCredentials();
 
   bool                     hasCandidates() const;
 

--- a/src/src/Helpers/_Plugin_init.cpp
+++ b/src/src/Helpers/_Plugin_init.cpp
@@ -2083,6 +2083,8 @@ constexpr const Plugin_ptr_t PROGMEM Plugin_ptr[] =
 #endif // ifdef USES_P255
 };
 
+bool _Plugin_init_setupDone = false;
+
 
 constexpr size_t DeviceIndex_to_Plugin_id_size = NR_ELEMENTS(DeviceIndex_to_Plugin_id);
 
@@ -2174,7 +2176,7 @@ deviceIndex_t getDeviceIndex_from_PluginID(pluginID_t pluginID)
 
 pluginID_t getPluginID_from_DeviceIndex(deviceIndex_t deviceIndex)
 {
-  if (deviceIndex < DeviceIndex_to_Plugin_id_size)
+  if (validDeviceIndex_init(deviceIndex))
   {
     return pluginID_t::toPluginID(pgm_read_byte(DeviceIndex_to_Plugin_id + deviceIndex.value));
   }
@@ -2183,13 +2185,16 @@ pluginID_t getPluginID_from_DeviceIndex(deviceIndex_t deviceIndex)
 
 bool validDeviceIndex_init(deviceIndex_t deviceIndex)
 {
-  return deviceIndex < DeviceIndex_to_Plugin_id_size;
+  if (_Plugin_init_setupDone) {
+    return deviceIndex < DeviceIndex_to_Plugin_id_size;
+  }
+  return false;
 }
 
 // Array containing "DeviceIndex" alfabetically sorted.
 deviceIndex_t getDeviceIndex_sorted(deviceIndex_t deviceIndex)
 {
-  if (deviceIndex < DeviceIndex_to_Plugin_id_size) {
+  if (validDeviceIndex_init(deviceIndex)) {
     return DeviceIndex_sorted[deviceIndex.value];
   }
   return INVALID_DEVICE_INDEX;
@@ -2198,7 +2203,7 @@ deviceIndex_t getDeviceIndex_sorted(deviceIndex_t deviceIndex)
 
 boolean PluginCall(deviceIndex_t deviceIndex, uint8_t function, struct EventStruct *event, String& string)
 {
-  if (deviceIndex < DeviceIndex_to_Plugin_id_size)
+  if (validDeviceIndex_init(deviceIndex))
   {
     Plugin_ptr_t plugin_call = (Plugin_ptr_t)pgm_read_ptr(Plugin_ptr + deviceIndex.value);
     return plugin_call(function, event, string);
@@ -2208,10 +2213,9 @@ boolean PluginCall(deviceIndex_t deviceIndex, uint8_t function, struct EventStru
 
 void PluginSetup()
 {
-  static bool setupDone = false;
-  if (setupDone) return;
+  if (_Plugin_init_setupDone) return;
 
-  setupDone = true;
+  _Plugin_init_setupDone = true;
 
   for (size_t id = 0; id < Plugin_id_to_DeviceIndex_size; ++id)
   {


### PR DESCRIPTION
Resolves #4118
Resolves #4655 
Resolves #4873 

Bugfix: AP-mode wasn't started consistently, and some, mostly ESP8266, builds weren't starting AP mode at all on a fresh install.

Background: A check was done on the number of known credentials, instead of the number of APs with matching/recognized credentials.

TODO:
- [ ] Testing by issue-reporters