### PR TITLE
[CDN URL] Update fallback CDN path...

### DIFF
--- a/tools/pio/generate-compiletime-defines.py
+++ b/tools/pio/generate-compiletime-defines.py
@@ -62,9 +62,9 @@ def get_cdn_url_prefix():
                 tag = tag.replace('refs/tags/','@')
                 return "https://cdn.jsdelivr.net/gh/letscontrolit/ESPEasy{0}/static/".format(tag)
         except:
-            return 'https://cdn.jsdelivr.net/gh/letscontrolit/ESPEasy@mega-20231013/static/'
+            return 'https://cdn.jsdelivr.net/gh/letscontrolit/ESPEasy@mega/static/'
     except ImportError:
-        return 'https://cdn.jsdelivr.net/gh/letscontrolit/ESPEasy@mega-20231013/static/'
+        return 'https://cdn.jsdelivr.net/gh/letscontrolit/ESPEasy@mega/static/'
 
 
 


### PR DESCRIPTION
I changed the path to a more generic URL as suggested here: https://github.com/jsdelivr/jsdelivr/issues/18541