### PR TITLE
[I2C] Add Device flag for 100 kHz-only devices

### DIFF
--- a/src/_P007_PCF8591.ino
+++ b/src/_P007_PCF8591.ino
@@ -6,6 +6,7 @@
 // #######################################################################################################
 
 /** Changelog:
+ * 2023-11-24 tonhuisman: Add Device flag for I2CMax100kHz as this sensor won't work at 400 kHz
  * 2022-05-08 tonhuisman: Use ESPEasy core I2C functions where possible
  *                        Add support for use of the Analog output pin and 'analogout,<value>' command
  *                        Add configuration of all possible analog input modes
@@ -47,6 +48,7 @@ boolean Plugin_007(uint8_t function, struct EventStruct *event, String& string)
       Device[deviceCount].TimerOption        = true;
       Device[deviceCount].GlobalSyncOption   = true;
       Device[deviceCount].OutputDataType     = Output_Data_type_t::Simple;
+      Device[deviceCount].I2CMax100kHz       = true; // Max 100 kHz allowed/supported
       break;
     }
 

--- a/src/_P024_MLX90614.ino
+++ b/src/_P024_MLX90614.ino
@@ -5,6 +5,10 @@
 // #################################### Plugin 024: MLX90614 IR temperature I2C 0x5A)  ###############################################
 // #######################################################################################################
 
+/** Changelog:
+ * 2023-11-23 tonhuisman: Add Device flag for I2CMax100kHz as this sensor won't work at 400 kHz
+ * 2023-11-23 tonhuisman: Add Changelog
+*/
 
 # include "src/PluginStructs/P024_data_struct.h"
 
@@ -36,6 +40,7 @@ boolean Plugin_024(uint8_t function, struct EventStruct *event, String& string)
       Device[deviceCount].TimerOption        = true;
       Device[deviceCount].GlobalSyncOption   = true;
       Device[deviceCount].PluginStats        = true;
+      Device[deviceCount].I2CMax100kHz       = true; // Max 100 kHz allowed/supported
       break;
     }
 

--- a/src/_P117_SCD30.ino
+++ b/src/_P117_SCD30.ino
@@ -11,6 +11,7 @@
 
 // Changelog:
 //
+// 2023-11-24 tonhuisman: Add Device flag for I2CMax100kHz as this sensor won't work at 400 kHz
 // 2022-02-26 tonhuisman: Implement commands for get/set measurement interval, and a setting too. Bugfix.
 // 2022-02-26 tonhuisman: Implement commands for auto/manual CO2 calibration, and setting for auto calibration
 // 2021-11-20 tonhuisman: Implement multi-instance support (using PluginStruct)
@@ -56,6 +57,7 @@ boolean Plugin_117(uint8_t function, struct EventStruct *event, String& string)
       Device[deviceCount].TimerOption        = true;
       Device[deviceCount].GlobalSyncOption   = true;
       Device[deviceCount].PluginStats        = true;
+      Device[deviceCount].I2CMax100kHz       = true; // Max 100 kHz allowed/supported
       break;
     }
 

--- a/src/_P135_SCD4x.ino
+++ b/src/_P135_SCD4x.ino
@@ -6,6 +6,7 @@
 // #######################################################################################################
 
 /**
+ * 2023-11-23 tonhuisman: Add Device flag for I2CMax100kHz as this sensor won't work at 400 kHz
  * 2022-08-28 tonhuisman: Include 'CO2' in plugin name, to be in line with other CO2 plugins
  * 2022-08-24 tonhuisman: Removed [TESTING] tag
  * 2022-08-04 tonhuisman: Add forced recalibration subcommand scd4x,setfrc,<frcvalue>
@@ -49,6 +50,7 @@ boolean Plugin_135(uint8_t function, struct EventStruct *event, String& string)
       Device[deviceCount].TimerOption        = true;
       Device[deviceCount].GlobalSyncOption   = true;
       Device[deviceCount].PluginStats        = true;
+      Device[deviceCount].I2CMax100kHz       = true; // Max 100 kHz allowed/supported
 
       break;
     }

--- a/src/src/DataStructs/DeviceStruct.h
+++ b/src/src/DataStructs/DeviceStruct.h
@@ -93,6 +93,7 @@ struct __attribute__((__packed__)) DeviceStruct
                                      // (F.e.: M5Stack Core/Core2 needs to power the TFT before SPI can be started)
   bool TaskLogsOwnPeaks   : 1;       // When PluginStats is enabled, a call to PLUGIN_READ will also check for peaks. With this enabled, the plugin must call to check for peaks itself.
   bool I2CNoDeviceCheck   : 1;       // When enabled, NO I2C check will be done on the I2C address returned from PLUGIN_I2C_GET_ADDRESS function call
+  bool I2CMax100kHz       : 1;       // When enabled, the device is only able to handle 100 kHz bus-clock speed, shows warning and enables "Force Slow I2C speed" by default
 };
 
 

--- a/src/src/WebServer/DevicesPage.cpp
+++ b/src/src/WebServer/DevicesPage.cpp
@@ -147,6 +147,14 @@ void handle_devices() {
     {
       // change of device: cleanup old device and reset default settings
       setTaskDevice_to_TaskIndex(taskdevicenumber, taskIndex);
+      const deviceIndex_t DeviceIndex = getDeviceIndex(taskdevicenumber);
+
+      if (validDeviceIndex(DeviceIndex)) { 
+        const DeviceStruct& device = Device[DeviceIndex];
+        if ((device.Type == DEVICE_TYPE_I2C) && device.I2CMax100kHz) {      // 100 kHz-only I2C device?
+          bitWrite(Settings.I2C_Flags[taskIndex], I2C_FLAGS_SLOW_SPEED, 1); // Then: Enable Force Slow I2C speed checkbox by default
+        }
+      }
     }
     else if (taskdevicenumber != INVALID_PLUGIN_ID) // save settings
     {
@@ -936,7 +944,7 @@ void handle_devices_TaskSettingsPage(taskIndex_t taskIndex, uint8_t page)
           addPinConfig = false;
 
           if (Settings.TaskDeviceDataFeed[taskIndex] == 0) {
-            devicePage_show_I2C_config(taskIndex);
+            devicePage_show_I2C_config(taskIndex, DeviceIndex);
           }
       }
 
@@ -1130,7 +1138,7 @@ void devicePage_show_serial_config(taskIndex_t taskIndex)
 }
 #endif
 
-void devicePage_show_I2C_config(taskIndex_t taskIndex)
+void devicePage_show_I2C_config(taskIndex_t taskIndex, deviceIndex_t DeviceIndex)
 {
   struct EventStruct TempEvent(taskIndex);
 
@@ -1144,6 +1152,9 @@ void devicePage_show_I2C_config(taskIndex_t taskIndex)
 
   PluginCall(PLUGIN_WEBFORM_SHOW_I2C_PARAMS, &TempEvent, dummy);
   addFormCheckBox(F("Force Slow I2C speed"), F("taskdeviceflags0"), bitRead(Settings.I2C_Flags[taskIndex], I2C_FLAGS_SLOW_SPEED));
+  if (Device[DeviceIndex].I2CMax100kHz) {
+    addFormNote(F("This device is specified for max. 100 kHz operation!"));
+  }
 
   # if FEATURE_I2CMULTIPLEXER
 

--- a/src/src/WebServer/DevicesPage.h
+++ b/src/src/WebServer/DevicesPage.h
@@ -56,7 +56,7 @@ void devicePage_show_pin_config(taskIndex_t taskIndex, deviceIndex_t DeviceIndex
 void devicePage_show_serial_config(taskIndex_t taskIndex);
 #endif
 
-void devicePage_show_I2C_config(taskIndex_t taskIndex);
+void devicePage_show_I2C_config(taskIndex_t taskIndex, deviceIndex_t DeviceIndex);
 
 void devicePage_show_output_data_type(taskIndex_t taskIndex, deviceIndex_t DeviceIndex);
 


### PR DESCRIPTION
Resolves: #4888 

Features:
- Add device-flag for 100 kHz-only devices
  - Enable **Force Slow I2C speed** checkbox by default when *adding* the device
  - Show message when having such device that it should be using 100 kHz max I2C speed
- Updated documentation

100 kHz-Only devices:
- P007 - Analog input - PCF8591
- P024 - Environment - MLX90614
- P117 - Gases - SCD30 CO2, Humidity, Temperature
- P135 - Gases - CO2 SCD4x
