### PR TITLE
[Bugfix] [P159] Saving settings checkbox failed on ESP8266

### DIFF
--- a/src/_P159_LD2410.ino
+++ b/src/_P159_LD2410.ino
@@ -227,7 +227,7 @@ boolean Plugin_159(uint8_t function, struct EventStruct *event, String& string)
     case PLUGIN_WEBFORM_SAVE:
     {
       P159_SET_ENGINEERING_MODE(getFormItemInt(F("eng")));
-      P159_SET_UPDATE_DIFF_ONLY(isFormItemChecked(F("diff")) ? 1 : 0);
+      P159_SET_UPDATE_DIFF_ONLY(isFormItemChecked(F("diff")));
 
       P159_data_struct *P159_data = static_cast<P159_data_struct *>(getPluginTaskData(event->TaskIndex));
 


### PR DESCRIPTION
Resolves #4896 

Bugfix for the settings checkbox 'Generate Events only when changed' that wasn't being saved on ESP8266.