### PR TITLE
[ESPEasy p2p] Fix rejecting data from nodes running build < 20230505

### DIFF
--- a/src/_C013.cpp
+++ b/src/_C013.cpp
@@ -312,13 +312,13 @@ void C013_Receive(struct EventStruct *event) {
           //
           // If the node is not present in the nodes list (e.g. it had not announced itself in the last 10 minutes or announcement was missed)
           // Then we cannot be sure about its build.
-          bool mustMatchPluginID = false;
+          bool mustMatch = false;
           NodeStruct *sourceNode = Nodes.getNode(dataReply.sourceUnit);
           if (sourceNode != nullptr) {
-            mustMatchPluginID = sourceNode->build >= 20460;
+            mustMatch = sourceNode->build >= 20460;
           }
 
-          if (mustMatchPluginID && !dataReply.matchesPluginID(Settings.getPluginID_for_task(dataReply.destTaskIndex))) {
+          if (mustMatch && !dataReply.matchesPluginID(Settings.getPluginID_for_task(dataReply.destTaskIndex))) {
             // Mismatch in plugin ID from sending node
             if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
               String log = concat(F("P2P data : PluginID mismatch for task "), dataReply.destTaskIndex + 1);
@@ -333,7 +333,7 @@ void C013_Receive(struct EventStruct *event) {
 
             const Sensor_VType sensorType = TempEvent.getSensorType();
 
-            if (dataReply.matchesSensorType(sensorType)) {
+            if (!mustMatch || dataReply.matchesSensorType(sensorType)) {
               TaskValues_Data_t *taskValues = UserVar.getTaskValues_Data(dataReply.destTaskIndex);
 
               if (taskValues != nullptr) {

--- a/src/_C013.cpp
+++ b/src/_C013.cpp
@@ -306,7 +306,19 @@ void C013_Receive(struct EventStruct *event) {
 
         if ((remoteFeed != 0) && (remoteFeed == dataReply.sourceUnit))
         {
-          if (!dataReply.matchesPluginID(Settings.getPluginID_for_task(dataReply.destTaskIndex))) {
+          // deviceNumber and sensorType were not present before build 2023-05-05. (build NR 20460)
+          // See: https://github.com/letscontrolit/ESPEasy/commit/cf791527eeaf31ca98b07c45c1b64e2561a7b041#diff-86b42dd78398b103e272503f05f55ee0870ae5fb907d713c2505d63279bb0321
+          // Thus should not be checked
+          //
+          // If the node is not present in the nodes list (e.g. it had not announced itself in the last 10 minutes or announcement was missed)
+          // Then we cannot be sure about its build.
+          bool mustMatchPluginID = false;
+          NodeStruct *sourceNode = Nodes.getNode(dataReply.sourceUnit);
+          if (sourceNode != nullptr) {
+            mustMatchPluginID = sourceNode->build >= 20460;
+          }
+
+          if (mustMatchPluginID && !dataReply.matchesPluginID(Settings.getPluginID_for_task(dataReply.destTaskIndex))) {
             // Mismatch in plugin ID from sending node
             if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
               String log = concat(F("P2P data : PluginID mismatch for task "), dataReply.destTaskIndex + 1);

--- a/src/src/DataStructs/C013_p2p_dataStructs.h
+++ b/src/src/DataStructs/C013_p2p_dataStructs.h
@@ -48,6 +48,10 @@ struct C013_SensorDataStruct
   uint8_t           destUnit        = 0;
   taskIndex_t       sourceTaskIndex = INVALID_TASK_INDEX;
   taskIndex_t       destTaskIndex   = INVALID_TASK_INDEX;
+
+  // deviceNumber and sensorType were not present before build 2023-05-05. (build NR 20460)
+  // See: https://github.com/letscontrolit/ESPEasy/commit/cf791527eeaf31ca98b07c45c1b64e2561a7b041#diff-86b42dd78398b103e272503f05f55ee0870ae5fb907d713c2505d63279bb0321
+  // Thus should not be checked
   pluginID_t        deviceNumber    = INVALID_PLUGIN_ID;
   Sensor_VType      sensorType      = Sensor_VType::SENSOR_TYPE_NONE;
   TaskValues_Data_t values{};


### PR DESCRIPTION
In 20230505 build some extra data was added which was not present on older builds. However this data is being used as an extra check for validity of data.

So ESPEasy should not check for these on packets received from nodes running an older build.