### PR TITLE
[IR] Enable all protocols for ESP32 IR builds

### DIFF
--- a/tools/pio/ir_build_check.py
+++ b/tools/pio/ir_build_check.py
@@ -10,8 +10,12 @@ if "_IR_" in pioenv or "_IRext_" in pioenv:
     ir_defines=["-include src/CustomIR.h"]
     env.Append(BUILD_FLAGS=ir_defines)
   else:
-    if os.path.isfile('src/CustomIR-sample.h'):
-      print(" IR build detected. Using CustomIR-sample.h for defaults.")
-      ir_defines=["-include src/CustomIR-sample.h"] # Use as default settings
-      env.Append(BUILD_FLAGS=ir_defines)
+    # For all ESP32 IR builds enable all IR protocols, except when CustomIR.h is available (above)
+    if "_ESP32" in pioenv:
+      print("\n ESP32 IR build. See CustomIR-sample.h how to customize included IR protocols.\n Default: All protocols enabled.\n")
+    else:
+      if os.path.isfile('src/CustomIR-sample.h'):
+        print(" IR build detected. Using CustomIR-sample.h for defaults.")
+        ir_defines=["-include src/CustomIR-sample.h"] # Use as default settings
+        env.Append(BUILD_FLAGS=ir_defines)
 


### PR DESCRIPTION
From this [Forum thread](https://www.letscontrolit.com/forum/viewtopic.php?t=9994)

Feature:
- Include all IR protocols for ESP32 IR builds
- Still allow customization by creating a `CustomIR.h` file, as documented in `CustomIR-sample.h`