### PR TITLE
[Bugfix] Update bootstrap version for Sphinx to fix documentation menus

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -179,7 +179,7 @@ html_theme_options = {
 
     # Choose Bootstrap version.
     # Values: "3" (default) or "2" (in quotes)
-    'bootstrap_version': "3",
+    'bootstrap_version': "5",
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
Features:
- Update Sphinx `bootstrap` version to latest (5) to fix documentation issues

Since the upgrade to latest Sphinx documentation compiler, the drop-down menus no longer work as intended (errors in the browser console, some weird presentation)
