### PR TITLE
[Commands] Allow commands from external source to be queued (stack)

### DIFF
--- a/platformio_esp82xx_envs.ini
+++ b/platformio_esp82xx_envs.ini
@@ -349,20 +349,21 @@ build_unflags             = ${core312_platform.build_unflags}
 ; IR builds                                                           ;
 ; *********************************************************************
 
+; TD-er: disabled as it no longer fits in 1M builds
 
 ; Minimal IR: 1024k version --------------------------
 ; Build including IR libraries, including extended AC commands
 ; Minimal set of other plugins
-[env:minimal_IRext_ESP8266_1M]
-extends                   = esp8266_1M
-platform                  = ${ir.platform}
-platform_packages         = ${ir.platform_packages}
-lib_ignore                = ${ir.lib_ignore}  
-build_flags               = ${minimal_ir_extended.build_flags} 
-                            ${esp8266_1M.build_flags}
-build_unflags             = ${esp8266_1M_OTA.build_unflags} -DPLUGIN_BUILD_NORMAL_IR
-extra_scripts             = ${esp8266_1M.extra_scripts}
-                            pre:tools/pio/ir_build_check.py
+;[env:minimal_IRext_ESP8266_1M]
+;extends                   = esp8266_1M
+;platform                  = ${ir.platform}
+;platform_packages         = ${ir.platform_packages}
+;lib_ignore                = ${ir.lib_ignore}  
+;build_flags               = ${minimal_ir_extended.build_flags} 
+;                            ${esp8266_1M.build_flags}
+;build_unflags             = ${esp8266_1M_OTA.build_unflags} -DPLUGIN_BUILD_NORMAL_IR
+;extra_scripts             = ${esp8266_1M.extra_scripts}
+;                            pre:tools/pio/ir_build_check.py
 
 
 ; Minimal IR: 4096k version --------------------------

--- a/src/_C002.cpp
+++ b/src/_C002.cpp
@@ -159,7 +159,14 @@ bool CPlugin_002(CPlugin::Function function, struct EventStruct *event, String& 
                 mustSendEvent = true;
 
                 // Try plugin and internal
-                ExecuteCommand(x, EventValueSource::Enum::VALUE_SOURCE_MQTT, action.c_str(), true, true, false);
+                ExecuteCommandArgs args(
+                  x, 
+                  EventValueSource::Enum::VALUE_SOURCE_MQTT, 
+                  action.c_str(), 
+                  true, 
+                  true, 
+                  false);
+                ExecuteCommand(std::move(args), true);
               }
 
               if (mustSendEvent) {

--- a/src/_C005.cpp
+++ b/src/_C005.cpp
@@ -281,7 +281,7 @@ bool C005_parse_command(struct EventStruct *event) {
         eventQueue.addMove(std::move(cmd), true);
       }
     } else {
-      ExecuteCommand_all(EventValueSource::Enum::VALUE_SOURCE_MQTT, cmd.c_str());
+      ExecuteCommand_all({EventValueSource::Enum::VALUE_SOURCE_MQTT, std::move(cmd)}, true);
     }
   }
   return validTopic;

--- a/src/_C006.cpp
+++ b/src/_C006.cpp
@@ -100,7 +100,7 @@ bool CPlugin_006(CPlugin::Function function, struct EventStruct *event, String& 
         {
           cmd += event->String2; // Par2
         }
-        ExecuteCommand_all(EventValueSource::Enum::VALUE_SOURCE_MQTT, cmd.c_str());
+        ExecuteCommand_all({EventValueSource::Enum::VALUE_SOURCE_MQTT, std::move(cmd)}, true);
       }
       break;
     }

--- a/src/_C014.cpp
+++ b/src/_C014.cpp
@@ -862,31 +862,8 @@ bool CPlugin_014(CPlugin::Function function, struct EventStruct *event, String& 
               eventQueue.addMove(std::move(newEvent));
             }
           } else { // not an event
-            String log;
-            if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-              log = F("C014 :");
-            }
-
             // FIXME TD-er: Command is not parsed, should we call ExecuteCommand here?
-            if (ExecuteCommand_internal(EventValueSource::Enum::VALUE_SOURCE_MQTT, cmd.c_str())) {
-              if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-                log += F(" Internal Command: OK!");
-              }
-            } else if (PluginCall(PLUGIN_WRITE, &TempEvent, cmd)) {
-              if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-                log += F(" PluginCall: OK!");
-              }
-            } else {
-              remoteConfig(&TempEvent, cmd);
-
-              if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-                log += F(" Plugin/Internal command failed! remoteConfig?");
-              }
-            }
-
-            if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-              addLogMove(LOG_LEVEL_INFO, log);
-            }
+            ExecuteCommand_all_config({EventValueSource::Enum::VALUE_SOURCE_MQTT, std::move(cmd)}, true);
           }
         }
       }

--- a/src/src/Commands/ExecuteCommand.h
+++ b/src/src/Commands/ExecuteCommand.h
@@ -6,20 +6,65 @@
 #include "../DataTypes/EventValueSource.h"
 #include "../DataTypes/TaskIndex.h"
 
+#include <list>
+
+struct ExecuteCommandArgs {
+  ExecuteCommandArgs(EventValueSource::Enum source,
+                     const char            *Line);
+
+  ExecuteCommandArgs(EventValueSource::Enum source,
+                     const String         & Line);
+
+  ExecuteCommandArgs(EventValueSource::Enum source,
+                     String              && Line);
+
+
+  ExecuteCommandArgs(taskIndex_t            taskIndex,
+                     EventValueSource::Enum source,
+                     const char            *Line,
+                     bool                   tryPlugin,
+                     bool                   tryInternal,
+                     bool                   tryRemoteConfig);
+
+  ExecuteCommandArgs(taskIndex_t            taskIndex,
+                     EventValueSource::Enum source,
+                     const String         & Line,
+                     bool                   tryPlugin,
+                     bool                   tryInternal,
+                     bool                   tryRemoteConfig);
+
+  ExecuteCommandArgs(taskIndex_t            taskIndex,
+                     EventValueSource::Enum source,
+                     String              && Line,
+                     bool                   tryPlugin,
+                     bool                   tryInternal,
+                     bool                   tryRemoteConfig);
+
+  taskIndex_t            _taskIndex = INVALID_TASK_INDEX;
+  EventValueSource::Enum _source    = EventValueSource::Enum::VALUE_SOURCE_NOT_SET;
+  String                 _Line;
+  bool                   _tryPlugin       = false;
+  bool                   _tryInternal     = false;
+  bool                   _tryRemoteConfig = false;
+};
+
+extern std::list<ExecuteCommandArgs> ExecuteCommand_queue;
+
+bool processExecuteCommandQueue();
 
 // Execute command which may be plugin or internal commands
-bool ExecuteCommand_all(EventValueSource::Enum source,
-                        const char            *Line);
+bool ExecuteCommand_all(ExecuteCommandArgs&& args,
+                        bool                      addToQueue = false);
 
-bool ExecuteCommand_all_config(EventValueSource::Enum source,
-                               const char            *Line);
+bool ExecuteCommand_all_config(ExecuteCommandArgs&& args,
+                               bool                      addToQueue = false);
 
-bool ExecuteCommand_plugin_config(EventValueSource::Enum source,
-                                  const char            *Line);
+bool ExecuteCommand_plugin_config(ExecuteCommandArgs&& args,
+                                  bool                      addToQueue = false);
 
 
-bool ExecuteCommand_internal(EventValueSource::Enum source,
-                             const char            *Line);
+bool ExecuteCommand_internal(ExecuteCommandArgs&& args,
+                             bool                      addToQueue = false);
 
 
 bool ExecuteCommand(taskIndex_t            taskIndex,
@@ -27,7 +72,10 @@ bool ExecuteCommand(taskIndex_t            taskIndex,
                     const char            *Line,
                     bool                   tryPlugin,
                     bool                   tryInternal,
-                    bool                   tryRemoteConfig);
+                    bool                   tryRemoteConfig,
+                    bool                   addToQueue = false);
+
+bool ExecuteCommand(ExecuteCommandArgs&& args, bool addToQueue);
 
 
 #endif // ifndef COMMANDS_EXECUTECOMMAND_H

--- a/src/src/ESPEasyCore/ESPEasyRules.cpp
+++ b/src/src/ESPEasyCore/ESPEasyRules.cpp
@@ -979,9 +979,10 @@ void processMatchedRule(String& action, const String& event,
     }
 
     if (executeRestricted) {
-      ExecuteCommand_all(EventValueSource::Enum::VALUE_SOURCE_RULES_RESTRICTED, parseStringToEndKeepCase(action, 2).c_str());
+      ExecuteCommand_all({EventValueSource::Enum::VALUE_SOURCE_RULES_RESTRICTED, parseStringToEndKeepCase(action, 2)});
     } else {
-      ExecuteCommand_all(EventValueSource::Enum::VALUE_SOURCE_RULES, action.c_str());
+      // Use action.c_str() here as we need to preserve the action string.
+      ExecuteCommand_all({EventValueSource::Enum::VALUE_SOURCE_RULES, action.c_str()});
     }
     delay(0);
   }

--- a/src/src/ESPEasyCore/ESPEasy_Console_Port.cpp
+++ b/src/src/ESPEasyCore/ESPEasy_Console_Port.cpp
@@ -142,9 +142,10 @@ bool EspEasy_Console_Port::process_consoleInput(uint8_t SerialInByte)
     if (SerialInByteCounter != 0) {
       InputBuffer_Serial[SerialInByteCounter] = 0; // serial data completed
       addToSerialBuffer('>');
-      addToSerialBuffer(String(InputBuffer_Serial));
+      String cmd(InputBuffer_Serial);
+      addToSerialBuffer(cmd);
       addToSerialBuffer('\n');
-      ExecuteCommand_all(EventValueSource::Enum::VALUE_SOURCE_SERIAL, InputBuffer_Serial);
+      ExecuteCommand_all({EventValueSource::Enum::VALUE_SOURCE_SERIAL, std::move(cmd)}, true);
       SerialInByteCounter   = 0;
       InputBuffer_Serial[0] = 0; // serial data processed, clear buffer
       return true;

--- a/src/src/ESPEasyCore/ESPEasy_loop.cpp
+++ b/src/src/ESPEasyCore/ESPEasy_loop.cpp
@@ -2,6 +2,7 @@
 
 
 #include "../../ESPEasy-Globals.h"
+#include "../Commands/ExecuteCommand.h"
 #include "../DataStructs/TimingStats.h"
 #include "../ESPEasyCore/ESPEasyNetwork.h"
 #include "../ESPEasyCore/ESPEasyWifi_ProcessEvent.h"
@@ -162,11 +163,13 @@ void ESPEasy_loop()
   else
   {
     if (!UseRTOSMultitasking) {
-      // On ESP32 the schedule is executed on the 2nd core.
+      // On ESP32, when using RTOS multitasking, the schedule is executed in a separate RTOS task
       Scheduler.handle_schedule();
     }
   }
 
+  // Calls above may have received/generated commands for the command queue, thus need to process them.
+  processExecuteCommandQueue();
   backgroundtasks();
 
   if (readyForSleep()) {

--- a/src/src/Helpers/Networking.cpp
+++ b/src/src/Helpers/Networking.cpp
@@ -310,7 +310,7 @@ void checkUDP()
                   ));
             }
             #endif
-            ExecuteCommand_all(EventValueSource::Enum::VALUE_SOURCE_SYSTEM, &packetBuffer[0]);
+            ExecuteCommand_all({EventValueSource::Enum::VALUE_SOURCE_SYSTEM, &packetBuffer[0]}, true);
           }
           else
           {

--- a/src/src/Helpers/WebServer_commandHelper.cpp
+++ b/src/src/Helpers/WebServer_commandHelper.cpp
@@ -35,7 +35,7 @@ HandledWebCommand_result handle_command_from_web(EventValueSource::Enum source, 
   if (command_e == ESPEasy_cmd_e::NotMatched) {
     // For sure not an internal command, try plugin or remote config
     printToWeb = true;
-    handledCmd = ExecuteCommand_plugin_config(source, webrequest.c_str());
+    handledCmd = ExecuteCommand_plugin_config({source, webrequest.c_str()});
     sendOK     = false;
   } else {
     if ((command_e == ESPEasy_cmd_e::event) || (command_e == ESPEasy_cmd_e::asyncevent))
@@ -80,7 +80,7 @@ HandledWebCommand_result handle_command_from_web(EventValueSource::Enum source, 
     } 
     if (!handledCmd) {
       printToWeb = true;
-      handledCmd = ExecuteCommand_internal(source, webrequest.c_str());
+      handledCmd = ExecuteCommand_internal({source, webrequest.c_str()});
     }
   }
 

--- a/src/src/PluginStructs/P016_data_struct.cpp
+++ b/src/src/PluginStructs/P016_data_struct.cpp
@@ -223,7 +223,7 @@ void P016_data_struct::ExecuteCode(uint64_t Code, decode_type_t DecodeType, uint
         #  ifdef PLUGIN_016_DEBUG
         bool _success =
         #  endif // ifdef PLUGIN_016_DEBUG
-        ExecuteCommand_all(EventValueSource::Enum::VALUE_SOURCE_SYSTEM, CommandLines[i].Command);
+        ExecuteCommand_all({EventValueSource::Enum::VALUE_SOURCE_SYSTEM, CommandLines[i].Command}, true);
         #  ifdef PLUGIN_016_DEBUG
 
         if (loglevelActiveFor(LOG_LEVEL_INFO)) {

--- a/src/src/WebServer/CustomPage.cpp
+++ b/src/src/WebServer/CustomPage.cpp
@@ -137,7 +137,7 @@ bool handle_custom(const String& path) {
   String webrequest = webArg(F("cmd"));
 
   if (webrequest.length() > 0) {
-    ExecuteCommand_all_config(EventValueSource::Enum::VALUE_SOURCE_HTTP, webrequest.c_str());
+    ExecuteCommand_all_config({EventValueSource::Enum::VALUE_SOURCE_HTTP, webrequest.c_str()});
 
     // handle some update processes first, before returning page update...
     String dummy;

--- a/src/src/WebServer/RootPage.cpp
+++ b/src/src/WebServer/RootPage.cpp
@@ -123,7 +123,7 @@ void handle_root() {
       addHtml(F(
                 "OK. Please wait > 1 min and connect to Access point.<BR><BR>PW=configesp<BR>URL=<a href='http://192.168.4.1'>192.168.4.1</a>"));
       TXBuffer.endStream();
-      ExecuteCommand_internal(EventValueSource::Enum::VALUE_SOURCE_HTTP, sCommand.c_str());
+      ExecuteCommand_internal({EventValueSource::Enum::VALUE_SOURCE_HTTP, sCommand.c_str()}, true);
       return;
     }
   } else {

--- a/tools/pio/pre_custom_esp82xx_IR.py
+++ b/tools/pio/pre_custom_esp82xx_IR.py
@@ -29,6 +29,7 @@ else:
     "-DUSES_P002",  # ADC
     "-DUSES_P003",  # Generic Pulse Counter
     "-DUSES_P004",  # Dallas DS18b20
+    "-DUSES_P016",  # IR
     "-DUSES_P026",  # System info
     "-DUSES_P027",  # INA219
     "-DUSES_P028",  # BME280
@@ -41,7 +42,7 @@ else:
 #    "-DUSES_P059",  # Encoder
 #    "-DUSES_P080",  # Dallas iButton
     "-DUSES_P081",  # Cron
-    "-DUSES_P082",  # GPS
+#    "-DUSES_P082",  # GPS
 #   "-DUSES_P085",  # AcuDC24x
     "-DUSES_P098",  # PWM motor
 #   "-DUSES_P100",  # Pulse Counter - DS2423
@@ -60,13 +61,13 @@ else:
 #    "-DFEATURE_MDNS=1",
 #    "-DFEATURE_SD=1",
 #    "-DFEATURE_EXT_RTC=1",
-    "-DFEATURE_I2CMULTIPLEXER=1",
+    "-DFEATURE_I2CMULTIPLEXER=0",
     "-DFEATURE_TRIGONOMETRIC_FUNCTIONS_RULES=1",
 #    "-DFEATURE_CUSTOM_PROVISIONING=1",
 
     "-DFEATURE_ESPEASY_P2P=1",
 
-    "-DFEATURE_SETTINGS_ARCHIVE=1"
+    "-DFEATURE_SETTINGS_ARCHIVE=0"
   ]
 
 my_flags = env.ParseFlags(env['BUILD_FLAGS'])


### PR DESCRIPTION
To be a bit more friendly on the stack usage, we need to be able to queue commands so they can be processed directly from the loop() instead of deep in the processing of some plugin or controller code.

ToDo:
- [x] testing
- [ ] Verify with @uwekaditz and his P016 IR plugin PR.