### PR TITLE
[SPI Ethernet] Allow selecting RMII pins for SPI Ethernet

### DIFF
--- a/src/src/DataStructs_templ/SettingsStruct.cpp
+++ b/src/src/DataStructs_templ/SettingsStruct.cpp
@@ -955,6 +955,9 @@ template<unsigned int N_TASKS>
 bool SettingsStruct_tmpl<N_TASKS>::isEthernetPin(int8_t pin) const {
   #if FEATURE_ETHERNET
   if (pin < 0) return false;
+  if (isSPI_EthernetType(ETH_Phy_Type)) {
+    return false;
+  }
   if (NetworkMedium == NetworkMedium_t::Ethernet) {
     if (19 == pin) return true; // ETH TXD0
     if (21 == pin) return true; // ETH TX EN

--- a/src/src/Helpers/StringGenerator_GPIO.cpp
+++ b/src/src/Helpers/StringGenerator_GPIO.cpp
@@ -287,21 +287,30 @@ const __FlashStringHelper* getConflictingUse(int gpio, PinSelectPurpose purpose)
 
 
   #if FEATURE_ETHERNET
+  if (isSPI_EthernetType(Settings.ETH_Phy_Type)) {
+    if (includeEthernet && Settings.isEthernetPinOptional(gpio)) {
+      if (Settings.ETH_Pin_mdc_cs == gpio) { return F("Eth SPI CS"); }
 
-  if (Settings.isEthernetPin(gpio)) {
-    return F("Eth");
-  }
+      if (Settings.ETH_Pin_mdio_irq == gpio) { return F("Eth SPI IRQ"); }
 
-  if (includeEthernet && Settings.isEthernetPinOptional(gpio)) {
-    if (isGpioUsedInETHClockMode(Settings.ETH_Clock_Mode, gpio)) { return F("Eth Clock"); }
+      if (Settings.ETH_Pin_power_rst == gpio) { return F("Eth SPI RST"); }
+    }
+  } else {
+    if (Settings.isEthernetPin(gpio)) {
+      return F("Eth");
+    }
 
-    if (Settings.ETH_Pin_mdc_cs == gpio) { return F("Eth MDC"); }
+    if (includeEthernet && Settings.isEthernetPinOptional(gpio)) {
+      if (isGpioUsedInETHClockMode(Settings.ETH_Clock_Mode, gpio)) { return F("Eth Clock"); }
 
-    if (Settings.ETH_Pin_mdio_irq == gpio) { return F("Eth MDIO"); }
+      if (Settings.ETH_Pin_mdc_cs == gpio) { return F("Eth MDC"); }
 
-    if (Settings.ETH_Pin_power_rst == gpio) { return F("Eth Pwr"); }
+      if (Settings.ETH_Pin_mdio_irq == gpio) { return F("Eth MDIO"); }
 
-    return F("Eth");
+      if (Settings.ETH_Pin_power_rst == gpio) { return F("Eth Pwr"); }
+
+      return F("Eth");
+    }
   }
   #endif // if FEATURE_ETHERNET
 


### PR DESCRIPTION
As is required when using the M5Stack W5500 module on M5 Stack Core2