### PR TITLE
[SPI Ethernet] Fix concurrency issue with shared SPI bus for ETH/display

### DIFF
--- a/src/src/CustomBuild/ESPEasyDefaults.h
+++ b/src/src/CustomBuild/ESPEasyDefaults.h
@@ -255,18 +255,10 @@
 #define DEFAULT_ETH_PHY_TYPE             EthPhyType_t::notSet
 #endif
 #ifndef DEFAULT_ETH_PIN_MDC
-#ifdef ESP32_CLASSIC
-#define DEFAULT_ETH_PIN_MDC              23
-#else
 #define DEFAULT_ETH_PIN_MDC              -1
 #endif
-#endif
 #ifndef DEFAULT_ETH_PIN_MDIO
-#ifdef ESP32_CLASSIC
-#define DEFAULT_ETH_PIN_MDIO             18
-#else
 #define DEFAULT_ETH_PIN_MDIO             -1
-#endif
 #endif
 #ifndef DEFAULT_ETH_PIN_POWER
 #define DEFAULT_ETH_PIN_POWER            -1
@@ -275,11 +267,7 @@
 #define DEFAULT_ETH_CLOCK_MODE           EthClockMode_t::Ext_crystal_osc
 #endif
 #ifndef DEFAULT_NETWORK_MEDIUM
-  #if FEATURE_ETHERNET
-    #define DEFAULT_NETWORK_MEDIUM       NetworkMedium_t::Ethernet
-  #else
-    #define DEFAULT_NETWORK_MEDIUM       NetworkMedium_t::WIFI
-  #endif
+  #define DEFAULT_NETWORK_MEDIUM       NetworkMedium_t::WIFI
 #endif
 #ifndef DEFAULT_JSON_BOOL_WITHOUT_QUOTES
 #define DEFAULT_JSON_BOOL_WITHOUT_QUOTES false

--- a/src/src/DataStructs_templ/SettingsStruct.cpp
+++ b/src/src/DataStructs_templ/SettingsStruct.cpp
@@ -882,20 +882,24 @@ spi_host_device_t SettingsStruct_tmpl<N_TASKS>::getSPI_host() const
     switch (SPI_selection) {
       case SPI_Options_e::Vspi_Fspi:
       {
-        return VSPI_HOST;
+        #if CONFIG_IDF_TARGET_ESP32
+        return static_cast<spi_host_device_t>(VSPI);
+        #else
+        return static_cast<spi_host_device_t>(FSPI);
+        #endif
       }
 #ifdef ESP32_CLASSIC
       case SPI_Options_e::Hspi:
       {
-        return HSPI_HOST;
+        return static_cast<spi_host_device_t>(HSPI);
       }
 #endif
       case SPI_Options_e::UserDefined:
       {
         #if CONFIG_IDF_TARGET_ESP32
-        return VSPI_HOST;
+        return static_cast<spi_host_device_t>(VSPI);
         #else
-        return FSPI_HOST;
+        return static_cast<spi_host_device_t>(FSPI);
         #endif
       }
       case SPI_Options_e::None:
@@ -904,7 +908,11 @@ spi_host_device_t SettingsStruct_tmpl<N_TASKS>::getSPI_host() const
 
   }
   #if ESP_IDF_VERSION_MAJOR < 5
-  return SPI_HOST;
+  #if CONFIG_IDF_TARGET_ESP32
+  return static_cast<spi_host_device_t>(VSPI);
+  #else
+  return static_cast<spi_host_device_t>(FSPI);
+  #endif
   #else
   return spi_host_device_t::SPI_HOST_MAX;
   #endif

--- a/src/src/DataStructs_templ/SettingsStruct.cpp
+++ b/src/src/DataStructs_templ/SettingsStruct.cpp
@@ -565,9 +565,9 @@ void SettingsStruct_tmpl<N_TASKS>::clearMisc() {
 #ifdef ESP32
   // Ethernet related settings are never used on ESP8266
   ETH_Phy_Addr             = DEFAULT_ETH_PHY_ADDR;
-  ETH_Pin_mdc_cs              = DEFAULT_ETH_PIN_MDC;
-  ETH_Pin_mdio_irq             = DEFAULT_ETH_PIN_MDIO;
-  ETH_Pin_power_rst            = DEFAULT_ETH_PIN_POWER;
+  ETH_Pin_mdc_cs           = DEFAULT_ETH_PIN_MDC;
+  ETH_Pin_mdio_irq         = DEFAULT_ETH_PIN_MDIO;
+  ETH_Pin_power_rst        = DEFAULT_ETH_PIN_POWER;
   ETH_Phy_Type             = DEFAULT_ETH_PHY_TYPE;
   ETH_Clock_Mode           = DEFAULT_ETH_CLOCK_MODE;
 #endif

--- a/src/src/DataTypes/EthernetParameters.h
+++ b/src/src/DataTypes/EthernetParameters.h
@@ -44,7 +44,7 @@ enum class EthPhyType_t : uint8_t {
   KSZ8851 = 12,
 #endif
 #endif
-  notSet = 255
+  notSet = 127   // Might be processed in some code as int, uint8_t and int8_t
 };
 
 bool   isValid(EthPhyType_t phyType);

--- a/src/src/ESPEasyCore/ESPEasyEth.cpp
+++ b/src/src/ESPEasyCore/ESPEasyEth.cpp
@@ -184,6 +184,15 @@ bool ETHConnectRelaxed() {
       }
       // else 
       {
+#if ETH_SPI_SUPPORTS_CUSTOM
+        EthEventData.ethInitSuccess = ETH.begin( 
+          to_ESP_phy_type(Settings.ETH_Phy_Type),
+          Settings.ETH_Phy_Addr,
+          Settings.ETH_Pin_mdc_cs,
+          Settings.ETH_Pin_mdio_irq,
+          Settings.ETH_Pin_power_rst,
+          SPI);
+#else
         EthEventData.ethInitSuccess = ETH.begin( 
           to_ESP_phy_type(Settings.ETH_Phy_Type),
           Settings.ETH_Phy_Addr,
@@ -194,6 +203,7 @@ bool ETHConnectRelaxed() {
           static_cast<int>(Settings.SPI_SCLK_pin),
           static_cast<int>(Settings.SPI_MISO_pin),
           static_cast<int>(Settings.SPI_MOSI_pin));
+#endif
       }
     } else {
 # if CONFIG_ETH_USE_ESP32_EMAC

--- a/src/src/Helpers/ESPEasy_Storage.cpp
+++ b/src/src/Helpers/ESPEasy_Storage.cpp
@@ -337,14 +337,14 @@ bool BuildFixes()
   if (Settings.Build < 20108) {
 #ifdef ESP32
   // Ethernet related settings are never used on ESP8266
-    Settings.ETH_Phy_Addr   = DEFAULT_ETH_PHY_ADDR;
+    Settings.ETH_Phy_Addr      = DEFAULT_ETH_PHY_ADDR;
     Settings.ETH_Pin_mdc_cs    = DEFAULT_ETH_PIN_MDC;
-    Settings.ETH_Pin_mdio_irq   = DEFAULT_ETH_PIN_MDIO;
-    Settings.ETH_Pin_power_rst  = DEFAULT_ETH_PIN_POWER;
-    Settings.ETH_Phy_Type   = DEFAULT_ETH_PHY_TYPE;
-    Settings.ETH_Clock_Mode = DEFAULT_ETH_CLOCK_MODE;
+    Settings.ETH_Pin_mdio_irq  = DEFAULT_ETH_PIN_MDIO;
+    Settings.ETH_Pin_power_rst = DEFAULT_ETH_PIN_POWER;
+    Settings.ETH_Phy_Type      = DEFAULT_ETH_PHY_TYPE;
+    Settings.ETH_Clock_Mode    = DEFAULT_ETH_CLOCK_MODE;
 #endif
-    Settings.NetworkMedium  = DEFAULT_NETWORK_MEDIUM;
+    Settings.NetworkMedium     = DEFAULT_NETWORK_MEDIUM;
   }
   if (Settings.Build < 20109) {
     Settings.SyslogPort = 514;

--- a/src/src/Helpers/Hardware.cpp
+++ b/src/src/Helpers/Hardware.cpp
@@ -234,7 +234,9 @@ void hardwareInit()
       isValid(Settings.ETH_Phy_Type) && 
       isSPI_EthernetType(Settings.ETH_Phy_Type)) 
   {
+#if !ETH_SPI_SUPPORTS_CUSTOM
       tryInitSPI = false;
+#endif
   }
 #endif
 


### PR DESCRIPTION
SPI Ethernet does do funky stuff with initializing the SPI bus. It must be exclusive on that bus, or being handed an already initialized SPI bus for `ETH.begin()`