### PR TITLE
[Build] Allow FEATURE_SERVO for Custom builds with LIMIT_BUILD_SIZE set

### DIFF
--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -2568,10 +2568,12 @@ To create/register a plugin, you have to :
   #endif
   #define FEATURE_SETTINGS_ARCHIVE  0
 
+  #ifndef PLUGIN_BUILD_CUSTOM
   #ifdef FEATURE_SERVO
     #undef FEATURE_SERVO
   #endif
   #define FEATURE_SERVO 0
+  #endif
   #ifdef FEATURE_RTTTL
     #undef FEATURE_RTTTL
   #endif


### PR DESCRIPTION
From a [Forum question](https://www.letscontrolit.com/forum/viewtopic.php?t=10029)

Feature:
- When using `FEATURE_SERVO` in a Custom build that gets `LIMIT_BUILD_SIZE` applied, the Servo feature could not be enabled. This adds an exception for Custom builds.