### PR TITLE
[Bugfix] `%vcc%` variable isn't recognized

### DIFF
--- a/src/src/Helpers/SystemVariables.cpp
+++ b/src/src/Helpers/SystemVariables.cpp
@@ -481,7 +481,8 @@ SystemVariables::Enum SystemVariables::startIndex_beginWith(char beginchar)
     case 'r': return Enum::S_CR;
     case 's': return Enum::SPACE;
     case 'u': return Enum::UNIT_sysvar;
-    case 'v': return Enum::VARIABLE;
+    // case 'v': return Enum::VARIABLE; // Can not be the first 'v' variable, as the name is only 1 character long
+    case 'v': return Enum::VCC;
     case 'w': return Enum::WI_CH;
   }
 
@@ -596,8 +597,8 @@ const __FlashStringHelper * SystemVariables::toFlashString(SystemVariables::Enum
     case Enum::UNIXTIME:           return F("unixtime");
     case Enum::UPTIME:             return F("uptime");
     case Enum::UPTIME_MS:          return F("uptime_ms");
-    case Enum::VARIABLE:           return F("v");
     case Enum::VCC:                return F("vcc");
+    case Enum::VARIABLE:           return F("v"); // Can not be the first 'v' variable, as the name is only 1 character long
     case Enum::WI_CH:              return F("wi_ch");
 
     case Enum::UNKNOWN: break;

--- a/src/src/Helpers/SystemVariables.h
+++ b/src/src/Helpers/SystemVariables.h
@@ -113,8 +113,8 @@ public:
     UNIXTIME,
     UPTIME,
     UPTIME_MS,
-    VARIABLE,
     VCC,
+    VARIABLE, // Can not be the first 'v' variable, as the name is only 1 character long
     WI_CH,
 
 


### PR DESCRIPTION
Resolves #4971 

Bugfix:
- The `%vcc%` variable wasn't recognized because of optimization in finding the next variable