### PR TITLE
[IPv6] Reduce events to keep webserver alive

### DIFF
--- a/src/src/ESPEasyCore/ESPEasyEth_ProcessEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyEth_ProcessEvent.cpp
@@ -255,7 +255,7 @@ void processEthernetGotIPv6() {
       addLog(LOG_LEVEL_INFO, String(F("ETH event: Got IP6 ")) + EthEventData.unprocessed_IP6.toString(true));
     EthEventData.processedGotIP6 = true;
 #if FEATURE_ESPEASY_P2P
-    updateUDPport(true);
+    // updateUDPport(true);
 #endif
 
   }

--- a/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
+++ b/src/src/ESPEasyCore/ESPEasyWifi_ProcessEvent.cpp
@@ -466,7 +466,7 @@ void processGotIPv6() {
     if (loglevelActiveFor(LOG_LEVEL_INFO))
       addLog(LOG_LEVEL_INFO, String(F("WIFI : STA got IP6 ")) + WiFiEventData.unprocessed_IP6.toString(true));
 #if FEATURE_ESPEASY_P2P
-    updateUDPport(true);
+    // updateUDPport(true);
 #endif
   }
 }

--- a/src/src/WebServer/ESPEasy_WebServer.cpp
+++ b/src/src/WebServer/ESPEasy_WebServer.cpp
@@ -158,6 +158,11 @@ void sendHeadandTail_stdtemplate(bool Tail, bool rebooting) {
   */
     #endif // ifndef BUILD_NO_DEBUG
   }
+  // We have sent a lot of data at once.
+  // try to flush it to the connected client to free up some RAM 
+  // from pending transfers
+  TXBuffer.flush();
+  delay(10);
 }
 
 bool captivePortal() {


### PR DESCRIPTION
(Bug)fixes:
- This should keep the webserver alive, as after some time the unit seemed to be overloaded by (IPv6) events
- Reduce memory used by flushing buffer after sending web page (code by @TD-er )