### PR TITLE
[MQTT] Add PublishR command: publish with will-retain

### DIFF
--- a/docs/source/Plugin/P000_commands.repl
+++ b/docs/source/Plugin/P000_commands.repl
@@ -469,9 +469,15 @@
     "
     Publish","
     :green:`Rules`","
-    Send command using MQTT broker service. Uses the first enabled MQTT Controller.
+    Send command using MQTT broker service. The 'Will Retain' option as configured in the MQTT Controller settings is used. Uses the first enabled MQTT Controller.
 
     ``Publish,<topic>[,<payload>]``"
+    "
+    PublishR","
+    :green:`Rules`","
+    Send command using MQTT broker service, with the MQTT 'Will Retain' flag enabled. Uses the first enabled MQTT Controller.
+
+    ``PublishR,<topic>[,<payload>]``"
     "
     PutToHTTP","
     :green:`Rules`","

--- a/src/src/Commands/InternalCommands.cpp
+++ b/src/src/Commands/InternalCommands.cpp
@@ -383,6 +383,7 @@ bool InternalCommands::executeInternalCommand()
     case ESPEasy_cmd_e::pulse:                      COMMAND_CASE_A(Command_GPIO_Pulse,        3);                 // GPIO.h
 #if FEATURE_MQTT
     case ESPEasy_cmd_e::publish:                    COMMAND_CASE_A(Command_MQTT_Publish,     -1);                 // MQTT.h
+    case ESPEasy_cmd_e::publishr:                   COMMAND_CASE_A(Command_MQTT_PublishR,    -1);                 // MQTT.h
 #endif // if FEATURE_MQTT
 #if FEATURE_PUT_TO_HTTP
     case ESPEasy_cmd_e::puttohttp:                  COMMAND_CASE_A(Command_HTTP_PutToHTTP,  -1);                  // HTTP.h

--- a/src/src/Commands/InternalCommands_decoder.cpp
+++ b/src/src/Commands/InternalCommands_decoder.cpp
@@ -175,6 +175,7 @@ const char Internal_commands_p[] PROGMEM =
   "pulse|"
 #if FEATURE_MQTT
   "publish|"
+  "publishr|"
 #endif // #if FEATURE_MQTT
 #if FEATURE_PUT_TO_HTTP
   "puttohttp|"

--- a/src/src/Commands/InternalCommands_decoder.h
+++ b/src/src/Commands/InternalCommands_decoder.h
@@ -143,6 +143,7 @@ enum class ESPEasy_cmd_e : uint8_t {
   pulse,
 #if FEATURE_MQTT
   publish,
+  publishr,
 #endif // #if FEATURE_MQTT
 #if FEATURE_PUT_TO_HTTP
   puttohttp,

--- a/src/src/Commands/MQTT.cpp
+++ b/src/src/Commands/MQTT.cpp
@@ -21,7 +21,15 @@
 #include "../Helpers/StringConverter.h"
 
 
-const __FlashStringHelper * Command_MQTT_Publish(struct EventStruct *event, const char *Line)
+const __FlashStringHelper* Command_MQTT_Publish(struct EventStruct *event, const char *Line) {
+  return Command_MQTT_Publish_handler(event, Line, false);
+}
+
+const __FlashStringHelper* Command_MQTT_PublishR(struct EventStruct *event, const char *Line) {
+  return Command_MQTT_Publish_handler(event, Line, true);
+}
+
+const __FlashStringHelper* Command_MQTT_Publish_handler(struct EventStruct *event, const char *Line, const bool forceRetain)
 {
   // ToDo TD-er: Not sure about this function, but at least it sends to an existing MQTTclient
   controllerIndex_t enabledMqttController = firstEnabledMQTT_ControllerIndex();
@@ -34,13 +42,13 @@ const __FlashStringHelper * Command_MQTT_Publish(struct EventStruct *event, cons
   const String topic = parseStringKeepCase(Line, 2);
   const String value = tolerantParseStringKeepCase(Line, 3);
   # ifndef BUILD_NO_DEBUG
-  addLog(LOG_LEVEL_DEBUG, concat(F("Publish: "), topic) + value);
-  #endif
+  addLog(LOG_LEVEL_DEBUG, strformat(F("Publish%s: %s:%s"), forceRetain ? F("R") : F(""), topic.c_str(), value.c_str()));
+  # endif
 
   if (!topic.isEmpty()) {
 
-    bool mqtt_retainFlag;
-    {
+    bool mqtt_retainFlag = forceRetain;
+    if (!forceRetain) {
       // Place the ControllerSettings in a scope to free the memory as soon as we got all relevant information.
       MakeControllerSettings(ControllerSettings); //-V522
       if (!AllocatedControllerSettings()) {

--- a/src/src/Commands/MQTT.cpp
+++ b/src/src/Commands/MQTT.cpp
@@ -42,7 +42,7 @@ const __FlashStringHelper* Command_MQTT_Publish_handler(struct EventStruct *even
   const String topic = parseStringKeepCase(Line, 2);
   const String value = tolerantParseStringKeepCase(Line, 3);
   # ifndef BUILD_NO_DEBUG
-  addLog(LOG_LEVEL_DEBUG, strformat(F("Publish%s: %s:%s"), forceRetain ? F("R") : F(""), topic.c_str(), value.c_str()));
+  addLog(LOG_LEVEL_DEBUG, strformat(F("Publish%c: %s:%s"), forceRetain ? 'R' : ' ', topic.c_str(), value.c_str()));
   # endif
 
   if (!topic.isEmpty()) {

--- a/src/src/Commands/MQTT.h
+++ b/src/src/Commands/MQTT.h
@@ -5,11 +5,16 @@
 
 #if FEATURE_MQTT
 
-const __FlashStringHelper * Command_MQTT_Publish(struct EventStruct *event,
-                            const char         *Line);
+const __FlashStringHelper* Command_MQTT_Publish(struct EventStruct *event,
+                                                const char         *Line);
+const __FlashStringHelper* Command_MQTT_PublishR(struct EventStruct *event,
+                                                 const char         *Line);
+const __FlashStringHelper* Command_MQTT_Publish_handler(struct EventStruct *event,
+                                                        const char         *Line,
+                                                        const bool          forceRetain);
 
-const __FlashStringHelper * Command_MQTT_Subscribe(struct EventStruct *event,
-                              const char* Line);
+const __FlashStringHelper* Command_MQTT_Subscribe(struct EventStruct *event,
+                                                  const char         *Line);
 
 #endif // if FEATURE_MQTT
 


### PR DESCRIPTION
Resolves #1718 
Resolves #967 

Features:
- Add command `PublishR,<topic>,<value>` to send a value to a topic on the first enabled MQTT Controller
  _with the Will Retain flag enabled_
- Updated documentation

