### PR TITLE
[Build] Add ESP32-C6 MAX builds (preliminary)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ ESPEasy_mega-20230822_max_ESP32s3_8M1M_LittleFS_OPI_PSRAM_CDC.bin | ESP32-S3 8MB
 ESPEasy_mega-20230822_max_ESP32_16M1M.bin                         | ESP32 with 16MB flash                 | All available plugins            |
 ESPEasy_mega-20230822_max_ESP32_16M8M_LittleFS.bin                | ESP32 with 16MB flash                 | All available plugins            |
 
-NB: Since 2023-05-10 the binary files for the different ESP32 variants (S2, C3, S3, 'Classic') are available in separate archives.
+The binary files for the different ESP32 variants (S2, C3, S3, C2, C6, 'Classic') are available in separate archives.
 
 To see what plugins are included in which collection set, you can find that on the [ESPEasy Plugin overview page](https://espeasy.readthedocs.io/en/latest/Plugin/_Plugin.html)
 

--- a/boards/esp32c6cdc-16M.json
+++ b/boards/esp32c6cdc-16M.json
@@ -1,0 +1,40 @@
+{
+    "build": {
+      "arduino":{
+        "ldscript": "esp32c6_out.ld"
+      },
+      "core": "esp32",
+      "extra_flags": "-DARDUINO_TASMOTA -DARDUINO_USB_MODE=1 -DUSE_USB_CDC_CONSOLE -DESP32_16M -DESP32C6 -DARDUINO_USB_CDC_ON_BOOT=1",
+      "f_cpu": "160000000L",
+      "f_flash": "80000000L",
+      "flash_mode": "qio",
+      "mcu": "esp32c6",
+      "variant": "esp32c6",
+      "partitions": "boards/partitions/esp32_partition_app4096k_spiffs8124k.csv"
+    },
+    "connectivity": [
+      "wifi",
+      "bluetooth"
+    ],
+    "debug": {
+      "default_tool": "esp-builtin",
+      "onboard_tools": [
+        "esp-builtin"
+      ],
+      "openocd_target": "esp32c6.cfg"
+    },
+    "frameworks": [
+      "arduino",
+      "espidf"
+    ],
+    "name": "Espressif Generic ESP32-C6 16M Flash, ESPEasy 4096k Code/OTA 8M FS",
+    "upload": {
+      "flash_size": "16MB",
+      "maximum_ram_size": 327680,
+      "maximum_size": 16777216,
+      "require_upload_port": true,
+      "speed": 460800
+    },
+    "url": "https://docs.espressif.com/projects/espressif-esp-dev-kits/en/latest/esp32c6/esp32-c6-devkitc-1/index.html",
+    "vendor": "Espressif"
+  }

--- a/boards/esp32c6cdc-8M.json
+++ b/boards/esp32c6cdc-8M.json
@@ -1,0 +1,40 @@
+{
+    "build": {
+      "arduino":{
+        "ldscript": "esp32c6_out.ld"
+      },
+      "core": "esp32",
+      "extra_flags": "-DARDUINO_TASMOTA -DARDUINO_USB_MODE=1 -DUSE_USB_CDC_CONSOLE -DESP32_8M -DESP32C6 -DARDUINO_USB_CDC_ON_BOOT=1",
+      "f_cpu": "160000000L",
+      "f_flash": "80000000L",
+      "flash_mode": "qio",
+      "mcu": "esp32c6",
+      "variant": "esp32c6",
+      "partitions": "boards/partitions/esp32_partition_app3520k_spiffs1088k.csv"
+    },
+    "connectivity": [
+      "wifi",
+      "bluetooth"
+    ],
+    "debug": {
+      "default_tool": "esp-builtin",
+      "onboard_tools": [
+        "esp-builtin"
+      ],
+      "openocd_target": "esp32c6.cfg"
+    },
+    "frameworks": [
+      "arduino",
+      "espidf"
+    ],
+    "name": "Espressif Generic ESP32-C6 >= 8M Flash, ESPEasy 3520k Code/OTA 1088k FS",
+    "upload": {
+      "flash_size": "8MB",
+      "maximum_ram_size": 327680,
+      "maximum_size": 8388608,
+      "require_upload_port": true,
+      "speed": 460800
+    },
+    "url": "https://docs.espressif.com/projects/espressif-esp-dev-kits/en/latest/esp32c6/esp32-c6-devkitc-1/index.html",
+    "vendor": "Espressif"
+  }

--- a/docs/source/ESPEasy/ESPchips.rst
+++ b/docs/source/ESPEasy/ESPchips.rst
@@ -328,7 +328,7 @@ ESPEasy does support a number of variants of the processors manufactured by Espr
       - 0
    *  - Ethernet
       - 0
-      - 1 (RMII)
+      - 1 (RMII and SPI)
       - 1 (SPI)
       - 1 (SPI)
       - 1 (SPI)
@@ -700,7 +700,7 @@ Added: 2023/11/10
 
 The ESP32-C6 seems to be aimed at being used as a gateway for the new Thread protocol and Wi-Fi.
 
-It is the more powerful version of the ESP32-H2 and also includes not only the traditional 2.4 GHz Wi-Fi, but also the new Wi-Fi6 standard on 2.4 GHz and IEEE 802.15.4 (Zigbee/Thread).
+It is the more powerful version of the ESP32-H2 and also includes not only the traditional 2.4 GHz Wi-Fi, but also the new Wi-Fi6 standard on 2.4 GHz and IEEE 802.15.4 (Zigbee/Thread). Zigbee/Thread not yet supported by ESPEasy (March 2024).
 
 .. note:: Labeled as "unstable" by the Arduino team (as of Nov 2023), preliminary support in ESPEasy
 

--- a/docs/source/ESPEasy/ESPchips.rst
+++ b/docs/source/ESPEasy/ESPchips.rst
@@ -10,8 +10,8 @@ ESPEasy does support a number of variants of the processors manufactured by Espr
 * **ESP32-S2** Has more GPIO pins than the ESP32, but only 1 CPU core. Initial support in ESPEasy added since 2021-09-19.
 * **ESP32-S3** Support added: 2023-05-03
 * **ESP32-C3 / ESP8685** Support added: 2023-05-03
-* **ESP32-C2 / ESP8684** Not yet supported
-* **ESP32-C6** Not yet supported
+* **ESP32-C2 / ESP8684** Support added: 2023-11-10
+* **ESP32-C6** Support added: 2023-11-10
 * **ESP32-H2** Not yet supported
 
 
@@ -83,7 +83,7 @@ ESPEasy does support a number of variants of the processors manufactured by Espr
       - 2022
       - 2021
       - 2021
-   *  - Status (2023/05)
+   *  - Status (2024/03)
       - NRND
       - Mass Production (solo1: NRND)
       - NRND
@@ -91,7 +91,7 @@ ESPEasy does support a number of variants of the processors manufactured by Espr
       - Mass Production
       - Mass Production
       - Mass Production
-      - Sample
+      - Mass Production
    *  - Wi-Fi
       - IEEE 802.11 b/g/n; 2.4 GHz; HT20; up to 72 Mbps
       - IEEE 802.11 b/g/n; 2.4 GHz; HT20/40; up to 150 Mbps
@@ -329,11 +329,11 @@ ESPEasy does support a number of variants of the processors manufactured by Espr
    *  - Ethernet
       - 0
       - 1 (RMII)
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
+      - 1 (SPI)
+      - 1 (SPI)
+      - 1 (SPI)
+      - 1 (SPI)
+      - 1 (SPI)
       - 0
    *  - TWAI (CAN)
       - 0
@@ -683,7 +683,7 @@ ESP32-C2/ESP8684
 
 Added: 2023/11/10
 
-The ESP32-C2 is only available with embedded flash and can only be found labelled as "ESP8684".
+The ESP32-C2 is only available with embedded flash and can also be found labeled as "ESP8684".
 
 It looks like it is aimed to be used in single purpose devices, due to its low GPIO count and only requiring a bare minimum of external parts.
 
@@ -700,9 +700,9 @@ Added: 2023/11/10
 
 The ESP32-C6 seems to be aimed at being used as a gateway for the new Thread protocol and Wi-Fi.
 
-It is the more powerful version of the ESP32-H2 and also includes not only the traditional 2.4 GHz Wi-Fi, but also the new Wi-Fi6 standard on 2.4 GHz.
+It is the more powerful version of the ESP32-H2 and also includes not only the traditional 2.4 GHz Wi-Fi, but also the new Wi-Fi6 standard on 2.4 GHz and IEEE 802.15.4 (Zigbee/Thread).
 
-.. note:: Labelled as "unstable" by the Arduino team (as of Nov 2023), preliminary support in ESPEasy
+.. note:: Labeled as "unstable" by the Arduino team (as of Nov 2023), preliminary support in ESPEasy
 
 ESP32-H2
 ========

--- a/docs/source/Participate/ProjectStructure.rst
+++ b/docs/source/Participate/ProjectStructure.rst
@@ -29,7 +29,7 @@ Below a list of the most important directories and files used in this project.
 * ``platformio.ini``  Configuration file for PlatformIO to define various build setups.
 * ``uncrustify.cfg``  Configuration file for Uncrustify, to format source code using some uniform formatting rules.
 * ``requirements.txt``  List of used Python libraries and their version (result of ``pip freeze`` with Virtual env active)
-* ``esp32_partition_app1810k_spiffs316k.csv`` Used partition layout in ESP32 builds.
+* ``boards/partitions/esp32_partition_app1810k_spiffs316k.csv`` Used partition layout in ESP32 4M builds.
 
 
 ESPEasy src dir
@@ -90,11 +90,11 @@ The filename is quite descriptive:
 Build Type
 ----------
 
-Build type can be:  (differ in included plugins)
+Build type can be:  (differences in included plugins)
 
-* normal  => Only Stable plugins and controllers
-* test    => Stable + Testing (split into multiple sets, A/B/C/D)
-* max     => All available plugins
+* normal     => Only Stable plugins and controllers
+* collection => Stable + Collection (split into multiple sets, A/B/C/D/E/F/G)
+* max        => All available plugins and features
 
 There is also a number of special builds:
 
@@ -111,8 +111,10 @@ ESP Chip Type
 * ``ESP8285`` Supported in ``ESP8266`` builds. Used in some Sonoff modules. This chip has embedded flash, so no extra flash chip.
 * ``ESP32``   Allows for more memory and more GPIO pins.
 * ``ESP32-S2`` Newer version of ESP32. Has even more GPIO pins, but some specific features of ESP32 were removed.
-* ``ESP32-S3`` Not yet available.
-* ``ESP32-C3`` Support will be added soon.
+* ``ESP32-S3`` Newer version of ESP32 and ESP32-S2. Has even more GPIO pins, some specific features of ESP32 were removed, and some design choices of ESP32-S2 are reverted and implemented differently.
+* ``ESP32-C2`` Preliminary supported. Cheaper variant of ESP32-C3, and also an ESP8266 replacement. Available as pin-compatible module for ESP8266. Single core, and max 120 MHz clock speed.
+* ``ESP32-C3`` Intended as a replacement for ESP8266, using ESP32 technology, though single-core and with limited clock speed (160 MHz, some models 120 MHz).
+* ``ESP32-C6`` Preliminary supported. Will allow connectivity with IEEE 802.15.4 (Thread/Zigbee) wireless protocol.
 
 Memory Size and Partitioning
 ----------------------------
@@ -124,23 +126,27 @@ Memory Size and Partitioning
 * ``4M1M`` 4 MB flash modules with 1 MB filesystem (usually SPIFFS)
 * ``4M2M`` 4 MB flash modules with 2 MB filesystem (usually SPIFFS)
 * ``4M316k`` 4 MB flash modules using 1.8 MB sketch size, with 316 kB filesystem (usually SPIFFS) (for ESP32)
+* ``8M1M`` 8 MB flash modules using 3.5MB sketch size, with 1 MB filesystem (LittleFS) (ESP32 only a.t.m.)
 * ``16M1M`` 16 MB flash modules using 4MB sketch size, with 1 MB filesystem (usually SPIFFS) (ESP32 only a.t.m.)
-* ``16M2M`` 16 MB flash modules using 4MB sketch size, with 2 MB filesystem (LittleFS) (ESP32 only a.t.m.)
 * ``16M8M`` 16 MB flash modules using 4MB sketch size, with 8 MB filesystem (LittleFS) (ESP32 only a.t.m.)
 
 Optional build options
 ----------------------
 
-* ``LittleFS`` Use LittleFS instead of SPIFFS filesystem (SPIFFS is unstable > 2 MB)
+* ``LittleFS`` Use LittleFS instead of SPIFFS filesystem (SPIFFS is unstable \> 2 MB and no longer available from IDF 5.x)
 * ``VCC`` Analog input configured to measure VCC voltage
 * ``OTA`` Arduino OTA (Over The Air) update feature enabled
 * ``Domoticz`` Only Domoticz controllers (HTTP+MQTT) and plugins included
 * ``FHEM_HA`` Only FHEM/OpenHAB/Home Assistant (MQTT) controllers and plugins included
 * ``lolin_d32_pro`` Specific Lolin hardware options enabled
+* ``PSRAM`` Additional PSRAM support (ESP32 only)
+* ``OPI`` Flash via OPI protocol support (ESP32 only)
+* ``QIO`` Flash via QIO protocol support (ESP32 only)
+* ``CDC`` CDC Serial (built-in USB) support (ESP32 only)
 * ``ETH`` Ethernet interface enabled (ESP32 only)
 
 
-Please note that the performance of 14MB SPIFFS (16M flash modules) is really slow.
+Please note that the performance of 14MB SPIFFS (16M flash ESP8266 modules) is really slow.
 All file access takes a lot longer and since the settings are also read from flash, the entire node will perform slower.
 See `Arduino issue - SPIFFS file access slow on 16/14M flash config <https://github.com/esp8266/Arduino/issues/5932>`_
 
@@ -150,7 +156,7 @@ Special memory partitioning:
 
 * ``2M256``  2 MB flash modules (e.g. Shelly1/WROOM02) with 256k SPIFFS (only core 2.5.0 or newer)
 * ``4M316k`` For ESP32 with 4MB flash, sketch size is set to 1.8 MByte (default: 1.4 MByte)
-* ``4M1M``   4MB flash, 1 MB SPIFFS. Default layout for 4MB flash.
+* ``4M1M``   4MB flash, 1 MB SPIFFS. Default layout for ESP8266 4MB flash.
 * ``4M2M``   4MB flash, 2 MB SPIFFS. Introduced in October 2019. Only possible with core 2.5.2 or newer.
 
 .. warning::
@@ -165,7 +171,7 @@ Difference between .bin and .bin.gz
 
 Starting on esp8266/Arduino core 2.7.0, it is possible to flash images that have been compressed using GZip.
 
-Please note that this only can be used on installs already running a very recent build.
+Please note that this only can be used on installs already running a recent build.
 
 This also means we still need to update the 2-step updater to support .bin.gz files.
 
@@ -182,17 +188,17 @@ There are several builds for ESP32:
 * ``normal_ESP32_4M316k``  Build using the "stable" set of plugins for ESP32
 * ``normal_ESP32_4M316k_ETH``  Build using the "stable" set of plugins for ESP32, with support for an on-board Ethernet controller
 * ``custom_ESP32_4M316k``  Build template using either the plugin set defined in ``Custom.h`` or ``tools/pio/pre_custom_esp32.py``
-* ``test_A_ESP32_4M316k``  Build using the "testing" set "A" of plugins for ESP32
-* ``test_B_ESP32_4M316k``  Build using the "testing" set "B" of plugins for ESP32
-* ``test_C_ESP32_4M316k``  Build using the "testing" set "C" of plugins for ESP32
-* ``test_D_ESP32_4M316k``  Build using the "testing" set "D" of plugins for ESP32
-* ``test_A_ESP32-wrover-kit_4M316k``  A build for ESP32 including build flags for the official WRover test kit.
+* ``collection_A_ESP32_4M316k``  Build using the "Collection" set "A" of plugins for ESP32
+* ``collection_B_ESP32_4M316k``  Build using the "Collection" set "B" of plugins for ESP32
+* ``collection_C_ESP32_4M316k``  Build using the "Collection" set "C" of plugins for ESP32
+* ``collection_D_ESP32_4M316k``  Build using the "Collection" set "D" of plugins for ESP32
+* ``collection_A_ESP32-wrover-kit_4M316k``  A build for ESP32 including build flags for the official WRover test kit.
 * ``max_ESP32_16M8M_LittleFS``  Build using all available plugins and controllers for ESP32 with 16 MB flash (some lolin_d32_pro boards)
 
 Since ESP32 does have its flash partitioned in several blocks, we have 2 bin files of each ESP32 build, f.e.:
 
-* ``test_D_ESP32_4M316k.bin`` Use for OTA upgrades.
-* ``test_D_ESP32_4M316k.factory.bin`` Use on clean nodes as initial inistall.
+* ``collection_D_ESP32_4M316k.bin`` Use for OTA upgrades.
+* ``collection_D_ESP32_4M316k.factory.bin`` Use on clean nodes as initial inistall.
 
 The binary with ``.factory`` in the name must be flashed on a new node, via the serial interface of the board.
 This flash must be started at address 0.
@@ -208,7 +214,8 @@ To help recover from a bad flash, there are also blank images included.
 * ``blank_1MB.bin``
 * ``blank_2MB.bin``
 * ``blank_4MB.bin``
+* ``blank_8MB.bin``
 * ``blank_16MB.bin``
 
 When the wrong image is flashed, or the module behaves unstable, or is in a reboot loop,
-flash these images first and then the right image for the module.
+flash these images first to clear out any remaining or hidden settings (Arduino framework...) and then the right image for the module.

--- a/platformio_esp32c6_envs.ini
+++ b/platformio_esp32c6_envs.ini
@@ -11,9 +11,6 @@ build_unflags             = ${esp32_base_idf5.build_unflags}
                             -fexceptions
 board_build.filesystem    = littlefs
 lib_ignore                = ${esp32_base_idf5.lib_ignore}
-                            NeoPixelBus
-                            NeoPixelBus_wrapper
-                            Adafruit NeoMatrix via NeoPixelBus
 board                     = esp32c6cdc
 
 
@@ -29,3 +26,27 @@ extra_scripts             = ${esp32c6_common_LittleFS.extra_scripts}
 extends                   = esp32c6_common_LittleFS
 lib_ignore                = ${esp32c6_common_LittleFS.lib_ignore}
                             ${no_ir.lib_ignore}
+
+
+[env:max_ESP32c6_8M1M_LittleFS_CDC_ETH]
+extends                   = esp32c6_common_LittleFS
+board                     = esp32c6cdc-8M
+build_flags               = ${esp32c6_common_LittleFS.build_flags}  
+                            -DFEATURE_ETHERNET=1
+                            -DFEATURE_ARDUINO_OTA=1
+                            -DPLUGIN_BUILD_MAX_ESP32
+                            -DPLUGIN_BUILD_IR_EXTENDED
+extra_scripts             = ${esp32c6_common_LittleFS.extra_scripts}
+
+
+[env:max_ESP32c6_16M8M_LittleFS_CDC_ETH]
+extends                   = esp32c6_common_LittleFS
+board                     = esp32c6cdc-16M
+build_flags               = ${esp32c6_common_LittleFS.build_flags}  
+                            -DFEATURE_ETHERNET=1
+                            -DFEATURE_ARDUINO_OTA=1
+                            -DPLUGIN_BUILD_MAX_ESP32
+                            -DPLUGIN_BUILD_IR_EXTENDED
+extra_scripts             = ${esp32c6_common_LittleFS.extra_scripts}
+
+

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -3251,8 +3251,8 @@ To create/register a plugin, you have to :
 # endif
 #endif
 
-// Incompatible plugins with ESP32-C2/C6
-#if defined(ESP32C2) || defined(ESP32C6)
+// Incompatible plugins with ESP32-C2 // (C6 seems to work as intended)
+#if defined(ESP32C2) // || defined(ESP32C6)
  #define DISABLE_NEOPIXEL_PLUGINS 1
 #endif
 

--- a/tools/pio/copy_files.py
+++ b/tools/pio/copy_files.py
@@ -21,11 +21,11 @@ def get_max_bin_size(env_name, file_suffix):
     if "4M316k" in env_name or "_ESP32_4M2M" in env_name:
         # ESP32 with 1800k of sketch space.
         max_bin_size = 1900544
-    if "_ESP32_" in env_name or "_ESP32s2_" in env_name or "_ESP32s3_" in env_name:
+    if "_ESP32_" in env_name or "_ESP32c6_" in env_name or "_ESP32s2_" in env_name or "_ESP32s3_" in env_name:
         if "_8M1M" in env_name:
             # ESP32 with 3520k of sketch space.
             max_bin_size = 3604480
-    if "_ESP32_" in env_name or "_ESP32c3_" in env_name or "_ESP32s2_" in env_name or "_ESP32s3_" in env_name:
+    if "_ESP32_" in env_name or "_ESP32c3_" in env_name or "_ESP32c6_" in env_name or "_ESP32s2_" in env_name or "_ESP32s3_" in env_name:
         if "_16M8M" in env_name or "_16M2M" in env_name or "_16M1M" in env_name:
             # ESP32 with 4096k of sketch space.
             max_bin_size = 4194304


### PR DESCRIPTION
From a [Forum request](https://www.letscontrolit.com/forum/viewtopic.php?t=10072)

Features:
- ESP32-C6 8M1M MAX ETH build
- ESP32-C6 16M8M MAX ETH build
- Re-enable Neopixel plugins for ESP32-C6 (tested using the on-board Neopixel led, P128 Neopixel BusFX and P131 NeoMatrix)
- Update/correct documentation

NB: These configurations are **_preliminary_**, as we may need to change the Flash partitioning to support the Zigbee/Thread protocol and configuration supported by the ESP32-C6!

TODO:
- [ ] Testing by requester