### PR TITLE
[Build] Disable Notifiers in full binaries

### DIFF
--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -1467,7 +1467,7 @@ To create/register a plugin, you have to :
       #undef USES_N001   // Email
     #endif
     #ifdef USES_N002
-      #define USES_N002   // Buzzer
+      #undef USES_N002   // Buzzer
     #endif
     
     // Do not include large blobs but fetch them from CDN
@@ -1718,7 +1718,7 @@ To create/register a plugin, you have to :
          #undef USES_N001   // Email
        #endif
        #ifdef USES_N002
-         #define USES_N002   // Buzzer
+         #undef USES_N002   // Buzzer
        #endif
      #endif
    #endif

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -1463,6 +1463,12 @@ To create/register a plugin, you have to :
     #ifndef NOTIFIER_SET_NONE
       #define NOTIFIER_SET_NONE
     #endif
+    #ifdef USES_N001
+      #undef USES_N001   // Email
+    #endif
+    #ifdef USES_N002
+      #define USES_N002   // Buzzer
+    #endif
     
     // Do not include large blobs but fetch them from CDN
     #ifndef WEBSERVER_USE_CDN_JS_CSS
@@ -1706,6 +1712,13 @@ To create/register a plugin, you have to :
        #endif
        #ifndef P037_LIMIT_BUILD_SIZE
          #define P037_LIMIT_BUILD_SIZE // Reduce build size for P037 (MQTT Import) only
+       #endif
+       #define NOTIFIER_SET_NONE
+       #ifdef USES_N001
+         #undef USES_N001   // Email
+       #endif
+       #ifdef USES_N002
+         #define USES_N002   // Buzzer
        #endif
      #endif
    #endif


### PR DESCRIPTION
Bugfix:
- Disable Notifiers/Notifications in ESP8266 Collection builds, as intended (`NOTIFIER_SET_NONE`)
- Disable Notifiers/Notifications in ESP8266 Display build, to make build less tight

For those that still need Notifications, there are 2 solutions:
- Create a Custom build ([documentation](https://espeasy.readthedocs.io/en/latest/Participate/PlatformIO.html)), enabling the plugins and features required
- Use an ESP32 Collection, Display or MAX build (these include the Notification plugins)