### PR TITLE
[Bugfix][P135] SCD4x fix reading sensor settings

### DIFF
--- a/src/_P135_SCD4x.ino
+++ b/src/_P135_SCD4x.ino
@@ -6,6 +6,7 @@
 // #######################################################################################################
 
 /**
+ * 2024-04-27 tonhuisman: Fix bug that sensor settings can only be retrieved if measuring is stopped
  * 2023-11-23 tonhuisman: Add Device flag for I2CMax100kHz as this sensor won't work at 400 kHz
  * 2022-08-28 tonhuisman: Include 'CO2' in plugin name, to be in line with other CO2 plugins
  * 2022-08-24 tonhuisman: Removed [TESTING] tag

--- a/src/src/PluginStructs/P135_data_struct.cpp
+++ b/src/src/PluginStructs/P135_data_struct.cpp
@@ -23,13 +23,12 @@ bool P135_data_struct::init() {
     if (scd4x->begin(false, _autoCalibrate)) {
       const uint16_t orgAltitude = scd4x->getSensorAltitude();
 
-      if (_altitude != 0) {
+      if ((_altitude != 0) && (_altitude !-orgAltitude)) {
         scd4x->setSensorAltitude(_altitude);
       }
       const float orgTempOffset = scd4x->getTemperatureOffset();
 
-      // FIXME TD-er: Is this correct? Checking _tempOffset and not checking orgTempOffset? (same for altitude)
-      if (!essentiallyZero(_tempOffset)) {
+      if (!essentiallyZero(_tempOffset) && !essentiallyEqual(_tempOffset, orgTempOffset)) {
         scd4x->setTemperatureOffset(_tempOffset);
       }
       const bool hasSerial = scd4x->getSerialNumber(serialNumber); // Not yet reading, get serial

--- a/src/src/PluginStructs/P135_data_struct.cpp
+++ b/src/src/PluginStructs/P135_data_struct.cpp
@@ -23,7 +23,7 @@ bool P135_data_struct::init() {
     if (scd4x->begin(false, _autoCalibrate)) {
       const uint16_t orgAltitude = scd4x->getSensorAltitude();
 
-      if ((_altitude != 0) && (_altitude !-orgAltitude)) {
+      if ((_altitude != 0) && (_altitude != orgAltitude)) {
         scd4x->setSensorAltitude(_altitude);
       }
       const float orgTempOffset = scd4x->getTemperatureOffset();


### PR DESCRIPTION
Resolves #4992 

Bugfix:
- Reading sensor settings/parameters like the altitude and temperature compensation can only be retrieved when the sensor isn't measuring.
- During initialization, only set sensor parameters if needed (resolves a FIXME)

TODO:
- [ ] Testing by bug reporter (tested locally)