### PR TITLE
[Build] Set ETH enabled for all IDF 5.1 builds

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -28,7 +28,7 @@ extra_configs =
   platformio_esp32c6_envs.ini
 
 ;default_envs = normal_ESP32_4M
-default_envs = max_ESP32_16M8M_LittleFS
+default_envs = max_ESP32_16M8M_LittleFS_ETH
 ;default_envs = normal_ESP32c6_4M316k_LittleFS_CDC
 ; default_envs = custom_ESP8266_4M1M
 

--- a/platformio_esp32_envs.ini
+++ b/platformio_esp32_envs.ini
@@ -150,14 +150,16 @@ extra_scripts             = ${esp32_common_LittleFS.extra_scripts}
 extends                   = esp32_custom_base
 board                     = esp32_4M
 
-[env:custom_ESP32_4M316k_LittleFS]
-extends                   = esp32_custom_base_LittleFS
-board                     = esp32_4M
+; [env:custom_ESP32_4M316k_LittleFS]
+; extends                   = esp32_custom_base_LittleFS
+; board                     = esp32_4M
 
-[env:custom_ESP32_16M8M_LittleFS]
+[env:custom_ESP32_16M8M_LittleFS_ETH]
 extends                   = esp32_custom_base_LittleFS
 board                     = esp32_16M8M
 board_upload.flash_size   = 16MB
+build_flags               = ${esp32_custom_base_LittleFS.build_flags}
+                            -DFEATURE_ETHERNET=1
 
 [env:custom_IR_ESP32_4M316k]
 extends                   = esp32_common
@@ -171,11 +173,12 @@ extra_scripts             = ${esp32_common.extra_scripts}
                             pre:tools/pio/pre_custom_esp32_IR.py
                             pre:tools/pio/ir_build_check.py
 
-[env:custom_ESP32_4M2M_NO_OTA_LittleFS]
+[env:custom_ESP32_4M2M_NO_OTA_LittleFS_ETH]
 extends                   = esp32_custom_base_LittleFS
 board                     = esp32_4M2M
 build_flags               = ${esp32_custom_base_LittleFS.build_flags}
                             -DNO_HTTP_UPDATER
+                            -DFEATURE_ETHERNET=1
 
 
 [env:normal_ESP32_4M316k]
@@ -184,11 +187,11 @@ board                     = esp32_4M
 lib_ignore                = ${esp32_common.lib_ignore}
                             ${no_ir.lib_ignore}
 
-[env:normal_ESP32_4M316k_LittleFS]
-extends                   = esp32_common_LittleFS
-board                     = esp32_4M
-lib_ignore                = ${esp32_common_LittleFS.lib_ignore}
-                            ${no_ir.lib_ignore}
+; [env:normal_ESP32_4M316k_LittleFS]
+; extends                   = esp32_common_LittleFS
+; board                     = esp32_4M
+; lib_ignore                = ${esp32_common_LittleFS.lib_ignore}
+;                             ${no_ir.lib_ignore}
 
 [env:collection_A_ESP32_4M316k]
 extends                   = esp32_common
@@ -536,7 +539,7 @@ build_flags               = ${env:max_ESP32_16M1M.build_flags}
 
 
 ; A Lolin D32 PRO with 16MB Flash, allowing 4MB sketch size, and file storage using LittleFS filesystem
-[env:max_ESP32_16M8M_LittleFS]
+[env:max_ESP32_16M8M_LittleFS_ETH]
 extends                   = esp32_common_LittleFS
 board                     = esp32_16M8M
 board_upload.flash_size   = 16MB
@@ -547,15 +550,16 @@ build_flags               = ${esp32_common_LittleFS.build_flags}
                             -DFEATURE_ARDUINO_OTA=1
                             -DPLUGIN_BUILD_MAX_ESP32
                             -DPLUGIN_BUILD_IR_EXTENDED
+                            -DFEATURE_ETHERNET=1
 extra_scripts             = ${esp32_common.extra_scripts}
 board_build.filesystem    = littlefs
 
 ; If you have a board with Ethernet integrated and 16MB Flash, then this configuration could be enabled, it's based on the max_ESP32_16M8M_LittleFS definition
-[env:max_ESP32_16M8M_LittleFS_ETH]
-extends                   = env:max_ESP32_16M8M_LittleFS
-board                     = ${env:max_ESP32_16M8M_LittleFS.board}
-build_flags               = ${env:max_ESP32_16M8M_LittleFS.build_flags}
-                            -DFEATURE_ETHERNET=1
+; [env:max_ESP32_16M8M_LittleFS_ETH]
+; extends                   = env:max_ESP32_16M8M_LittleFS
+; board                     = ${env:max_ESP32_16M8M_LittleFS.board}
+; build_flags               = ${env:max_ESP32_16M8M_LittleFS.build_flags}
+;                             -DFEATURE_ETHERNET=1
 
 
 

--- a/platformio_esp32_solo1.ini
+++ b/platformio_esp32_solo1.ini
@@ -28,30 +28,35 @@ build_unflags             = ${esp32_base_idf5.build_unflags}
 board_build.filesystem    = littlefs
 
 
-[env:custom_ESP32solo1_4M316k_LittleFS]
+[env:custom_ESP32solo1_4M316k_LittleFS_ETH]
 extends                   = esp32_solo1_common_LittleFS
 board                     = esp32_solo1_4M
 build_flags               = ${esp32_solo1_common_LittleFS.build_flags} 
                             -DPLUGIN_BUILD_CUSTOM
+                            -DFEATURE_ETHERNET=1
 extra_scripts             = ${esp32_solo1_common_LittleFS.extra_scripts}
                             pre:tools/pio/pre_custom_esp32.py
 
 
-[env:normal_ESP32solo1_4M316k_LittleFS]
+[env:normal_ESP32solo1_4M316k_LittleFS_ETH]
 extends                   = esp32_solo1_common_LittleFS
 board                     = esp32_solo1_4M
+build_flags               = ${esp32_solo1_common_LittleFS.build_flags} 
+                            -DFEATURE_ETHERNET=1
 lib_ignore                = ${esp32_solo1_common_LittleFS.lib_ignore}
                             ${no_ir.lib_ignore}
 
 
-[env:energy_ESP32solo1_4M316k_LittleFS]
+[env:energy_ESP32solo1_4M316k_LittleFS_ETH]
 extends                   = esp32_solo1_common_LittleFS
 board                     = esp32_solo1_4M
 build_flags               = ${esp32_solo1_common_LittleFS.build_flags}  
                             -D PLUGIN_ENERGY_COLLECTION
+                            -DFEATURE_ETHERNET=1
 
-[env:climate_ESP32solo1_4M316k_LittleFS]
+[env:climate_ESP32solo1_4M316k_LittleFS_ETH]
 extends                   = esp32_solo1_common_LittleFS
 board                     = esp32_solo1_4M
 build_flags               = ${esp32_solo1_common_LittleFS.build_flags}  
                             -D PLUGIN_CLIMATE_COLLECTION
+                            -DFEATURE_ETHERNET=1

--- a/platformio_esp32c2_envs.ini
+++ b/platformio_esp32c2_envs.ini
@@ -16,35 +16,40 @@ lib_ignore                = ${esp32_base_idf5.lib_ignore}
                             Adafruit NeoMatrix via NeoPixelBus
 
 
-[env:safeboot_ESP32c2_4M_LittleFS]
+[env:safeboot_ESP32c2_4M_LittleFS_ETH]
 extends                   = esp32c2_common_LittleFS
 board                     = esp32c2
 build_flags               = ${esp32c2_common_LittleFS.build_flags} 
                             -DPLUGIN_BUILD_CUSTOM
                             -DPLUGIN_BUILD_SAFEBOOT
+                            -DFEATURE_ETHERNET=1
 extra_scripts             = ${esp32c2_common_LittleFS.extra_scripts}
                             pre:tools/pio/pre_safeboot_esp32c2.py
 lib_ignore                = ${esp32c2_common_LittleFS.lib_ignore}
 
 
-[env:custom_ESP32c2_2M320k_LittleFS_noOTA]
+[env:custom_ESP32c2_2M320k_LittleFS_noOTA_ETH]
 extends                   = esp32c2_common_LittleFS
 board                     = esp32c2_2M
 build_flags               = ${esp32c2_common_LittleFS.build_flags} 
                             -DPLUGIN_BUILD_CUSTOM
+                            -DFEATURE_ETHERNET=1
 extra_scripts             = ${esp32c2_common_LittleFS.extra_scripts}
                             pre:tools/pio/pre_custom_esp32c2.py
 
-[env:custom_ESP32c2_4M316k_LittleFS]
+[env:custom_ESP32c2_4M316k_LittleFS_ETH]
 extends                   = esp32c2_common_LittleFS
 board                     = esp32c2
 build_flags               = ${esp32c2_common_LittleFS.build_flags} 
                             -DPLUGIN_BUILD_CUSTOM
+                            -DFEATURE_ETHERNET=1
 extra_scripts             = ${esp32c2_common_LittleFS.extra_scripts}
                             pre:tools/pio/pre_custom_esp32c2.py
 
-[env:normal_ESP32c2_4M316k_LittleFS]
+[env:normal_ESP32c2_4M316k_LittleFS_ETH]
 extends                   = esp32c2_common_LittleFS
 board                     = esp32c2
+build_flags               = ${esp32c2_common_LittleFS.build_flags} 
+                            -DFEATURE_ETHERNET=1
 lib_ignore                = ${esp32c2_common_LittleFS.lib_ignore}
                             ${no_ir.lib_ignore}

--- a/platformio_esp32c3_envs.ini
+++ b/platformio_esp32c3_envs.ini
@@ -47,13 +47,13 @@ extra_scripts             = ${esp32c3_common.extra_scripts}
                             pre:tools/pio/pre_custom_esp32_IR.py
                             pre:tools/pio/ir_build_check.py
 
-[env:custom_ESP32c3_4M316k_LittleFS_CDC]
-extends                   = esp32c3_common_LittleFS
-board                     = esp32c3cdc
-build_flags               = ${esp32c3_common_LittleFS.build_flags} 
-                            -DPLUGIN_BUILD_CUSTOM
-extra_scripts             = ${esp32c3_common_LittleFS.extra_scripts}
-                            pre:tools/pio/pre_custom_esp32.py
+; [env:custom_ESP32c3_4M316k_LittleFS_CDC]
+; extends                   = esp32c3_common_LittleFS
+; board                     = esp32c3cdc
+; build_flags               = ${esp32c3_common_LittleFS.build_flags} 
+;                             -DPLUGIN_BUILD_CUSTOM
+; extra_scripts             = ${esp32c3_common_LittleFS.extra_scripts}
+;                             pre:tools/pio/pre_custom_esp32.py
 
 [env:custom_ESP32c3_4M316k_LittleFS_CDC_ETH]
 extends                   = esp32c3_common_LittleFS
@@ -73,9 +73,11 @@ lib_ignore                = ${esp32_common.lib_ignore}
                             ${no_ir.lib_ignore}
 
 
-[env:normal_ESP32c3_4M316k_LittleFS_CDC]
+[env:normal_ESP32c3_4M316k_LittleFS_CDC_ETH]
 extends                   = esp32c3_common_LittleFS
 board                     = esp32c3cdc
+build_flags               = ${esp32c3_common_LittleFS.build_flags} 
+                            -DFEATURE_ETHERNET=1
 lib_ignore                = ${esp32c3_common_LittleFS.lib_ignore}
                             ${no_ir.lib_ignore}
 
@@ -135,6 +137,13 @@ board                     = esp32c3cdc
 build_flags               = ${esp32c3_common.build_flags}  
                             -D PLUGIN_ENERGY_COLLECTION
 
+[env:energy_ESP32c3_4M316k_LittleFS_CDC_ETH]
+extends                   = esp32c3_common_LittleFS
+board                     = esp32c3cdc
+build_flags               = ${esp32c3_common_LittleFS.build_flags}  
+                            -D PLUGIN_ENERGY_COLLECTION
+                            -DFEATURE_ETHERNET=1
+
 [env:display_ESP32c3_4M316k_CDC]
 extends                   = esp32c3_common
 board                     = esp32c3cdc
@@ -155,10 +164,11 @@ build_flags               = ${esp32c3_common.build_flags}
                             -DFEATURE_SD=1
                             -DPLUGIN_NEOPIXEL_COLLECTION
 
-[env:neopixel_ESP32c3_4M316k_LittleFS_CDC]
+[env:neopixel_ESP32c3_4M316k_LittleFS_CDC_ETH]
 extends                   = esp32c3_common_LittleFS
 board                     = esp32c3cdc
 build_flags               = ${esp32c3_common_LittleFS.build_flags} 
                             -DFEATURE_ARDUINO_OTA=1
                             -DFEATURE_SD=1
+                            -DFEATURE_ETHERNET=1
                             -DPLUGIN_NEOPIXEL_COLLECTION

--- a/platformio_esp32c6_envs.ini
+++ b/platformio_esp32c6_envs.ini
@@ -14,16 +14,19 @@ lib_ignore                = ${esp32_base_idf5.lib_ignore}
 board                     = esp32c6cdc
 
 
-[env:custom_ESP32c6_4M316k_LittleFS_CDC]
+[env:custom_ESP32c6_4M316k_LittleFS_CDC_ETH]
 extends                   = esp32c6_common_LittleFS
 build_flags               = ${esp32c6_common_LittleFS.build_flags} 
                             -DPLUGIN_BUILD_CUSTOM
+                            -DFEATURE_ETHERNET=1
 extra_scripts             = ${esp32c6_common_LittleFS.extra_scripts}
                             pre:tools/pio/pre_custom_esp32c6.py
 
 
-[env:normal_ESP32c6_4M316k_LittleFS_CDC]
+[env:normal_ESP32c6_4M316k_LittleFS_CDC_ETH]
 extends                   = esp32c6_common_LittleFS
+build_flags               = ${esp32c6_common_LittleFS.build_flags} 
+                            -DFEATURE_ETHERNET=1
 lib_ignore                = ${esp32c6_common_LittleFS.lib_ignore}
                             ${no_ir.lib_ignore}
 

--- a/platformio_esp32s2_envs.ini
+++ b/platformio_esp32s2_envs.ini
@@ -44,13 +44,14 @@ build_flags               = ${esp32s2_common.build_flags}
                             -DFEATURE_SD=1
                             -DPLUGIN_NEOPIXEL_COLLECTION
 
-[env:neopixel_ESP32s2_4M316k_LittleFS_CDC]
+[env:neopixel_ESP32s2_4M316k_LittleFS_CDC_ETH]
 extends                   = esp32s2_common_LittleFS
 board                     = esp32s2cdc
 build_flags               = ${esp32s2_common_LittleFS.build_flags} 
                             -DFEATURE_ARDUINO_OTA=1
                             -DFEATURE_SD=1
                             -DPLUGIN_NEOPIXEL_COLLECTION
+                            -DFEATURE_ETHERNET=1
 
 
 [env:custom_IR_ESP32s2_4M316k_CDC]
@@ -73,7 +74,7 @@ board                     = esp32s2cdc
 lib_ignore                = ${esp32s2_common.lib_ignore}
                             ${no_ir.lib_ignore}
 
-[env:custom_ESP32s2_4M316k_LittleFS_CDC]
+[env:custom_ESP32s2_4M316k_LittleFS_CDC_ETH]
 extends                   = esp32s2_common_LittleFS
 board                     = esp32s2cdc
 lib_ignore                = ${esp32s2_common_LittleFS.lib_ignore}
@@ -81,14 +82,18 @@ lib_ignore                = ${esp32s2_common_LittleFS.lib_ignore}
 build_flags               = ${esp32s2_common_LittleFS.build_flags}
                             -DPLUGIN_BUILD_CUSTOM
                             -DESP_CONSOLE_USB_CDC=y
+                            -DFEATURE_ETHERNET=1
 extra_scripts             = ${esp32s2_common_LittleFS.extra_scripts}
                             pre:tools/pio/pre_custom_esp32.py
 
 
 
-[env:normal_ESP32s2_4M316k_LittleFS_CDC]
+[env:normal_ESP32s2_4M316k_LittleFS_CDC_ETH]
 extends                   = esp32s2_common_LittleFS
 board                     = esp32s2cdc
+build_flags               = ${esp32s2_common_LittleFS.build_flags}
+                            -DESP_CONSOLE_USB_CDC=y
+                            -DFEATURE_ETHERNET=1
 lib_ignore                = ${esp32s2_common_LittleFS.lib_ignore}
                             ${no_ir.lib_ignore}
 

--- a/platformio_esp32s3_envs.ini
+++ b/platformio_esp32s3_envs.ini
@@ -137,13 +137,14 @@ build_flags               = ${esp32s3_common.build_flags}
                             -DFEATURE_SD=1
                             -DPLUGIN_NEOPIXEL_COLLECTION
 
-[env:neopixel_ESP32s3_4M316k_LittleFS_CDC]
+[env:neopixel_ESP32s3_4M316k_LittleFS_CDC_ETH]
 extends                   = esp32s3_common_LittleFS
 board                     = esp32s3cdc-qio_qspi
 build_flags               = ${esp32s3_common_LittleFS.build_flags} 
                             -DFEATURE_ARDUINO_OTA=1
                             -DFEATURE_SD=1
                             -DPLUGIN_NEOPIXEL_COLLECTION
+                            -DFEATURE_ETHERNET=1
 
 
 [env:custom_ESP32s3_8M1M_LittleFS_CDC_ETH]


### PR DESCRIPTION
Features:
- Enable Ethernet support (`_ETH`) for all IDF 5.1 builds, and disable/remove duplicates
- Add `ESP32-C3 Energy LittleFS ETH` build

TODO:
- [ ] Testing
- [ ] Check/update documentation