### PR TITLE
[Controller] Fail gracefully when almost out of memory

### DIFF
--- a/platformio_core_defs.ini
+++ b/platformio_core_defs.ini
@@ -208,8 +208,12 @@ lib_ignore =
 
 ; ESP_IDF 5.1
 [core_esp32_IDF5_1__3_0_0]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2024.04.14/platform-espressif32.zip
-platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/2334/framework-arduinoespressif32-all-release_v5.1-08e138f.zip
+;platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2024.04.11/platform-espressif32.zip
+;platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/2286/framework-arduinoespressif32-all-release_v5.1-11140aa.zip
+;platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2024.04.14/platform-espressif32.zip
+;platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/2386/framework-arduinoespressif32-all-release_v5.1-324fdc1.zip
+platform                     = https://github.com/tasmota/platform-espressif32/releases/download/2024.05.11/platform-espressif32-2024.05.11.zip
+platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/2404/framework-arduinoespressif32-all-release_v5.1-fa138fe.zip
 build_flags                 = -DESP32_STAGE
                               -DESP_IDF_VERSION_MAJOR=5
                               -DLIBRARIES_NO_LOG=1

--- a/src/_C001.cpp
+++ b/src/_C001.cpp
@@ -100,7 +100,7 @@ bool CPlugin_001(CPlugin::Function function, struct EventStruct *event, String& 
           url += mapVccToDomoticz();
             # endif // if FEATURE_ADC_VCC
 
-          std::unique_ptr<C001_queue_element> element(new C001_queue_element(event->ControllerIndex, event->TaskIndex, std::move(url)));
+          std::unique_ptr<C001_queue_element> element(new (std::nothrow) C001_queue_element(event->ControllerIndex, event->TaskIndex, std::move(url)));
 
           success = C001_DelayHandler->addToQueue(std::move(element));
           Scheduler.scheduleNextDelayQueue(SchedulerIntervalTimer_e::TIMER_C001_DELAY_QUEUE,

--- a/src/_C003.cpp
+++ b/src/_C003.cpp
@@ -59,7 +59,7 @@ bool CPlugin_003(CPlugin::Function function, struct EventStruct *event, String& 
         event->idx,
         formatUserVarNoCheck(event, 0).c_str());
       std::unique_ptr<C003_queue_element> element(
-        new C003_queue_element(
+        new (std::nothrow) C003_queue_element(
           event->ControllerIndex, 
           event->TaskIndex, 
           std::move(url)));

--- a/src/_C004.cpp
+++ b/src/_C004.cpp
@@ -71,7 +71,7 @@ bool CPlugin_004(CPlugin::Function function, struct EventStruct *event, String& 
         break;
       }
 
-      std::unique_ptr<C004_queue_element> element(new C004_queue_element(event));
+      std::unique_ptr<C004_queue_element> element(new (std::nothrow) C004_queue_element(event));
 
       success = C004_DelayHandler->addToQueue(std::move(element));
       Scheduler.scheduleNextDelayQueue(SchedulerIntervalTimer_e::TIMER_C004_DELAY_QUEUE, C004_DelayHandler->getNextScheduleTime());

--- a/src/_C007.cpp
+++ b/src/_C007.cpp
@@ -68,7 +68,7 @@ bool CPlugin_007(CPlugin::Function function, struct EventStruct *event, String& 
         break;
       }
 
-      std::unique_ptr<C007_queue_element> element(new C007_queue_element(event));
+      std::unique_ptr<C007_queue_element> element(new (std::nothrow) C007_queue_element(event));
       success = C007_DelayHandler->addToQueue(std::move(element));
 
       Scheduler.scheduleNextDelayQueue(SchedulerIntervalTimer_e::TIMER_C007_DELAY_QUEUE, C007_DelayHandler->getNextScheduleTime());

--- a/src/_C008.cpp
+++ b/src/_C008.cpp
@@ -78,7 +78,7 @@ bool CPlugin_008(CPlugin::Function function, struct EventStruct *event, String& 
       }
 
       uint8_t valueCount = getValueCountForTask(event->TaskIndex);
-      std::unique_ptr<C008_queue_element> element(new C008_queue_element(event, valueCount));
+      std::unique_ptr<C008_queue_element> element(new (std::nothrow) C008_queue_element(event, valueCount));
       success = C008_DelayHandler->addToQueue(std::move(element));
 
       if (success) {

--- a/src/_C009.cpp
+++ b/src/_C009.cpp
@@ -80,7 +80,7 @@ bool CPlugin_009(CPlugin::Function function, struct EventStruct *event, String& 
           break;
         }
 
-        std::unique_ptr<C009_queue_element> element(new C009_queue_element(event));
+        std::unique_ptr<C009_queue_element> element(new (std::nothrow) C009_queue_element(event));
         success = C009_DelayHandler->addToQueue(std::move(element));
         Scheduler.scheduleNextDelayQueue(SchedulerIntervalTimer_e::TIMER_C009_DELAY_QUEUE, C009_DelayHandler->getNextScheduleTime());
       }

--- a/src/_C010.cpp
+++ b/src/_C010.cpp
@@ -69,7 +69,7 @@ bool CPlugin_010(CPlugin::Function function, struct EventStruct *event, String& 
 
       //LoadTaskSettings(event->TaskIndex); // FIXME TD-er: This can probably be removed
 
-      std::unique_ptr<C010_queue_element> element(new C010_queue_element(event, valueCount));
+      std::unique_ptr<C010_queue_element> element(new (std::nothrow) C010_queue_element(event, valueCount));
 
 
       {

--- a/src/_C011.cpp
+++ b/src/_C011.cpp
@@ -246,7 +246,7 @@ boolean Create_schedule_HTTP_C011(struct EventStruct *event)
   //LoadTaskSettings(event->TaskIndex); // FIXME TD-er: This can probably be removed
 
   // Add a new element to the queue with the minimal payload
-  std::unique_ptr<C011_queue_element> element(new C011_queue_element(event));
+  std::unique_ptr<C011_queue_element> element(new (std::nothrow) C011_queue_element(event));
   bool success = C011_DelayHandler->addToQueue(std::move(element));
 
   if (success) {

--- a/src/_C012.cpp
+++ b/src/_C012.cpp
@@ -59,7 +59,7 @@ bool CPlugin_012(CPlugin::Function function, struct EventStruct *event, String& 
 
       // Collect the values at the same run, to make sure all are from the same sample
       uint8_t valueCount = getValueCountForTask(event->TaskIndex);
-      std::unique_ptr<C012_queue_element> element(new C012_queue_element(event, valueCount));
+      std::unique_ptr<C012_queue_element> element(new (std::nothrow) C012_queue_element(event, valueCount));
 
       for (uint8_t x = 0; x < valueCount; x++)
       {

--- a/src/_C015.cpp
+++ b/src/_C015.cpp
@@ -184,7 +184,7 @@ bool CPlugin_015(CPlugin::Function function, struct EventStruct *event, String& 
       // Collect the values at the same run, to make sure all are from the same sample
       uint8_t valueCount = getValueCountForTask(event->TaskIndex);
 
-      std::unique_ptr<C015_queue_element> element(new C015_queue_element(event, valueCount));
+      std::unique_ptr<C015_queue_element> element(new (std::nothrow) C015_queue_element(event, valueCount));
       success = C015_DelayHandler->addToQueue(std::move(element));
 
       if (success) {

--- a/src/_C017.cpp
+++ b/src/_C017.cpp
@@ -67,7 +67,7 @@ bool CPlugin_017(CPlugin::Function function, struct EventStruct *event, String& 
         break;
       }
 
-      std::unique_ptr<C017_queue_element> element(new C017_queue_element(event));
+      std::unique_ptr<C017_queue_element> element(new (std::nothrow) C017_queue_element(event));
       success = C017_DelayHandler->addToQueue(std::move(element));
       Scheduler.scheduleNextDelayQueue(SchedulerIntervalTimer_e::TIMER_C017_DELAY_QUEUE, C017_DelayHandler->getNextScheduleTime());
       break;

--- a/src/_C018.cpp
+++ b/src/_C018.cpp
@@ -186,7 +186,7 @@ bool CPlugin_018(CPlugin::Function function, struct EventStruct *event, String& 
 
       if (C018_data != nullptr) {
         {
-          std::unique_ptr<C018_queue_element> element(new C018_queue_element(event, C018_data->getSampleSetCount(event->TaskIndex)));
+          std::unique_ptr<C018_queue_element> element(new (std::nothrow) C018_queue_element(event, C018_data->getSampleSetCount(event->TaskIndex)));
           success = C018_DelayHandler->addToQueue(std::move(element));
           Scheduler.scheduleNextDelayQueue(SchedulerIntervalTimer_e::TIMER_C018_DELAY_QUEUE,
                                            C018_DelayHandler->getNextScheduleTime());

--- a/src/src/DataStructs/ControllerSettingsStruct.h
+++ b/src/src/DataStructs/ControllerSettingsStruct.h
@@ -215,13 +215,15 @@ private:
   bool updateIPcache();
 };
 
+#include "../Helpers/Memory.h"
+
 typedef std::shared_ptr<ControllerSettingsStruct> ControllerSettingsStruct_ptr_type;
 /*
 # ifdef USE_SECOND_HEAP
 #define MakeControllerSettings(T) HeapSelectIram ephemeral; ControllerSettingsStruct_ptr_type T(new (std::nothrow)  ControllerSettingsStruct());
 #else
 */
-#define MakeControllerSettings(T) ControllerSettingsStruct_ptr_type T(new (std::nothrow)  ControllerSettingsStruct());
+#define MakeControllerSettings(T) void * calloc_ptr = special_calloc(1,sizeof(ControllerSettingsStruct)); ControllerSettingsStruct_ptr_type T(new (calloc_ptr)  ControllerSettingsStruct());
 //#endif
 
 // Check to see if MakeControllerSettings was successful

--- a/src/src/ESPEasyCore/Controller.cpp
+++ b/src/src/ESPEasyCore/Controller.cpp
@@ -535,7 +535,7 @@ bool MQTTpublish(controllerIndex_t controller_idx, taskIndex_t taskIndex, const 
   if (MQTT_queueFull(controller_idx)) {
     return false;
   }
-  const bool success = MQTTDelayHandler->addToQueue(std::unique_ptr<MQTT_queue_element>(new MQTT_queue_element(controller_idx, taskIndex, topic, payload, retained, callbackTask)));
+  const bool success = MQTTDelayHandler->addToQueue(std::unique_ptr<MQTT_queue_element>(new (std::nothrow) MQTT_queue_element(controller_idx, taskIndex, topic, payload, retained, callbackTask)));
 
   scheduleNextMQTTdelayQueue();
   return success;
@@ -550,7 +550,7 @@ bool MQTTpublish(controllerIndex_t controller_idx, taskIndex_t taskIndex,  Strin
     return false;
   }
 
-  const bool success = MQTTDelayHandler->addToQueue(std::unique_ptr<MQTT_queue_element>(new MQTT_queue_element(controller_idx, taskIndex, std::move(topic), std::move(payload), retained, callbackTask)));
+  const bool success = MQTTDelayHandler->addToQueue(std::unique_ptr<MQTT_queue_element>(new (std::nothrow) MQTT_queue_element(controller_idx, taskIndex, std::move(topic), std::move(payload), retained, callbackTask)));
 
   scheduleNextMQTTdelayQueue();
   return success;

--- a/src/src/PluginStructs/P104_data_struct.cpp
+++ b/src/src/PluginStructs/P104_data_struct.cpp
@@ -128,7 +128,7 @@ void P104_data_struct::loadSettings() {
       reservedBuffer = P104_SETTINGS_BUFFER_V2 + 1; // just add 1 for storing a string-terminator
     }
     reservedBuffer++;                               // Add 1 for 0..size use
-    settingsBuffer = new char[reservedBuffer]();    // Allocate buffer and reset to all zeroes
+    settingsBuffer = new (std::nothrow) char[reservedBuffer]();    // Allocate buffer and reset to all zeroes
     loadOffset    += sizeof(bufferSize);
 
     if (settingsVersionV2) {

--- a/src/src/PluginStructs/P147_data_struct.cpp
+++ b/src/src/PluginStructs/P147_data_struct.cpp
@@ -37,14 +37,14 @@ bool P147_data_struct::init(struct EventStruct *event) {
 
     // TODO Add initialization of IndexAlgorithm objects
     # if P147_FEATURE_GASINDEXALGORITHM
-    vocGasIndexAlgorithm = new VOCGasIndexAlgorithm((P147_LOW_POWER_MEASURE == 0 ? P147_SHORT_COUNTER : P147_LONG_COUNTER) * 1.0f);
+    vocGasIndexAlgorithm = new (std::nothrow) VOCGasIndexAlgorithm((P147_LOW_POWER_MEASURE == 0 ? P147_SHORT_COUNTER : P147_LONG_COUNTER) * 1.0f);
 
     if (nullptr == vocGasIndexAlgorithm) {
       _initialized = false;
     }
 
     if (_initialized && (_sensorType == P147_sensor_e::SGP41)) {
-      noxGasIndexAlgorithm = new NOxGasIndexAlgorithm(); // Algorithm doesn't support a sampling interval
+      noxGasIndexAlgorithm = new (std::nothrow) NOxGasIndexAlgorithm(); // Algorithm doesn't support a sampling interval
 
       if (nullptr == noxGasIndexAlgorithm) {
         _initialized = false;

--- a/src/src/WebServer/UploadPage.cpp
+++ b/src/src/WebServer/UploadPage.cpp
@@ -174,7 +174,7 @@ void handleFileUploadBase(bool toSDcard) {
         # if FEATURE_TARSTREAM_SUPPORT
 
         if ((upload.filename.length() > 3) && upload.filename.substring(upload.filename.length() - 4).equalsIgnoreCase(F(".tar"))) {
-          tarStream = new TarStream(upload.filename, destination);
+          tarStream = new (std::nothrow) TarStream(upload.filename, destination);
           #  ifndef BUILD_NO_DEBUG
 
           if (loglevelActiveFor(LOG_LEVEL_INFO)) {


### PR DESCRIPTION
One often reported issue is that the ESPEasy node (especially ESP8266 ones) will crash when WiFi is unstable.

This could be due to memory suddenly filling up by the controller queue. When creating a new item for the controller queue, there was no `(std::nothrow)` included on the `new` calls, so if running out of memory this might have thrown a `std::bad_alloc` exception, which are not caught and thus ESPEasy might crash on it.

Fixes: #4726
Fixes: #3649
Fixes: #2341


Before merge, see: https://github.com/letscontrolit/ESPEasy/pull/4770