### PR TITLE
[Build] Remove P094 from ESP8266 Collection D for size reasons

### DIFF
--- a/docs/source/Plugin/_plugin_sets_overview.repl
+++ b/docs/source/Plugin/_plugin_sets_overview.repl
@@ -487,7 +487,6 @@ Build set:  :yellow:`COLLECTION D`
       ":ref:`P082_page`","P082"
       ":ref:`P089_page`","P089"
       ":ref:`P093_page`","P093"
-      ":ref:`P094_page`","P094"
       ":ref:`P095_page`","P095"
       ":ref:`P098_page`","P098"
       ":ref:`P114_page`","P114"

--- a/docs/source/Plugin/_plugin_substitutions_p09x.repl
+++ b/docs/source/Plugin/_plugin_substitutions_p09x.repl
@@ -50,7 +50,7 @@
 .. |P094_name| replace:: :cyan:`CUL Reader`
 .. |P094_type| replace:: :cyan:`Communication`
 .. |P094_typename| replace:: :cyan:`Communication - CUL Reader`
-.. |P094_status| replace:: :yellow:`COLLECTION D`
+.. |P094_status| replace:: :yellow:`MAX`
 .. |P094_github| replace:: P094_CULReader.ino
 .. _P094_github: https://github.com/letscontrolit/ESPEasy/blob/mega/src/_P094_CULReader.ino
 .. |P094_usedby| replace:: `.`

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -1577,7 +1577,9 @@ To create/register a plugin, you have to :
 
 #ifdef PLUGIN_SET_COLLECTION_D
     #define USES_P093   // Mitsubishi Heat Pump
-    #define USES_P094  // CUL Reader
+    #ifdef ESP32
+      #define USES_P094  // CUL Reader
+    #endif
     #ifndef USES_P098
       #define USES_P098   // PWM motor
     #endif

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -1577,9 +1577,9 @@ To create/register a plugin, you have to :
 
 #ifdef PLUGIN_SET_COLLECTION_D
     #define USES_P093   // Mitsubishi Heat Pump
-    #ifdef ESP32
-      #define USES_P094  // CUL Reader
-    #endif
+    // #ifdef ESP32
+    //   #define USES_P094  // CUL Reader
+    // #endif
     #ifndef USES_P098
       #define USES_P098   // PWM motor
     #endif


### PR DESCRIPTION
For build-size reasons, and the low usage of this plugin, this has been removed from the ESP8266 `Collection D` build.
Still available in `MAX` builds, and can be added to Custom builds using a `Custom.h` file.

Also removed from ESP32 Collection D builds, because of the very specific hardware requirements and software setup.