### PR TITLE
[Commands] Rename `Reset` to `FactoryReset`

### DIFF
--- a/docs/source/Plugin/P000_commands.repl
+++ b/docs/source/Plugin/P000_commands.repl
@@ -207,6 +207,14 @@
 
     ``ExecuteRules,<filename>``"
     "
+    FactoryReset","
+    :red:`Internal`","
+    Reset config to factory default. Caution, all settings will be lost!
+
+    |changed| 2024-08-10: Renamed ``Reset`` command to ``FactoryReset`` to avoid accidentally wiping the configuration when ``Reboot`` was the intended action...
+
+    ``FactoryReset``"
+    "
     Gateway","
     :red:`Internal`","
     Get or set the gateway configuration
@@ -594,10 +602,9 @@
     ``Reboot``"
     "
     Reset","
-    :red:`Internal`","
-    Reset config to factory default. Caution, all settings will be lost!
-
-    ``Reset``"
+    :gray:`Renamed`","
+    |changed| 2024-08-10: Renamed ``Reset`` command to ``FactoryReset``.
+    "
     "
     Reset Flash Write Counter","
     :red:`Internal`","

--- a/src/src/Commands/InternalCommands.cpp
+++ b/src/src/Commands/InternalCommands.cpp
@@ -305,6 +305,7 @@ bool InternalCommands::executeInternalCommand()
     case ESPEasy_cmd_e::erasesdkwifi:               COMMAND_CASE_R(Command_WiFi_Erase,     0);               // WiFi.h
     case ESPEasy_cmd_e::event:                      COMMAND_CASE_A(Command_Rules_Events,  -1);               // Rule.h
     case ESPEasy_cmd_e::executerules:               COMMAND_CASE_A(Command_Rules_Execute, -1);               // Rule.h
+    case ESPEasy_cmd_e::factoryreset:               COMMAND_CASE_R(Command_Settings_FactoryReset, 0);        // Settings.h
     case ESPEasy_cmd_e::gateway:                    COMMAND_CASE_R(Command_Gateway,     1);                  // Network Command
     case ESPEasy_cmd_e::gpio:                       COMMAND_CASE_A(Command_GPIO,        2);                  // Gpio.h
     case ESPEasy_cmd_e::gpiotoggle:                 COMMAND_CASE_A(Command_GPIO_Toggle, 1);                  // Gpio.h
@@ -396,7 +397,6 @@ bool InternalCommands::executeInternalCommand()
 #endif // if FEATURE_PUT_TO_HTTP
     case ESPEasy_cmd_e::pwm:                        COMMAND_CASE_A(Command_GPIO_PWM,          4);                 // GPIO.h
     case ESPEasy_cmd_e::reboot:                     COMMAND_CASE_A(Command_System_Reboot,              0);        // System.h
-    case ESPEasy_cmd_e::reset:                      COMMAND_CASE_R(Command_Settings_Reset,             0);        // Settings.h
     case ESPEasy_cmd_e::resetflashwritecounter:     COMMAND_CASE_A(Command_RTC_resetFlashWriteCounter, 0);        // RTC.h
     case ESPEasy_cmd_e::restart:                    COMMAND_CASE_A(Command_System_Reboot,              0);        // System.h
     case ESPEasy_cmd_e::rtttl:                      COMMAND_CASE_A(Command_GPIO_RTTTL,                -1);        // GPIO.h

--- a/src/src/Commands/InternalCommands_decoder.cpp
+++ b/src/src/Commands/InternalCommands_decoder.cpp
@@ -78,8 +78,9 @@ const char Internal_commands_e[] PROGMEM =
 #endif // FEATURE_ETHERNET
 ;
 
-#define Int_cmd_ghij_offset ESPEasy_cmd_e::gateway
-const char Internal_commands_ghij[] PROGMEM =
+#define Int_cmd_fghij_offset ESPEasy_cmd_e::factoryreset
+const char Internal_commands_fghij[] PROGMEM =
+  "factoryreset|"
   "gateway|"
   "gpio|"
   "gpiotoggle|"
@@ -189,7 +190,6 @@ const char Internal_commands_p[] PROGMEM =
 #define Int_cmd_r_offset ESPEasy_cmd_e::reboot
 const char Internal_commands_r[] PROGMEM =
   "reboot|"
-  "reset|"
   "resetflashwritecounter|"
   "restart|"
   "rtttl|"
@@ -304,12 +304,13 @@ const char* getInternalCommand_Haystack_Offset(const char firstLetter, int& offs
       offset   = static_cast<int>(Int_cmd_e_offset);
       haystack = Internal_commands_e;
       break;
+    case 'f':
     case 'g':
     case 'h':
     case 'i':
     case 'j':
-      offset   = static_cast<int>(Int_cmd_ghij_offset);
-      haystack = Internal_commands_ghij;
+      offset   = static_cast<int>(Int_cmd_fghij_offset);
+      haystack = Internal_commands_fghij;
       break;
     case 'l':
       offset   = static_cast<int>(Int_cmd_l_offset);

--- a/src/src/Commands/InternalCommands_decoder.h
+++ b/src/src/Commands/InternalCommands_decoder.h
@@ -59,6 +59,8 @@ enum class ESPEasy_cmd_e : uint8_t {
   ethwifimode,
 #endif // FEATURE_ETHERNET
 
+  factoryreset,
+
   gateway,
   gpio,
   gpiotoggle,
@@ -155,7 +157,6 @@ enum class ESPEasy_cmd_e : uint8_t {
   pwm,
 
   reboot,
-  reset,
   resetflashwritecounter,
   restart,
   rtttl,

--- a/src/src/Commands/Settings.cpp
+++ b/src/src/Commands/Settings.cpp
@@ -104,7 +104,7 @@ const __FlashStringHelper * Command_Settings_Print(struct EventStruct *event, co
 	return return_see_serial(event);
 }
 
-const __FlashStringHelper * Command_Settings_Reset(struct EventStruct *event, const char* Line)
+const __FlashStringHelper * Command_Settings_FactoryReset(struct EventStruct *event, const char* Line)
 {
 	ResetFactory();
 	reboot(IntendedRebootReason_e::ResetFactoryCommand);

--- a/src/src/Commands/Settings.h
+++ b/src/src/Commands/Settings.h
@@ -11,6 +11,6 @@ const __FlashStringHelper * Command_Settings_Password_Clear(struct EventStruct *
 const __FlashStringHelper * Command_Settings_Save(struct EventStruct *event, const char* Line);
 const __FlashStringHelper * Command_Settings_Load(struct EventStruct *event, const char* Line);
 const __FlashStringHelper * Command_Settings_Print(struct EventStruct *event, const char* Line);
-const __FlashStringHelper * Command_Settings_Reset(struct EventStruct *event, const char* Line);
+const __FlashStringHelper * Command_Settings_FactoryReset(struct EventStruct *event, const char* Line);
 
 #endif // COMMAND_SETTINGS_H


### PR DESCRIPTION
For an improved User Experience, renaming the `Reset` command to `FactoryReset`, as some users accidentally type reset when they intend to use `Reboot`.

- Updated command handling
- Updated documentation
- Tested (surrounding commands, old group 'r' and new group 'fghij' still work as intended 😃)