### PR TITLE
[Console] Exclude Serial Console fall-back GPIOs only when fall-back enabled

### DIFF
--- a/docs/source/Tools/Tools.rst
+++ b/docs/source/Tools/Tools.rst
@@ -325,7 +325,7 @@ This console can be accessed via a serial port.
 * Serial Port - The selected serial port to use for the console.
 * ESP RX GPIO ← TX - GPIO pin used as RX, to connect with the TX of the other device.
 * ESP TX GPIO → RX - GPIO pin used as TX, to connect with the RX of the other device.
-* Fallback to Serial 0 - (Only on ESP32-C3/S2/S3) Configure HW Serial0 port as secondary port for the ESPEasy console.
+* Fallback to Serial 0 - (Only on ESP32-C3/S2/S3) Configure HW Serial0 port as secondary port for the ESPEasy console. When unchecked, the Fallback RX/TX pins will be available for selection in the GPIO pin selector and GPIO boot-states configuration on the Hardware tab.
 
 GPIO pin selection will only be shown for Serial Port types which require action GPIO pins.
 For example USB CDC and HW CDC ports do not need specific GPIO pins for their configuration.

--- a/src/src/Helpers/Hardware_GPIO.cpp
+++ b/src/src/Helpers/Hardware_GPIO.cpp
@@ -489,22 +489,35 @@ bool isSerialConsolePin(int gpio) {
   if (!Settings.UseSerial) { return false; }
 
 #if defined(SOC_RX0) && defined(SOC_TX0)
-  return gpio == SOC_TX0 || gpio == SOC_RX0;
+  return (gpio == SOC_TX0 || gpio == SOC_RX0)
+         #if USES_ESPEASY_CONSOLE_FALLBACK_PORT
+         && Settings.console_serial0_fallback
+         #endif // if USES_ESPEASY_CONSOLE_FALLBACK_PORT
+  ;
 #else
 #ifdef ESP32S2
 
-  // FIXME TD-er: Must check whether USB serial is used
-  return gpio == 1 || gpio == 3;
+  return (gpio == 1 || gpio == 3)
+         #if USES_ESPEASY_CONSOLE_FALLBACK_PORT
+         && Settings.console_serial0_fallback
+         #endif // if USES_ESPEASY_CONSOLE_FALLBACK_PORT
+  ;
 
 #elif defined(ESP32S3)
 
-  // FIXME TD-er: Must check whether USB serial is used
-  return gpio == 43 || gpio == 44;
+  return (gpio == 43 || gpio == 44)
+         #if USES_ESPEASY_CONSOLE_FALLBACK_PORT
+         && Settings.console_serial0_fallback
+         #endif // if USES_ESPEASY_CONSOLE_FALLBACK_PORT
+  ;
 
 #elif defined(ESP32C3)
 
-  // FIXME TD-er: Must check whether USB serial is used
-  return gpio == 21 || gpio == 20;
+  return (gpio == 21 || gpio == 20) 
+         #if USES_ESPEASY_CONSOLE_FALLBACK_PORT
+         && Settings.console_serial0_fallback
+         #endif // if USES_ESPEASY_CONSOLE_FALLBACK_PORT
+  ;
 
 #elif defined(ESP32_CLASSIC)
   return gpio == 1 || gpio == 3;

--- a/src/src/Helpers/StringGenerator_GPIO.cpp
+++ b/src/src/Helpers/StringGenerator_GPIO.cpp
@@ -218,12 +218,7 @@ const __FlashStringHelper* getConflictingUse(int gpio, PinSelectPurpose purpose)
   #if FEATURE_SD
   bool includeSDCard = true;
   #endif
-  #if FEATURE_DEFINE_SERIAL_CONSOLE_PORT
-  // FIXME TD-er: Must check whether this can be a conflict.
-  bool includeSerial = false;
-  #else
-  bool includeSerial = true;
-  #endif
+  bool includeSerial = Settings.UseSerial; // Only need to check if Serial Port Console is enabled
 
   #if FEATURE_ETHERNET
   bool includeEthernet = true;
@@ -270,7 +265,11 @@ const __FlashStringHelper* getConflictingUse(int gpio, PinSelectPurpose purpose)
   if (includeSerial) {
     #if FEATURE_DEFINE_SERIAL_CONSOLE_PORT
     if (Settings.UseSerial && 
-        Settings.console_serial_port == 2)  // 2 == ESPEasySerialPort::serial0
+        (Settings.console_serial_port == 2  // 2 == ESPEasySerialPort::serial0
+         #if USES_ESPEASY_CONSOLE_FALLBACK_PORT
+         || Settings.console_serial0_fallback
+         #endif // if USES_ESPEASY_CONSOLE_FALLBACK_PORT
+        ))
     #else
     if (Settings.UseSerial) 
     #endif


### PR DESCRIPTION
From a [Forum report](https://www.letscontrolit.com/forum/viewtopic.php?t=10386)

Features: (actually a TODO that had to be completed)
- Allow Serial Console Fall-back GPIO pins to be available for plugins when Console Fall-back is disabled.
- Show GPIO use for these pins correctly in the GPIO boot states list.

TODO:
- [ ] Testing by requester