### PR TITLE
[Build] Reduce ESP8266 1M builds to make 'm fit again

### DIFF
--- a/docs/source/Plugin/P011.rst
+++ b/docs/source/Plugin/P011.rst
@@ -34,6 +34,8 @@ After installing the software on the Arduino Nano, the simplest solution is to p
 
 NB: This software can also be installed on other Arduino models, that support I2C, Analog and Digital pins, but this hasn't been actively tested. Depending on the available IO pins, some of the features may not match with the Arduino Nano.
 
+2024-08-13: This plugin is excluded from ESP8266 1M builds for size reasons. It can still be used for Custom builds and is normally available in other builds.
+
 Device Configuration
 --------------------
 

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -1376,7 +1376,9 @@ To create/register a plugin, you have to :
     #define USES_P009   // MCP
 
     #define USES_P010   // BH1750
-    #define USES_P011   // PME
+    #ifndef ESP8266_1M
+      #define USES_P011   // PME (2024-08-13: moved to Collection builds)
+    #endif
     #define USES_P012   // LCD
     #define USES_P013   // HCSR04
     #define USES_P014   // SI7021

--- a/src/src/PluginStructs/P036_data_struct.h
+++ b/src/src/PluginStructs/P036_data_struct.h
@@ -24,7 +24,11 @@
 // # define P036_CHECK_HEAP        // Enable to add extra logging during Plugin_036()
 // # define P036_CHECK_INDIVIDUAL_FONT // Enable to add extra logging for individual font calculation
 # ifndef P036_FEATURE_DISPLAY_PREVIEW
-#  define P036_FEATURE_DISPLAY_PREVIEW   1
+#  ifdef ESP8266_1M
+#   define P036_FEATURE_DISPLAY_PREVIEW   0 // Disabled for 1M builds
+#  else // ifdef ESP8266_1M
+#   define P036_FEATURE_DISPLAY_PREVIEW   1
+#  endif // ifdef ESP8266_1M
 # endif // ifndef P036_FEATURE_DISPLAY_PREVIEW
 # ifndef P036_FEATURE_ALIGN_PREVIEW
 #  define P036_FEATURE_ALIGN_PREVIEW     1


### PR DESCRIPTION
The latest improvements have caused the 1M builds to no longer fit the binary limitations.

- [P011] ProMini Extender plugin: excluded from 1M builds (not often used, requires specific hardware)
- [P036] OledFramed plugin: Exclude the content-preview in the Web-UI for 1M builds.

TODO:
- [ ] Consider excluding other features (or plugins) when needed.