### PR TITLE
[Build] Fix: Use package with Solo1 'autodetect' (Solo1 specific packaged removed)

### DIFF
--- a/platformio_esp32_solo1.ini
+++ b/platformio_esp32_solo1.ini
@@ -3,7 +3,7 @@
 [esp32_solo1_common_LittleFS]
 extends                   = esp32_base_idf5
 platform                  = https://github.com/Jason2866/platform-espressif32.git#Arduino/IDF53
-platform_packages         = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/3020/framework-arduinoespressif32-solo1-release_v5.3-98aecc7e.zip
+platform_packages         = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/3085/framework-arduinoespressif32-all-release_v5.3-4c885a26.zip
 build_flags               = ${esp32_base_idf5.build_flags}
                             -DFEATURE_ARDUINO_OTA=1
                             -DUSE_LITTLEFS


### PR DESCRIPTION
Platform packages are no longer specific for ESP32-Solo1.