### PR TITLE
[Build] Enable Servo support for most builds

### DIFF
--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -2748,10 +2748,10 @@ To create/register a plugin, you have to :
   #define FEATURE_SETTINGS_ARCHIVE  0
 
   #ifndef PLUGIN_BUILD_CUSTOM
-  #ifdef FEATURE_SERVO
-    #undef FEATURE_SERVO
-  #endif
-  #define FEATURE_SERVO 0
+  // #ifdef FEATURE_SERVO
+  //   #undef FEATURE_SERVO
+  // #endif
+  // #define FEATURE_SERVO 0
   #endif
   #ifdef FEATURE_RTTTL
     #undef FEATURE_RTTTL
@@ -3210,7 +3210,7 @@ To create/register a plugin, you have to :
 #endif
 
 #ifndef FEATURE_SERVO
-#define FEATURE_SERVO                         0
+#define FEATURE_SERVO                         1
 #endif
 
 #ifndef FEATURE_SETTINGS_ARCHIVE              


### PR DESCRIPTION
From a [Forum request](https://www.letscontrolit.com/forum/viewtopic.php?t=10492)

Feature:
- Enable Servo support for most builds (adds ca. 1.2 kB to the bin size)

TODO:
- [ ] Fine-tuning for builds where it won't fit