### PR TITLE
[C002] Bugfix: Use correct GPIO pin for controlling P001

### DIFF
--- a/src/_C002.cpp
+++ b/src/_C002.cpp
@@ -110,7 +110,7 @@ bool CPlugin_002(CPlugin::Function function, struct EventStruct *event, String& 
               switch (Settings.getPluginID_for_task(x).value) {
                 case 1: // temp solution, if input switch, update state
                 {
-                  action = strformat(F("gpio,%d,%d"), x, static_cast<int>(nvalue));
+                  action = strformat(F("gpio,%d,%d"), Settings.TaskDevicePin1[x], static_cast<int>(nvalue));
                   break;
                 }
                 case 29: // temp solution, if plugin 029, set gpio


### PR DESCRIPTION
Resolves #5170 

Bugfix:
- Domoticz MQTT should use the correct GPIO pin for controlling Switch plugin (P001)