### PR TITLE
[ESP32-solo1] Fix bootloop on Solo1 boards

### DIFF
--- a/boards/esp32_solo1_4M.json
+++ b/boards/esp32_solo1_4M.json
@@ -1,9 +1,5 @@
 {
   "build": {
-    "arduino":{
-      "ldscript": "esp32_out.ld",
-      "memory_type": "dio_qspi"
-    },
     "core": "esp32",
     "extra_flags": "-DARDUINO_TASMOTA -DARDUINO_ESP32_DEV -DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_4M -DCORE32SOLO1  -DESP32_CLASSIC",
     "f_cpu": "160000000L",

--- a/platformio_esp32_solo1.ini
+++ b/platformio_esp32_solo1.ini
@@ -8,6 +8,7 @@ platform_packages = framework-arduino-solo1 @ https://github.com/Jason2866/esp32
 build_flags               = ${esp32_base_idf5.build_flags}
                             -DFEATURE_ARDUINO_OTA=1
                             -DUSE_LITTLEFS
+                            -DCORE32SOLO1
 extra_scripts             = ${esp32_base_idf5.extra_scripts}
 build_unflags             = ${esp32_base_idf5.build_unflags}
                             -fexceptions

--- a/src/src/ESPEasyCore/ESPEasy_setup.cpp
+++ b/src/src/ESPEasyCore/ESPEasy_setup.cpp
@@ -162,8 +162,8 @@ void ESPEasy_setup()
 
     if (pkg_version <= 7) { // D0WD, S0WD, D2WD
 #ifdef CORE32SOLO1
-      gpio_num_t PSRAM_CLK = GPIO_NUM_17;
-      gpio_num_t PSRAM_CS  = GPIO_NUM_16;
+      gpio_num_t PSRAM_CLK = GPIO_NUM_NC; //GPIO_NUM_17;
+      gpio_num_t PSRAM_CS  = GPIO_NUM_NC; //GPIO_NUM_16;
 #else
       gpio_num_t PSRAM_CLK = static_cast<gpio_num_t>(CONFIG_D0WD_PSRAM_CLK_IO);
       gpio_num_t PSRAM_CS  = static_cast<gpio_num_t>(CONFIG_D0WD_PSRAM_CS_IO);
@@ -187,14 +187,18 @@ void ESPEasy_setup()
       if (PSRAM_CLK != GPIO_NUM_NC) {
         esp_gpio_revoke(BIT64(PSRAM_CLK) | BIT64(PSRAM_CS));
       } else {
-        esp_gpio_revoke(BIT64(PSRAM_CS));
+        if (PSRAM_CS != GPIO_NUM_NC) {
+          esp_gpio_revoke(BIT64(PSRAM_CS));
+        }
       }
 #  endif // if ESP_IDF_VERSION > ESP_IDF_VERSION_VAL(5, 2, 0)
 
       if (PSRAM_CLK != GPIO_NUM_NC) {
         gpio_reset_pin(PSRAM_CLK);
       }
-      gpio_reset_pin(PSRAM_CS);
+      if (PSRAM_CS != GPIO_NUM_NC) {
+        gpio_reset_pin(PSRAM_CS);
+      }
     }
   }
 # endif  // if CONFIG_IDF_TARGET_ESP32
@@ -359,6 +363,7 @@ void ESPEasy_setup()
   #endif // ifndef BUILD_NO_RAM_TRACKER
 
 #ifdef ESP32
+#ifndef CORE32SOLO1
 
   // Configure dynamic frequency scaling:
   // maximum and minimum frequencies are set in sdkconfig,
@@ -373,6 +378,7 @@ void ESPEasy_setup()
 # endif // if CONFIG_FREERTOS_USE_TICKLESS_IDLE
   };
   esp_pm_configure(&pm_config);
+#endif
 #endif // ifdef ESP32
 
 


### PR DESCRIPTION
- Remove obsolete defines in board definition
- So not free up GPIO-16 and -17 during setup
- Do not set clock frequency