### PR TITLE
[MQTT] Add setting for Keep Alive Time

### DIFF
--- a/src/src/DataStructs/ControllerSettingsStruct.cpp
+++ b/src/src/DataStructs/ControllerSettingsStruct.cpp
@@ -36,6 +36,7 @@ void ControllerSettingsStruct::reset() {
   ClientTimeout                                 = CONTROLLER_CLIENTTIMEOUT_DFLT;
   MustCheckReply                                = DEFAULT_CONTROLLER_MUST_CHECK_REPLY;
   SampleSetInitiator                            = INVALID_TASK_INDEX;
+  KeepAliveTime                                 = CONTROLLER_KEEP_ALIVE_TIME_DFLT;
   VariousBits1.mqtt_cleanSession                = 0;
   VariousBits1.mqtt_not_sendLWT                 = 0;
   VariousBits1.mqtt_not_willRetain              = 0;
@@ -46,6 +47,7 @@ void ControllerSettingsStruct::reset() {
   VariousBits1.allowExpire                      = 0;
   VariousBits1.deduplicate                      = 0;
   VariousBits1.useLocalSystemTime               = 0;
+  VariousBits1.TLStype                          = 0;
 
   safe_strncpy(ClientID, F(CONTROLLER_DEFAULT_CLIENTID), sizeof(ClientID));
 }

--- a/src/src/DataStructs/ControllerSettingsStruct.h
+++ b/src/src/DataStructs/ControllerSettingsStruct.h
@@ -54,6 +54,14 @@
 # define CONTROLLER_CLIENTTIMEOUT_DFLT     100
 #endif // ifndef CONTROLLER_CLIENTTIMEOUT_DFLT
 
+// MQTT Keep Alive Timeout
+#ifndef CONTROLLER_KEEP_ALIVE_TIME_MAX
+# define CONTROLLER_KEEP_ALIVE_TIME_MAX    65535
+#endif // ifndef CONTROLLER_KEEP_ALIVE_TIME_MAX
+#ifndef CONTROLLER_KEEP_ALIVE_TIME_DFLT
+# define CONTROLLER_KEEP_ALIVE_TIME_DFLT      60
+#endif // ifndef CONTROLLER_KEEP_ALIVE_TIME_DFLT
+
 #ifndef CONTROLLER_DEFAULT_CLIENTID
 # define CONTROLLER_DEFAULT_CLIENTID  "%sysname%_%unit%"
 #endif // ifndef CONTROLLER_DEFAULT_CLIENTID
@@ -99,6 +107,7 @@ struct ControllerSettingsStruct
     CONTROLLER_SEND_LWT,
     CONTROLLER_WILL_RETAIN,
     CONTROLLER_CLEAN_SESSION,
+    CONTROLLER_KEEP_ALIVE_TIME,
 #endif
     CONTROLLER_TIMEOUT,
     CONTROLLER_SAMPLE_SET_INITIATOR,
@@ -198,7 +207,7 @@ struct ControllerSettingsStruct
   unsigned int ClientTimeout;
   bool         MustCheckReply;     // When set to false, a sent message is considered always successful.
   taskIndex_t  SampleSetInitiator; // The first task to start a sample set.
-  uint8_t      UNUSED_4[2];
+  uint16_t     KeepAliveTime;      // The configured Keep Alive time in seconds, can be 0 (disabled) to 65535 (18+ hours)
 
   struct {
     uint32_t unused_00                        : 1; // Bit 00

--- a/src/src/ESPEasyCore/Controller.cpp
+++ b/src/src/ESPEasyCore/Controller.cpp
@@ -255,7 +255,7 @@ bool MQTTConnect(controllerIndex_t controller_idx)
       mqtt.setTimeout(timeout); // in msec as it should be!
   #  endif // ifdef MUSTFIX_CLIENT_TIMEOUT_IN_SECONDS
       MQTTclient.setClient(mqtt);
-      MQTTclient.setKeepAlive(10);
+      MQTTclient.setKeepAlive(ControllerSettings->KeepAliveTime);
       MQTTclient.setSocketTimeout(timeout);
       break;
     }
@@ -360,7 +360,7 @@ bool MQTTConnect(controllerIndex_t controller_idx)
     mqtt_tls->setBufferSizes(1024, 1024);
     #  endif // ifdef ESP8266
     MQTTclient.setClient(*mqtt_tls);
-    MQTTclient.setKeepAlive(10);
+    MQTTclient.setKeepAlive(ControllerSettings->KeepAliveTime);
     MQTTclient.setSocketTimeout(timeout);
 
 
@@ -394,7 +394,7 @@ bool MQTTConnect(controllerIndex_t controller_idx)
 #  endif // ifdef MUSTFIX_CLIENT_TIMEOUT_IN_SECONDS
 
   MQTTclient.setClient(mqtt);
-  MQTTclient.setKeepAlive(10);
+  MQTTclient.setKeepAlive(ControllerSettings->KeepAliveTime);
   MQTTclient.setSocketTimeout(timeout);
 # endif // if FEATURE_MQTT_TLS
 

--- a/src/src/Helpers/_CPlugin_Helper_webform.cpp
+++ b/src/src/Helpers/_CPlugin_Helper_webform.cpp
@@ -57,6 +57,7 @@ const __FlashStringHelper* toString(ControllerSettingsStruct::VarType parameterI
     case ControllerSettingsStruct::CONTROLLER_SEND_LWT:                 return F("Send LWT to broker");
     case ControllerSettingsStruct::CONTROLLER_WILL_RETAIN:              return F("Will Retain");
     case ControllerSettingsStruct::CONTROLLER_CLEAN_SESSION:            return F("Clean Session");
+    case ControllerSettingsStruct::CONTROLLER_KEEP_ALIVE_TIME:          return F("Keep Alive Time");
 #endif // if FEATURE_MQTT
     case ControllerSettingsStruct::CONTROLLER_USE_EXTENDED_CREDENTIALS: return F("Use Extended Credentials");
     case ControllerSettingsStruct::CONTROLLER_SEND_BINARY:              return F("Send Binary");
@@ -360,6 +361,10 @@ void addControllerParameterForm(const ControllerSettingsStruct  & ControllerSett
     case ControllerSettingsStruct::CONTROLLER_CLEAN_SESSION:
       addFormCheckBox(displayName, internalName, ControllerSettings.mqtt_cleanSession());
       break;
+    case ControllerSettingsStruct::CONTROLLER_KEEP_ALIVE_TIME:
+      addFormNumericBox(displayName, internalName, ControllerSettings.KeepAliveTime, 0, CONTROLLER_KEEP_ALIVE_TIME_MAX);
+      addUnit(F("sec"));
+      break;
 #endif // if FEATURE_MQTT
     case ControllerSettingsStruct::CONTROLLER_USE_EXTENDED_CREDENTIALS:
       addFormCheckBox(displayName, internalName, ControllerSettings.useExtendedCredentials());
@@ -535,6 +540,9 @@ void saveControllerParameterForm(ControllerSettingsStruct        & ControllerSet
       break;
     case ControllerSettingsStruct::CONTROLLER_CLEAN_SESSION:
       ControllerSettings.mqtt_cleanSession(isFormItemChecked(internalName));
+      break;
+    case ControllerSettingsStruct::CONTROLLER_KEEP_ALIVE_TIME:
+      ControllerSettings.KeepAliveTime = getFormItemInt(internalName, ControllerSettings.KeepAliveTime);
       break;
 #endif // if FEATURE_MQTT
     case ControllerSettingsStruct::CONTROLLER_USE_EXTENDED_CREDENTIALS:

--- a/src/src/WebServer/ControllerPage.cpp
+++ b/src/src/WebServer/ControllerPage.cpp
@@ -458,6 +458,7 @@ void handle_controllers_ControllerSettingsPage(controllerIndex_t controllerindex
             addControllerParameterForm(*ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_SEND_LWT);
             addControllerParameterForm(*ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_WILL_RETAIN);
             addControllerParameterForm(*ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_CLEAN_SESSION);
+            addControllerParameterForm(*ControllerSettings, controllerindex, ControllerSettingsStruct::CONTROLLER_KEEP_ALIVE_TIME);
           }
           # endif // if FEATURE_MQTT
         }


### PR DESCRIPTION
Features:
- Add `Keep Alive Time` setting for MQTT Controllers
  - Configurable from 0 (disabled) to 65535 seconds, as defined in the MQTT specifications
  - Default used to be 10 seconds, but as that's quite short, the common default of 60 seconds is set during upgrade.

TODO:
- [x] Testing