### PR TITLE
[Build] Reduce code size to allow for some bugfixes in limited builds

### DIFF
--- a/src/_P001_Switch.ino
+++ b/src/_P001_Switch.ino
@@ -34,15 +34,16 @@ boolean Plugin_001(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_001;
-      Device[deviceCount].Type               = DEVICE_TYPE_SINGLE;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SWITCH;
-      Device[deviceCount].PullUpOption       = true;
-      Device[deviceCount].InverseLogicOption = true;
-      Device[deviceCount].ValueCount         = 1;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].TimerOptional      = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number             = PLUGIN_ID_001;
+      dev.Type               = DEVICE_TYPE_SINGLE;
+      dev.VType              = Sensor_VType::SENSOR_TYPE_SWITCH;
+      dev.PullUpOption       = true;
+      dev.InverseLogicOption = true;
+      dev.ValueCount         = 1;
+      dev.SendDataOption     = true;
+      dev.TimerOption        = true;
+      dev.TimerOptional      = true;
       break;
     }
 

--- a/src/_P001_Switch.ino
+++ b/src/_P001_Switch.ino
@@ -37,15 +37,12 @@ boolean Plugin_001(uint8_t function, struct EventStruct *event, String& string)
       Device[++deviceCount].Number           = PLUGIN_ID_001;
       Device[deviceCount].Type               = DEVICE_TYPE_SINGLE;
       Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SWITCH;
-      Device[deviceCount].Ports              = 0;
       Device[deviceCount].PullUpOption       = true;
       Device[deviceCount].InverseLogicOption = true;
-      Device[deviceCount].FormulaOption      = false;
       Device[deviceCount].ValueCount         = 1;
       Device[deviceCount].SendDataOption     = true;
       Device[deviceCount].TimerOption        = true;
       Device[deviceCount].TimerOptional      = true;
-      Device[deviceCount].GlobalSyncOption   = true;
       break;
     }
 
@@ -87,7 +84,8 @@ boolean Plugin_001(uint8_t function, struct EventStruct *event, String& string)
         const __FlashStringHelper *options[] = { F("Switch"), F("Dimmer") };
         const int optionValues[]             = { PLUGIN_001_TYPE_SWITCH, PLUGIN_001_TYPE_DIMMER };
         const uint8_t switchtype             = P001_data_struct::P001_getSwitchType(event);
-        addFormSelector(F("Switch Type"), F("type"), NR_ELEMENTS(optionValues), options, optionValues, switchtype);
+        constexpr size_t optionCount         = NR_ELEMENTS(optionValues);
+        addFormSelector(F("Switch Type"), F("type"), optionCount, options, optionValues, switchtype);
 
         if (switchtype == PLUGIN_001_TYPE_DIMMER)
         {

--- a/src/_P002_ADC.ino
+++ b/src/_P002_ADC.ino
@@ -23,19 +23,15 @@ boolean Plugin_002(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_002;
-      Device[deviceCount].Type               = DEVICE_TYPE_ANALOG;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 1;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
-      Device[deviceCount].TaskLogsOwnPeaks   = true;
+      Device[++deviceCount].Number         = PLUGIN_ID_002;
+      Device[deviceCount].Type             = DEVICE_TYPE_ANALOG;
+      Device[deviceCount].VType            = Sensor_VType::SENSOR_TYPE_SINGLE;
+      Device[deviceCount].FormulaOption    = true;
+      Device[deviceCount].ValueCount       = 1;
+      Device[deviceCount].SendDataOption   = true;
+      Device[deviceCount].TimerOption      = true;
+      Device[deviceCount].PluginStats      = true;
+      Device[deviceCount].TaskLogsOwnPeaks = true;
       break;
     }
 
@@ -133,7 +129,7 @@ boolean Plugin_002(uint8_t function, struct EventStruct *event, String& string)
 
         if (loglevelActiveFor(LOG_LEVEL_INFO)) {
           String log = strformat(
-            F("ADC  : Analog value: %d = %s"), 
+            F("ADC  : Analog value: %d = %s"),
             raw_value,
             formatUserVarNoCheck(event, 0).c_str());
 

--- a/src/_P002_ADC.ino
+++ b/src/_P002_ADC.ino
@@ -23,15 +23,16 @@ boolean Plugin_002(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number         = PLUGIN_ID_002;
-      Device[deviceCount].Type             = DEVICE_TYPE_ANALOG;
-      Device[deviceCount].VType            = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].FormulaOption    = true;
-      Device[deviceCount].ValueCount       = 1;
-      Device[deviceCount].SendDataOption   = true;
-      Device[deviceCount].TimerOption      = true;
-      Device[deviceCount].PluginStats      = true;
-      Device[deviceCount].TaskLogsOwnPeaks = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number           = PLUGIN_ID_002;
+      dev.Type             = DEVICE_TYPE_ANALOG;
+      dev.VType            = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.FormulaOption    = true;
+      dev.ValueCount       = 1;
+      dev.SendDataOption   = true;
+      dev.TimerOption      = true;
+      dev.PluginStats      = true;
+      dev.TaskLogsOwnPeaks = true;
       break;
     }
 

--- a/src/_P003_Pulse.ino
+++ b/src/_P003_Pulse.ino
@@ -53,17 +53,18 @@ boolean Plugin_003(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number         = PLUGIN_ID_003;
-      Device[deviceCount].Type             = DEVICE_TYPE_SINGLE;
-      Device[deviceCount].VType            = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].PullUpOption     = true;
-      Device[deviceCount].FormulaOption    = true;
-      Device[deviceCount].ValueCount       = PLUGIN_NR_VALUENAMES_003;
-      Device[deviceCount].SendDataOption   = true;
-      Device[deviceCount].TimerOption      = true;
-      Device[deviceCount].TimerOptional    = true;
-      Device[deviceCount].PluginStats      = true;
-      Device[deviceCount].TaskLogsOwnPeaks = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number           = PLUGIN_ID_003;
+      dev.Type             = DEVICE_TYPE_SINGLE;
+      dev.VType            = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.PullUpOption     = true;
+      dev.FormulaOption    = true;
+      dev.ValueCount       = PLUGIN_NR_VALUENAMES_003;
+      dev.SendDataOption   = true;
+      dev.TimerOption      = true;
+      dev.TimerOptional    = true;
+      dev.PluginStats      = true;
+      dev.TaskLogsOwnPeaks = true;
       break;
     }
 

--- a/src/_P003_Pulse.ino
+++ b/src/_P003_Pulse.ino
@@ -53,20 +53,17 @@ boolean Plugin_003(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_003;
-      Device[deviceCount].Type               = DEVICE_TYPE_SINGLE;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = true;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = PLUGIN_NR_VALUENAMES_003;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].TimerOptional      = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
-      Device[deviceCount].TaskLogsOwnPeaks   = true;
+      Device[++deviceCount].Number         = PLUGIN_ID_003;
+      Device[deviceCount].Type             = DEVICE_TYPE_SINGLE;
+      Device[deviceCount].VType            = Sensor_VType::SENSOR_TYPE_SINGLE;
+      Device[deviceCount].PullUpOption     = true;
+      Device[deviceCount].FormulaOption    = true;
+      Device[deviceCount].ValueCount       = PLUGIN_NR_VALUENAMES_003;
+      Device[deviceCount].SendDataOption   = true;
+      Device[deviceCount].TimerOption      = true;
+      Device[deviceCount].TimerOptional    = true;
+      Device[deviceCount].PluginStats      = true;
+      Device[deviceCount].TaskLogsOwnPeaks = true;
       break;
     }
 
@@ -165,7 +162,8 @@ boolean Plugin_003(uint8_t function, struct EventStruct *event, String& string)
           F("Time/Delta"),
           # endif // if P003_USE_EXTRA_COUNTERTYPES
         };
-        addFormSelector(F("Counter Type"), F("countertype"), NR_ELEMENTS(options), options, nullptr, choice);
+        constexpr size_t optionCount = NR_ELEMENTS(options);
+        addFormSelector(F("Counter Type"), F("countertype"), optionCount, options, nullptr, choice);
 
         if (choice != 0) {
           addHtml(F("<span style=\"color:red\">Total count is not persistent!</span>"));

--- a/src/_P004_Dallas.ino
+++ b/src/_P004_Dallas.ino
@@ -51,17 +51,15 @@ boolean Plugin_004(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number         = PLUGIN_ID_004;
-      Device[deviceCount].Type             = DEVICE_TYPE_DUAL;
-      Device[deviceCount].VType            = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].Ports            = 0;
-      Device[deviceCount].FormulaOption    = true;
-      Device[deviceCount].ValueCount       = 1;
-      Device[deviceCount].SendDataOption   = true;
-      Device[deviceCount].TimerOption      = true;
-      Device[deviceCount].GlobalSyncOption = true;
-      Device[deviceCount].OutputDataType   = Output_Data_type_t::Simple;
-      Device[deviceCount].PluginStats      = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_004;
+      Device[deviceCount].Type           = DEVICE_TYPE_DUAL;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 1;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].OutputDataType = Output_Data_type_t::Simple;
+      Device[deviceCount].PluginStats    = true;
       Device[deviceCount].setPin2Direction(gpio_direction::gpio_output);
       break;
     }
@@ -139,18 +137,20 @@ boolean Plugin_004(uint8_t function, struct EventStruct *event, String& string)
           int resolutionChoice = P004_RESOLUTION;
 
           if ((resolutionChoice < 9) || (resolutionChoice > 12)) { resolutionChoice = activeRes; }
-          const __FlashStringHelper *resultsOptions[4] = { F("9"), F("10"), F("11"), F("12") };
-          int resultsOptionValues[4]                   = { 9, 10, 11, 12 };
-          addFormSelector(F("Device Resolution"), F("res"), 4, resultsOptions, resultsOptionValues, resolutionChoice);
+          const __FlashStringHelper *resultsOptions[] = { F("9"), F("10"), F("11"), F("12") };
+          const int resultsOptionValues[]             = { 9, 10, 11, 12 };
+          constexpr size_t optionCount                = NR_ELEMENTS(resultsOptionValues);
+          addFormSelector(F("Device Resolution"), F("res"), optionCount, resultsOptions, resultsOptionValues, resolutionChoice);
           addHtml(F(" Bit"));
         }
 
         {
           // Value in case of Error
-          const __FlashStringHelper *resultsOptions[5] = { F("NaN"), F("-127"), F("0"), F("125"), F("Ignore") };
-          int resultsOptionValues[5]                   =
+          const __FlashStringHelper *resultsOptions[] = { F("NaN"), F("-127"), F("0"), F("125"), F("Ignore") };
+          int resultsOptionValues[]                   =
           { P004_ERROR_NAN, P004_ERROR_MIN_RANGE, P004_ERROR_ZERO, P004_ERROR_MAX_RANGE, P004_ERROR_IGNORE };
-          addFormSelector(F("Error State Value"), F("err"), 5, resultsOptions, resultsOptionValues, P004_ERROR_STATE_OUTPUT);
+          constexpr size_t optionCount = NR_ELEMENTS(resultsOptionValues);
+          addFormSelector(F("Error State Value"), F("err"), optionCount, resultsOptions, resultsOptionValues, P004_ERROR_STATE_OUTPUT);
         }
         addFormNote(F("External pull up resistor is needed, see docs!"));
 
@@ -338,9 +338,7 @@ boolean Plugin_004(uint8_t function, struct EventStruct *event, String& string)
                 } else {
                   log += F("Error!");
                 }
-                log += F(" (");
-                log += P004_data->get_formatted_address(i);
-                log += ')';
+                log += strformat(F(" (%s)"), P004_data->get_formatted_address(i).c_str());
                 addLogMove(LOG_LEVEL_INFO, log);
               }
             }

--- a/src/_P004_Dallas.ino
+++ b/src/_P004_Dallas.ino
@@ -51,16 +51,17 @@ boolean Plugin_004(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_004;
-      Device[deviceCount].Type           = DEVICE_TYPE_DUAL;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 1;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].OutputDataType = Output_Data_type_t::Simple;
-      Device[deviceCount].PluginStats    = true;
-      Device[deviceCount].setPin2Direction(gpio_direction::gpio_output);
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_004;
+      dev.Type           = DEVICE_TYPE_DUAL;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 1;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.OutputDataType = Output_Data_type_t::Simple;
+      dev.PluginStats    = true;
+      dev.setPin2Direction(gpio_direction::gpio_output);
       break;
     }
 

--- a/src/_P005_DHT.ino
+++ b/src/_P005_DHT.ino
@@ -23,14 +23,15 @@ boolean Plugin_005(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_005;
-      Device[deviceCount].Type               = DEVICE_TYPE_SINGLE;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 2;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].PluginStats        = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number             = PLUGIN_ID_005;
+      dev.Type               = DEVICE_TYPE_SINGLE;
+      dev.VType              = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
+      dev.FormulaOption      = true;
+      dev.ValueCount         = 2;
+      dev.SendDataOption     = true;
+      dev.TimerOption        = true;
+      dev.PluginStats        = true;
       break;
     }
 

--- a/src/_P005_DHT.ino
+++ b/src/_P005_DHT.ino
@@ -1,18 +1,18 @@
 #include "_Plugin_Helper.h"
 #ifdef USES_P005
-//#######################################################################################################
-//######################## Plugin 005: Temperature and Humidity sensor DHT 11/22 ########################
-//#######################################################################################################
 
-#include "src/PluginStructs/P005_data_struct.h"
+// #######################################################################################################
+// ######################## Plugin 005: Temperature and Humidity sensor DHT 11/22 ########################
+// #######################################################################################################
 
-#define PLUGIN_005
-#define PLUGIN_ID_005         5
-#define PLUGIN_NAME_005       "Environment - DHT11/12/22  SONOFF2301/7021/MS01"
-#define PLUGIN_VALUENAME1_005      "Temperature"
-#define PLUGIN_VALUENAME1_005_MS01 "RAW"
-#define PLUGIN_VALUENAME2_005      "Humidity"
+# include "src/PluginStructs/P005_data_struct.h"
 
+# define PLUGIN_005
+# define PLUGIN_ID_005         5
+# define PLUGIN_NAME_005       "Environment - DHT11/12/22  SONOFF2301/7021/MS01"
+# define PLUGIN_VALUENAME1_005      "Temperature"
+# define PLUGIN_VALUENAME1_005_MS01 "RAW"
+# define PLUGIN_VALUENAME2_005      "Humidity"
 
 
 boolean Plugin_005(uint8_t function, struct EventStruct *event, String& string)
@@ -22,85 +22,81 @@ boolean Plugin_005(uint8_t function, struct EventStruct *event, String& string)
   switch (function)
   {
     case PLUGIN_DEVICE_ADD:
-      {
-        Device[++deviceCount].Number = PLUGIN_ID_005;
-        Device[deviceCount].Type = DEVICE_TYPE_SINGLE;
-        Device[deviceCount].VType = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
-        Device[deviceCount].Ports = 0;
-        Device[deviceCount].PullUpOption = false;
-        Device[deviceCount].InverseLogicOption = false;
-        Device[deviceCount].FormulaOption = true;
-        Device[deviceCount].ValueCount = 2;
-        Device[deviceCount].SendDataOption = true;
-        Device[deviceCount].TimerOption = true;
-        Device[deviceCount].GlobalSyncOption = true;
-        Device[deviceCount].PluginStats = true;
-        break;
-      }
+    {
+      Device[++deviceCount].Number           = PLUGIN_ID_005;
+      Device[deviceCount].Type               = DEVICE_TYPE_SINGLE;
+      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
+      Device[deviceCount].FormulaOption      = true;
+      Device[deviceCount].ValueCount         = 2;
+      Device[deviceCount].SendDataOption     = true;
+      Device[deviceCount].TimerOption        = true;
+      Device[deviceCount].PluginStats        = true;
+      break;
+    }
 
     case PLUGIN_GET_DEVICENAME:
-      {
-        string = F(PLUGIN_NAME_005);
-        break;
-      }
+    {
+      string = F(PLUGIN_NAME_005);
+      break;
+    }
 
     case PLUGIN_GET_DEVICEVALUENAMES:
-      {
-        if (PCONFIG(0) == P005_MS01) {
-          strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[0], PSTR(PLUGIN_VALUENAME1_005_MS01));
-        } else {
-          strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[0], PSTR(PLUGIN_VALUENAME1_005));
-        }
-        strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[1], PSTR(PLUGIN_VALUENAME2_005));
-        break;
+    {
+      if (PCONFIG(0) == P005_MS01) {
+        strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[0], PSTR(PLUGIN_VALUENAME1_005_MS01));
+      } else {
+        strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[0], PSTR(PLUGIN_VALUENAME1_005));
       }
+      strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[1], PSTR(PLUGIN_VALUENAME2_005));
+      break;
+    }
 
     case PLUGIN_GET_DEVICEGPIONAMES:
-      {
-        event->String1 = formatGpioName_bidirectional(F("Data"));
-        break;
-      }
+    {
+      event->String1 = formatGpioName_bidirectional(F("Data"));
+      break;
+    }
 
     case PLUGIN_WEBFORM_LOAD:
-      {
-        const __FlashStringHelper * options[] = { F("DHT 11"), F("DHT 22"), F("DHT 12"), F("Sonoff am2301"), F("Sonoff si7021"), F("Sonoff MS01") };
-        const int indices[] = { P005_DHT11, P005_DHT22, P005_DHT12, P005_AM2301, P005_SI7021, P005_MS01 };
+    {
+      const __FlashStringHelper *options[] = { F("DHT 11"), F("DHT 22"), F("DHT 12"), F("Sonoff am2301"), F("Sonoff si7021"),
+                                               F("Sonoff MS01") };
+      const int indices[] = { P005_DHT11, P005_DHT22, P005_DHT12, P005_AM2301, P005_SI7021, P005_MS01 };
 
-        constexpr size_t nrElements = NR_ELEMENTS(indices);
+      constexpr size_t nrElements = NR_ELEMENTS(indices);
 
-        addFormSelector(F("Sensor model"), F("dhttype"), nrElements, options, indices, PCONFIG(0) );
+      addFormSelector(F("Sensor model"), F("dhttype"), nrElements, options, indices, PCONFIG(0));
 
-        success = true;
-        break;
-      }
+      success = true;
+      break;
+    }
 
     case PLUGIN_WEBFORM_SAVE:
-      {
-        PCONFIG(0) = getFormItemInt(F("dhttype"));
+    {
+      PCONFIG(0) = getFormItemInt(F("dhttype"));
 
-        success = true;
-        break;
-      }
+      success = true;
+      break;
+    }
 
     case PLUGIN_INIT:
-      {
-        success = initPluginTaskData(event->TaskIndex, new (std::nothrow) P005_data_struct(event));
-        break;
-      }
+    {
+      success = initPluginTaskData(event->TaskIndex, new (std::nothrow) P005_data_struct(event));
+      break;
+    }
 
     case PLUGIN_READ:
-      {
-        P005_data_struct *P005_data =
-          static_cast<P005_data_struct *>(getPluginTaskData(event->TaskIndex));
+    {
+      P005_data_struct *P005_data =
+        static_cast<P005_data_struct *>(getPluginTaskData(event->TaskIndex));
 
-        if (nullptr != P005_data) {
-          success = P005_data->readDHT(event);
-        }
-        break;
+      if (nullptr != P005_data) {
+        success = P005_data->readDHT(event);
       }
+      break;
+    }
   }
   return success;
 }
-
 
 #endif // USES_P005

--- a/src/_P006_BMP085.ino
+++ b/src/_P006_BMP085.ino
@@ -23,14 +23,15 @@ boolean Plugin_006(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_006;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_TEMP_BARO;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 2;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_006;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_TEMP_BARO;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 2;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P006_BMP085.ino
+++ b/src/_P006_BMP085.ino
@@ -23,18 +23,14 @@ boolean Plugin_006(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_006;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TEMP_BARO;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 2;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_006;
+      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_TEMP_BARO;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 2;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].PluginStats    = true;
       break;
     }
 

--- a/src/_P007_PCF8591.ino
+++ b/src/_P007_PCF8591.ino
@@ -36,15 +36,16 @@ boolean Plugin_007(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_007;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 1;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].OutputDataType = Output_Data_type_t::Simple;
-      Device[deviceCount].I2CMax100kHz   = true; // Max 100 kHz allowed/supported
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_007;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 1;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.OutputDataType = Output_Data_type_t::Simple;
+      dev.I2CMax100kHz   = true; // Max 100 kHz allowed/supported
       break;
     }
 

--- a/src/_P007_PCF8591.ino
+++ b/src/_P007_PCF8591.ino
@@ -36,19 +36,15 @@ boolean Plugin_007(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_007;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 1;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].OutputDataType     = Output_Data_type_t::Simple;
-      Device[deviceCount].I2CMax100kHz       = true; // Max 100 kHz allowed/supported
+      Device[++deviceCount].Number       = PLUGIN_ID_007;
+      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 1;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].OutputDataType = Output_Data_type_t::Simple;
+      Device[deviceCount].I2CMax100kHz   = true; // Max 100 kHz allowed/supported
       break;
     }
 
@@ -109,7 +105,8 @@ boolean Plugin_007(uint8_t function, struct EventStruct *event, String& string)
         }
         addFormSelectorI2C(F("pi2c"), 8, i2cAddressValues, address);
         addFormSelector(F("Port"), F("pport"), 4, portNames, portValues, port);
-        addFormNote(F("Selected Port value will be stored in first 'Values' field and consecutively for 'Number Output Values' &gt; Single."));
+        addFormNote(F(
+                      "Selected Port value will be stored in first 'Values' field and consecutively for 'Number Output Values' &gt; Single."));
       } else {
         success = intArrayContains(8, i2cAddressValues, event->Par1);
       }
@@ -143,7 +140,8 @@ boolean Plugin_007(uint8_t function, struct EventStruct *event, String& string)
         0b00100000,
         0b00110000,
       };
-      addFormSelector(F("Input mode"), F("input_mode"), 4, inputModeOptions, inputModeValues, P007_INPUT_MODE);
+      constexpr size_t optionCount = NR_ELEMENTS(inputModeValues);
+      addFormSelector(F("Input mode"), F("input_mode"), optionCount, inputModeOptions, inputModeValues, P007_INPUT_MODE);
 
       addFormCheckBox(F("Enable Analog output (AOUT)"), F("output_mode"), P007_OUTPUT_MODE == P007_OUTPUT_ENABLED);
 
@@ -209,12 +207,12 @@ boolean Plugin_007(uint8_t function, struct EventStruct *event, String& string)
             success = true;
           }
         } else {
-          UserVar.setFloat(event->TaskIndex, var, 0);
+          UserVar.setFloat(event->TaskIndex, var, 0.0f);
         }
       }
 
       for (; var < VARS_PER_TASK; ++var) {
-        UserVar.setFloat(event->TaskIndex, var, 0);
+        UserVar.setFloat(event->TaskIndex, var, 0.0f);
       }
       break;
     }

--- a/src/_P008_RFID.ino
+++ b/src/_P008_RFID.ino
@@ -47,11 +47,12 @@ boolean Plugin_008(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_008;
-      Device[deviceCount].Type           = DEVICE_TYPE_DUAL;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_ULONG;
-      Device[deviceCount].ValueCount     = 1;
-      Device[deviceCount].SendDataOption = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_008;
+      dev.Type           = DEVICE_TYPE_DUAL;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_ULONG;
+      dev.ValueCount     = 1;
+      dev.SendDataOption = true;
       break;
     }
 

--- a/src/_P008_RFID.ino
+++ b/src/_P008_RFID.ino
@@ -47,13 +47,11 @@ boolean Plugin_008(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number         = PLUGIN_ID_008;
-      Device[deviceCount].Type             = DEVICE_TYPE_DUAL;
-      Device[deviceCount].VType            = Sensor_VType::SENSOR_TYPE_ULONG;
-      Device[deviceCount].Ports            = 0;
-      Device[deviceCount].ValueCount       = 1;
-      Device[deviceCount].SendDataOption   = true;
-      Device[deviceCount].GlobalSyncOption = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_008;
+      Device[deviceCount].Type           = DEVICE_TYPE_DUAL;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_ULONG;
+      Device[deviceCount].ValueCount     = 1;
+      Device[deviceCount].SendDataOption = true;
       break;
     }
 
@@ -159,15 +157,6 @@ boolean Plugin_008(uint8_t function, struct EventStruct *event, String& string)
       P008_COMPATIBILITY  = isFormItemChecked(F("comp")) ? 0 : 1;    // Inverted logic!
       P008_REMOVE_VALUE   = getFormItemInt(F("rmvval"));
       P008_REMOVE_TIMEOUT = getFormItemInt(F("rmvtime"));
-
-      // uint64_t keyMask = 0LL;
-      // keyMask = (0x1ull << (P008_DATA_BITS - 2));
-      // keyMask--;
-      // String log = F("P008: testing keyMask = 0x");
-      // log += ull2String(keyMask, HEX);
-      // log += F(" bits: ");
-      // log += P008_DATA_BITS;
-      // addLog(LOG_LEVEL_INFO, log);
 
       success = true;
       break;

--- a/src/_P009_MCP.ino
+++ b/src/_P009_MCP.ino
@@ -31,15 +31,11 @@ boolean Plugin_009(uint8_t function, struct EventStruct *event, String& string)
       Device[++deviceCount].Number           = PLUGIN_ID_009;
       Device[deviceCount].Type               = DEVICE_TYPE_I2C;
       Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SWITCH;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
       Device[deviceCount].InverseLogicOption = true;
-      Device[deviceCount].FormulaOption      = false;
       Device[deviceCount].ValueCount         = 1;
       Device[deviceCount].SendDataOption     = true;
       Device[deviceCount].TimerOption        = true;
       Device[deviceCount].TimerOptional      = true;
-      Device[deviceCount].GlobalSyncOption   = true;
       break;
     }
 

--- a/src/_P009_MCP.ino
+++ b/src/_P009_MCP.ino
@@ -28,14 +28,15 @@ boolean Plugin_009(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_009;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SWITCH;
-      Device[deviceCount].InverseLogicOption = true;
-      Device[deviceCount].ValueCount         = 1;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].TimerOptional      = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number             = PLUGIN_ID_009;
+      dev.Type               = DEVICE_TYPE_I2C;
+      dev.VType              = Sensor_VType::SENSOR_TYPE_SWITCH;
+      dev.InverseLogicOption = true;
+      dev.ValueCount         = 1;
+      dev.SendDataOption     = true;
+      dev.TimerOption        = true;
+      dev.TimerOptional      = true;
       break;
     }
 

--- a/src/_P010_BH1750.ino
+++ b/src/_P010_BH1750.ino
@@ -23,14 +23,15 @@ boolean Plugin_010(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_010;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 1;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_010;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 1;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P010_BH1750.ino
+++ b/src/_P010_BH1750.ino
@@ -23,18 +23,14 @@ boolean Plugin_010(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_010;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 1;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_010;
+      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 1;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].PluginStats    = true;
       break;
     }
 
@@ -87,7 +83,8 @@ boolean Plugin_010(uint8_t function, struct EventStruct *event, String& string)
         RESOLUTION_HIGH,
         RESOLUTION_AUTO_HIGH,
       };
-      addFormSelector(F("Measurement mode"), F("pmode"), 4, optionsMode, optionValuesMode, PCONFIG(1));
+      constexpr size_t optionCount = NR_ELEMENTS(optionValuesMode);
+      addFormSelector(F("Measurement mode"), F("pmode"), optionCount, optionsMode, optionValuesMode, PCONFIG(1));
 
       addFormCheckBox(F("Send sensor to sleep"), F("psleep"), PCONFIG(2));
 

--- a/src/_P011_PME.ino
+++ b/src/_P011_PME.ino
@@ -40,16 +40,14 @@ boolean Plugin_011(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_011;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].Ports              = PLUGIN_011_PORTS;
-      Device[deviceCount].ValueCount         = 1;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_011;
+      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].Ports          = PLUGIN_011_PORTS;
+      Device[deviceCount].ValueCount     = 1;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
       break;
     }
 
@@ -84,7 +82,8 @@ boolean Plugin_011(uint8_t function, struct EventStruct *event, String& string)
     {
       const __FlashStringHelper *options[] = { F("Digital"), F("Analog"), F("Input (switch)") };
       const int optionValues[]             = { P011_TYPE_DIGITAL, P011_TYPE_ANALOG, P011_TYPE_SWITCH };
-      addFormSelector(F("Port Type"), F("p011"), NR_ELEMENTS(options), options, optionValues, P011_PORT_TYPE);
+      constexpr size_t optionCount         = NR_ELEMENTS(options);
+      addFormSelector(F("Port Type"), F("p011"), optionCount, options, optionValues, P011_PORT_TYPE);
 
       success = true;
       break;

--- a/src/_P011_PME.ino
+++ b/src/_P011_PME.ino
@@ -40,14 +40,15 @@ boolean Plugin_011(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_011;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].Ports          = PLUGIN_011_PORTS;
-      Device[deviceCount].ValueCount     = 1;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_011;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.FormulaOption  = true;
+      dev.Ports          = PLUGIN_011_PORTS;
+      dev.ValueCount     = 1;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
       break;
     }
 

--- a/src/_P012_LCD.ino
+++ b/src/_P012_LCD.ino
@@ -45,10 +45,11 @@ boolean Plugin_012(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number    = PLUGIN_ID_012;
-      Device[deviceCount].Type        = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType       = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].TimerOption = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number      = PLUGIN_ID_012;
+      dev.Type        = DEVICE_TYPE_I2C;
+      dev.VType       = Sensor_VType::SENSOR_TYPE_NONE;
+      dev.TimerOption = true;
       break;
     }
 

--- a/src/_P012_LCD.ino
+++ b/src/_P012_LCD.ino
@@ -45,16 +45,10 @@ boolean Plugin_012(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_012;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].ValueCount         = 0;
-      Device[deviceCount].SendDataOption     = false;
-      Device[deviceCount].TimerOption        = true;
+      Device[++deviceCount].Number    = PLUGIN_ID_012;
+      Device[deviceCount].Type        = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType       = Sensor_VType::SENSOR_TYPE_NONE;
+      Device[deviceCount].TimerOption = true;
       break;
     }
 
@@ -74,11 +68,12 @@ boolean Plugin_012(uint8_t function, struct EventStruct *event, String& string)
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
       const uint8_t i2cAddressValues[] = { 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f };
+      constexpr size_t optionCount     = NR_ELEMENTS(i2cAddressValues);
 
       if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
-        addFormSelectorI2C(F("i2c_addr"), 16, i2cAddressValues, P012_I2C_ADDR);
+        addFormSelectorI2C(F("i2c_addr"), optionCount, i2cAddressValues, P012_I2C_ADDR);
       } else {
-        success = intArrayContains(16, i2cAddressValues, event->Par1);
+        success = intArrayContains(optionCount, i2cAddressValues, event->Par1);
       }
       break;
     }
@@ -99,8 +94,9 @@ boolean Plugin_012(uint8_t function, struct EventStruct *event, String& string)
           F("2 x 16"),
           F("4 x 20"),
         };
-        const int optionValues2[2] = { 1, 2 };
-        addFormSelector(F("Display Size"), F("psize"), 2, options2, optionValues2, P012_SIZE);
+        const int optionValues2[2]   = { 1, 2 };
+        constexpr size_t optionCount = NR_ELEMENTS(optionValues2);
+        addFormSelector(F("Display Size"), F("psize"), optionCount, options2, optionValues2, P012_SIZE);
       }
 
       {
@@ -126,8 +122,9 @@ boolean Plugin_012(uint8_t function, struct EventStruct *event, String& string)
           F("Truncate exceeding message"),
           F("Clear then truncate exceeding message"),
         };
-        const int optionValues3[] = { 0, 1, 2 };
-        addFormSelector(F("LCD command Mode"), F("pmode"), 3, options3, optionValues3, P012_MODE);
+        const int optionValues3[]    = { 0, 1, 2 };
+        constexpr size_t optionCount = NR_ELEMENTS(optionValues3);
+        addFormSelector(F("LCD command Mode"), F("pmode"), optionCount, options3, optionValues3, P012_MODE);
       }
 
       success = true;
@@ -253,23 +250,23 @@ boolean Plugin_012(uint8_t function, struct EventStruct *event, String& string)
       if (nullptr != P012_data) {
         String cmd = parseString(string, 1);
 
-        if (cmd.equalsIgnoreCase(F("LCDCMD")))
+        if (equals(cmd, F("lcdcmd")))
         {
           success = true;
           String arg1 = parseString(string, 2);
 
-          if (arg1.equalsIgnoreCase(F("Off"))) {
+          if (equals(arg1, F("off"))) {
             P012_data->lcd.noBacklight();
           }
-          else if (arg1.equalsIgnoreCase(F("On"))) {
+          else if (equals(arg1, F("on"))) {
             P012_data->lcd.backlight();
           }
-          else if (arg1.equalsIgnoreCase(F("Clear"))) {
+          else if (equals(arg1, F("clear"))) {
             P012_data->lcd.clear();
             P012_data->splashState = P012_splashState_e::SplashCleared;
           }
         }
-        else if (cmd.equalsIgnoreCase(F("LCD")))
+        else if (equals(cmd, F("lcd")))
         {
           success = true;
           int colPos  = event->Par2 - 1;

--- a/src/_P013_HCSR04.ino
+++ b/src/_P013_HCSR04.ino
@@ -47,16 +47,17 @@ boolean                    Plugin_013(uint8_t function, struct EventStruct *even
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_013;
-      Device[deviceCount].Type           = DEVICE_TYPE_DUAL;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 1;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].TimerOptional  = true;
-      Device[deviceCount].PluginStats    = true;
-      Device[deviceCount].setPin1Direction(gpio_direction::gpio_output);
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_013;
+      dev.Type           = DEVICE_TYPE_DUAL;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 1;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.TimerOptional  = true;
+      dev.PluginStats    = true;
+      dev.setPin1Direction(gpio_direction::gpio_output);
 
       break;
     }

--- a/src/_P013_HCSR04.ino
+++ b/src/_P013_HCSR04.ino
@@ -47,17 +47,15 @@ boolean                    Plugin_013(uint8_t function, struct EventStruct *even
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number         = PLUGIN_ID_013;
-      Device[deviceCount].Type             = DEVICE_TYPE_DUAL;
-      Device[deviceCount].VType            = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].Ports            = 0;
-      Device[deviceCount].FormulaOption    = true;
-      Device[deviceCount].ValueCount       = 1;
-      Device[deviceCount].SendDataOption   = true;
-      Device[deviceCount].TimerOption      = true;
-      Device[deviceCount].TimerOptional    = true;
-      Device[deviceCount].GlobalSyncOption = true;
-      Device[deviceCount].PluginStats      = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_013;
+      Device[deviceCount].Type           = DEVICE_TYPE_DUAL;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 1;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].TimerOptional  = true;
+      Device[deviceCount].PluginStats    = true;
       Device[deviceCount].setPin1Direction(gpio_direction::gpio_output);
 
       break;
@@ -131,13 +129,8 @@ boolean                    Plugin_013(uint8_t function, struct EventStruct *even
           F("Combined"),
           # endif // if P013_FEATURE_COMBINED_MODE
         };
-        addFormSelector(F("Mode"), F("pmode"),
-                        # if P013_FEATURE_COMBINED_MODE
-                        3
-                        # else // if P013_FEATURE_COMBINED_MODE
-                        2
-                        # endif // if P013_FEATURE_COMBINED_MODE
-                        , optionsOpMode, optionValuesOpMode, P013_OPERATINGMODE);
+        constexpr size_t optionCount = NR_ELEMENTS(optionValuesOpMode);
+        addFormSelector(F("Mode"), F("pmode"), optionCount, optionsOpMode, optionValuesOpMode, P013_OPERATINGMODE);
       }
 
       if ((P013_OPERATINGMODE == OPMODE_STATE)
@@ -155,21 +148,23 @@ boolean                    Plugin_013(uint8_t function, struct EventStruct *even
       addUnit(strUnit);
 
       {
-        const int optionValuesUnit[2] = { UNIT_CM, UNIT_INCH };
+        const int optionValuesUnit[] = { UNIT_CM, UNIT_INCH };
         const __FlashStringHelper *optionsUnit[] {
           F("Metric"),
           F("Imperial"),
         };
-        addFormSelector(F("Unit"), F("pUnit"), 2, optionsUnit, optionValuesUnit, P013_MEASURINGUNIT);
+        constexpr size_t optionCount = NR_ELEMENTS(optionValuesUnit);
+        addFormSelector(F("Unit"), F("pUnit"), optionCount, optionsUnit, optionValuesUnit, P013_MEASURINGUNIT);
       }
 
       {
-        const int optionValuesFilter[2] = { FILTER_NONE, FILTER_MEDIAN };
+        const int optionValuesFilter[] = { FILTER_NONE, FILTER_MEDIAN };
         const __FlashStringHelper *optionsFilter[] {
           F("None"),
           F("Median"),
         };
-        addFormSelector(F("Filter"), F("fltr"), 2, optionsFilter, optionValuesFilter, P013_FILTERTYPE);
+        constexpr size_t optionCount = NR_ELEMENTS(optionValuesFilter);
+        addFormSelector(F("Filter"), F("fltr"), optionCount, optionsFilter, optionValuesFilter, P013_FILTERTYPE);
       }
 
       // enable filtersize option if filter is used,

--- a/src/_P014_SI70xx.ino
+++ b/src/_P014_SI70xx.ino
@@ -44,16 +44,17 @@ boolean Plugin_014(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number         = PLUGIN_ID_014;
-      Device[deviceCount].Type             = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType            = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
-      Device[deviceCount].FormulaOption    = true;
-      Device[deviceCount].ValueCount       = 3;
-      Device[deviceCount].SendDataOption   = true;
-      Device[deviceCount].TimerOption      = true;
-      Device[deviceCount].I2CNoDeviceCheck = true;
-      Device[deviceCount].PluginStats      = true;
-      Device[deviceCount].OutputDataType   = Output_Data_type_t::All;
+      auto& dev = Device[++deviceCount];
+      dev.Number           = PLUGIN_ID_014;
+      dev.Type             = DEVICE_TYPE_I2C;
+      dev.VType            = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
+      dev.FormulaOption    = true;
+      dev.ValueCount       = 3;
+      dev.SendDataOption   = true;
+      dev.TimerOption      = true;
+      dev.I2CNoDeviceCheck = true;
+      dev.PluginStats      = true;
+      dev.OutputDataType   = Output_Data_type_t::All;
       break;
     }
 

--- a/src/_P014_SI70xx.ino
+++ b/src/_P014_SI70xx.ino
@@ -44,21 +44,16 @@ boolean Plugin_014(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_014;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 3;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].I2CNoDeviceCheck   = true;
-
-      // Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats    = true;
-      Device[deviceCount].OutputDataType = Output_Data_type_t::All;
+      Device[++deviceCount].Number         = PLUGIN_ID_014;
+      Device[deviceCount].Type             = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType            = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
+      Device[deviceCount].FormulaOption    = true;
+      Device[deviceCount].ValueCount       = 3;
+      Device[deviceCount].SendDataOption   = true;
+      Device[deviceCount].TimerOption      = true;
+      Device[deviceCount].I2CNoDeviceCheck = true;
+      Device[deviceCount].PluginStats      = true;
+      Device[deviceCount].OutputDataType   = Output_Data_type_t::All;
       break;
     }
 
@@ -108,25 +103,22 @@ boolean Plugin_014(uint8_t function, struct EventStruct *event, String& string)
 
     case PLUGIN_WEBFORM_LOAD:
     {
-      # define P014_RESOLUTION_OPTIONS 4
-
-      const __FlashStringHelper *options[P014_RESOLUTION_OPTIONS] = {
+      const __FlashStringHelper *options[] = {
         F("Temp 14 bits / RH 12 bits"),
         F("Temp 13 bits / RH 10 bits"),
         F("Temp 12 bits / RH  8 bits"),
         F("Temp 11 bits / RH 11 bits"),
       };
-      const int optionValues[P014_RESOLUTION_OPTIONS] = {
+      const int optionValues[] = {
         SI70xx_RESOLUTION_14T_12RH,
         SI70xx_RESOLUTION_13T_10RH,
         SI70xx_RESOLUTION_12T_08RH,
         SI70xx_RESOLUTION_11T_11RH,
       };
-      addFormSelector(F("Resolution"), F("pres"), P014_RESOLUTION_OPTIONS, options, optionValues, P014_RESOLUTION);
+      constexpr size_t optionCount = NR_ELEMENTS(optionValues);
+      addFormSelector(F("Resolution"), F("pres"), optionCount, options, optionValues, P014_RESOLUTION);
 
       addFormNumericBox("ADC Filter Power", F("pfilter"), P014_FILTER_POWER, 0, 4);
-
-      // addUnit(F("bits"));
 
       success = true;
       break;
@@ -137,12 +129,6 @@ boolean Plugin_014(uint8_t function, struct EventStruct *event, String& string)
       P014_I2C_ADDRESS  = getFormItemInt(F("i2c_addr"));
       P014_RESOLUTION   = getFormItemInt(F("pres"));
       P014_FILTER_POWER = getFormItemInt(F("pfilter"));
-
-      // Force device setup next time
-      // P014_data_struct *P014_data = static_cast<P014_data_struct *>(getPluginTaskData(event->TaskIndex));
-      // if (nullptr != P014_data) {
-      //  P014_data->state = P014_state::Uninitialized;
-      // }
 
       success = true;
       break;

--- a/src/_P015_TSL2561.ino
+++ b/src/_P015_TSL2561.ino
@@ -36,18 +36,14 @@ boolean Plugin_015(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_015;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TRIPLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 3;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_015;
+      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_TRIPLE;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 3;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].PluginStats    = true;
       break;
     }
 
@@ -99,38 +95,33 @@ boolean Plugin_015(uint8_t function, struct EventStruct *event, String& string)
     case PLUGIN_WEBFORM_LOAD:
     {
       {
-        # define TSL2561_INTEGRATION_OPTION 3
-        const __FlashStringHelper * options[TSL2561_INTEGRATION_OPTION] = {
+        const __FlashStringHelper *options[] = {
           F("13.7 ms"),
           F("101 ms"),
           F("402 ms"),
         };
-        const int optionValues[TSL2561_INTEGRATION_OPTION] = {
-          0x00,
-          0x01,
-          0x02,
-        };
-        addFormSelector(F("Integration time"), F("pintegration"), TSL2561_INTEGRATION_OPTION, options, optionValues, P015_INTEGRATION);
+        constexpr size_t optionCount = NR_ELEMENTS(options);
+        addFormSelector(F("Integration time"), F("pintegration"), optionCount, options, nullptr, P015_INTEGRATION);
       }
 
       addFormCheckBox(F("Send sensor to sleep:"), F("psleep"),
                       P015_SLEEP);
 
       {
-        # define TSL2561_GAIN_OPTION 4
-        const __FlashStringHelper *options[TSL2561_GAIN_OPTION] = {
+        const __FlashStringHelper *options[] = {
           F("No Gain"),
           F("16x Gain"),
           F("Auto Gain"),
           F("Extended Auto Gain"),
         };
-        const int optionValues[TSL2561_GAIN_OPTION] = {
+        const int optionValues[] = {
           P015_NO_GAIN,
           P015_16X_GAIN,
           P015_AUTO_GAIN,
           P015_EXT_AUTO_GAIN,
         };
-        addFormSelector(F("Gain"), F("pgain"), TSL2561_GAIN_OPTION, options, optionValues, P015_GAIN);
+        constexpr size_t optionCount = NR_ELEMENTS(optionValues);
+        addFormSelector(F("Gain"), F("pgain"), optionCount, options, optionValues, P015_GAIN);
       }
 
       success = true;

--- a/src/_P015_TSL2561.ino
+++ b/src/_P015_TSL2561.ino
@@ -36,14 +36,15 @@ boolean Plugin_015(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_015;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_TRIPLE;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 3;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_015;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_TRIPLE;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 3;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P016_IR.ino
+++ b/src/_P016_IR.ino
@@ -206,13 +206,11 @@ boolean Plugin_016(uint8_t function, struct EventStruct *event, String& string)
       # else // if P016_SEND_IR_TO_CONTROLLER
       Device[deviceCount].VType = Sensor_VType::SENSOR_TYPE_ULONG;
       # endif // if P016_SEND_IR_TO_CONTROLLER
-      Device[deviceCount].Ports              = 0;
       Device[deviceCount].PullUpOption       = true;
       Device[deviceCount].InverseLogicOption = true;
-      Device[deviceCount].FormulaOption      = false;
       Device[deviceCount].ValueCount         = 1;
       Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = false;
+      Device[deviceCount].TimerOption        = true;
       Device[deviceCount].TimerOptional      = true;
       break;
     }
@@ -378,7 +376,7 @@ boolean Plugin_016(uint8_t function, struct EventStruct *event, String& string)
           int protocolCount = 0;
 
           for (int i = static_cast<int>(decode_type_t::UNKNOWN); i < size; i++) {
-              const String protocol = typeToString(static_cast<decode_type_t>(i), false);
+            const String protocol = typeToString(static_cast<decode_type_t>(i), false);
 
             if ((!bAcceptUnknownType) && (static_cast<decode_type_t>(i) == UNKNOWN)) {
               continue;

--- a/src/_P016_IR.ino
+++ b/src/_P016_IR.ino
@@ -199,19 +199,20 @@ boolean Plugin_016(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number = PLUGIN_ID_016;
-      Device[deviceCount].Type     = DEVICE_TYPE_SINGLE;
+      auto& dev = Device[++deviceCount];
+      dev.Number   = PLUGIN_ID_016;
+      dev.Type     = DEVICE_TYPE_SINGLE;
       # if P016_SEND_IR_TO_CONTROLLER
-      Device[deviceCount].VType = Sensor_VType::SENSOR_TYPE_STRING;
+      dev.VType = Sensor_VType::SENSOR_TYPE_STRING;
       # else // if P016_SEND_IR_TO_CONTROLLER
-      Device[deviceCount].VType = Sensor_VType::SENSOR_TYPE_ULONG;
+      dev.VType = Sensor_VType::SENSOR_TYPE_ULONG;
       # endif // if P016_SEND_IR_TO_CONTROLLER
-      Device[deviceCount].PullUpOption       = true;
-      Device[deviceCount].InverseLogicOption = true;
-      Device[deviceCount].ValueCount         = 1;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].TimerOptional      = true;
+      dev.PullUpOption       = true;
+      dev.InverseLogicOption = true;
+      dev.ValueCount         = 1;
+      dev.SendDataOption     = true;
+      dev.TimerOption        = true;
+      dev.TimerOptional      = true;
       break;
     }
 

--- a/src/_P017_PN532.ino
+++ b/src/_P017_PN532.ino
@@ -84,12 +84,13 @@ boolean Plugin_017(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_017;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_ULONG;
-      Device[deviceCount].ValueCount     = 1;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOptional  = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_017;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_ULONG;
+      dev.ValueCount     = 1;
+      dev.SendDataOption = true;
+      dev.TimerOptional  = true;
       break;
     }
 

--- a/src/_P017_PN532.ino
+++ b/src/_P017_PN532.ino
@@ -84,17 +84,12 @@ boolean Plugin_017(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_017;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_ULONG;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].ValueCount         = 1;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = false;
-      Device[deviceCount].TimerOptional      = true;
-      Device[deviceCount].GlobalSyncOption   = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_017;
+      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_ULONG;
+      Device[deviceCount].ValueCount     = 1;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOptional  = true;
       break;
     }
 
@@ -149,15 +144,9 @@ boolean Plugin_017(uint8_t function, struct EventStruct *event, String& string)
       addFormNumericBox(F("Automatic Tag removal after"), F("removetime"), P017_REMOVAL_TIMEOUT, 250, 60000);
       addUnit(F("mSec."));
 
-
       addFormNumericBox(F("Value to set on Tag removal"), F("removevalue"), P017_NO_TAG_DETECTED_VALUE, 0, 2147483647);
 
-      // Max allowed is int
-      // =
-      // 0x7FFFFFFF ...
-
-      const bool eventOnRemoval = P017_EVENT_ON_TAG_REMOVAL == 1; // Normal state!
-      addFormCheckBox(F("Event on Tag removal"), F("eventremove"), eventOnRemoval);
+      addFormCheckBox(F("Event on Tag removal"), F("eventremove"), P017_EVENT_ON_TAG_REMOVAL == 1);
 
       success = true;
       break;
@@ -339,17 +328,10 @@ bool P017_handle_timer_in(struct EventStruct *event)
         tempcounter++;
 
         if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-          String log = F("PN532: ");
-
-          if (new_key) {
-            log += F("New Tag: ");
-          } else {
-            log += F("Old Tag: ");
-          }
-          log += key;
-          log += ' ';
-          log += tempcounter;
-          addLogMove(LOG_LEVEL_INFO, log);
+          addLog(LOG_LEVEL_INFO, strformat(F("PN532: %s Tag: %d %u"),
+                                           FsP(new_key ? F("New") : F("Old")),
+                                           key,
+                                           tempcounter));
         }
 
         if (new_key) { sendData(event); }

--- a/src/_P018_Dust.ino
+++ b/src/_P018_Dust.ino
@@ -1,17 +1,21 @@
 #include "_Plugin_Helper.h"
 #ifdef USES_P018
 
-#include "src/Helpers/Hardware.h"
+# include "src/Helpers/Hardware.h"
 # include <GPIO_Direct_Access.h>
 
-//#######################################################################################################
-//#################################### Plugin 018: GP2Y10 ###############################################
-//#######################################################################################################
+// #######################################################################################################
+// #################################### Plugin 018: GP2Y10 ###############################################
+// #######################################################################################################
 
-#define PLUGIN_018
-#define PLUGIN_ID_018 18
-#define PLUGIN_NAME_018 "Dust - Sharp GP2Y10"
-#define PLUGIN_VALUENAME1_018 "Dust"
+/** Changelog:
+ * 2025-01-03 tonhuisman: Small code size improvements, source formatted using Uncrustify
+ */
+
+# define PLUGIN_018
+# define PLUGIN_ID_018          18
+# define PLUGIN_NAME_018        "Dust - Sharp GP2Y10"
+# define PLUGIN_VALUENAME1_018  "Dust"
 
 boolean Plugin_018_init = false;
 
@@ -22,73 +26,72 @@ boolean Plugin_018(uint8_t function, struct EventStruct *event, String& string)
   switch (function)
   {
     case PLUGIN_DEVICE_ADD:
-      {
-        Device[++deviceCount].Number = PLUGIN_ID_018;
-        Device[deviceCount].Type = DEVICE_TYPE_SINGLE;
-        Device[deviceCount].VType = Sensor_VType::SENSOR_TYPE_SINGLE;
-        Device[deviceCount].Ports = 0;
-        Device[deviceCount].FormulaOption = true;
-        Device[deviceCount].ValueCount = 1;
-        Device[deviceCount].SendDataOption = true;
-        Device[deviceCount].TimerOption = true;
-        Device[deviceCount].GlobalSyncOption = true;
-        Device[deviceCount].PluginStats = true;
-        Device[deviceCount].setPin1Direction(gpio_direction::gpio_output);
-        break;
-      }
+    {
+      Device[++deviceCount].Number       = PLUGIN_ID_018;
+      Device[deviceCount].Type           = DEVICE_TYPE_SINGLE;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 1;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].PluginStats    = true;
+      Device[deviceCount].setPin1Direction(gpio_direction::gpio_output);
+      break;
+    }
 
     case PLUGIN_GET_DEVICENAME:
-      {
-        string = F(PLUGIN_NAME_018);
-        break;
-      }
+    {
+      string = F(PLUGIN_NAME_018);
+      break;
+    }
 
     case PLUGIN_GET_DEVICEVALUENAMES:
-      {
-        strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[0], PSTR(PLUGIN_VALUENAME1_018));
-        break;
-      }
+    {
+      strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[0], PSTR(PLUGIN_VALUENAME1_018));
+      break;
+    }
 
     case PLUGIN_GET_DEVICEGPIONAMES:
-      {
-        event->String1 = formatGpioName_output(F("LED"));
-        break;
-      }
+    {
+      event->String1 = formatGpioName_output(F("LED"));
+      break;
+    }
 
     case PLUGIN_INIT:
-      {
-        Plugin_018_init = true;
-        pinMode(CONFIG_PIN1, OUTPUT);
-        DIRECT_pinWrite(CONFIG_PIN1, HIGH);
-        success = true;
-        break;
-      }
+    {
+      Plugin_018_init = true;
+      pinMode(CONFIG_PIN1, OUTPUT);
+      DIRECT_pinWrite(CONFIG_PIN1, HIGH);
+      success = true;
+      break;
+    }
 
 
     case PLUGIN_READ:
-      {
-        ISR_noInterrupts();
-        int value = 0;
+    {
+      ISR_noInterrupts();
+      int value = 0;
 
-        for (uint8_t x = 0; x < 25; x++) {
-          DIRECT_pinWrite(CONFIG_PIN1, LOW);
-          delayMicroseconds(280);
-          value = value + espeasy_analogRead(A0);
-          delayMicroseconds(40);
-          DIRECT_pinWrite(CONFIG_PIN1, HIGH);
-          delayMicroseconds(9680);
-        }
-        ISR_interrupts();
-        UserVar.setFloat(event->TaskIndex, 0, value);
-
-        if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-          addLogMove(LOG_LEVEL_INFO, concat(F("GPY  : Dust value: "), value));
-        }
-
-        success = true;
-        break;
+      for (uint8_t x = 0; x < 25; ++x) {
+        DIRECT_pinWrite(CONFIG_PIN1, LOW);
+        delayMicroseconds(280);
+        value = value + espeasy_analogRead(A0);
+        delayMicroseconds(40);
+        DIRECT_pinWrite(CONFIG_PIN1, HIGH);
+        delayMicroseconds(9680);
       }
+      ISR_interrupts();
+      UserVar.setFloat(event->TaskIndex, 0, value);
+
+      if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+        addLogMove(LOG_LEVEL_INFO, concat(F("GPY  : Dust value: "), value));
+      }
+
+      success = true;
+      break;
+    }
   }
   return success;
 }
+
 #endif // USES_P018

--- a/src/_P018_Dust.ino
+++ b/src/_P018_Dust.ino
@@ -27,15 +27,16 @@ boolean Plugin_018(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_018;
-      Device[deviceCount].Type           = DEVICE_TYPE_SINGLE;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 1;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].PluginStats    = true;
-      Device[deviceCount].setPin1Direction(gpio_direction::gpio_output);
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_018;
+      dev.Type           = DEVICE_TYPE_SINGLE;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 1;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
+      dev.setPin1Direction(gpio_direction::gpio_output);
       break;
     }
 

--- a/src/_P019_PCF8574.ino
+++ b/src/_P019_PCF8574.ino
@@ -29,15 +29,11 @@ boolean Plugin_019(uint8_t function, struct EventStruct *event, String& string)
       Device[++deviceCount].Number           = PLUGIN_ID_019;
       Device[deviceCount].Type               = DEVICE_TYPE_I2C;
       Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SWITCH;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
       Device[deviceCount].InverseLogicOption = true;
-      Device[deviceCount].FormulaOption      = false;
       Device[deviceCount].ValueCount         = 1;
       Device[deviceCount].SendDataOption     = true;
       Device[deviceCount].TimerOption        = true;
       Device[deviceCount].TimerOptional      = true;
-      Device[deviceCount].GlobalSyncOption   = true;
       break;
     }
 

--- a/src/_P019_PCF8574.ino
+++ b/src/_P019_PCF8574.ino
@@ -26,14 +26,15 @@ boolean Plugin_019(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_019;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SWITCH;
-      Device[deviceCount].InverseLogicOption = true;
-      Device[deviceCount].ValueCount         = 1;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].TimerOptional      = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number             = PLUGIN_ID_019;
+      dev.Type               = DEVICE_TYPE_I2C;
+      dev.VType              = Sensor_VType::SENSOR_TYPE_SWITCH;
+      dev.InverseLogicOption = true;
+      dev.ValueCount         = 1;
+      dev.SendDataOption     = true;
+      dev.TimerOption        = true;
+      dev.TimerOptional      = true;
       break;
     }
 

--- a/src/_P020_Ser2Net.ino
+++ b/src/_P020_Ser2Net.ino
@@ -93,15 +93,8 @@ boolean Plugin_020(uint8_t function, struct EventStruct *event, String& string)
         Device[++deviceCount].Number       = PLUGIN_ID_020;
         Device[deviceCount].SendDataOption = true;
       }
-      Device[deviceCount].Type               = DEVICE_TYPE_SERIAL;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_STRING;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].ValueCount         = 0;
-      Device[deviceCount].TimerOption        = false;
-      Device[deviceCount].GlobalSyncOption   = false;
+      Device[deviceCount].Type  = DEVICE_TYPE_SERIAL;
+      Device[deviceCount].VType = Sensor_VType::SENSOR_TYPE_STRING;
       break;
     }
     case PLUGIN_GET_DEVICENAME:
@@ -388,8 +381,8 @@ boolean Plugin_020(uint8_t function, struct EventStruct *event, String& string)
 
         if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
           addLogMove(LOG_LEVEL_DEBUG, strformat(
-            F("Ser2net  : P020_RESET_TARGET_PIN : %d"), 
-            P020_RESET_TARGET_PIN));
+                       F("Ser2net  : P020_RESET_TARGET_PIN : %d"),
+                       P020_RESET_TARGET_PIN));
         }
         # endif // ifndef BUILD_NO_DEBUG
         pinMode(P020_RESET_TARGET_PIN, OUTPUT);
@@ -408,10 +401,10 @@ boolean Plugin_020(uint8_t function, struct EventStruct *event, String& string)
         task->_CRCcheck = P020_GET_BAUDRATE == 115200;
         # ifndef BUILD_NO_DEBUG
 
-        if (task->_CRCcheck) {
-          addLog(LOG_LEVEL_DEBUG, F("P1   : DSMR version 5 meter, CRC on"));
-        } else {
-          addLog(LOG_LEVEL_DEBUG, F("P1   : DSMR version 4 meter, CRC off"));
+        if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+          addLog(LOG_LEVEL_DEBUG, strformat(F("P1   : DSMR version %d meter, CRC %s"),
+                                            task->_CRCcheck ? 5 : 4,
+                                            FsP(task->_CRCcheck ? F("on") : F("off"))));
         }
         # endif // ifndef BUILD_NO_DEBUG
       }

--- a/src/_P020_Ser2Net.ino
+++ b/src/_P020_Ser2Net.ino
@@ -86,15 +86,17 @@ boolean Plugin_020(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
+      auto& dev = Device[++deviceCount];
+
       if (P020_Emulate_P044) {
-        Device[++deviceCount].Number       = PLUGIN_ID_020_044;
-        Device[deviceCount].SendDataOption = false;
+        dev.Number         = PLUGIN_ID_020_044;
+        dev.SendDataOption = false;
       } else {
-        Device[++deviceCount].Number       = PLUGIN_ID_020;
-        Device[deviceCount].SendDataOption = true;
+        dev.Number         = PLUGIN_ID_020;
+        dev.SendDataOption = true;
       }
-      Device[deviceCount].Type  = DEVICE_TYPE_SERIAL;
-      Device[deviceCount].VType = Sensor_VType::SENSOR_TYPE_STRING;
+      dev.Type  = DEVICE_TYPE_SERIAL;
+      dev.VType = Sensor_VType::SENSOR_TYPE_STRING;
       break;
     }
     case PLUGIN_GET_DEVICENAME:

--- a/src/_P021_Level.ino
+++ b/src/_P021_Level.ino
@@ -110,12 +110,13 @@ boolean Plugin_021(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_021;
-      Device[deviceCount].Type           = DEVICE_TYPE_SINGLE;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SWITCH;
-      Device[deviceCount].ValueCount     = 1;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].setPin1Direction(gpio_direction::gpio_output);
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_021;
+      dev.Type           = DEVICE_TYPE_SINGLE;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SWITCH;
+      dev.ValueCount     = 1;
+      dev.SendDataOption = true;
+      dev.setPin1Direction(gpio_direction::gpio_output);
       break;
     }
 

--- a/src/_P021_Level.ino
+++ b/src/_P021_Level.ino
@@ -113,7 +113,6 @@ boolean Plugin_021(uint8_t function, struct EventStruct *event, String& string)
       Device[++deviceCount].Number       = PLUGIN_ID_021;
       Device[deviceCount].Type           = DEVICE_TYPE_SINGLE;
       Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SWITCH;
-      Device[deviceCount].Ports          = 0;
       Device[deviceCount].ValueCount     = 1;
       Device[deviceCount].SendDataOption = true;
       Device[deviceCount].setPin1Direction(gpio_direction::gpio_output);
@@ -236,7 +235,8 @@ boolean Plugin_021(uint8_t function, struct EventStruct *event, String& string)
         const __FlashStringHelper *options[] = { F("Classic"), F("Off"), F("Standby"), F("On"), F("Local"), F("Remote") };
         const int optionValues[]             =
         { P021_OPMODE_CLASSIC, P021_OPMODE_OFF, P021_OPMODE_STANDBY, P021_OPMODE_ON, P021_OPMODE_TEMP, P021_OPMODE_REMOTE };
-        addFormSelector(F("Control mode"), F(P021_GUID_OPMODE), NR_ELEMENTS(optionValues), options, optionValues, P021_OPMODE);
+        constexpr size_t optionCount = NR_ELEMENTS(optionValues);
+        addFormSelector(F("Control mode"), F(P021_GUID_OPMODE), optionCount, options, optionValues, P021_OPMODE);
 
         // Add timer values depending on build size
         //  - minimum build size: units are always in seconds; drop the units on the form
@@ -487,24 +487,13 @@ boolean Plugin_021(uint8_t function, struct EventStruct *event, String& string)
 
       if (equals(command, F("levelcontrol")))
       {
-        if (equals(subcmd, F("remote")) && hasValue)
+        if (equals(subcmd, F("remote")) && hasValue && ((event->Par2 == 0) || (event->Par2 == 1)))
         {
-          if (event->Par2 == 1)
-          {
-            P021_remote[event->TaskIndex] = true;
-            #  ifndef P021_MIN_BUILD_SIZE
-            addLogMove(LOG_LEVEL_INFO, F("P021 write: levelcontrol remote=on"));
-            #  endif // ifndef P021_MIN_BUILD_SIZE
-            success = true;
-          }
-          else if (event->Par2 == 0)
-          {
-            P021_remote[event->TaskIndex] = false;
-            #  ifndef P021_MIN_BUILD_SIZE
-            addLogMove(LOG_LEVEL_INFO, F("P021 write: levelcontrol remote=off"));
-            #  endif // ifndef P021_MIN_BUILD_SIZE
-            success = true;
-          }
+          P021_remote[event->TaskIndex] = event->Par2 != 0;
+          #  ifndef P021_MIN_BUILD_SIZE
+          addLogMove(LOG_LEVEL_INFO, concat(F("P021 write: levelcontrol remote="), P021_remote[event->TaskIndex] ? F("on") : F("off")));
+          #  endif // ifndef P021_MIN_BUILD_SIZE
+          success = true;
         }
 
         // If not successful rely upon ESPeasy framework to report the issue
@@ -552,11 +541,11 @@ const __FlashStringHelper* P021_printControlState(int state)
 {
   switch (state)
   {
-    case P021_STATE_IDLE:     return F("Idle");
-    case P021_STATE_ACTIVE:  return F("Active");
-    case P021_STATE_EXTEND:   return F("Extend");
-    case P021_STATE_FORCE:    return F("Force");
-    default:                  return F("***ERROR***");
+    case P021_STATE_IDLE:   return F("Idle");
+    case P021_STATE_ACTIVE: return F("Active");
+    case P021_STATE_EXTEND: return F("Extend");
+    case P021_STATE_FORCE:  return F("Force");
+    default:                return F("***ERROR***");
   }
 }
 

--- a/src/_P022_PCA9685.ino
+++ b/src/_P022_PCA9685.ino
@@ -54,12 +54,13 @@ boolean Plugin_022(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_022;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].Ports              = 1;
-      Device[deviceCount].Custom             = true;
-      Device[deviceCount].ExitTaskBeforeSave = false;
+      auto& dev = Device[++deviceCount];
+      dev.Number             = PLUGIN_ID_022;
+      dev.Type               = DEVICE_TYPE_I2C;
+      dev.VType              = Sensor_VType::SENSOR_TYPE_NONE;
+      dev.Ports              = 1;
+      dev.Custom             = true;
+      dev.ExitTaskBeforeSave = false;
       break;
     }
 

--- a/src/_P022_PCA9685.ino
+++ b/src/_P022_PCA9685.ino
@@ -58,12 +58,7 @@ boolean Plugin_022(uint8_t function, struct EventStruct *event, String& string)
       Device[deviceCount].Type               = DEVICE_TYPE_I2C;
       Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_NONE;
       Device[deviceCount].Ports              = 1;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].ValueCount         = 0;
       Device[deviceCount].Custom             = true;
-      Device[deviceCount].TimerOption        = false;
       Device[deviceCount].ExitTaskBeforeSave = false;
       break;
     }

--- a/src/_P023_OLED.ino
+++ b/src/_P023_OLED.ino
@@ -43,8 +43,6 @@ boolean Plugin_023(uint8_t function, struct EventStruct *event, String& string)
       Device[++deviceCount].Number      = PLUGIN_ID_023;
       Device[deviceCount].Type          = DEVICE_TYPE_I2C;
       Device[deviceCount].VType         = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].Ports         = 0;
-      Device[deviceCount].ValueCount    = 0;
       Device[deviceCount].TimerOption   = true;
       Device[deviceCount].TimerOptional = true;
       break;
@@ -104,9 +102,10 @@ boolean Plugin_023(uint8_t function, struct EventStruct *event, String& string)
         OLedFormSizes(F("size"), optionValues3, PCONFIG(3));
       }
       {
-        const __FlashStringHelper *options4[2] = { F("Normal"), F("Optimized") };
-        const int optionValues4[2]             = { 1, 2 };
-        addFormSelector(F("Font Width"), F("font_spacing"), 2, options4, optionValues4, PCONFIG(4));
+        const __FlashStringHelper *options4[] = { F("Normal"), F("Optimized") };
+        const int optionValues4[]             = { 1, 2 };
+        constexpr size_t optionCount = NR_ELEMENTS(optionValues4);
+        addFormSelector(F("Font Width"), F("font_spacing"), optionCount, options4, optionValues4, PCONFIG(4));
       }
       {
         String strings[P23_Nlines];

--- a/src/_P023_OLED.ino
+++ b/src/_P023_OLED.ino
@@ -40,11 +40,12 @@ boolean Plugin_023(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number      = PLUGIN_ID_023;
-      Device[deviceCount].Type          = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType         = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].TimerOption   = true;
-      Device[deviceCount].TimerOptional = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number        = PLUGIN_ID_023;
+      dev.Type          = DEVICE_TYPE_I2C;
+      dev.VType         = Sensor_VType::SENSOR_TYPE_NONE;
+      dev.TimerOption   = true;
+      dev.TimerOptional = true;
       break;
     }
 

--- a/src/_P024_MLX90614.ino
+++ b/src/_P024_MLX90614.ino
@@ -29,17 +29,16 @@ boolean Plugin_024(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number         = PLUGIN_ID_024;
-      Device[deviceCount].Type             = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType            = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].Ports            = 16;
-      Device[deviceCount].FormulaOption    = true;
-      Device[deviceCount].SendDataOption   = true;
-      Device[deviceCount].ValueCount       = 1;
-      Device[deviceCount].TimerOption      = true;
-      Device[deviceCount].GlobalSyncOption = true;
-      Device[deviceCount].PluginStats      = true;
-      Device[deviceCount].I2CMax100kHz     = true; // Max 100 kHz allowed/supported
+      Device[++deviceCount].Number       = PLUGIN_ID_024;
+      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      Device[deviceCount].Ports          = 16;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].ValueCount     = 1;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].PluginStats    = true;
+      Device[deviceCount].I2CMax100kHz   = true; // Max 100 kHz allowed/supported
       break;
     }
 
@@ -80,7 +79,8 @@ boolean Plugin_024(uint8_t function, struct EventStruct *event, String& string)
         (0x07),
         (0x06)
       };
-      addFormSelector(F("Option"), F("option"), NR_ELEMENTS(optionValues), options, optionValues, PCONFIG(0));
+      constexpr size_t optionCount = NR_ELEMENTS(optionValues);
+      addFormSelector(F("Option"), F("option"), optionCount, options, optionValues, PCONFIG(0));
 
       success = true;
       break;
@@ -110,7 +110,7 @@ boolean Plugin_024(uint8_t function, struct EventStruct *event, String& string)
         UserVar.setFloat(event->TaskIndex, 0, P024_data->readTemperature(PCONFIG(0)));
 
         if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-          addLog(LOG_LEVEL_INFO, concat(F("MLX90614  : Temperature: "), formatUserVarNoCheck(event, 0)));
+          addLog(LOG_LEVEL_INFO, concat(F("MLX90614 : Temperature: "), formatUserVarNoCheck(event, 0)));
         }
 
         //        send(msgObjTemp024->set(UserVar[event->BaseVarIndex], 1)); // Mysensors

--- a/src/_P024_MLX90614.ino
+++ b/src/_P024_MLX90614.ino
@@ -29,16 +29,17 @@ boolean Plugin_024(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_024;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].Ports          = 16;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].ValueCount     = 1;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].PluginStats    = true;
-      Device[deviceCount].I2CMax100kHz   = true; // Max 100 kHz allowed/supported
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_024;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.Ports          = 16;
+      dev.FormulaOption  = true;
+      dev.SendDataOption = true;
+      dev.ValueCount     = 1;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
+      dev.I2CMax100kHz   = true; // Max 100 kHz allowed/supported
       break;
     }
 

--- a/src/_P025_ADS1115.ino
+++ b/src/_P025_ADS1115.ino
@@ -23,19 +23,15 @@ boolean Plugin_025(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_025;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 1;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].OutputDataType     = Output_Data_type_t::Simple;
-      Device[deviceCount].PluginStats        = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_025;
+      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 1;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].OutputDataType = Output_Data_type_t::Simple;
+      Device[deviceCount].PluginStats    = true;
       break;
     }
 

--- a/src/_P025_ADS1115.ino
+++ b/src/_P025_ADS1115.ino
@@ -23,15 +23,16 @@ boolean Plugin_025(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_025;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 1;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].OutputDataType = Output_Data_type_t::Simple;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_025;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 1;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.OutputDataType = Output_Data_type_t::Simple;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P026_Sysinfo.ino
+++ b/src/_P026_Sysinfo.ino
@@ -32,14 +32,15 @@ boolean Plugin_026(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_026;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].ValueCount     = 4;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].OutputDataType = Output_Data_type_t::Simple;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_026;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      dev.ValueCount     = 4;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.FormulaOption  = true;
+      dev.OutputDataType = Output_Data_type_t::Simple;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P027_INA219.ino
+++ b/src/_P027_INA219.ino
@@ -53,18 +53,14 @@ boolean Plugin_027(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_027;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TRIPLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 3;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_027;
+      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_TRIPLE;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 3;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].PluginStats    = true;
       break;
     }
 

--- a/src/_P027_INA219.ino
+++ b/src/_P027_INA219.ino
@@ -53,14 +53,15 @@ boolean Plugin_027(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_027;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_TRIPLE;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 3;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_027;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_TRIPLE;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 3;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P028_BME280.ino
+++ b/src/_P028_BME280.ino
@@ -33,15 +33,16 @@ boolean Plugin_028(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number         = PLUGIN_ID_028;
-      Device[deviceCount].Type             = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType            = Sensor_VType::SENSOR_TYPE_TEMP_HUM_BARO;
-      Device[deviceCount].FormulaOption    = true;
-      Device[deviceCount].ValueCount       = 3;
-      Device[deviceCount].SendDataOption   = true;
-      Device[deviceCount].TimerOption      = true;
-      Device[deviceCount].ErrorStateValues = true;
-      Device[deviceCount].PluginStats      = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number           = PLUGIN_ID_028;
+      dev.Type             = DEVICE_TYPE_I2C;
+      dev.VType            = Sensor_VType::SENSOR_TYPE_TEMP_HUM_BARO;
+      dev.FormulaOption    = true;
+      dev.ValueCount       = 3;
+      dev.SendDataOption   = true;
+      dev.TimerOption      = true;
+      dev.ErrorStateValues = true;
+      dev.PluginStats      = true;
       break;
     }
 

--- a/src/_P028_BME280.ino
+++ b/src/_P028_BME280.ino
@@ -33,19 +33,15 @@ boolean Plugin_028(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_028;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TEMP_HUM_BARO;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 3;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].ErrorStateValues   = true;
-      Device[deviceCount].PluginStats        = true;
+      Device[++deviceCount].Number         = PLUGIN_ID_028;
+      Device[deviceCount].Type             = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType            = Sensor_VType::SENSOR_TYPE_TEMP_HUM_BARO;
+      Device[deviceCount].FormulaOption    = true;
+      Device[deviceCount].ValueCount       = 3;
+      Device[deviceCount].SendDataOption   = true;
+      Device[deviceCount].TimerOption      = true;
+      Device[deviceCount].ErrorStateValues = true;
+      Device[deviceCount].PluginStats      = true;
       break;
     }
 
@@ -209,7 +205,7 @@ boolean Plugin_028(uint8_t function, struct EventStruct *event, String& string)
 
       if (nullptr != P028_data) {
         if ((P028_data_struct::BMx_DetectMode::BMP280 != static_cast<P028_data_struct::BMx_DetectMode>(P028_DETECTION_MODE)) &&
-            P028_data->hasHumidity()) 
+            P028_data->hasHumidity())
         {
           P028_data->plot_ChartJS_scatter(
             0,
@@ -221,10 +217,11 @@ boolean Plugin_028(uint8_t function, struct EventStruct *event, String& string)
             500);
         }
       }
+
       // Do not set success = true, since we're not actually adding stats, but just plotting a scatter plot
       break;
     }
-#endif
+# endif // if FEATURE_PLUGIN_STATS && FEATURE_CHART_JS
 
 
     case PLUGIN_WEBFORM_SHOW_ERRORSTATE_OPT:
@@ -350,17 +347,17 @@ boolean Plugin_028(uint8_t function, struct EventStruct *event, String& string)
 
           if (loglevelActiveFor(LOG_LEVEL_INFO)) {
             String hum;
+
             if (P028_data->hasHumidity()) {
               hum = formatUserVarNoCheck(event, 1);
             }
-            addLogMove(LOG_LEVEL_INFO, concat(
-              P028_data_struct::getDeviceName(P028_data->sensorID),
-              strformat(
-                F(": Addr: %s T: %s H: %s P: %s"), 
-                formatToHex(P028_I2C_ADDRESS, 2).c_str(),
-                formatUserVarNoCheck(event, 0).c_str(),
-                hum.c_str(),
-                formatUserVarNoCheck(event, 2).c_str())));
+            addLogMove(LOG_LEVEL_INFO,
+                       strformat(F("%s: Addr: %s T: %s H: %s P: %s"),
+                                 FsP(P028_data_struct::getDeviceName(P028_data->sensorID)),
+                                 formatToHex(P028_I2C_ADDRESS, 2).c_str(),
+                                 formatUserVarNoCheck(event, 0).c_str(),
+                                 hum.c_str(),
+                                 formatUserVarNoCheck(event, 2).c_str()));
           }
           # endif // ifndef LIMIT_BUILD_SIZE
           success = true;

--- a/src/_P029_Output.ino
+++ b/src/_P029_Output.ino
@@ -25,12 +25,13 @@ boolean Plugin_029(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_029;
-      Device[deviceCount].Type               = DEVICE_TYPE_SINGLE;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SWITCH;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].ValueCount         = 1;
-      Device[deviceCount].setPin1Direction(gpio_direction::gpio_output);
+      auto& dev = Device[++deviceCount];
+      dev.Number             = PLUGIN_ID_029;
+      dev.Type               = DEVICE_TYPE_SINGLE;
+      dev.VType              = Sensor_VType::SENSOR_TYPE_SWITCH;
+      dev.Ports              = 0;
+      dev.ValueCount         = 1;
+      dev.setPin1Direction(gpio_direction::gpio_output);
       break;
     }
 

--- a/src/_P031_SHT1X.ino
+++ b/src/_P031_SHT1X.ino
@@ -22,16 +22,14 @@ boolean Plugin_031(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_031;
-      Device[deviceCount].Type           = DEVICE_TYPE_DUAL;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
-      Device[deviceCount].Ports          = 0;
-      Device[deviceCount].PullUpOption   = true;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 2;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].PluginStats    = true;
+      Device[++deviceCount].Number      = PLUGIN_ID_031;
+      Device[deviceCount].Type          = DEVICE_TYPE_DUAL;
+      Device[deviceCount].VType         = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
+      Device[deviceCount].PullUpOption  = true;
+      Device[deviceCount].FormulaOption = true;
+      Device[deviceCount].ValueCount    = 2;
+      Device[deviceCount].TimerOption   = true;
+      Device[deviceCount].PluginStats   = true;
       Device[deviceCount].setPin2Direction(gpio_direction::gpio_output);
       break;
     }
@@ -88,20 +86,16 @@ boolean Plugin_031(uint8_t function, struct EventStruct *event, String& string)
         CONFIG_PIN1, CONFIG_PIN2,
         Settings.TaskDevicePin1PullUp[event->TaskIndex],
         PCONFIG(0));
-        # ifndef BUILD_NO_DEBUG
+      # ifndef BUILD_NO_DEBUG
 
       if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
-        String log = F("SHT1x : Status uint8_t: ");
-        log += String(status, HEX);
-        log += F(" - resolution: ");
-        log += ((status & 1) ? F("low") : F("high"));
-        log += F(" reload from OTP: ");
-        log += (((status >> 1) & 1) ? F("yes") : F("no"));
-        log += F(", heater: ");
-        log += (((status >> 2) & 1) ? F("on") : F("off"));
-        addLogMove(LOG_LEVEL_DEBUG, log);
+        addLog(LOG_LEVEL_DEBUG, strformat(F("SHT1x : Status uint8_t: %x - resolution: %s reload from OTP: %s, heater: %s"),
+                                          status,
+                                          FsP((status & 1) ? F("low") : F("high")),
+                                          FsP(((status >> 1) & 1) ? F("yes") : F("no")),
+                                          FsP(((status >> 2) & 1) ? F("on") : F("off"))));
       }
-        # endif // ifndef BUILD_NO_DEBUG
+      # endif // ifndef BUILD_NO_DEBUG
       success = true;
       break;
     }

--- a/src/_P031_SHT1X.ino
+++ b/src/_P031_SHT1X.ino
@@ -22,15 +22,16 @@ boolean Plugin_031(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number      = PLUGIN_ID_031;
-      Device[deviceCount].Type          = DEVICE_TYPE_DUAL;
-      Device[deviceCount].VType         = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
-      Device[deviceCount].PullUpOption  = true;
-      Device[deviceCount].FormulaOption = true;
-      Device[deviceCount].ValueCount    = 2;
-      Device[deviceCount].TimerOption   = true;
-      Device[deviceCount].PluginStats   = true;
-      Device[deviceCount].setPin2Direction(gpio_direction::gpio_output);
+      auto& dev = Device[++deviceCount];
+      dev.Number        = PLUGIN_ID_031;
+      dev.Type          = DEVICE_TYPE_DUAL;
+      dev.VType         = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
+      dev.PullUpOption  = true;
+      dev.FormulaOption = true;
+      dev.ValueCount    = 2;
+      dev.TimerOption   = true;
+      dev.PluginStats   = true;
+      dev.setPin2Direction(gpio_direction::gpio_output);
       break;
     }
 

--- a/src/_P032_MS5611.ino
+++ b/src/_P032_MS5611.ino
@@ -23,18 +23,14 @@ boolean Plugin_032(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_032;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TEMP_BARO;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 2;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_032;
+      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_TEMP_BARO;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 2;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].PluginStats    = true;
       break;
     }
 

--- a/src/_P032_MS5611.ino
+++ b/src/_P032_MS5611.ino
@@ -23,14 +23,15 @@ boolean Plugin_032(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_032;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_TEMP_BARO;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 2;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_032;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_TEMP_BARO;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 2;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P033_Dummy.ino
+++ b/src/_P033_Dummy.ino
@@ -17,21 +17,16 @@ boolean Plugin_033(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_033;
-      Device[deviceCount].Type               = DEVICE_TYPE_DUMMY;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].DecimalsOnly       = true;
-      Device[deviceCount].ValueCount         = 4;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].TimerOptional      = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].OutputDataType     = Output_Data_type_t::All;
-      Device[deviceCount].PluginStats        = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_033;
+      Device[deviceCount].Type           = DEVICE_TYPE_DUMMY;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      Device[deviceCount].DecimalsOnly   = true;
+      Device[deviceCount].ValueCount     = 4;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].TimerOptional  = true;
+      Device[deviceCount].OutputDataType = Output_Data_type_t::All;
+      Device[deviceCount].PluginStats    = true;
       break;
     }
 

--- a/src/_P033_Dummy.ino
+++ b/src/_P033_Dummy.ino
@@ -17,16 +17,17 @@ boolean Plugin_033(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_033;
-      Device[deviceCount].Type           = DEVICE_TYPE_DUMMY;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].DecimalsOnly   = true;
-      Device[deviceCount].ValueCount     = 4;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].TimerOptional  = true;
-      Device[deviceCount].OutputDataType = Output_Data_type_t::All;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_033;
+      dev.Type           = DEVICE_TYPE_DUMMY;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.DecimalsOnly   = true;
+      dev.ValueCount     = 4;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.TimerOptional  = true;
+      dev.OutputDataType = Output_Data_type_t::All;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P034_DHT12.ino
+++ b/src/_P034_DHT12.ino
@@ -22,13 +22,14 @@ boolean Plugin_034(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_034;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 2;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_034;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 2;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
       break;
     }
 

--- a/src/_P034_DHT12.ino
+++ b/src/_P034_DHT12.ino
@@ -22,17 +22,13 @@ boolean Plugin_034(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_034;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 2;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_034;
+      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 2;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
       break;
     }
 

--- a/src/_P035_IRTX.ino
+++ b/src/_P035_IRTX.ino
@@ -59,10 +59,11 @@ boolean Plugin_035(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_035;
-      Device[deviceCount].Type           = DEVICE_TYPE_SINGLE;
-      Device[deviceCount].SendDataOption = false;
-      Device[deviceCount].setPin1Direction(gpio_direction::gpio_output);
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_035;
+      dev.Type           = DEVICE_TYPE_SINGLE;
+      dev.SendDataOption = false;
+      dev.setPin1Direction(gpio_direction::gpio_output);
       break;
     }
 

--- a/src/_P036_FrameOLED.ino
+++ b/src/_P036_FrameOLED.ino
@@ -15,7 +15,8 @@
 // As long as the device is not enabled, no RAM is wasted.
 //
 // @uwekaditz: 2024-08-06
-// ADD: Using template notations with escaped character (\%, \[ and \]) within oledframedcmd,<line>,<text> to reinterpreted <text> each time before the line is displayed,
+// ADD: Using template notations with escaped character (\%, \[ and \]) within oledframedcmd,<line>,<text> to reinterpreted <text> each time
+// before the line is displayed,
 //      not only once while issuing the command and creating the new line content
 // @tonhuisman: 2024-07-14
 // ADD: Selectable Header Time format, HH:MM:SS (default), HH:MM, HH:MM:SS AM/PM, HH:MM AM/PM, not enabled in LIMIT_BUILD_SIZE builds
@@ -241,17 +242,11 @@ boolean Plugin_036(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_036;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].ValueCount         = 0;
-      Device[deviceCount].SendDataOption     = false;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].TimerOptional      = true;
+      Device[++deviceCount].Number      = PLUGIN_ID_036;
+      Device[deviceCount].Type          = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType         = Sensor_VType::SENSOR_TYPE_NONE;
+      Device[deviceCount].TimerOption   = true;
+      Device[deviceCount].TimerOptional = true;
       break;
     }
 

--- a/src/_P036_FrameOLED.ino
+++ b/src/_P036_FrameOLED.ino
@@ -242,11 +242,12 @@ boolean Plugin_036(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number      = PLUGIN_ID_036;
-      Device[deviceCount].Type          = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType         = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].TimerOption   = true;
-      Device[deviceCount].TimerOptional = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number        = PLUGIN_ID_036;
+      dev.Type          = DEVICE_TYPE_I2C;
+      dev.VType         = Sensor_VType::SENSOR_TYPE_NONE;
+      dev.TimerOption   = true;
+      dev.TimerOptional = true;
       break;
     }
 

--- a/src/_P037_MQTTImport.ino
+++ b/src/_P037_MQTTImport.ino
@@ -11,6 +11,7 @@
 // This task reads data from the MQTT Import input stream and saves the value
 
 /**
+ * 2025-01-03, tonhuisman: Small code cleanup
  * 2023-06-17, tonhuisman: Replace Device[].FormulaOption by Device[].DecimalsOnly option, as no (successful) PLUGIN_READ is done
  * 2023-03-06, tonhuisman: Fix PLUGIN_INIT behavior to now always return success = true
  * 2022-12-13, tonhuisman: Implement separator character input selector
@@ -61,7 +62,7 @@ String P037_getMQTTLastTopicPart(const String& topic) {
   const int16_t lastSlash = topic.lastIndexOf('/');
 
   if (lastSlash >= static_cast<int16_t>(topic.length() - 1)) {
-    return F("");
+    return EMPTY_STRING;
   }
   String result = topic.substring(lastSlash + 1); // Take last part of the topic
 
@@ -80,8 +81,8 @@ bool P037_addEventToQueue(struct EventStruct *event, String& newEvent) {
     # if P037_REPLACE_BY_COMMA_SUPPORT
 
     if (P037_REPLACE_BY_COMMA != 0x0) {
-      const String character = String(static_cast<char>(P037_REPLACE_BY_COMMA));
-      newEvent.replace(character, F(","));
+      const char character = static_cast<char>(P037_REPLACE_BY_COMMA);
+      newEvent.replace(character, ',');
     }
     # endif // if P037_REPLACE_BY_COMMA_SUPPORT
     eventQueue.add(newEvent, P037_DEDUPLICATE_EVENTS);
@@ -112,16 +113,11 @@ boolean Plugin_037(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_037;
-      Device[deviceCount].Type               = DEVICE_TYPE_DUMMY;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SINGLE; // This means it has a single pin
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].DecimalsOnly       = true; // We only want to have the decimals option
-      Device[deviceCount].ValueCount         = VARS_PER_TASK;
-      Device[deviceCount].SendDataOption     = false;
-      Device[deviceCount].TimerOption        = false;
+      Device[++deviceCount].Number     = PLUGIN_ID_037;
+      Device[deviceCount].Type         = DEVICE_TYPE_DUMMY;
+      Device[deviceCount].VType        = Sensor_VType::SENSOR_TYPE_SINGLE; // This means it has a single pin
+      Device[deviceCount].DecimalsOnly = true;                             // We only want to have the decimals option
+      Device[deviceCount].ValueCount   = VARS_PER_TASK;
       break;
     }
 
@@ -166,7 +162,7 @@ boolean Plugin_037(uint8_t function, struct EventStruct *event, String& string)
       addFormSubHeader(F("Options"));
 
       addFormCheckBox(F("Generate events for accepted topics"),
-                      F("p037_send_events"), P037_SEND_EVENTS);
+                      F("psend_events"), P037_SEND_EVENTS);
       # if !defined(P037_LIMIT_BUILD_SIZE)
       addFormNote(F("Event: &lt;TaskName&gt;#&lt;topic&gt;=&lt;payload&gt;"));
       #  if P037_JSON_SUPPORT
@@ -248,7 +244,7 @@ boolean Plugin_037(uint8_t function, struct EventStruct *event, String& string)
       # if P037_FILTER_SUPPORT
       P037_APPLY_FILTERS = getFormItemInt(F("pfilters"));
       # endif // if P037_FILTER_SUPPORT
-      P037_SEND_EVENTS        = isFormItemChecked(F("p037_send_events")) ? 1 : 0;
+      P037_SEND_EVENTS        = isFormItemChecked(F("psend_events")) ? 1 : 0;
       P037_DEDUPLICATE_EVENTS = isFormItemChecked(F("pdedupe")) ? 1 : 0;
       P037_QUEUEDEPTH_EVENTS  = getFormItemInt(F("pquedepth"));
 
@@ -331,11 +327,9 @@ boolean Plugin_037(uint8_t function, struct EventStruct *event, String& string)
       # ifdef PLUGIN_037_DEBUG
 
       if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-        String info = F("P037 : topic: ");
-        info += event->String1;
-        info += F(" value: ");
-        info += Payload;
-        addLog(LOG_LEVEL_INFO, info);
+        addLog(LOG_LEVEL_INFO, strformat(F("P037 : topic: %s value: %s"),
+                                         event->String1.c_str(),
+                                         Payload.c_str()));
       }
       # endif // ifdef PLUGIN_037_DEBUG
 
@@ -379,7 +373,7 @@ boolean Plugin_037(uint8_t function, struct EventStruct *event, String& string)
 
       if (matchedTopic &&
           P037_PARSE_JSON &&
-          Payload.startsWith(F("{"))) { // With JSON enabled and rudimentary check for JSon content
+          Payload.startsWith(F("{"))) { // With JSON enabled a rudimentary check for JSon content
         #  ifdef PLUGIN_037_DEBUG
         addLog(LOG_LEVEL_INFO, F("IMPT : MQTT JSON data detected."));
         #  endif // ifdef PLUGIN_037_DEBUG
@@ -459,9 +453,7 @@ boolean Plugin_037(uint8_t function, struct EventStruct *event, String& string)
 
       if (matchedTopic && P037_data->hasFilters() && // Single log statement
           loglevelActiveFor(LOG_LEVEL_DEBUG)) {      // Reduce standard logging
-        String log = F("IMPT : MQTT filter result: ");
-        log += processData ? F("true") : F("false");
-        addLogMove(LOG_LEVEL_DEBUG, log);
+        addLog(LOG_LEVEL_DEBUG, concat(F("IMPT : MQTT filter result: "), boolToString(processData)));
       }
       #  endif // ifndef BUILD_NO_DEBUG
       # endif // if P037_FILTER_SUPPORT
@@ -540,11 +532,9 @@ boolean Plugin_037(uint8_t function, struct EventStruct *event, String& string)
                   #  if !defined(P037_LIMIT_BUILD_SIZE) || defined(P037_OVERRIDE)
 
                   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-                    String log = F("IMPT : MQTT fetched json attribute: ");
-                    log.reserve(48);
-                    log += key;
-                    log += F(" payload: ");
-                    log += Payload;
+                    String log = strformat(F("IMPT : MQTT fetched json attribute: %s payload: "),
+                                           key.c_str(),
+                                           Payload.c_str());
 
                     if (!jsonIndex.isEmpty()) {
                       log += F(" index: ");
@@ -562,16 +552,14 @@ boolean Plugin_037(uint8_t function, struct EventStruct *event, String& string)
                 #  ifdef PLUGIN_037_DEBUG
 
                 if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-                  String log = F("P037 json key: ");
-                  log.reserve(48);
-                  log += key;
-                  log += F(" payload: ");
-                  #   if P037_MAPPING_SUPPORT
-                  log += (P037_APPLY_MAPPINGS ? P037_data->mapValue(Payload, key) : Payload);
-                  #   else // if P037_MAPPING_SUPPORT
-                  log += Payload;
-                  #   endif // if P037_MAPPING_SUPPORT
-                  addLogMove(LOG_LEVEL_INFO, log);
+                  addLog(LOG_LEVEL_INFO, strformat(F("P037 json key: %s payload: %s"),
+                                                   key.c_str(),
+                                                   #   if P037_MAPPING_SUPPORT
+                                                   P037_APPLY_MAPPINGS ? P037_data->mapValue(Payload, key).c_str() : Payload.c_str()
+                                                   #   else // if P037_MAPPING_SUPPORT
+                                                   Payload.c_str()
+                                                   #   endif // if P037_MAPPING_SUPPORT
+                                                   ));
                 }
                 #  endif // ifdef PLUGIN_037_DEBUG
                 ++P037_data->iter;
@@ -590,19 +578,13 @@ boolean Plugin_037(uint8_t function, struct EventStruct *event, String& string)
 
                 if (!validDoubleFromString(Payload, doublePayload)) {
                   if (!checkJson && (P037_SEND_EVENTS == 0)) { // If we want all values as events, then no error logged and don't stop here
-                    String log = F("IMPT : Bad Import MQTT Command ");
-                    log.reserve(64);
-                    log += event->String1;
-                    addLog(LOG_LEVEL_ERROR, log);
+                    addLog(LOG_LEVEL_ERROR, concat(F("IMPT : Bad Import MQTT Command "), event->String1));
                     # if !defined(P037_LIMIT_BUILD_SIZE) || defined(P037_OVERRIDE)
 
                     if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-                      log.clear();
-                      log += F("ERR  : Illegal Payload ");
-                      log += Payload;
-                      log += ' ';
-                      log += getTaskDeviceName(event->TaskIndex);
-                      addLogMove(LOG_LEVEL_INFO, log);
+                      addLog(LOG_LEVEL_INFO, strformat(F("ERR  : Illegal Payload %s %s"),
+                                                       Payload.c_str(),
+                                                       getTaskDeviceName(event->TaskIndex).c_str()));
                     }
                     # endif // if !defined(P037_LIMIT_BUILD_SIZE) || defined(P037_OVERRIDE)
                     success = false;
@@ -611,16 +593,13 @@ boolean Plugin_037(uint8_t function, struct EventStruct *event, String& string)
                   numericPayload = false;                                  // No, it isn't numeric
                   doublePayload  = NAN;                                    // Invalid value
                 }
-                UserVar.setFloat(event->TaskIndex, x, doublePayload);          // Save the new value
+                UserVar.setFloat(event->TaskIndex, x, doublePayload);      // Save the new value
 
                 if (!checkJson && P037_SEND_EVENTS && Settings.UseRules) { // Generate event of all non-json topic/payloads
-                  String RuleEvent;
-                  RuleEvent.reserve(64);
-                  RuleEvent += getTaskDeviceName(event->TaskIndex);
-                  RuleEvent += '#';
-                  RuleEvent += event->String1;
-                  RuleEvent += '=';
-                  RuleEvent += wrapWithQuotesIfContainsParameterSeparatorChar(unparsedPayload);
+                  String RuleEvent = strformat(F("%s#%s=%s"),
+                                               getTaskDeviceName(event->TaskIndex).c_str(),
+                                               event->String1.c_str(),
+                                               wrapWithQuotesIfContainsParameterSeparatorChar(unparsedPayload).c_str());
                   P037_addEventToQueue(event, RuleEvent);
                 }
 
@@ -628,18 +607,10 @@ boolean Plugin_037(uint8_t function, struct EventStruct *event, String& string)
                 # if !defined(P037_LIMIT_BUILD_SIZE) || defined(P037_OVERRIDE)
 
                 if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-                  String log = F("IMPT : [");
-                  log += getTaskDeviceName(event->TaskIndex);
-                  log += '#';
-
-                  if (checkJson) {
-                    log += key;
-                  } else {
-                    log += getTaskValueName(event->TaskIndex, x);
-                  }
-                  log += F("] : ");
-                  log += doublePayload;
-                  addLogMove(LOG_LEVEL_INFO, log);
+                  addLog(LOG_LEVEL_INFO, strformat(F("IMPT : [%s#%s] : %.3f"),
+                                                   getTaskDeviceName(event->TaskIndex),
+                                                   checkJson ? key.c_str() : getTaskValueName(event->TaskIndex, x).c_str(),
+                                                   doublePayload));
                 }
                 # endif // if !defined(P037_LIMIT_BUILD_SIZE) || defined(P037_OVERRIDE)
 
@@ -738,7 +709,8 @@ bool MQTT_unsubscribe_037(struct EventStruct *event)
 
     for (taskIndex_t task = 0; task < INVALID_TASK_INDEX && canUnsubscribe; ++task) {
       if (task != event->TaskIndex) {
-        constexpr pluginID_t P037_PLUGIN_ID{PLUGIN_ID_037};
+        constexpr pluginID_t P037_PLUGIN_ID{ PLUGIN_ID_037 };
+
         if (Settings.TaskDeviceEnabled[task] &&
             (Settings.getPluginID_for_task(task) == P037_PLUGIN_ID)) {
           P037_data_struct *P037_data_other = static_cast<P037_data_struct *>(getPluginTaskData(task));
@@ -748,15 +720,11 @@ bool MQTT_unsubscribe_037(struct EventStruct *event)
               canUnsubscribe = false;
 
               if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-                String log = F("IMPT : Cannot unsubscribe topic: ");
-                log += topic;
-                log += F(" used by: [");
-                log += getTaskDeviceName(event->TaskIndex);
-                log += '#';
-                log += getTaskValueName(event->TaskIndex, x);
-                log += ']';
-                log += topic;
-                addLogMove(LOG_LEVEL_INFO, log);
+                addLog(LOG_LEVEL_INFO, strformat(F("IMPT : Cannot unsubscribe topic: %s used by: [%s#%s]%s"),
+                                                 topic.c_str(),
+                                                 getTaskDeviceName(event->TaskIndex).c_str(),
+                                                 getTaskValueName(event->TaskIndex, x).c_str(),
+                                                 topic.c_str()));
               }
             }
           }
@@ -766,13 +734,10 @@ bool MQTT_unsubscribe_037(struct EventStruct *event)
 
     if (canUnsubscribe && (topic.length() > 0) && MQTTclient.unsubscribe(topic.c_str())) {
       if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-        String log = F("IMPT : [");
-        log += getTaskDeviceName(event->TaskIndex);
-        log += '#';
-        log += getTaskValueName(event->TaskIndex, x);
-        log += F("] : Unsubscribe topic: ");
-        log += topic;
-        addLogMove(LOG_LEVEL_INFO, log);
+        addLog(LOG_LEVEL_INFO, strformat(F("IMPT : [%s#%s] : Unsubscribe topic: %s"),
+                                         getTaskDeviceName(event->TaskIndex).c_str(),
+                                         getTaskValueName(event->TaskIndex, x).c_str(),
+                                         topic.c_str()));
       }
     }
   }
@@ -800,19 +765,14 @@ bool MQTTSubscribe_037(struct EventStruct *event)
 
       if (MQTTclient.subscribe(subscribeTo.c_str())) {
         if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-          String log = F("IMPT : [");
-          log += getTaskDeviceName(event->TaskIndex);
-          log += F("#");
-          log += getTaskValueName(event->TaskIndex, x);
-          log += F("] subscribed to ");
-          log += subscribeTo;
-          addLogMove(LOG_LEVEL_INFO, log);
+          addLog(LOG_LEVEL_INFO, strformat(F("IMPT : [%s#%s] subscribed to %s"),
+                                           getTaskDeviceName(event->TaskIndex).c_str(),
+                                           getTaskValueName(event->TaskIndex, x).c_str(),
+                                           subscribeTo.c_str()));
         }
       } else {
         if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
-          String log = F("IMPT : Error subscribing to ");
-          log += subscribeTo;
-          addLogMove(LOG_LEVEL_ERROR, log);
+          addLog(LOG_LEVEL_ERROR, concat(F("IMPT : Error subscribing to "), subscribeTo));
         }
         return false;
       }
@@ -846,7 +806,7 @@ bool MQTTCheckSubscription_037(const String& Topic, const String& Subscription) 
   if (equals(tmpSub, '#')) { return true; } // If the subscription is for '#' then all topics are accepted
 
   if (tmpSub.endsWith(F("/#"))) {           // A valid MQTT multi-level wildcard is a # at the end of the topic that's preceded by a /
-    bool multiLevelWildcard = tmpTopic.startsWith(tmpSub.substring(0, tmpSub.length() - 1));
+    const bool multiLevelWildcard = tmpTopic.startsWith(tmpSub.substring(0, tmpSub.length() - 1));
 
     if (tmpSub.indexOf('+') == -1) {
       return multiLevelWildcard;                   // It matched, or not
@@ -858,11 +818,11 @@ bool MQTTCheckSubscription_037(const String& Topic, const String& Subscription) 
 
   // Add trailing / if required
 
-  int lenTopic = tmpTopic.length();
+  const int lenTopic = tmpTopic.length();
 
   if (tmpTopic.substring(lenTopic - 1, lenTopic) != "/") { tmpTopic += '/'; }
 
-  int lenSub = tmpSub.length();
+  const int lenSub = tmpSub.length();
 
   if (tmpSub.substring(lenSub - 1, lenSub) != "/") { tmpSub += '/'; }
 

--- a/src/_P037_MQTTImport.ino
+++ b/src/_P037_MQTTImport.ino
@@ -608,7 +608,7 @@ boolean Plugin_037(uint8_t function, struct EventStruct *event, String& string)
 
                 if (loglevelActiveFor(LOG_LEVEL_INFO)) {
                   addLog(LOG_LEVEL_INFO, strformat(F("IMPT : [%s#%s] : %.3f"),
-                                                   getTaskDeviceName(event->TaskIndex),
+                                                   getTaskDeviceName(event->TaskIndex).c_str(),
                                                    checkJson ? key.c_str() : getTaskValueName(event->TaskIndex, x).c_str(),
                                                    doublePayload));
                 }

--- a/src/_P037_MQTTImport.ino
+++ b/src/_P037_MQTTImport.ino
@@ -113,11 +113,12 @@ boolean Plugin_037(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number     = PLUGIN_ID_037;
-      Device[deviceCount].Type         = DEVICE_TYPE_DUMMY;
-      Device[deviceCount].VType        = Sensor_VType::SENSOR_TYPE_SINGLE; // This means it has a single pin
-      Device[deviceCount].DecimalsOnly = true;                             // We only want to have the decimals option
-      Device[deviceCount].ValueCount   = VARS_PER_TASK;
+      auto& dev = Device[++deviceCount];
+      dev.Number       = PLUGIN_ID_037;
+      dev.Type         = DEVICE_TYPE_DUMMY;
+      dev.VType        = Sensor_VType::SENSOR_TYPE_SINGLE; // This means it has a single pin
+      dev.DecimalsOnly = true;                             // We only want to have the decimals option
+      dev.ValueCount   = VARS_PER_TASK;
       break;
     }
 

--- a/src/_P038_NeoPixel.ino
+++ b/src/_P038_NeoPixel.ino
@@ -57,10 +57,11 @@ boolean Plugin_038(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number      = PLUGIN_ID_038;
-      Device[deviceCount].Type          = DEVICE_TYPE_SINGLE;
-      Device[deviceCount].TimerOption   = false;
-      Device[deviceCount].setPin1Direction(gpio_direction::gpio_output);
+      auto& dev = Device[++deviceCount];
+      dev.Number        = PLUGIN_ID_038;
+      dev.Type          = DEVICE_TYPE_SINGLE;
+      dev.TimerOption   = false;
+      dev.setPin1Direction(gpio_direction::gpio_output);
       break;
     }
 

--- a/src/_P039_Thermosensors.ino
+++ b/src/_P039_Thermosensors.ino
@@ -259,14 +259,15 @@ boolean Plugin_039(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_039;
-      Device[deviceCount].Type           = DEVICE_TYPE_SPI;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 1;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_039;
+      dev.Type           = DEVICE_TYPE_SPI;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 1;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P039_Thermosensors.ino
+++ b/src/_P039_Thermosensors.ino
@@ -19,6 +19,7 @@
 // Have fun ... Dominik
 
 /** Changelog:
+ * 2025-01-03 tonhuisman: Small code size reductions, cleanup of DEBUG level logging
  * 2024-01-04 tonhuisman: Minor corrections, formatted source using Uncrustify
  * 2023-01-08 tonhuisman: Add Low temperature threshold setting (default 0 K/-273.15 C) to ignore temperatures below that value
  * 2023-01-02 tonhuisman: Cleanup and uncrustify source
@@ -258,18 +259,14 @@ boolean Plugin_039(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_039;
-      Device[deviceCount].Type               = DEVICE_TYPE_SPI;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 1;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_039;
+      Device[deviceCount].Type           = DEVICE_TYPE_SPI;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 1;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].PluginStats    = true;
       break;
     }
 
@@ -419,7 +416,7 @@ boolean Plugin_039(uint8_t function, struct EventStruct *event, String& string)
       # ifndef BUILD_NO_DEBUG
 
       if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-        addLogMove(LOG_LEVEL_INFO, strformat(F("P039 : %s : SPI Init - DONE"), getTaskDeviceName(event->TaskIndex).c_str()));
+        addLog(LOG_LEVEL_INFO, strformat(F("P039 : %s : SPI Init - DONE"), getTaskDeviceName(event->TaskIndex).c_str()));
       }
       # endif // ifndef BUILD_NO_DEBUG
 
@@ -433,9 +430,10 @@ boolean Plugin_039(uint8_t function, struct EventStruct *event, String& string)
 
       const uint8_t family = P039_FAM_TYPE;
       {
-        const __FlashStringHelper *Foptions[2] = { F("Thermocouple"), F("RTD") };
-        const int FoptionValues[2]             = { P039_TC, P039_RTD };
-        addFormSelector(F("Sensor Family Type"), F("famtype"), 2, Foptions, FoptionValues, family, true); // auto reload activated
+        const __FlashStringHelper *Foptions[] = { F("Thermocouple"), F("RTD") };
+        const int FoptionValues[]             = { P039_TC, P039_RTD };
+        constexpr size_t optionCount          = NR_ELEMENTS(FoptionValues);
+        addFormSelector(F("Sensor Family Type"), F("famtype"), optionCount, Foptions, FoptionValues, family, true); // auto reload activated
       }
 
       const uint8_t choice = P039_MAX_TYPE;
@@ -444,15 +442,16 @@ boolean Plugin_039(uint8_t function, struct EventStruct *event, String& string)
 
       if (family == P039_TC) {
         {
-          const __FlashStringHelper *options[3] = {   F("MAX 6675"), F("MAX 31855"), F("MAX 31856") };
-          const int optionValues[3]             = { P039_MAX6675, P039_MAX31855, P039_MAX31856 };
-          addFormSelector(F("Adapter IC"), F("maxtype"), 3, options, optionValues, choice, true); // auto reload activated
+          const __FlashStringHelper *options[] = {   F("MAX 6675"), F("MAX 31855"), F("MAX 31856") };
+          const int optionValues[]             = { P039_MAX6675, P039_MAX31855, P039_MAX31856 };
+          constexpr size_t optionCount         = NR_ELEMENTS(optionValues);
+          addFormSelector(F("Adapter IC"), F("maxtype"), optionCount, options, optionValues, choice, true); // auto reload activated
         }
 
         if (choice == P039_MAX31856) {
           addFormSubHeader(F("Device Settings"));
           {
-            const __FlashStringHelper *Toptions[10] = { F("B"), F("E"), F("J"), F("K"), F("N"), F("R"), F("S"), F("T"), F("VM8"), F("VM32") };
+            const __FlashStringHelper *Toptions[] = { F("B"), F("E"), F("J"), F("K"), F("N"), F("R"), F("S"), F("T"), F("VM8"), F("VM32") };
 
             // 2021-05-17: c.k.i.: values are directly written to device register for configuration, therefore no linear values are used
             // here
@@ -470,13 +469,15 @@ boolean Plugin_039(uint8_t function, struct EventStruct *event, String& string)
             //    11xx = Voltage Mode, Gain = 32. Code = 32 x 1.6 x 217 x VIN
             //    Where Code is 19 bit signed number from TC registers and VIN is thermocouple input voltage
 
-            const int ToptionValues[10] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 12 };
-            addFormSelector(F("Thermocouple type"), F("tctype"), 10, Toptions, ToptionValues, P039_TC_TYPE);
+            const int ToptionValues[]    = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 12 };
+            constexpr size_t optionCount = NR_ELEMENTS(ToptionValues);
+            addFormSelector(F("Thermocouple type"), F("tctype"), optionCount, Toptions, ToptionValues, P039_TC_TYPE);
           }
           {
-            const __FlashStringHelper *Coptions[5] = { F("1"), F("2"), F("4"), F("8"), F("16") };
-            const int CoptionValues[5]             = { 0, 1, 2, 3, 4 };
-            addFormSelector(F("Averaging"), F("contype"), 5, Coptions, CoptionValues, P039_CONFIG_4);
+            const __FlashStringHelper *Coptions[] = { F("1"), F("2"), F("4"), F("8"), F("16") };
+            const int CoptionValues[]             = { 0, 1, 2, 3, 4 };
+            constexpr size_t optionCount          = NR_ELEMENTS(CoptionValues);
+            addFormSelector(F("Averaging"), F("contype"), optionCount, Coptions, CoptionValues, P039_CONFIG_4);
             addUnit(F("sample(s)"));
           }
           P039_AddMainsFrequencyFilterSelection(event);
@@ -484,9 +485,10 @@ boolean Plugin_039(uint8_t function, struct EventStruct *event, String& string)
       }
       else {
         {
-          const __FlashStringHelper *TPoptions[2] = { F("MAX 31865"), F("LM7x") };
-          const int TPoptionValues[2]             = { P039_MAX31865, P039_LM7x };
-          addFormSelector(F("Adapter IC"), F("maxtype"), 2, TPoptions, TPoptionValues, choice, true); // auto reload activated
+          const __FlashStringHelper *TPoptions[] = { F("MAX 31865"), F("LM7x") };
+          const int TPoptionValues[]             = { P039_MAX31865, P039_LM7x };
+          constexpr size_t optionCount           = NR_ELEMENTS(TPoptionValues);
+          addFormSelector(F("Adapter IC"), F("maxtype"), optionCount, TPoptions, TPoptionValues, choice, true); // auto reload activated
           addFormNote(F("LM7x support is experimental."));
         }
 
@@ -497,14 +499,15 @@ boolean Plugin_039(uint8_t function, struct EventStruct *event, String& string)
             addFormSubHeader(F("Device Settings"));
           }
           {
-            const __FlashStringHelper *PToptions[2] = { F("PT100"), F("PT1000") };
-            const int PToptionValues[2]             = { MAX31865_PT100, MAX31865_PT1000 };
-            addFormSelector(F("Resistor Type"), F("rtdtype"), 2, PToptions, PToptionValues, P039_RTD_TYPE);
+            const __FlashStringHelper *PToptions[] = { F("PT100"), F("PT1000") };
+            const int PToptionValues[]             = { MAX31865_PT100, MAX31865_PT1000 };
+            constexpr size_t optionCount           = NR_ELEMENTS(PToptionValues);
+            addFormSelector(F("Resistor Type"), F("rtdtype"), optionCount, PToptions, PToptionValues, P039_RTD_TYPE);
           }
           {
-            const __FlashStringHelper *Coptions[2] = { F("2-/4"), F("3") };
-            const int CoptionValues[2]             = { 0, 1 };
-            addFormSelector(F("Connection Type"), F("contype"), 2, Coptions, CoptionValues, P039_CONFIG_4);
+            const __FlashStringHelper *Coptions[] = { F("2-/4"), F("3") };
+            constexpr size_t optionCount          = NR_ELEMENTS(Coptions);
+            addFormSelector(F("Connection Type"), F("contype"), optionCount, Coptions, nullptr, P039_CONFIG_4);
             addUnit(F("wire"));
           }
 
@@ -531,10 +534,11 @@ boolean Plugin_039(uint8_t function, struct EventStruct *event, String& string)
           }
 
           {
-            const __FlashStringHelper *PToptions[8] =
+            const __FlashStringHelper *PToptions[] =
             { F("LM70"), F("LM71"), F("LM74"), F("TMP121"), F("TMP122"), F("TMP123"), F("TMP124"), F("TMP125") };
-            const int PToptionValues[8] = { LM7x_SD70, LM7x_SD71, LM7x_SD74, LM7x_SD121, LM7x_SD122, LM7x_SD123, LM7x_SD124, LM7x_SD125 };
-            addFormSelector(F("LM7x device details"), F("rtd_lm_type"), 8, PToptions, PToptionValues, P039_RTD_LM_TYPE);
+            const int PToptionValues[]   = { LM7x_SD70, LM7x_SD71, LM7x_SD74, LM7x_SD121, LM7x_SD122, LM7x_SD123, LM7x_SD124, LM7x_SD125 };
+            constexpr size_t optionCount = NR_ELEMENTS(PToptionValues);
+            addFormSelector(F("LM7x device details"), F("rtd_lm_type"), optionCount, PToptions, PToptionValues, P039_RTD_LM_TYPE);
             addFormNote(F("TMP122/124 Limited support -> fixed 12 Bit res, no advanced options"));
           }
           {
@@ -737,19 +741,12 @@ boolean Plugin_039(uint8_t function, struct EventStruct *event, String& string)
                 # ifndef BUILD_NO_DEBUG
 
                 if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
-                  String log;
-
-                  if ((log.reserve(170u))) {                                 // reserve value derived from example log file
-                    log  = F("P039 : ");                                     // 7 char
-                    log += getTaskDeviceName(event->TaskIndex);              // 41 char ( max length of task device name + 1)
-                    log += F(" : conversionResult: ");                       // 21 char
-                    log += formatToHex_decimal(P039_data->conversionResult); // 11 char
-                    log += F("; deviceFaults: ");                            // 16 char
-                    log += formatToHex_decimal(P039_data->deviceFaults);     // 9 char
-                    log += F("; Next State: ");                              // 13 char
-                    log += event->Par1;                                      // 4 char
-                    addLogMove(LOG_LEVEL_DEBUG, log);
-                  }
+                  addLog(LOG_LEVEL_DEBUG,
+                         strformat(F("P039 : %s : conversionResult: %s; deviceFaults: %s; Next State: %d"),
+                                   getTaskDeviceName(event->TaskIndex).c_str(),
+                                   formatToHex_decimal(P039_data->conversionResult).c_str(),
+                                   formatToHex_decimal(P039_data->deviceFaults).c_str(),
+                                   event->Par1));
                 }
                 # endif // ifndef BUILD_NO_DEBUG
 
@@ -773,18 +770,11 @@ boolean Plugin_039(uint8_t function, struct EventStruct *event, String& string)
                 # ifndef BUILD_NO_DEBUG
 
                 if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
-                  String log;
+                  addLog(LOG_LEVEL_DEBUG, strformat(F("P039 : %s : current state: MAX31865_INIT_STATE, "
+                                                      "default; next state: MAX31865_BIAS_ON_STATE"),
+                                                    getTaskDeviceName(event->TaskIndex).c_str()));
 
-                  if ((log.reserve(140u))) {                                  // reserve value derived from example log file
-                    log  = F("P039 : ");                                      // 7 char
-                    log += getTaskDeviceName(event->TaskIndex);               // 41 char
-                    log += F(" : ");                                          // 3 char
-                    log += F("current state: MAX31865_INIT_STATE, default;"); // many char - 44
-                    log += F(" next state: MAX31865_BIAS_ON_STATE");          // a little less char - 35
-                    addLogMove(LOG_LEVEL_DEBUG, log);
-                  }
-
-                  // save current timer for next calculation
+                  // FIXME: Shouldn't this be in active code? // save current timer for next calculation
                   P039_data->timer = millis();
                 }
                 # endif // ifndef BUILD_NO_DEBUG
@@ -822,7 +812,11 @@ void P039_AddMainsFrequencyFilterSelection(struct EventStruct *event)
 
   addFormSelector(F("Supply Frequency Filter"), F("filttype"), 2, FToptions, FToptionValues, P039_RTD_FILT_TYPE);
   addUnit(F("Hz"));
+  # ifndef LIMIT_BUILD_SIZE
   addFormNote(F("Filter power net frequency (50/60 Hz)"));
+  # else // ifndef LIMIT_BUILD_SIZE
+  addUnit(F("net frequency"));
+  # endif // ifndef LIMIT_BUILD_SIZE
 }
 
 float readMax6675(struct EventStruct *event)
@@ -843,21 +837,12 @@ float readMax6675(struct EventStruct *event)
 
   if (loglevelActiveFor(LOG_LEVEL_DEBUG))
   {
-    String log;
-
-    if ((log.reserve(130u))) {                      // reserve value derived from example log file
-      log  = F("P039 : MAX6675 : RAW - BIN: ");     // 27 char
-      log += String(rawvalue, BIN);                 // 18 char
-      log += F(" HEX: ");                           // 5 char
-      log += formatToHex(rawvalue);                 // 4 char
-      log += F(" DEC: ");                           // 5 char
-      log += String(rawvalue);                      // 5 char
-      log += F(" MSB: ");                           // 5 char
-      log += formatToHex_decimal(messageBuffer[0]); // 9 char
-      log += F(" LSB: ");                           // 5 char
-      log += formatToHex_decimal(messageBuffer[1]); // 9 char
-      addLogMove(LOG_LEVEL_DEBUG, log);
-    }
+    addLog(LOG_LEVEL_DEBUG, strformat(F("P039 : MAX6675 : RAW - BIN: %s HEX: %s DEC: %d MSB: %s LSB: %s"),
+                                      String(rawvalue, BIN).c_str(),
+                                      formatToHex(rawvalue).c_str(),
+                                      rawvalue,
+                                      formatToHex_decimal(messageBuffer[0]).c_str(),
+                                      formatToHex_decimal(messageBuffer[1]).c_str()));
   }
 
   # endif // ifndef BUILD_NO_DEBUG
@@ -908,14 +893,11 @@ float readMax31855(struct EventStruct *event)
   {
     String log;
 
-    if ((log.reserve(200u))) {                   // reserve value derived from example log file
-      log  = F("P039 : MAX31855 : RAW - BIN: "); // 35 char
-      log += String(rawvalue, BIN);              // 16 char
-      log += F(" rawvalue,HEX: ");               // 15 char
-      log += formatToHex(rawvalue);              // 4 char
-      log += F(" rawvalue,DEC: ");               // 15 char
-      log += rawvalue;                           // 5 char
-      log += F(" messageBuffer[],HEX:");         // 21 char
+    if ((log.reserve(200u))) { // reserve value derived from example log file
+      log = strformat(F("P039 : MAX31855 : RAW - BIN: %s rawvalue,HEX: %s rawvalue,DEC: %d messageBuffer[],HEX:"),
+                      String(rawvalue, BIN).c_str(),
+                      formatToHex(rawvalue).c_str(),
+                      rawvalue);
 
       for (size_t i = 0u; i < 4; ++i)
       {
@@ -972,16 +954,9 @@ float readMax31855(struct EventStruct *event)
 
     if (loglevelActiveFor(LOG_LEVEL_DEBUG))
     {
-      String log;
-
-      if ((log.reserve(120u))) { // reserve value derived from example log file
-        log  = F("P039 : MAX31855 : ");
-        log += F("rawvalue: ");
-        log += formatToHex_decimal(rawvalue);
-        log += F(" P039_data->sensorFault: ");
-        log += formatToHex_decimal(P039_data->sensorFault);
-        addLogMove(LOG_LEVEL_DEBUG, log);
-      }
+      addLog(LOG_LEVEL_DEBUG, strformat(F("P039 : MAX31855 : rawvalue: %s P039_data->sensorFault: "),
+                                        formatToHex_decimal(rawvalue).c_str(),
+                                        formatToHex_decimal(P039_data->sensorFault).c_str()));
     }
 
     # endif // ifndef BUILD_NO_DEBUG
@@ -1360,16 +1335,9 @@ float readMax31865(struct EventStruct *event)
 
   if (loglevelActiveFor(LOG_LEVEL_DEBUG))
   {
-    String log;
-
-    if ((log.reserve(85u))) {                                // reserve value derived from example log file
-      log  = F("P039 : Temperature :");                      // 20 char
-      log += F(" registers[MAX31865_FAULT]: ");              // 33 char
-      log += formatToHex_decimal(registers[MAX31865_FAULT]); // 7 char
-      log += F(" ValueValid: ");                             // 13 char
-      log += boolToString(ValueValid);                       // 5 char
-      addLogMove(LOG_LEVEL_DEBUG, log);
-    }
+    addLog(LOG_LEVEL_DEBUG, strformat(F("P039 : Temperature : registers[MAX31865_FAULT]: %s ValueValid: %s"),
+                                      formatToHex_decimal(registers[MAX31865_FAULT]).c_str(),
+                                      FsP(boolToString(ValueValid))));
   }
 
   # endif // ifndef BUILD_NO_DEBUG
@@ -1384,20 +1352,11 @@ float readMax31865(struct EventStruct *event)
 
     if (loglevelActiveFor(LOG_LEVEL_DEBUG))
     {
-      String log;
-
-      if ((log.reserve(110u))) {              // reserve value derived from example log file
-        log  = F("P039 : Temperature :");     // 20 char
-        log += F(" rawValue: ");              // 11 char
-        log += formatToHex_decimal(rawValue); // 9 char
-        log += F(" temperature: ");           // 14 char
-        log += temperature;                   // 11 char
-        log += F(" P039_RTD_TYPE: ");         // 16 char
-        log += P039_RTD_TYPE;                 // 1 char
-        log += F(" P039_RTD_RES: ");          // 15 char
-        log += P039_RTD_RES;                  // 4 char
-        addLogMove(LOG_LEVEL_DEBUG, log);
-      }
+      addLog(LOG_LEVEL_DEBUG, strformat(F("P039 : Temperature : rawValue: %s temperature: %.3f P039_RTD_TYPE: %d P039_RTD_RES: %d"),
+                                        formatToHex_decimal(rawValue).c_str(),
+                                        temperature,
+                                        P039_RTD_TYPE,
+                                        P039_RTD_RES));
     }
 
     # endif // ifndef BUILD_NO_DEBUG
@@ -1565,20 +1524,11 @@ float readLM7x(struct EventStruct *event)
 
   if (loglevelActiveFor(LOG_LEVEL_DEBUG))
   {
-    String log;
-
-    if ((log.reserve(130u))) { // reserve value derived from example log file
-      log  = F("P039 : LM7x : readLM7x : ");
-      log += F(" rawValue: ");
-      log += formatToHex_decimal(rawValue);
-      log += F(" device_id: ");
-      log += formatToHex(device_id);
-      log += F(" temperature: ");
-      log += temperature;
-      addLogMove(LOG_LEVEL_DEBUG, log);
-    }
+    addLog(LOG_LEVEL_DEBUG, strformat(F("P039 : LM7x : readLM7x :  rawValue: %s device_id: %s temperature: %.3f"),
+                                      formatToHex_decimal(rawValue).c_str(),
+                                      formatToHex(device_id).c_str(),
+                                      temperature));
   }
-
   # endif // ifndef BUILD_NO_DEBUG
 
   return temperature;
@@ -1636,22 +1586,13 @@ float convertLM7xTemp(uint16_t l_rawValue, uint16_t l_LM7xsubtype)
 
   if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE))
   {
-    String log;
-
-    if ((log.reserve(185u))) { // reserve value derived from example log file
-      log  = F("P039 : LM7x : convertLM7xTemp : ");
-      log += F(" l_returnValue: ");
-      log += formatToHex_decimal(l_returnValue);
-      log += F(" l_LM7xsubtype: ");
-      log += formatToHex_decimal(l_LM7xsubtype);
-      log += F(" l_rawValue: ");
-      log += formatToHex_decimal(l_rawValue);
-      log += F(" l_noBits: ");
-      log += l_noBits;
-      log += F(" l_lsbvalue: ");
-      log += l_lsbvalue;
-      addLogMove(LOG_LEVEL_DEBUG_MORE, log);
-    }
+    addLog(LOG_LEVEL_DEBUG_MORE,
+           strformat(F("P039 : LM7x : convertLM7xTemp :  l_returnValue: %s l_LM7xsubtype: %s l_rawValue: %s l_noBits: %d l_lsbvalue: %.3f"),
+                     formatToHex_decimal(l_returnValue).c_str(),
+                     formatToHex_decimal(l_LM7xsubtype).c_str(),
+                     formatToHex_decimal(l_rawValue).c_str(),
+                     l_noBits,
+                     l_lsbvalue));
   }
 
   # endif // ifndef BUILD_NO_DEBUG
@@ -1774,16 +1715,9 @@ uint16_t readLM7xRegisters(int8_t l_CS_pin_no, uint8_t l_LM7xsubType, uint8_t l_
 
   if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE))
   {
-    String log;
-
-    if ((log.reserve(115u))) { // reserve value derived from example log file
-      log  = F("P039 : LM7x : readLM7xRegisters : ");
-      log += F(" l_returnValue: ");
-      log += formatToHex_decimal(l_returnValue);
-      log += F(" l_device_id: ");
-      log += formatToHex(*(l_device_id));
-      addLogMove(LOG_LEVEL_DEBUG_MORE, log);
-    }
+    addLog(LOG_LEVEL_DEBUG_MORE, strformat(F("P039 : LM7x : readLM7xRegisters :  l_returnValue: %s l_device_id: %s"),
+                                           formatToHex_decimal(l_returnValue).c_str(),
+                                           formatToHex(*(l_device_id)).c_str()));
   }
 
   # endif // ifndef BUILD_NO_DEBUG
@@ -1883,16 +1817,9 @@ void write8BitRegister(int8_t l_CS_pin_no, uint8_t l_address, uint8_t value)
 
   if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE))
   {
-    String log;
-
-    if ((log.reserve(100u))) { // reserve value derived from example log file
-      log  = F("P039 : SPI : write8BitRegister : ");
-      log += F("l_address: ");
-      log += formatToHex(l_address);
-      log += F(" value: ");
-      log += formatToHex_decimal(value);
-      addLogMove(LOG_LEVEL_DEBUG_MORE, log);
-    }
+    addLog(LOG_LEVEL_DEBUG_MORE, strformat(F("P039 : SPI : write8BitRegister : l_address: %s value: %s"),
+                                           formatToHex(l_address).c_str(),
+                                           formatToHex_decimal(value).c_str()));
   }
 
   # endif // ifndef BUILD_NO_DEBUG
@@ -1921,16 +1848,9 @@ void write16BitRegister(int8_t l_CS_pin_no, uint8_t l_address, uint16_t value)
 
   if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE))
   {
-    String log;
-
-    if ((log.reserve(110u))) { // reserve value derived from example log file
-      log  = F("P039 : SPI : write16BitRegister : ");
-      log += F("l_address: ");
-      log += formatToHex(l_address);
-      log += F(" value: ");
-      log += formatToHex_decimal(value);
-      addLogMove(LOG_LEVEL_DEBUG_MORE, log);
-    }
+    addLog(LOG_LEVEL_DEBUG_MORE, strformat(F("P039 : SPI : write16BitRegister : l_address: %s value: %s"),
+                                           formatToHex(l_address).c_str(),
+                                           formatToHex_decimal(value).c_str()));
   }
 
   # endif // ifndef BUILD_NO_DEBUG
@@ -1958,16 +1878,9 @@ uint8_t read8BitRegister(int8_t l_CS_pin_no, uint8_t l_address)
 
   if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE))
   {
-    String log;
-
-    if ((log.reserve(100u))) { // reserve value derived from example log file
-      log  = F("P039 : SPI : read8BitRegister : ");
-      log += F("l_address: ");
-      log += formatToHex(l_address);
-      log += F(" returnvalue: ");
-      log += formatToHex_decimal(l_messageBuffer[1]);
-      addLogMove(LOG_LEVEL_DEBUG_MORE, log);
-    }
+    addLog(LOG_LEVEL_DEBUG_MORE, strformat(F("P039 : SPI : read8BitRegister : l_address: %s returnvalue: %s"),
+                                           formatToHex(l_address).c_str(),
+                                           formatToHex_decimal(l_messageBuffer[1]).c_str()));
   }
 
   # endif // ifndef BUILD_NO_DEBUG
@@ -1999,16 +1912,9 @@ uint16_t read16BitRegister(int8_t l_CS_pin_no, uint8_t l_address)
 
   if (loglevelActiveFor(LOG_LEVEL_DEBUG_MORE))
   {
-    String log;
-
-    if ((log.reserve(110u))) { // reserve value derived from example log file
-      log  = F("P039 : SPI : read16BitRegister : ");
-      log += F("l_address: ");
-      log += formatToHex(l_address);
-      log += F(" l_returnValue: ");
-      log += formatToHex_decimal(l_returnValue);
-      addLogMove(LOG_LEVEL_DEBUG_MORE, log);
-    }
+    addLog(LOG_LEVEL_DEBUG_MORE, strformat(F("P039 : SPI : read16BitRegister : l_address: %s l_returnValue: %s"),
+                                           formatToHex(l_address).c_str(),
+                                           formatToHex_decimal(l_returnValue).c_str()));
   }
 
   # endif // ifndef BUILD_NO_DEBUG

--- a/src/_P040_ID12.ino
+++ b/src/_P040_ID12.ino
@@ -25,10 +25,11 @@ boolean Plugin_040(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_040;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_ULONG;
-      Device[deviceCount].ValueCount     = 1;
-      Device[deviceCount].SendDataOption = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_040;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_ULONG;
+      dev.ValueCount     = 1;
+      dev.SendDataOption = true;
       break;
     }
 

--- a/src/_P040_ID12.ino
+++ b/src/_P040_ID12.ino
@@ -2,14 +2,18 @@
 #ifdef USES_P040
 
 
-//#######################################################################################################
-//#################################### Plugin 040: Serial RFID ID-12 ####################################
-//#######################################################################################################
+// #######################################################################################################
+// #################################### Plugin 040: Serial RFID ID-12 ####################################
+// #######################################################################################################
 
-#define PLUGIN_040
-#define PLUGIN_ID_040         40
-#define PLUGIN_NAME_040       "RFID - ID12LA/RDM6300"
-#define PLUGIN_VALUENAME1_040 "Tag"
+/** Changelog:
+ * 2025-01-03 tonhuisman: Format source code and small code size reductions
+ * TODO: Implement ESPEasySerial
+ */
+# define PLUGIN_040
+# define PLUGIN_ID_040         40
+# define PLUGIN_NAME_040       "RFID - ID12LA/RDM6300"
+# define PLUGIN_VALUENAME1_040 "Tag"
 
 boolean Plugin_040_init = false;
 
@@ -19,154 +23,156 @@ boolean Plugin_040(uint8_t function, struct EventStruct *event, String& string)
 
   switch (function)
   {
-
     case PLUGIN_DEVICE_ADD:
-      {
-        Device[++deviceCount].Number = PLUGIN_ID_040;
-        Device[deviceCount].VType = Sensor_VType::SENSOR_TYPE_ULONG;
-        Device[deviceCount].Ports = 0;
-        Device[deviceCount].PullUpOption = false;
-        Device[deviceCount].InverseLogicOption = false;
-        Device[deviceCount].FormulaOption = false;
-        Device[deviceCount].ValueCount = 1;
-        Device[deviceCount].SendDataOption = true;
-        Device[deviceCount].TimerOption = false;
-        Device[deviceCount].GlobalSyncOption = true;
-        break;
-      }
+    {
+      Device[++deviceCount].Number       = PLUGIN_ID_040;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_ULONG;
+      Device[deviceCount].ValueCount     = 1;
+      Device[deviceCount].SendDataOption = true;
+      break;
+    }
 
     case PLUGIN_GET_DEVICENAME:
-      {
-        string = F(PLUGIN_NAME_040);
-        break;
-      }
+    {
+      string = F(PLUGIN_NAME_040);
+      break;
+    }
 
     case PLUGIN_GET_DEVICEVALUENAMES:
-      {
-        strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[0], PSTR(PLUGIN_VALUENAME1_040));
-        break;
-      }
+    {
+      strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[0], PSTR(PLUGIN_VALUENAME1_040));
+      break;
+    }
 
     case PLUGIN_INIT:
-      {
-        Plugin_040_init = true;
-        ESPEASY_SERIAL_0.begin(9600);
-        success = true;
-        break;
-      }
+    {
+      Plugin_040_init = true;
+      ESPEASY_SERIAL_0.begin(9600);
+      success = true;
+      break;
+    }
 
     case PLUGIN_TASKTIMER_IN:
-      {
-        if (Plugin_040_init) {
-            // Reset card id on timeout
-            UserVar.setSensorTypeLong(event->TaskIndex, 0);
-            addLog(LOG_LEVEL_INFO, F("RFID : Removed Tag"));
-            sendData(event);
-            success = true;
-        }
-        break;
+    {
+      if (Plugin_040_init) {
+        // Reset card id on timeout
+        UserVar.setSensorTypeLong(event->TaskIndex, 0);
+        addLog(LOG_LEVEL_INFO, F("RFID : Removed Tag"));
+        sendData(event);
+        success = true;
       }
+      break;
+    }
 
     case PLUGIN_SERIAL_IN:
+    {
+      if (Plugin_040_init)
       {
-        if (Plugin_040_init)
-        {
-          uint8_t val = 0;
-          uint8_t code[6];
-          uint8_t checksum = 0;
-          uint8_t bytesread = 0;
-          uint8_t tempbyte = 0;
+        uint8_t val = 0;
+        uint8_t code[6];
+        uint8_t checksum  = 0;
+        uint8_t bytesread = 0;
+        uint8_t tempbyte  = 0;
 
-          if ((val = ESPEASY_SERIAL_0.read()) == 2)
-          { // check for header
-            bytesread = 0;
-            while (bytesread < 12) {                        // read 10 digit code + 2 digit checksum
-              if ( ESPEASY_SERIAL_0.available() > 0) {
-                val = ESPEASY_SERIAL_0.read();
-                if ((val == 0x0D) || (val == 0x0A) || (val == 0x03) || (val == 0x02)) {
-                  // if header or stop bytes before the 10 digit reading
-                  break;
-                }
+        if ((val = ESPEASY_SERIAL_0.read()) == 2)
+        {                          // check for header
+          bytesread = 0;
 
-                // Do Ascii/Hex conversion:
-                if (isDigit(val)) {
-                  val = val - '0';
-                }
-                else if ((val >= 'A') && (val <= 'F')) {
-                  val = 10 + val - 'A';
-                }
+          while (bytesread < 12) { // read 10 digit code + 2 digit checksum
+            if (ESPEASY_SERIAL_0.available() > 0) {
+              val = ESPEASY_SERIAL_0.read();
 
-                // Every two hex-digits, add uint8_t to code:
-                if ( (bytesread & 1) == 1) {
-                  // make some space for this hex-digit by
-                  // shifting the previous hex-digit with 4 bits to the left:
-                  code[bytesread >> 1] = (val | (tempbyte << 4));
-
-                  if (bytesread >> 1 != 5) {                // If we're at the checksum uint8_t,
-                    checksum ^= code[bytesread >> 1];       // Calculate the checksum... (XOR)
-                  };
-                }
-                else {
-                  tempbyte = val;                           // Store the first hex digit first...
-                };
-                bytesread++;                                // ready to read next digit
-              }
-            }
-          }
-
-          if (bytesread == 12)
-          {
-            if (code[5] == checksum)
-            {
-              // temp woraround, ESP Easy framework does not currently prepare this...
-              taskIndex_t index = INVALID_TASK_INDEX;
-              constexpr pluginID_t PLUGIN_ID_P040_ID12(PLUGIN_ID_040);
-
-              for (taskIndex_t y = 0; y < TASKS_MAX; ++y) {
-                if (Settings.getPluginID_for_task(y) == PLUGIN_ID_P040_ID12) {
-                  index = y;
-                }
-              }
-              const deviceIndex_t DeviceIndex = getDeviceIndex_from_TaskIndex(index);
-              if (!validDeviceIndex(DeviceIndex)) {
+              if ((val == 0x0D) || (val == 0x0A) || (val == 0x03) || (val == 0x02)) {
+                // if header or stop bytes before the 10 digit reading
                 break;
               }
-              event->setTaskIndex(index);
-              if (!validUserVarIndex(event->BaseVarIndex)) {
-                break;
-              }
-              checkDeviceVTypeForTask(event);
-              // endof workaround
 
-              unsigned long key = 0, old_key = 0;
-              old_key = UserVar.getSensorTypeLong(event->TaskIndex);
-              for (uint8_t i = 1; i < 5; ++i) { key = key | (((unsigned long) code[i] << ((4 - i) * 8))); }
-              bool new_key = false;              
-              if (old_key != key) {
-                UserVar.setSensorTypeLong(event->TaskIndex, key);
-                new_key = true;
+              // Do Ascii/Hex conversion:
+              if (isDigit(val)) {
+                val = val - '0';
+              }
+              else if ((val >= 'A') && (val <= 'F')) {
+                val = 10 + val - 'A';
               }
 
-              if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-                String log = F("RFID : ");
-                if (new_key) {
-                  log += F("New Tag: ");
-                } else {
-                  log += F("Old Tag: "); 
+              // Every two hex-digits, add uint8_t to code:
+              if ((bytesread & 1) == 1) {
+                // make some space for this hex-digit by
+                // shifting the previous hex-digit with 4 bits to the left:
+                code[bytesread >> 1] = (val | (tempbyte << 4));
+
+                if (bytesread >> 1 != 5) {          // If we're at the checksum uint8_t,
+                  checksum ^= code[bytesread >> 1]; // Calculate the checksum... (XOR)
                 }
-                log += key;
-                addLogMove(LOG_LEVEL_INFO, log);
               }
-              
-              if (new_key) sendData(event);
-              Scheduler.setPluginTaskTimer(500, event->TaskIndex, event->Par1);
+              else {
+                tempbyte = val; // Store the first hex digit first...
+              }
+              bytesread++;      // ready to read next digit
             }
           }
-          success = true;
         }
-        break;
+
+        if (bytesread == 12)
+        {
+          if (code[5] == checksum)
+          {
+            // temp woraround, ESP Easy framework does not currently prepare this...
+            taskIndex_t index = INVALID_TASK_INDEX;
+            constexpr pluginID_t PLUGIN_ID_P040_ID12(PLUGIN_ID_040);
+
+            for (taskIndex_t y = 0; y < TASKS_MAX; ++y) {
+              if (Settings.getPluginID_for_task(y) == PLUGIN_ID_P040_ID12) {
+                index = y;
+              }
+            }
+            const deviceIndex_t DeviceIndex = getDeviceIndex_from_TaskIndex(index);
+
+            if (!validDeviceIndex(DeviceIndex)) {
+              break;
+            }
+            event->setTaskIndex(index);
+
+            if (!validUserVarIndex(event->BaseVarIndex)) {
+              break;
+            }
+            checkDeviceVTypeForTask(event);
+
+            // endof workaround
+
+            unsigned long key = 0, old_key = 0;
+            old_key = UserVar.getSensorTypeLong(event->TaskIndex);
+
+            for (uint8_t i = 1; i < 5; ++i) { key = key | (((unsigned long)code[i] << ((4 - i) * 8))); }
+            bool new_key = false;
+
+            if (old_key != key) {
+              UserVar.setSensorTypeLong(event->TaskIndex, key);
+              new_key = true;
+            }
+
+            if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+              String log = F("RFID : ");
+
+              if (new_key) {
+                log += F("New Tag: ");
+              } else {
+                log += F("Old Tag: ");
+              }
+              log += key;
+              addLogMove(LOG_LEVEL_INFO, log);
+            }
+
+            if (new_key) { sendData(event); }
+            Scheduler.setPluginTaskTimer(500, event->TaskIndex, event->Par1);
+          }
+        }
+        success = true;
       }
+      break;
+    }
   }
   return success;
 }
+
 #endif // USES_P040

--- a/src/_P041_NeoClock.ino
+++ b/src/_P041_NeoClock.ino
@@ -36,11 +36,9 @@ boolean Plugin_041(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number      = PLUGIN_ID_041;
-      Device[deviceCount].Type          = DEVICE_TYPE_SINGLE;
-      Device[deviceCount].VType         = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].Ports         = 0;
-      Device[deviceCount].ValueCount    = 0;
+      Device[++deviceCount].Number = PLUGIN_ID_041;
+      Device[deviceCount].Type     = DEVICE_TYPE_SINGLE;
+      Device[deviceCount].VType    = Sensor_VType::SENSOR_TYPE_NONE;
       Device[deviceCount].setPin1Direction(gpio_direction::gpio_output);
       break;
     }

--- a/src/_P041_NeoClock.ino
+++ b/src/_P041_NeoClock.ino
@@ -36,10 +36,11 @@ boolean Plugin_041(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number = PLUGIN_ID_041;
-      Device[deviceCount].Type     = DEVICE_TYPE_SINGLE;
-      Device[deviceCount].VType    = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].setPin1Direction(gpio_direction::gpio_output);
+      auto& dev = Device[++deviceCount];
+      dev.Number   = PLUGIN_ID_041;
+      dev.Type     = DEVICE_TYPE_SINGLE;
+      dev.VType    = Sensor_VType::SENSOR_TYPE_NONE;
+      dev.setPin1Direction(gpio_direction::gpio_output);
       break;
     }
 

--- a/src/_P042_Candle.ino
+++ b/src/_P042_Candle.ino
@@ -95,7 +95,6 @@ boolean Plugin_042(uint8_t function, struct EventStruct *event, String& string)
       Device[++deviceCount].Number       = PLUGIN_ID_042;
       Device[deviceCount].Type           = DEVICE_TYPE_SINGLE;
       Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_TRIPLE;
-      Device[deviceCount].Ports          = 0;
       Device[deviceCount].ValueCount     = 3;
       Device[deviceCount].SendDataOption = true;
       Device[deviceCount].TimerOption    = true;
@@ -164,18 +163,16 @@ boolean Plugin_042(uint8_t function, struct EventStruct *event, String& string)
       addHtml(F("<input type='radio' id='clrDef' name='" P042_WEBVAR_COLORTYPE_S "' value='0'"));
 
       if (Candle_color == P042_ColorType::ColorDefault) {
-        addHtml(F(" checked>"));
-      } else {
-        addHtml('>');
+        addHtml(F(" checked"));
       }
+      addHtml('>');
       addHtml(F("<label for='clrDef'> Use default color</label><br>"));
       addHtml(F("<input type='radio' id='clrSel' name='" P042_WEBVAR_COLORTYPE_S "' value='1'"));
 
       if (Candle_color == P042_ColorType::ColorSelected) {
-        addHtml(F(" checked>"));
-      } else {
-        addHtml('>');
+        addHtml(F(" checked"));
       }
+      addHtml('>');
       addHtml(F("<label for='clrSel'> Use selected color</label><br>"));
 
       // http://jscolor.com/examples/

--- a/src/_P042_Candle.ino
+++ b/src/_P042_Candle.ino
@@ -92,13 +92,14 @@ boolean Plugin_042(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_042;
-      Device[deviceCount].Type           = DEVICE_TYPE_SINGLE;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_TRIPLE;
-      Device[deviceCount].ValueCount     = 3;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].setPin1Direction(gpio_direction::gpio_output);
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_042;
+      dev.Type           = DEVICE_TYPE_SINGLE;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_TRIPLE;
+      dev.ValueCount     = 3;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.setPin1Direction(gpio_direction::gpio_output);
       break;
     }
 

--- a/src/_P043_ClkOutput.ino
+++ b/src/_P043_ClkOutput.ino
@@ -68,13 +68,14 @@ boolean Plugin_043(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_043;
-      Device[deviceCount].Type           = DEVICE_TYPE_SINGLE;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SWITCH;
-      Device[deviceCount].ValueCount     = 2;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].OutputDataType = Output_Data_type_t::Simple;
-      Device[deviceCount].setPin1Direction(gpio_direction::gpio_output);
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_043;
+      dev.Type           = DEVICE_TYPE_SINGLE;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SWITCH;
+      dev.ValueCount     = 2;
+      dev.SendDataOption = true;
+      dev.OutputDataType = Output_Data_type_t::Simple;
+      dev.setPin1Direction(gpio_direction::gpio_output);
       break;
     }
 

--- a/src/_P043_ClkOutput.ino
+++ b/src/_P043_ClkOutput.ino
@@ -71,7 +71,6 @@ boolean Plugin_043(uint8_t function, struct EventStruct *event, String& string)
       Device[++deviceCount].Number       = PLUGIN_ID_043;
       Device[deviceCount].Type           = DEVICE_TYPE_SINGLE;
       Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SWITCH;
-      Device[deviceCount].Ports          = 0;
       Device[deviceCount].ValueCount     = 2;
       Device[deviceCount].SendDataOption = true;
       Device[deviceCount].OutputDataType = Output_Data_type_t::Simple;

--- a/src/_P044_P1WifiGateway.ino
+++ b/src/_P044_P1WifiGateway.ino
@@ -35,10 +35,11 @@ boolean Plugin_044(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number    = PLUGIN_ID_044;
-      Device[deviceCount].Type        = DEVICE_TYPE_CUSTOM2;
-      Device[deviceCount].Custom      = true;
-      Device[deviceCount].TimerOption = false;
+      auto& dev = Device[++deviceCount];
+      dev.Number      = PLUGIN_ID_044;
+      dev.Type        = DEVICE_TYPE_CUSTOM2;
+      dev.Custom      = true;
+      dev.TimerOption = false;
       break;
     }
 

--- a/src/_P045_MPU6050.ino
+++ b/src/_P045_MPU6050.ino
@@ -82,14 +82,15 @@ boolean Plugin_045(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_045;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].ValueCount     = 1;    // Unfortunatly domoticz has no custom multivalue sensors.
-      Device[deviceCount].SendDataOption = true; //   and I use Domoticz ... so there.
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].FormulaOption  = false;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_045;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.ValueCount     = 1;    // Unfortunatly domoticz has no custom multivalue sensors.
+      dev.SendDataOption = true; //   and I use Domoticz ... so there.
+      dev.TimerOption    = true;
+      dev.FormulaOption  = false;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P046_VentusW266.ino
+++ b/src/_P046_VentusW266.ino
@@ -144,15 +144,16 @@ boolean Plugin_046(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
       {
-        Device[++deviceCount].Number = PLUGIN_ID_046;
-        Device[deviceCount].Type = DEVICE_TYPE_DUMMY;           // Nothing else really fit the bill ...
-        Device[deviceCount].VType = Sensor_VType::SENSOR_TYPE_DUAL;           // New type, see ESPEasy.ino
-        Device[deviceCount].Ports = 0;
-        Device[deviceCount].PullUpOption = false;
-        Device[deviceCount].InverseLogicOption = false;
-        Device[deviceCount].FormulaOption = true;
-        Device[deviceCount].SendDataOption = true;
-        Device[deviceCount].ValueCount = 3;
+        auto& dev = Device[++deviceCount];
+      dev.Number   = PLUGIN_ID_046;
+        dev.Type = DEVICE_TYPE_DUMMY;           // Nothing else really fit the bill ...
+        dev.VType = Sensor_VType::SENSOR_TYPE_DUAL;           // New type, see ESPEasy.ino
+        dev.Ports = 0;
+        dev.PullUpOption = false;
+        dev.InverseLogicOption = false;
+        dev.FormulaOption = true;
+        dev.SendDataOption = true;
+        dev.ValueCount = 3;
         break;
       }
 

--- a/src/_P047_i2c-soil-moisture-sensor.ino
+++ b/src/_P047_i2c-soil-moisture-sensor.ino
@@ -46,18 +46,14 @@ boolean Plugin_047(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_047;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TRIPLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 3;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_047;
+      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_TRIPLE;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 3;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].PluginStats    = true;
       break;
     }
 
@@ -170,7 +166,7 @@ boolean Plugin_047(uint8_t function, struct EventStruct *event, String& string)
         # if P047_FEATURE_BEFLE_V3
 
         if (P047_MODEL_CATNIP == static_cast<P047_SensorModels>(P047_MODEL))
-        # endif // if !P047_FEATURE_BEFLE_V3
+        # endif // if P047_FEATURE_BEFLE_V3
         {
           addFormCheckBox(F("Check sensor version"), F("version"), P047_CHECK_VERSION);
         }

--- a/src/_P047_i2c-soil-moisture-sensor.ino
+++ b/src/_P047_i2c-soil-moisture-sensor.ino
@@ -46,14 +46,15 @@ boolean Plugin_047(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_047;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_TRIPLE;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 3;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_047;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_TRIPLE;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 3;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P048_Motorshield_v2.ino
+++ b/src/_P048_Motorshield_v2.ino
@@ -32,17 +32,10 @@ boolean Plugin_048(uint8_t function, struct EventStruct *event, String& string) 
 
   switch (function) {
     case PLUGIN_DEVICE_ADD: {
-      Device[++deviceCount].Number           = PLUGIN_ID_048;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].ValueCount         = 0;
-      Device[deviceCount].SendDataOption     = false;
-      Device[deviceCount].TimerOption        = false;
-      Device[deviceCount].I2CNoDeviceCheck   = true;
+      Device[++deviceCount].Number         = PLUGIN_ID_048;
+      Device[deviceCount].Type             = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType            = Sensor_VType::SENSOR_TYPE_NONE;
+      Device[deviceCount].I2CNoDeviceCheck = true;
       break;
     }
 

--- a/src/_P048_Motorshield_v2.ino
+++ b/src/_P048_Motorshield_v2.ino
@@ -32,10 +32,11 @@ boolean Plugin_048(uint8_t function, struct EventStruct *event, String& string) 
 
   switch (function) {
     case PLUGIN_DEVICE_ADD: {
-      Device[++deviceCount].Number         = PLUGIN_ID_048;
-      Device[deviceCount].Type             = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType            = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].I2CNoDeviceCheck = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number           = PLUGIN_ID_048;
+      dev.Type             = DEVICE_TYPE_I2C;
+      dev.VType            = Sensor_VType::SENSOR_TYPE_NONE;
+      dev.I2CNoDeviceCheck = true;
       break;
     }
 

--- a/src/_P049_MHZ19.ino
+++ b/src/_P049_MHZ19.ino
@@ -48,15 +48,16 @@ boolean Plugin_049(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_049;
-      Device[deviceCount].Type               = DEVICE_TYPE_SERIAL;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TRIPLE;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 3;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].PluginStats        = true;
-      Device[deviceCount].ExitTaskBeforeSave = false;
+      auto& dev = Device[++deviceCount];
+      dev.Number             = PLUGIN_ID_049;
+      dev.Type               = DEVICE_TYPE_SERIAL;
+      dev.VType              = Sensor_VType::SENSOR_TYPE_TRIPLE;
+      dev.FormulaOption      = true;
+      dev.ValueCount         = 3;
+      dev.SendDataOption     = true;
+      dev.TimerOption        = true;
+      dev.PluginStats        = true;
+      dev.ExitTaskBeforeSave = false;
       break;
     }
 

--- a/src/_P049_MHZ19.ino
+++ b/src/_P049_MHZ19.ino
@@ -4,7 +4,8 @@
 # include "src/PluginStructs/P049_data_struct.h"
 
 /** Changelog:
- * 2024-01-04 tonhuisman: Add Device[].ExitBeforeSeve = false so ABD can be enabled during settings save
+ * 2025-01-03 tonhuisman: Small code size reductions
+ * 2024-01-04 tonhuisman: Add Device[].ExitBeforeSeve = false so ABC can be enabled during settings save
  * 2024-01-04 tonhuisman: Start changelog, most recent change on top
  */
 
@@ -50,14 +51,10 @@ boolean Plugin_049(uint8_t function, struct EventStruct *event, String& string)
       Device[++deviceCount].Number           = PLUGIN_ID_049;
       Device[deviceCount].Type               = DEVICE_TYPE_SERIAL;
       Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TRIPLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
       Device[deviceCount].FormulaOption      = true;
       Device[deviceCount].ValueCount         = 3;
       Device[deviceCount].SendDataOption     = true;
       Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
       Device[deviceCount].PluginStats        = true;
       Device[deviceCount].ExitTaskBeforeSave = false;
       break;
@@ -160,15 +157,15 @@ boolean Plugin_049(uint8_t function, struct EventStruct *event, String& string)
       if (nullptr == P049_data) {
         return success;
       }
-      bool expectReset  = false;
-      unsigned int ppm  = 0;
-      signed int   temp = 0;
-      unsigned int s    = 0;
-      float u           = 0;
+      bool expectReset   = false;
+      unsigned int ppm   = 0;
+      signed int   temp  = 0;
+      unsigned int s     = 0;
+      float u            = 0;
+      const bool mustLog = loglevelActiveFor(LOG_LEVEL_INFO);
 
       if (P049_data->read_ppm(ppm, temp, s, u)) {
-        const bool mustLog = loglevelActiveFor(LOG_LEVEL_INFO);
-        String     log;
+        String log;
 
         if (mustLog) {
           log = F("MHZ19: ");
@@ -247,7 +244,7 @@ boolean Plugin_049(uint8_t function, struct EventStruct *event, String& string)
 
         // log verbosely anything else that the sensor reports
       } else {
-        if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+        if (mustLog) {
           addLog(LOG_LEVEL_INFO,
                  concat(F("MHZ19: Unknown response:"), P049_data->getBufferHexDump()));
         }

--- a/src/_P050_TCS34725.ino
+++ b/src/_P050_TCS34725.ino
@@ -11,13 +11,17 @@
 // this code is based on 20170331 date version of the above library
 // this code is UNTESTED, because my TCS34725 sensor is still not shipped :(
 //
-// 2021-01-20 tonhuisman: Renamed Calibration to Transformation, fix some textual issues
-// 2021-01-20 tonhuisman: Added optional events for not selected RGB outputs, compile-time optional
-// 2021-01-19 tonhuisman: (Re)Added additional transformation & calculation options
-// 2021-01-16 tonhuisman: Move stuff to PluginStructs, add 3x3 matrix calibration
-// 2021-01-09 tonhuisman: Add R/G/B calibration factors, improved/corrected normalization
-// 2021-01-03 tonhuisman: Merged most of the changes in the library, for adding the getRGB() and calculateColorTemperature_dn40(0 functions)
-//
+
+/** Changelog
+ * 2025-01-03 tonhuisman: Small code cleanup and reformatting
+ * 2021-01-20 tonhuisman: Renamed Calibration to Transformation, fix some textual issues
+ * 2021-01-20 tonhuisman: Added optional events for not selected RGB outputs, compile-time optional
+ * 2021-01-19 tonhuisman: (Re)Added additional transformation & calculation options
+ * 2021-01-16 tonhuisman: Move stuff to PluginStructs, add 3x3 matrix calibration
+ * 2021-01-09 tonhuisman: Add R/G/B calibration factors, improved/corrected normalization
+ * 2021-01-03 tonhuisman: Merged most of the changes in the library, for adding the getRGB() and calculateColorTemperature_dn40(0 functions)
+ *
+ */
 
 # include "src/PluginStructs/P050_data_struct.h"
 
@@ -43,18 +47,14 @@ boolean Plugin_050(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_050;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 4;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_050;
+      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 4;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].PluginStats    = true;
       break;
     }
 
@@ -81,7 +81,7 @@ boolean Plugin_050(uint8_t function, struct EventStruct *event, String& string)
       # if FEATURE_I2C_DEVICE_CHECK
 
       if (!I2C_deviceCheck(0x29)) {
-        break;        // Will return the default false for success
+        break; // Will return the default false for success
       }
       # endif // if FEATURE_I2C_DEVICE_CHECK
       P050_data_struct *P050_data = new (std::nothrow) P050_data_struct(PCONFIG(0), PCONFIG(1));
@@ -150,8 +150,8 @@ boolean Plugin_050(uint8_t function, struct EventStruct *event, String& string)
       addFormSubHeader(F("Output settings"));
 
       {
-        # define P050_RGB_OPTIONS 6
-        const __FlashStringHelper *optionsRGB[P050_RGB_OPTIONS] = {
+        // # define P050_RGB_OPTIONS 6
+        const __FlashStringHelper *optionsRGB[] = {
           F("Raw RGB"),
           F("Raw RGB transformed (3x3 matrix, below)"),
           F("Normalized RGB (0..255)"),
@@ -159,28 +159,40 @@ boolean Plugin_050(uint8_t function, struct EventStruct *event, String& string)
           F("Normalized RGB (0.0000..1.0000)"),
           F("Normalized RGB (0.0000..1.0000) transformed (3x3 matrix, below)"),
         };
-        const int optionValuesRGB[P050_RGB_OPTIONS] = { 0, 1, 2, 3, 4, 5 };
-        addFormSelector(F("Output RGB Values"), F("outputrgb"), P050_RGB_OPTIONS, optionsRGB, optionValuesRGB, PCONFIG(2));
-        addFormNote(F("For 'normalized' or 'transformed' options, the Red/Green/Blue Decimals should best be increased."));
 
-# ifdef P050_OPTION_RGB_EVENTS
+        // const int optionValuesRGB[P050_RGB_OPTIONS] = { 0, 1, 2, 3, 4, 5 };
+        constexpr size_t valueCount = NR_ELEMENTS(optionsRGB);
+        addFormSelector(F("Output RGB Values"), F("outputrgb"), valueCount, optionsRGB, nullptr, PCONFIG(2));
+        # ifndef LIMIT_BUILD_SIZE
+        addFormNote(F("For 'normalized' or 'transformed' options, the Red/Green/Blue Decimals should best be increased."));
+        # endif // ifndef LIMIT_BUILD_SIZE
+
+        # ifdef P050_OPTION_RGB_EVENTS
         addFormCheckBox(F("Generate RGB events"), F("rgbevents"), PCONFIG(5) == 1);
         addFormNote(F("Eventnames: taskname + #RawRGB, #RawRGBtransformed, #NormRGB, #NormRGBtransformed, #NormSRGB, #NormSRGBtransformed"));
-        addFormNote(F("Only generated for not selected outputs, 3 values per event, =&lt;r&gt;,&lt;g&gt;,&lt;b&gt;"));
-# endif // ifdef P050_OPTION_RGB_EVENTS
+        addFormNote(F(
+                      #  ifndef LIMIT_BUILD_SIZE
+                      "Only generated for not selected outputs, "
+                      #  endif // ifndef LIMIT_BUILD_SIZE
+                      "3 values per event, =&lt;r&gt;,&lt;g&gt;,&lt;b&gt;"));
+        # endif // ifdef P050_OPTION_RGB_EVENTS
       }
 
       {
-        # define P050_VALUE4_OPTIONS 4
-        const __FlashStringHelper *optionsOutput[P050_VALUE4_OPTIONS] = {
+        // # define P050_VALUE4_OPTIONS 4
+        const __FlashStringHelper *optionsOutput[] = {
           F("Color Temperature (deprecated) [K]"),
           F("Color Temperature (DN40) [K]"),
           F("Ambient Light [Lux]"),
           F("Clear Channel"),
         };
-        const int optionValuesOutput[P050_VALUE4_OPTIONS] = { 0, 1, 2, 3 };
-        addFormSelector(F("Output at Values #4"), F("output4"), P050_VALUE4_OPTIONS, optionsOutput, optionValuesOutput, PCONFIG(3));
+
+        // const int optionValuesOutput[P050_VALUE4_OPTIONS] = { 0, 1, 2, 3 };
+        constexpr size_t valueCount = NR_ELEMENTS(optionsOutput);
+        addFormSelector(F("Output at Values #4"), F("output4"), valueCount, optionsOutput, nullptr, PCONFIG(3));
+        # ifndef LIMIT_BUILD_SIZE
         addFormNote(F("Optionally adjust Values #4 name accordingly."));
+        # endif // ifndef LIMIT_BUILD_SIZE
 
         addFormCheckBox(F("Generate all as events"), F("allevents"), PCONFIG(4) == 1);
         addFormNote(F("Eventnames: taskname + #CCT, #CCT_DN40, #Lux, #Clear"));
@@ -200,6 +212,7 @@ boolean Plugin_050(uint8_t function, struct EventStruct *event, String& string)
 
           for (int i = 0; i < 3; ++i) {
             addRowLabel(RGB.substring(i, i + 1));
+
             for (int j = 0; j < 3; ++j) {
               addHtml(strformat(F("%c<sub>%d</sub>:"), static_cast<char>('a' + i), j + 1));
               addFloatNumberBox(P050_data_struct::generate_cal_id(i, j),
@@ -208,10 +221,19 @@ boolean Plugin_050(uint8_t function, struct EventStruct *event, String& string)
                                 255.999f);
             }
           }
-          addFormNote(F("Check plugin documentation (i) on how to calibrate and how to calculate transformation matrix."));
+          addFormNote(F("Check plugin documentation (i)"
+                        # ifndef LIMIT_BUILD_SIZE
+                        " on how to calibrate and how to calculate transformation matrix"
+                        # endif // ifndef LIMIT_BUILD_SIZE
+                        "."
+                        ));
 
           addFormCheckBox(F("Reset transformation matrix"), F("resettrans"), false);
-          addFormNote(F("Select then Submit to confirm. Reset transformation matrix can't be un-done!"));
+          addFormNote(F(
+                        # ifndef LIMIT_BUILD_SIZE
+                        "Select then Submit to confirm. "
+                        # endif // ifndef LIMIT_BUILD_SIZE
+                        "Reset transformation matrix can't be un-done!"));
 
           // Need to delete the allocated object here
           delete P050_data;
@@ -228,9 +250,9 @@ boolean Plugin_050(uint8_t function, struct EventStruct *event, String& string)
       PCONFIG(2) = getFormItemInt(F("outputrgb"));
       PCONFIG(3) = getFormItemInt(F("output4"));
       PCONFIG(4) = isFormItemChecked(F("allevents")) ? 1 : 0;
-# ifdef P050_OPTION_RGB_EVENTS
+      # ifdef P050_OPTION_RGB_EVENTS
       PCONFIG(5) = isFormItemChecked(F("rgbevents")) ? 1 : 0;
-# endif // ifdef P050_OPTION_RGB_EVENTS
+      # endif // ifdef P050_OPTION_RGB_EVENTS
       bool resetTransformation = isFormItemChecked(F("resettrans"));
       {
         P050_data_struct *P050_data = new (std::nothrow) P050_data_struct(PCONFIG(0), PCONFIG(1));
@@ -246,7 +268,7 @@ boolean Plugin_050(uint8_t function, struct EventStruct *event, String& string)
             // Save new settings
             for (int i = 0; i < 3; ++i) {
               for (int j = 0; j < 3; ++j) {
-                P050_data->TransformationSettings.matrix[i][j] = 
+                P050_data->TransformationSettings.matrix[i][j] =
                   getFormItemFloat(P050_data_struct::generate_cal_id(i, j));
               }
             }
@@ -269,6 +291,7 @@ boolean Plugin_050(uint8_t function, struct EventStruct *event, String& string)
 
       if (nullptr != P050_data) {
         P050_data->resetTransformation();
+        P050_data->loadSettings(event->TaskIndex); // Loading once should be enough
         success = true;
       }
       break;
@@ -288,9 +311,7 @@ boolean Plugin_050(uint8_t function, struct EventStruct *event, String& string)
 # endif // ifndef BUILD_NO_DEBUG
 
         uint16_t r, g, b, c;
-        float value4 = 0.0f;
-
-        P050_data->loadSettings(event->TaskIndex);
+        float    value4 = 0.0f;
 
         P050_data->tcs.getRawData(&r, &g, &b, &c, true);
 
@@ -335,7 +356,6 @@ boolean Plugin_050(uint8_t function, struct EventStruct *event, String& string)
               UserVar.setFloat(event->TaskIndex, 0, r_f);
               UserVar.setFloat(event->TaskIndex, 1, g_f);
               UserVar.setFloat(event->TaskIndex, 2, b_f);
-
             }
             break;
           case 2:
@@ -397,7 +417,7 @@ boolean Plugin_050(uint8_t function, struct EventStruct *event, String& string)
           addLogMove(LOG_LEVEL_INFO, log);
         }
 
-# ifdef P050_OPTION_RGB_EVENTS
+        # ifdef P050_OPTION_RGB_EVENTS
 
         // First RGB events
         if ((PCONFIG(5) == 1) && (t != 0)) { // Not if invalid read/data
@@ -405,13 +425,13 @@ boolean Plugin_050(uint8_t function, struct EventStruct *event, String& string)
 
           for (int i = 0; i < 6; ++i) {
             if (i != PCONFIG(2)) { // Skip currently selected RGB output to keep nr. of events a bit limited
-              const __FlashStringHelper* varName = F("");
+              const __FlashStringHelper*varName = F("");
               String eventValues;
               sRGBFactor = 1.0f;
 
               switch (i) {
                 case 0:
-                  varName = F("RawRGB");
+                  varName      = F("RawRGB");
                   eventValues += strformat(F("%u,%u,%u"), r, g, b);
                   break;
                 case 3:
@@ -466,23 +486,23 @@ boolean Plugin_050(uint8_t function, struct EventStruct *event, String& string)
             }
           }
         }
-# endif // ifdef P050_OPTION_RGB_EVENTS
+        # endif // ifdef P050_OPTION_RGB_EVENTS
 
         // Then Values #4 events
         if (PCONFIG(4) == 1) {
           for (int i = 0; i < 4; ++i) {
             switch (i) {
               case 0:
-                eventQueue.add(event->TaskIndex, F("CCT"), P050_data->tcs.calculateColorTemperature(r, g, b));
+                eventQueue.add(event->TaskIndex, F("CCT"),      P050_data->tcs.calculateColorTemperature(r, g, b));
                 break;
               case 1:
                 eventQueue.add(event->TaskIndex, F("CCT_DN40"), P050_data->tcs.calculateColorTemperature_dn40(r, g, b, c));
                 break;
               case 2:
-                eventQueue.add(event->TaskIndex, F("Lux"), P050_data->tcs.calculateLux(r, g, b));
+                eventQueue.add(event->TaskIndex, F("Lux"),      P050_data->tcs.calculateLux(r, g, b));
                 break;
               case 3:
-                eventQueue.add(event->TaskIndex, F("Clear"), String(c));
+                eventQueue.add(event->TaskIndex, F("Clear"),    String(c));
                 break;
               default:
                 break;
@@ -492,9 +512,9 @@ boolean Plugin_050(uint8_t function, struct EventStruct *event, String& string)
 
         success = true;
       } else {
-# ifndef BUILD_NO_DEBUG
+        # ifndef BUILD_NO_DEBUG
         addLog(LOG_LEVEL_DEBUG, F("No TCS34725 found"));
-# endif // ifndef BUILD_NO_DEBUG
+        # endif // ifndef BUILD_NO_DEBUG
         success = false;
       }
 

--- a/src/_P050_TCS34725.ino
+++ b/src/_P050_TCS34725.ino
@@ -47,14 +47,15 @@ boolean Plugin_050(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_050;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 4;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_050;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 4;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P051_AM2320.ino
+++ b/src/_P051_AM2320.ino
@@ -35,19 +35,15 @@ boolean Plugin_051(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_051;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 2;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
-      Device[deviceCount].I2CNoDeviceCheck   = true; // Avoid device check
+      Device[++deviceCount].Number         = PLUGIN_ID_051;
+      Device[deviceCount].Type             = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType            = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
+      Device[deviceCount].FormulaOption    = true;
+      Device[deviceCount].ValueCount       = 2;
+      Device[deviceCount].SendDataOption   = true;
+      Device[deviceCount].TimerOption      = true;
+      Device[deviceCount].PluginStats      = true;
+      Device[deviceCount].I2CNoDeviceCheck = true; // Avoid device check
       break;
     }
 

--- a/src/_P051_AM2320.ino
+++ b/src/_P051_AM2320.ino
@@ -35,15 +35,16 @@ boolean Plugin_051(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number         = PLUGIN_ID_051;
-      Device[deviceCount].Type             = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType            = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
-      Device[deviceCount].FormulaOption    = true;
-      Device[deviceCount].ValueCount       = 2;
-      Device[deviceCount].SendDataOption   = true;
-      Device[deviceCount].TimerOption      = true;
-      Device[deviceCount].PluginStats      = true;
-      Device[deviceCount].I2CNoDeviceCheck = true; // Avoid device check
+      auto& dev = Device[++deviceCount];
+      dev.Number           = PLUGIN_ID_051;
+      dev.Type             = DEVICE_TYPE_I2C;
+      dev.VType            = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
+      dev.FormulaOption    = true;
+      dev.ValueCount       = 2;
+      dev.SendDataOption   = true;
+      dev.TimerOption      = true;
+      dev.PluginStats      = true;
+      dev.I2CNoDeviceCheck = true; // Avoid device check
       break;
     }
 

--- a/src/_P052_SenseAir.ino
+++ b/src/_P052_SenseAir.ino
@@ -38,16 +38,17 @@ boolean Plugin_052(uint8_t function, struct EventStruct *event, String& string) 
 
   switch (function) {
     case PLUGIN_DEVICE_ADD: {
-      Device[++deviceCount].Number           = PLUGIN_ID_052;
-      Device[deviceCount].Type               = DEVICE_TYPE_SERIAL;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 1;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].OutputDataType     = Output_Data_type_t::Simple;
-      Device[deviceCount].ExitTaskBeforeSave = false;
-      Device[deviceCount].PluginStats        = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number             = PLUGIN_ID_052;
+      dev.Type               = DEVICE_TYPE_SERIAL;
+      dev.VType              = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.FormulaOption      = true;
+      dev.ValueCount         = 1;
+      dev.SendDataOption     = true;
+      dev.TimerOption        = true;
+      dev.OutputDataType     = Output_Data_type_t::Simple;
+      dev.ExitTaskBeforeSave = false;
+      dev.PluginStats        = true;
       break;
     }
 

--- a/src/_P052_SenseAir.ino
+++ b/src/_P052_SenseAir.ino
@@ -7,6 +7,10 @@
 // ############################# Plugin 052: Senseair CO2 Sensors ########################################
 // #######################################################################################################
 
+/** Changelog:
+ * 25025-01-03 tonhuisman: Small code size reduction
+ */
+
 /*
    Plugin originally written by: Daniel Tedenljung
    info__AT__tedenljungconsulting.com
@@ -37,14 +41,10 @@ boolean Plugin_052(uint8_t function, struct EventStruct *event, String& string) 
       Device[++deviceCount].Number           = PLUGIN_ID_052;
       Device[deviceCount].Type               = DEVICE_TYPE_SERIAL;
       Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
       Device[deviceCount].FormulaOption      = true;
       Device[deviceCount].ValueCount         = 1;
       Device[deviceCount].SendDataOption     = true;
       Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
       Device[deviceCount].OutputDataType     = Output_Data_type_t::Simple;
       Device[deviceCount].ExitTaskBeforeSave = false;
       Device[deviceCount].PluginStats        = true;
@@ -151,13 +151,7 @@ boolean Plugin_052(uint8_t function, struct EventStruct *event, String& string) 
           {
             uint32_t reads_pass, reads_crc_failed, reads_nodata;
             P052_data->modbus.getStatistics(reads_pass, reads_crc_failed, reads_nodata);
-            String chksumStats;
-            chksumStats  = reads_pass;
-            chksumStats += '/';
-            chksumStats += reads_crc_failed;
-            chksumStats += '/';
-            chksumStats += reads_nodata;
-            addHtml(chksumStats);
+            addHtml(strformat(F("%d/%d/%d"), reads_pass, reads_crc_failed, reads_nodata));
           }
 
           bool hasFactorySettings = false;

--- a/src/_P053_PMSx003.ino
+++ b/src/_P053_PMSx003.ino
@@ -44,23 +44,24 @@ boolean Plugin_053(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_053;
-      Device[deviceCount].Type               = DEVICE_TYPE_SERIAL;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TRIPLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
+      auto& dev = Device[++deviceCount];
+      dev.Number             = PLUGIN_ID_053;
+      dev.Type               = DEVICE_TYPE_SERIAL;
+      dev.VType              = Sensor_VType::SENSOR_TYPE_TRIPLE;
+      dev.Ports              = 0;
+      dev.PullUpOption       = false;
+      dev.InverseLogicOption = false;
       # ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
-      Device[deviceCount].FormulaOption = true;
-      Device[deviceCount].ValueCount    = 4;
+      dev.FormulaOption = true;
+      dev.ValueCount    = 4;
       # else // ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
-      Device[deviceCount].FormulaOption = false;
-      Device[deviceCount].ValueCount    = 3;
+      dev.FormulaOption = false;
+      dev.ValueCount    = 3;
       # endif // ifdef PLUGIN_053_ENABLE_EXTRA_SENSORS
-      Device[deviceCount].SendDataOption   = true;
-      Device[deviceCount].TimerOption      = true;
-      Device[deviceCount].GlobalSyncOption = true;
-      Device[deviceCount].PluginStats      = true;
+      dev.SendDataOption   = true;
+      dev.TimerOption      = true;
+      dev.GlobalSyncOption = true;
+      dev.PluginStats      = true;
       success                              = true;
       break;
     }

--- a/src/_P054_DMX512.ino
+++ b/src/_P054_DMX512.ino
@@ -89,9 +89,10 @@ boolean Plugin_054(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number = PLUGIN_ID_054;
-      Device[deviceCount].Type     = DEVICE_TYPE_SERIAL;
-      Device[deviceCount].VType    = Sensor_VType::SENSOR_TYPE_NONE;
+      auto& dev = Device[++deviceCount];
+      dev.Number   = PLUGIN_ID_054;
+      dev.Type     = DEVICE_TYPE_SERIAL;
+      dev.VType    = Sensor_VType::SENSOR_TYPE_NONE;
       break;
     }
 

--- a/src/_P054_DMX512.ino
+++ b/src/_P054_DMX512.ino
@@ -89,11 +89,9 @@ boolean Plugin_054(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number   = PLUGIN_ID_054;
-      Device[deviceCount].Type       = DEVICE_TYPE_SERIAL;
-      Device[deviceCount].Ports      = 0;
-      Device[deviceCount].VType      = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].ValueCount = 0;
+      Device[++deviceCount].Number = PLUGIN_ID_054;
+      Device[deviceCount].Type     = DEVICE_TYPE_SERIAL;
+      Device[deviceCount].VType    = Sensor_VType::SENSOR_TYPE_NONE;
       break;
     }
 
@@ -137,12 +135,12 @@ boolean Plugin_054(uint8_t function, struct EventStruct *event, String& string)
     case PLUGIN_WEBFORM_SHOW_SERIAL_PARAMS:
     {
       addFormNote(F("An on-chip ESP Serial port"
-                    #if USES_USBCDC
+                    # if USES_USBCDC
                     " (<B>not</B> USB CDC)"
-                    #endif // if USES_USBCDC
-                    #if USES_HWCDC
+                    # endif // if USES_USBCDC
+                    # if USES_HWCDC
                     " (<B>not</B> USB HWCDC)"
-                    #endif // if USES_HWCDC
+                    # endif // if USES_HWCDC
                     " must be selected!"));
       break;
     }

--- a/src/_P055_Chiming.ino
+++ b/src/_P055_Chiming.ino
@@ -5,6 +5,11 @@
 // #################################### Plugin 055: Chiming Mechanism ####################################
 // #######################################################################################################
 
+/** Changelog:
+ * 2025-01-04 tonhuisman: Change check for a timesource to look for more than just NTP, but anything more reliable than 'Restore from RTC'
+ *                        Minor code cleanup
+ */
+
 // ESPEasy plugin to strike up to 4 physical bells and gongs with chiming sequences.
 // You also can use an antique door bell as a single strikes (not ringing) notification.
 // Optional you can use it as hourly chiming clock
@@ -91,11 +96,8 @@ boolean Plugin_055(uint8_t function, struct EventStruct *event, String& string)
     {
       Device[++deviceCount].Number           = PLUGIN_ID_055;
       Device[deviceCount].Type               = DEVICE_TYPE_TRIPLE;
-      Device[deviceCount].Ports              = 0;
       Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_NONE;
       Device[deviceCount].InverseLogicOption = true;
-      Device[deviceCount].ValueCount         = 0;
-      Device[deviceCount].GlobalSyncOption   = true;
       Device[deviceCount].setPin1Direction(gpio_direction::gpio_output);
       Device[deviceCount].setPin2Direction(gpio_direction::gpio_output);
       Device[deviceCount].setPin3Direction(gpio_direction::gpio_output);
@@ -156,8 +158,8 @@ boolean Plugin_055(uint8_t function, struct EventStruct *event, String& string)
       // addHtml(F("<TR><TD><TD>"));
       addButton(F("'control?cmd=chimeplay,hours'"), F("Test 1&hellip;12"));
 
-      if (PCONFIG(2) && !(Settings.UseNTP())) {
-        addFormNote(F("Enable and configure NTP!"));
+      if (PCONFIG(2) && !(node_time.getTimeSource() < timeSource_t::Restore_RTC_time_source)) { // Somewhat reliable timesource?
+        addFormNote(F("Configure a timesource! (NTP, P2P, RTC, GPS)"));
       }
 
       success = true;

--- a/src/_P055_Chiming.ino
+++ b/src/_P055_Chiming.ino
@@ -94,13 +94,14 @@ boolean Plugin_055(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_055;
-      Device[deviceCount].Type               = DEVICE_TYPE_TRIPLE;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].InverseLogicOption = true;
-      Device[deviceCount].setPin1Direction(gpio_direction::gpio_output);
-      Device[deviceCount].setPin2Direction(gpio_direction::gpio_output);
-      Device[deviceCount].setPin3Direction(gpio_direction::gpio_output);
+      auto& dev = Device[++deviceCount];
+      dev.Number             = PLUGIN_ID_055;
+      dev.Type               = DEVICE_TYPE_TRIPLE;
+      dev.VType              = Sensor_VType::SENSOR_TYPE_NONE;
+      dev.InverseLogicOption = true;
+      dev.setPin1Direction(gpio_direction::gpio_output);
+      dev.setPin2Direction(gpio_direction::gpio_output);
+      dev.setPin3Direction(gpio_direction::gpio_output);
       break;
     }
 

--- a/src/_P056_SDS011-Dust.ino
+++ b/src/_P056_SDS011-Dust.ino
@@ -23,7 +23,7 @@
 
 # include <jkSDS011.h>
 
-#include "ESPEasy-Globals.h"
+# include "ESPEasy-Globals.h"
 
 
 CjkSDS011 *Plugin_056_SDS = nullptr;
@@ -37,19 +37,14 @@ boolean Plugin_056(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_056;
-      Device[deviceCount].Type               = DEVICE_TYPE_SERIAL;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_DUAL;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 2;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].TimerOptional      = false;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_056;
+      Device[deviceCount].Type           = DEVICE_TYPE_SERIAL;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_DUAL;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 2;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].PluginStats    = true;
       break;
     }
 
@@ -191,7 +186,7 @@ String Plugin_056_ErrorToString(int error) {
   String log;
 
   if (error < 0) {
-    log  =  concat(F("comm error: "), error);
+    log =  concat(F("comm error: "), error);
   }
   return log;
 }

--- a/src/_P056_SDS011-Dust.ino
+++ b/src/_P056_SDS011-Dust.ino
@@ -37,14 +37,15 @@ boolean Plugin_056(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_056;
-      Device[deviceCount].Type           = DEVICE_TYPE_SERIAL;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_DUAL;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 2;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_056;
+      dev.Type           = DEVICE_TYPE_SERIAL;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_DUAL;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 2;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P057_HT16K33_LED.ino
+++ b/src/_P057_HT16K33_LED.ino
@@ -85,9 +85,10 @@ boolean Plugin_057(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number = PLUGIN_ID_057;
-      Device[deviceCount].Type     = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType    = Sensor_VType::SENSOR_TYPE_NONE;
+      auto& dev = Device[++deviceCount];
+      dev.Number   = PLUGIN_ID_057;
+      dev.Type     = DEVICE_TYPE_I2C;
+      dev.VType    = Sensor_VType::SENSOR_TYPE_NONE;
       break;
     }
 

--- a/src/_P057_HT16K33_LED.ino
+++ b/src/_P057_HT16K33_LED.ino
@@ -85,18 +85,9 @@ boolean Plugin_057(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_057;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].ValueCount         = 0;
-      Device[deviceCount].SendDataOption     = false;
-      Device[deviceCount].TimerOption        = false;
-      Device[deviceCount].TimerOptional      = false;
-      Device[deviceCount].GlobalSyncOption   = true;
+      Device[++deviceCount].Number = PLUGIN_ID_057;
+      Device[deviceCount].Type     = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType    = Sensor_VType::SENSOR_TYPE_NONE;
       break;
     }
 
@@ -233,99 +224,91 @@ boolean Plugin_057(uint8_t function, struct EventStruct *event, String& string)
         uint8_t  seg      = 0;
         uint16_t value    = 0;
 
-        String lowerString = string;
-        lowerString.toLowerCase();
-        lowerString.replace(F("  "), F(" "));
-        lowerString.replace(F(" ="), F("="));
-        lowerString.replace(F("= "), F("="));
+        String lString = string;
+        lString.replace(F("  "), F(" "));
+        lString.replace(F(" ="), F("="));
+        lString.replace(F("= "), F("="));
 
-        param = parseStringKeepCase(lowerString, paramIdx++);
+        param = parseString(lString, paramIdx++);
 
-        if (param.length())
+        while (!param.isEmpty())
         {
-          while (param.length())
+          # ifndef BUILD_NO_DEBUG
+          addLog(LOG_LEVEL_DEBUG_MORE, param);
+          # endif // ifndef BUILD_NO_DEBUG
+
+          if (equals(param, F("log")))
           {
-            # ifndef BUILD_NO_DEBUG
-            addLog(LOG_LEVEL_DEBUG_MORE, param);
-            # endif // ifndef BUILD_NO_DEBUG
+            if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+              String log = F("MX   : ");
 
-            if (equals(param, F("log")))
-            {
-              if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-                String log = F("MX   : ");
-
-                for (uint8_t i = 0; i < 8; ++i)
-                {
-                  log += formatToHex_no_prefix(P057_data->ledMatrix.GetRow(i));
-                  log += F("h, ");
-                }
-                addLogMove(LOG_LEVEL_INFO, log);
+              for (uint8_t i = 0; i < 8; ++i)
+              {
+                log += formatToHex_no_prefix(P057_data->ledMatrix.GetRow(i));
+                log += F("h, ");
               }
-              success = true;
+              addLogMove(LOG_LEVEL_INFO, log);
+            }
+            success = true;
+          }
+
+          else if (equals(param, F("test")))
+          {
+            for (uint8_t i = 0; i < 8; ++i) {
+              P057_data->ledMatrix.SetRow(i, 1 << i);
+            }
+            success = true;
+          }
+
+          else if (equals(param, F("clear")))
+          {
+            P057_data->ledMatrix.ClearRowBuffer();
+            success = true;
+          }
+
+          else
+          {
+            const int index = param.indexOf('=');
+
+            if (index > 0) // syntax: "<seg>=<value>"
+            {
+              paramKey = param.substring(0, index);
+              paramVal = param.substring(index + 1);
+              seg      = paramKey.toInt();
+            }
+            else // syntax: "<value>"
+            {
+              paramVal = param;
             }
 
-            else if (equals(param, F("test")))
+            if (equals(command, F("mnum")))
             {
-              for (uint8_t i = 0; i < 8; ++i) {
-                P057_data->ledMatrix.SetRow(i, 1 << i);
+              value = paramVal.toInt();
+
+              if (value < 16) {
+                P057_data->ledMatrix.SetDigit(seg, value);
               }
-              success = true;
+              else {
+                P057_data->ledMatrix.SetRow(seg, value);
+              }
             }
-
-            else if (equals(param, F("clear")))
+            else if (equals(command, F("mx")))
             {
-              P057_data->ledMatrix.ClearRowBuffer();
-              success = true;
+              char *ep;
+              value = strtol(paramVal.c_str(), &ep, 16);
+              P057_data->ledMatrix.SetRow(seg, value);
             }
-
             else
             {
-              int index = param.indexOf('=');
-
-              if (index > 0) // syntax: "<seg>=<value>"
-              {
-                paramKey = param.substring(0, index);
-                paramVal = param.substring(index + 1);
-                seg      = paramKey.toInt();
-              }
-              else // syntax: "<value>"
-              {
-                paramVal = param;
-              }
-
-              if (equals(command, F("mnum")))
-              {
-                value = paramVal.toInt();
-
-                if (value < 16) {
-                  P057_data->ledMatrix.SetDigit(seg, value);
-                }
-                else {
-                  P057_data->ledMatrix.SetRow(seg, value);
-                }
-              }
-              else if (equals(command, F("mx")))
-              {
-                char *ep;
-                value = strtol(paramVal.c_str(), &ep, 16);
-                P057_data->ledMatrix.SetRow(seg, value);
-              }
-              else
-              {
-                value = paramVal.toInt();
-                P057_data->ledMatrix.SetRow(seg, value);
-              }
-
-              success = true;
-              seg++;
+              value = paramVal.toInt();
+              P057_data->ledMatrix.SetRow(seg, value);
             }
 
-            param = parseStringKeepCase(lowerString, paramIdx++);
+            success = true;
+            seg++;
           }
-        }
-        else
-        {
-          // ??? no params
+
+          param = parseString(lString, paramIdx++);
         }
 
         if (success) {

--- a/src/_P058_HT16K33_KeyPad.ino
+++ b/src/_P058_HT16K33_KeyPad.ino
@@ -46,18 +46,13 @@ boolean Plugin_058(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_058;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SWITCH;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].ValueCount         = 1;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].TimerOptional      = true;
-      Device[deviceCount].GlobalSyncOption   = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_058;
+      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SWITCH;
+      Device[deviceCount].ValueCount     = 1;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].TimerOptional  = true;
       break;
     }
 

--- a/src/_P058_HT16K33_KeyPad.ino
+++ b/src/_P058_HT16K33_KeyPad.ino
@@ -46,13 +46,14 @@ boolean Plugin_058(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_058;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SWITCH;
-      Device[deviceCount].ValueCount     = 1;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].TimerOptional  = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_058;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SWITCH;
+      dev.ValueCount     = 1;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.TimerOptional  = true;
       break;
     }
 

--- a/src/_P059_Encoder.ino
+++ b/src/_P059_Encoder.ino
@@ -6,6 +6,10 @@
 // #################################### Plugin 059: Rotary Encoder #######################################
 // #######################################################################################################
 
+/** Changelog:
+ * 2025-01-04 tonhuisman: Minor code cleanup
+ */
+
 // ESPEasy Plugin to process the quadrature encoder interface signals (e.g. rotary encoder)
 // written by Jochen Krapf (jk@nerd2nerd.org)
 
@@ -34,18 +38,13 @@ boolean Plugin_059(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_059;
-      Device[deviceCount].Type               = DEVICE_TYPE_TRIPLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SWITCH;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].ValueCount         = 1;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].TimerOptional      = true;
-      Device[deviceCount].GlobalSyncOption   = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_059;
+      Device[deviceCount].Type           = DEVICE_TYPE_TRIPLE;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SWITCH;
+      Device[deviceCount].ValueCount     = 1;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].TimerOptional  = true;
       break;
     }
 
@@ -77,9 +76,10 @@ boolean Plugin_059(uint8_t function, struct EventStruct *event, String& string)
       }
 
       {
-        const __FlashStringHelper *options[3] = { F("1"), F("2"), F("4") };
-        int optionValues[3]                   = { 1, 2, 4 };
-        addFormSelector(F("Mode"), F("mode"), 3, options, optionValues, PCONFIG(0));
+        const __FlashStringHelper *options[] = { F("1"), F("2"), F("4") };
+        const int optionValues[]             = { 1, 2, 4 };
+        constexpr size_t optionCount         = NR_ELEMENTS(optionValues);
+        addFormSelector(F("Mode"), F("mode"), optionCount, options, optionValues, PCONFIG(0));
         addUnit(F("pulses per cycle"));
       }
 
@@ -119,12 +119,12 @@ boolean Plugin_059(uint8_t function, struct EventStruct *event, String& string)
 
       for (uint8_t i = 0; i < 3; ++i)
       {
-        int pin = PIN(i);
+        const int pin = PIN(i);
 
-        if (pin >= 0)
+        if (validGpio(pin))
         {
           // pinMode(pin, (Settings.TaskDevicePin1PullUp[event->TaskIndex]) ? INPUT_PULLUP : INPUT);
-          constexpr pluginID_t P059_PLUGIN_ID{PLUGIN_ID_059};
+          constexpr pluginID_t P059_PLUGIN_ID{ PLUGIN_ID_059 };
 
           const uint32_t key = createKey(P059_PLUGIN_ID, pin);
 
@@ -158,9 +158,8 @@ boolean Plugin_059(uint8_t function, struct EventStruct *event, String& string)
       {
         if (P_059_sensordefs[event->TaskIndex]->hasChanged())
         {
-          long c = P_059_sensordefs[event->TaskIndex]->read();
+          const long c = P_059_sensordefs[event->TaskIndex]->read();
           UserVar.setFloat(event->TaskIndex, 0, c);
-          event->sensorType            = Sensor_VType::SENSOR_TYPE_SWITCH;
 
           if (loglevelActiveFor(LOG_LEVEL_INFO)) {
             addLog(LOG_LEVEL_INFO, concat(F("QEI  : "), c));
@@ -187,7 +186,7 @@ boolean Plugin_059(uint8_t function, struct EventStruct *event, String& string)
     {
       if (P_059_sensordefs.count(event->TaskIndex) != 0)
       {
-        String command = parseString(string, 1);
+        const String command = parseString(string, 1);
 
         if (equals(command, F("encwrite")))
         {

--- a/src/_P059_Encoder.ino
+++ b/src/_P059_Encoder.ino
@@ -38,13 +38,14 @@ boolean Plugin_059(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_059;
-      Device[deviceCount].Type           = DEVICE_TYPE_TRIPLE;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SWITCH;
-      Device[deviceCount].ValueCount     = 1;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].TimerOptional  = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_059;
+      dev.Type           = DEVICE_TYPE_TRIPLE;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SWITCH;
+      dev.ValueCount     = 1;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.TimerOptional  = true;
       break;
     }
 

--- a/src/_P060_MCP3221.ino
+++ b/src/_P060_MCP3221.ino
@@ -25,18 +25,14 @@ boolean Plugin_060(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_060;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 1;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_060;
+      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 1;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].PluginStats    = true;
       break;
     }
 
@@ -126,7 +122,6 @@ boolean Plugin_060(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
-
     case PLUGIN_TEN_PER_SECOND:
     {
       if (PCONFIG(1)) // Oversampling?
@@ -154,10 +149,10 @@ boolean Plugin_060(uint8_t function, struct EventStruct *event, String& string)
 
         if (PCONFIG(3)) // Calibration?
         {
-          int   adc1 = PCONFIG_LONG(0);
-          int   adc2 = PCONFIG_LONG(1);
-          float out1 = PCONFIG_FLOAT(0);
-          float out2 = PCONFIG_FLOAT(1);
+          const int   adc1 = PCONFIG_LONG(0);
+          const int   adc2 = PCONFIG_LONG(1);
+          const float out1 = PCONFIG_FLOAT(0);
+          const float out2 = PCONFIG_FLOAT(1);
 
           if (adc1 != adc2)
           {

--- a/src/_P060_MCP3221.ino
+++ b/src/_P060_MCP3221.ino
@@ -25,14 +25,15 @@ boolean Plugin_060(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_060;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 1;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_060;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 1;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P061_KeyPad.ino
+++ b/src/_P061_KeyPad.ino
@@ -89,18 +89,13 @@ boolean Plugin_061(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_061;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SWITCH;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].ValueCount         = 1;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].TimerOptional      = true;
-      Device[deviceCount].GlobalSyncOption   = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_061;
+      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SWITCH;
+      Device[deviceCount].ValueCount     = 1;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].TimerOptional  = true;
       break;
     }
 
@@ -157,12 +152,7 @@ boolean Plugin_061(uint8_t function, struct EventStruct *event, String& string)
         F("PCF8575 (Direct 16)")
         # endif // ifdef P061_ENABLE_PCF8575
       };
-      const int optionsCount =
-      # ifdef P061_ENABLE_PCF8575
-        6;
-      # else // ifdef P061_ENABLE_PCF8575
-        4;
-      # endif // ifdef P061_ENABLE_PCF8575
+      constexpr int optionsCount = NR_ELEMENTS(options);
       addFormSelector(F("Chip (Mode)"), F("chip"), optionsCount, options, nullptr, P061_CONFIG_KEYPAD_TYPE);
 
       success = true;

--- a/src/_P061_KeyPad.ino
+++ b/src/_P061_KeyPad.ino
@@ -89,13 +89,14 @@ boolean Plugin_061(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_061;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SWITCH;
-      Device[deviceCount].ValueCount     = 1;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].TimerOptional  = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_061;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SWITCH;
+      dev.ValueCount     = 1;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.TimerOptional  = true;
       break;
     }
 

--- a/src/_P062_MPR121_KeyPad.ino
+++ b/src/_P062_MPR121_KeyPad.ino
@@ -44,14 +44,15 @@ boolean Plugin_062(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_062;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SWITCH;
-      Device[deviceCount].ValueCount         = 1;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].TimerOptional      = true;
-      Device[deviceCount].ExitTaskBeforeSave = false;
+      auto& dev = Device[++deviceCount];
+      dev.Number             = PLUGIN_ID_062;
+      dev.Type               = DEVICE_TYPE_I2C;
+      dev.VType              = Sensor_VType::SENSOR_TYPE_SWITCH;
+      dev.ValueCount         = 1;
+      dev.SendDataOption     = true;
+      dev.TimerOption        = true;
+      dev.TimerOptional      = true;
+      dev.ExitTaskBeforeSave = false;
       break;
     }
 

--- a/src/_P063_TTP229_KeyPad.ino
+++ b/src/_P063_TTP229_KeyPad.ino
@@ -76,14 +76,15 @@ boolean Plugin_063(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_063;
-      Device[deviceCount].Type           = DEVICE_TYPE_DUAL;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SWITCH;
-      Device[deviceCount].ValueCount     = 1;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].TimerOptional  = true;
-      Device[deviceCount].setPin1Direction(gpio_direction::gpio_output);
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_063;
+      dev.Type           = DEVICE_TYPE_DUAL;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SWITCH;
+      dev.ValueCount     = 1;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.TimerOptional  = true;
+      dev.setPin1Direction(gpio_direction::gpio_output);
       break;
     }
 

--- a/src/_P063_TTP229_KeyPad.ino
+++ b/src/_P063_TTP229_KeyPad.ino
@@ -5,6 +5,11 @@
 // #################################### Plugin 063: TTP229 KeyPad ########################################
 // #######################################################################################################
 
+/** Changelog:
+ * 2025-01-04 tonhuisman: Make plugin multi-instance by not using a static variable for lastKey, but reading back from UserVar
+ *                        Minor code optimizations
+ */
+
 // ESPEasy Plugin to scan a 16 key touch pad chip TTP229
 // written by Jochen Krapf (jk@nerd2nerd.org)
 
@@ -71,15 +76,13 @@ boolean Plugin_063(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number         = PLUGIN_ID_063;
-      Device[deviceCount].Type             = DEVICE_TYPE_DUAL;
-      Device[deviceCount].Ports            = 0;
-      Device[deviceCount].VType            = Sensor_VType::SENSOR_TYPE_SWITCH;
-      Device[deviceCount].ValueCount       = 1;
-      Device[deviceCount].SendDataOption   = true;
-      Device[deviceCount].TimerOption      = true;
-      Device[deviceCount].TimerOptional    = true;
-      Device[deviceCount].GlobalSyncOption = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_063;
+      Device[deviceCount].Type           = DEVICE_TYPE_DUAL;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SWITCH;
+      Device[deviceCount].ValueCount     = 1;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].TimerOptional  = true;
       Device[deviceCount].setPin1Direction(gpio_direction::gpio_output);
       break;
     }
@@ -168,9 +171,9 @@ boolean Plugin_063(uint8_t function, struct EventStruct *event, String& string)
 
     case PLUGIN_TEN_PER_SECOND:
     {
-      static uint16_t keyLast = 0;
-      int16_t pinSCL          = CONFIG_PIN1;
-      int16_t pinSDO          = CONFIG_PIN2;
+      const uint16_t keyLast = UserVar.getFloat(event->TaskIndex, 0); // Last set value, makes plugin multi-instance
+      const int16_t  pinSCL  = CONFIG_PIN1;
+      const int16_t  pinSDO  = CONFIG_PIN2;
 
       uint16_t key = readTTP229(pinSCL, pinSDO);
 
@@ -191,9 +194,7 @@ boolean Plugin_063(uint8_t function, struct EventStruct *event, String& string)
 
       if (keyLast != key)
       {
-        keyLast = key;
         UserVar.setFloat(event->TaskIndex, 0, key);
-        event->sensorType = Sensor_VType::SENSOR_TYPE_SWITCH;
 
         if (loglevelActiveFor(LOG_LEVEL_INFO)) {
           String log = F("Tkey : ");

--- a/src/_P064_APDS9960.ino
+++ b/src/_P064_APDS9960.ino
@@ -73,19 +73,14 @@ boolean Plugin_064(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_064;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SWITCH;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].ValueCount         = 3;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].TimerOptional      = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_064;
+      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SWITCH;
+      Device[deviceCount].ValueCount     = 3;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].TimerOptional  = true;
+      Device[deviceCount].PluginStats    = true;
       break;
     }
 
@@ -128,11 +123,12 @@ boolean Plugin_064(uint8_t function, struct EventStruct *event, String& string)
     case PLUGIN_WEBFORM_LOAD:
     {
       {
-        const __FlashStringHelper *optionsPluginMode[2] = {
+        const __FlashStringHelper *optionsPluginMode[] = {
           F("Gesture/Proximity/Ambient Light Sensor"),
           F("R/G/B Colors") };
-        const int optionsPluginModeValues[2] = { PLUGIN_MODE_GPL_064, PLUGIN_MODE_RGB_064 };
-        addFormSelector(F("Plugin Mode"), F("mode"), 2, optionsPluginMode, optionsPluginModeValues, P064_MODE, true);
+        const int optionsPluginModeValues[] = { PLUGIN_MODE_GPL_064, PLUGIN_MODE_RGB_064 };
+        constexpr size_t optionCount        = NR_ELEMENTS(optionsPluginModeValues);
+        addFormSelector(F("Plugin Mode"), F("mode"), optionCount, optionsPluginMode, optionsPluginModeValues, P064_MODE, true);
         # ifndef BUILD_NO_DEBUG
         addFormNote(F("After changing Plugin Mode you may want to change the Values names, below."));
         # endif // ifndef BUILD_NO_DEBUG
@@ -173,7 +169,8 @@ boolean Plugin_064(uint8_t function, struct EventStruct *event, String& string)
           F("2x"),
           F("4x (default)"),
           F("8x") };
-        const int optionsGainValues[] = { PGAIN_1X, PGAIN_2X, PGAIN_4X, PGAIN_8X }; // Also used for optionsALSGain
+        const int optionsGainValues[]     = { PGAIN_1X, PGAIN_2X, PGAIN_4X, PGAIN_8X }; // Also used for optionsALSGain
+        constexpr size_t optionsGainCount = NR_ELEMENTS(optionsGainValues);
 
         // Led_Drive options, all Led_Drive optionsets in SparkFun_APDS9960.h have the same valueset, so only defined once here
         const __FlashStringHelper *optionsLedDrive[] = {
@@ -181,7 +178,8 @@ boolean Plugin_064(uint8_t function, struct EventStruct *event, String& string)
           F("50 mA"),
           F("25 mA"),
           F("12.5 mA") };
-        const int optionsLedDriveValues[] = { LED_DRIVE_100MA, LED_DRIVE_50MA, LED_DRIVE_25MA, LED_DRIVE_12_5MA };
+        const int optionsLedDriveValues[]     = { LED_DRIVE_100MA, LED_DRIVE_50MA, LED_DRIVE_25MA, LED_DRIVE_12_5MA };
+        constexpr size_t optionsLedDriveCount = NR_ELEMENTS(optionsLedDriveValues);
 
 
         String lightSensorGainLabel;
@@ -192,14 +190,14 @@ boolean Plugin_064(uint8_t function, struct EventStruct *event, String& string)
 
           addFormSelector(F("Gesture Gain"),
                           F("ggain"),
-                          NR_ELEMENTS(optionsGainValues),
+                          optionsGainCount,
                           optionsGain,
                           optionsGainValues,
                           P064_GGAIN);
 
           addFormSelector(F("Gesture LED Drive"),
                           F("gldrive"),
-                          NR_ELEMENTS(optionsLedDriveValues),
+                          optionsLedDriveCount,
                           optionsLedDrive,
                           optionsLedDriveValues,
                           P064_GLDRIVE);
@@ -210,10 +208,11 @@ boolean Plugin_064(uint8_t function, struct EventStruct *event, String& string)
               F("150 %"),
               F("200 %"),
               F("300 % (default)") };
-            const int optionsLedBoostValues[] = { LED_BOOST_100, LED_BOOST_150, LED_BOOST_200, LED_BOOST_300 };
+            const int optionsLedBoostValues[]     = { LED_BOOST_100, LED_BOOST_150, LED_BOOST_200, LED_BOOST_300 };
+            constexpr size_t optionsLedBoostCount = NR_ELEMENTS(optionsLedBoostValues);
             addFormSelector(F("Gesture LED Boost"),
                             F("lboost"),
-                            NR_ELEMENTS(optionsLedBoostValues),
+                            optionsLedBoostCount,
                             optionsLedBoost,
                             optionsLedBoostValues,
                             P064_LED_BOOST);
@@ -221,7 +220,7 @@ boolean Plugin_064(uint8_t function, struct EventStruct *event, String& string)
 
           addFormSubHeader(F("Proximity & Ambient Light Sensor parameters"));
 
-          addFormSelector(F("Proximity Gain"), F("pgain"), NR_ELEMENTS(optionsGainValues), optionsGain, optionsGainValues, P064_PGAIN);
+          addFormSelector(F("Proximity Gain"), F("pgain"), optionsGainCount, optionsGain, optionsGainValues, P064_PGAIN);
 
           lightSensorGainLabel  = F("Ambient Light Sensor Gain");
           lightSensorDriveLabel = F("Proximity & ALS LED Drive");
@@ -238,11 +237,11 @@ boolean Plugin_064(uint8_t function, struct EventStruct *event, String& string)
             F("4x (default)"),
             F("16x"),
             F("64x") };
-          addFormSelector(lightSensorGainLabel, F("again"), NR_ELEMENTS(optionsGainValues), optionsALSGain, optionsGainValues, P064_AGAIN);
+          addFormSelector(lightSensorGainLabel, F("again"), optionsGainCount, optionsALSGain, optionsGainValues, P064_AGAIN);
         }
         addFormSelector(lightSensorDriveLabel,
                         F("ldrive"),
-                        NR_ELEMENTS(optionsLedDriveValues),
+                        optionsLedDriveCount,
                         optionsLedDrive,
                         optionsLedDriveValues,
                         P064_LDRIVE);
@@ -286,23 +285,23 @@ boolean Plugin_064(uint8_t function, struct EventStruct *event, String& string)
         success = true;
 
         if (P064_data->sensor.init(P064_GGAIN, P064_GLDRIVE, P064_PGAIN, P064_AGAIN, P064_LDRIVE)) {
-          log += F("Init");
+          log += F("Init ");
 
           P064_data->sensor.enablePower();
 
           if (!P064_data->sensor.enableLightSensor(false)) {
-            log    += F(" Error during light sensor init!");
+            log    += F("Error during light sensor init!");
             success = false;
           }
 
           // Always enable the proximity/gesture sensor.
           if (!P064_data->sensor.enableProximitySensor(false)) {
-            log    += F(" Error during proximity sensor init!");
+            log    += F("Error during proximity sensor init!");
             success = false;
           }
 
           if (!P064_data->sensor.enableGestureSensor(false, P064_LED_BOOST)) {
-            log    += F(" Error during gesture sensor init!");
+            log    += F("Error during gesture sensor init!");
             success = false;
           }
         } else {

--- a/src/_P064_APDS9960.ino
+++ b/src/_P064_APDS9960.ino
@@ -73,14 +73,15 @@ boolean Plugin_064(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_064;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SWITCH;
-      Device[deviceCount].ValueCount     = 3;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].TimerOptional  = true;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_064;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SWITCH;
+      dev.ValueCount     = 3;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.TimerOptional  = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P065_DRF0299_MP3.ino
+++ b/src/_P065_DRF0299_MP3.ino
@@ -62,9 +62,10 @@ boolean Plugin_065(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number = PLUGIN_ID_065;
-      Device[deviceCount].Type     = DEVICE_TYPE_SERIAL;
-      Device[deviceCount].VType    = Sensor_VType::SENSOR_TYPE_NONE;
+      auto& dev = Device[++deviceCount];
+      dev.Number   = PLUGIN_ID_065;
+      dev.Type     = DEVICE_TYPE_SERIAL;
+      dev.VType    = Sensor_VType::SENSOR_TYPE_NONE;
       break;
     }
 

--- a/src/_P065_DRF0299_MP3.ino
+++ b/src/_P065_DRF0299_MP3.ino
@@ -62,17 +62,9 @@ boolean Plugin_065(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_065;
-      Device[deviceCount].Type               = DEVICE_TYPE_SERIAL;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].ValueCount         = 0;
-      Device[deviceCount].SendDataOption     = false;
-      Device[deviceCount].TimerOption        = false;
-      Device[deviceCount].GlobalSyncOption   = false;
+      Device[++deviceCount].Number = PLUGIN_ID_065;
+      Device[deviceCount].Type     = DEVICE_TYPE_SERIAL;
+      Device[deviceCount].VType    = Sensor_VType::SENSOR_TYPE_NONE;
       break;
     }
 

--- a/src/_P066_VEML6040.ino
+++ b/src/_P066_VEML6040.ino
@@ -32,19 +32,14 @@ boolean Plugin_066(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_066;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 4;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].TimerOptional      = false;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_066;
+      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 4;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].PluginStats    = true;
       break;
     }
 
@@ -88,21 +83,29 @@ boolean Plugin_066(uint8_t function, struct EventStruct *event, String& string)
     case PLUGIN_WEBFORM_LOAD:
     {
       {
-        const __FlashStringHelper *optionsMode[6] = { F("40ms (16496)"), F("80ms (8248)"), F("160ms (4124)"), F("320ms (2062)"), F(
-                                                        "640ms (1031)"),                                             F(
-                                                        "1280ms (515)") };
-        addFormSelector(F("Integration Time (Max Lux)"), F("itime"), 6, optionsMode, nullptr, PCONFIG(1));
+        const __FlashStringHelper *optionsMode[] = {
+          F("40ms (16496)"),
+          F("80ms (8248)"),
+          F("160ms (4124)"),
+          F("320ms (2062)"),
+          F("640ms (1031)"),
+          F("1280ms (515)"),
+        };
+        constexpr size_t optionCount = NR_ELEMENTS(optionsMode);
+        addFormSelector(F("Integration Time (Max Lux)"), F("itime"), optionCount, optionsMode, nullptr, PCONFIG(1));
       }
 
       {
-        const __FlashStringHelper *optionsVarMap[6] = {
+        const __FlashStringHelper *optionsVarMap[] = {
           F("R, G, B, W"),
           F("r, g, b, W - relative rgb [&#37;]"),
           F("r, g, b, W - relative rgb^Gamma [&#37;]"),
           F("R, G, B, Color Temperature [K]"),
           F("R, G, B, Ambient Light [Lux]"),
-          F("Color Temperature [K], Ambient Light [Lux], Y, W") };
-        addFormSelector(F("Value Mapping"), F("map"), 6, optionsVarMap, nullptr, PCONFIG(2));
+          F("Color Temperature [K], Ambient Light [Lux], Y, W"),
+        };
+        constexpr size_t optionCount = NR_ELEMENTS(optionsVarMap);
+        addFormSelector(F("Value Mapping"), F("map"), optionCount, optionsVarMap, nullptr, PCONFIG(2));
       }
 
       success = true;

--- a/src/_P066_VEML6040.ino
+++ b/src/_P066_VEML6040.ino
@@ -32,14 +32,15 @@ boolean Plugin_066(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_066;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 4;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_066;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 4;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P067_HX711_Load_Cell.ino
+++ b/src/_P067_HX711_Load_Cell.ino
@@ -44,7 +44,6 @@ boolean Plugin_067(uint8_t function, struct EventStruct *event, String& string)
     {
       Device[++deviceCount].Number       = PLUGIN_ID_067;
       Device[deviceCount].Type           = DEVICE_TYPE_DUAL;
-      Device[deviceCount].Ports          = 0;
       Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_DUAL;
       Device[deviceCount].FormulaOption  = true;
       Device[deviceCount].ValueCount     = 2;

--- a/src/_P067_HX711_Load_Cell.ino
+++ b/src/_P067_HX711_Load_Cell.ino
@@ -42,15 +42,16 @@ boolean Plugin_067(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_067;
-      Device[deviceCount].Type           = DEVICE_TYPE_DUAL;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_DUAL;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 2;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].PluginStats    = true;
-      Device[deviceCount].setPin1Direction(gpio_direction::gpio_output);
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_067;
+      dev.Type           = DEVICE_TYPE_DUAL;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_DUAL;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 2;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
+      dev.setPin1Direction(gpio_direction::gpio_output);
       break;
     }
 

--- a/src/_P068_SHT3x.ino
+++ b/src/_P068_SHT3x.ino
@@ -42,14 +42,15 @@ boolean Plugin_068(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_068;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 2;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_068;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 2;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P068_SHT3x.ino
+++ b/src/_P068_SHT3x.ino
@@ -42,18 +42,14 @@ boolean Plugin_068(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_068;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 2;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_068;
+      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 2;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].PluginStats    = true;
       break;
     }
 

--- a/src/_P069_LM75A.ino
+++ b/src/_P069_LM75A.ino
@@ -13,13 +13,13 @@
 // #######################################################################################################
 
 
-#define PLUGIN_069
-#define PLUGIN_ID_069         69
-#define PLUGIN_NAME_069       "Environment - LM75A"
-#define PLUGIN_VALUENAME1_069 "Temperature"
+# define PLUGIN_069
+# define PLUGIN_ID_069         69
+# define PLUGIN_NAME_069       "Environment - LM75A"
+# define PLUGIN_VALUENAME1_069 "Temperature"
 
 
-#include "src/PluginStructs/P069_data_struct.h"
+# include "src/PluginStructs/P069_data_struct.h"
 
 
 boolean Plugin_069(uint8_t function, struct EventStruct *event, String& string)
@@ -30,18 +30,14 @@ boolean Plugin_069(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_069;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 1;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_069;
+      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 1;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].PluginStats    = true;
       break;
     }
 
@@ -61,6 +57,7 @@ boolean Plugin_069(uint8_t function, struct EventStruct *event, String& string)
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
       const uint8_t i2cAddressValues[] = { 0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4E, 0x4F };
+
       if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
         addFormSelectorI2C(F("i2c_addr"), 8, i2cAddressValues, PCONFIG(0));
       } else {
@@ -117,7 +114,7 @@ boolean Plugin_069(uint8_t function, struct EventStruct *event, String& string)
         }
         else
         {
-          addLogMove(LOG_LEVEL_INFO, concat(F("LM75A: Temperature: "), formatUserVarNoCheck(event,0)));
+          addLogMove(LOG_LEVEL_INFO, concat(F("LM75A: Temperature: "), formatUserVarNoCheck(event, 0)));
         }
       }
       break;

--- a/src/_P069_LM75A.ino
+++ b/src/_P069_LM75A.ino
@@ -30,14 +30,15 @@ boolean Plugin_069(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_069;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 1;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_069;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 1;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P070_NeoPixel_Clock.ino
+++ b/src/_P070_NeoPixel_Clock.ino
@@ -36,14 +36,15 @@ boolean Plugin_070(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number   = PLUGIN_ID_070;
-      Device[deviceCount].Type       = DEVICE_TYPE_SINGLE;
-      Device[deviceCount].VType      = Sensor_VType::SENSOR_TYPE_TRIPLE;
-      Device[deviceCount].ValueCount = 3;
-      Device[deviceCount].setPin1Direction(gpio_direction::gpio_output);
+      auto& dev = Device[++deviceCount];
+      dev.Number     = PLUGIN_ID_070;
+      dev.Type       = DEVICE_TYPE_SINGLE;
+      dev.VType      = Sensor_VType::SENSOR_TYPE_TRIPLE;
+      dev.ValueCount = 3;
+      dev.setPin1Direction(gpio_direction::gpio_output);
 
       // FIXME TD-er: Not sure if access to any existing task data is needed when saving
-      Device[deviceCount].ExitTaskBeforeSave = false;
+      dev.ExitTaskBeforeSave = false;
       break;
     }
 

--- a/src/_P070_NeoPixel_Clock.ino
+++ b/src/_P070_NeoPixel_Clock.ino
@@ -36,11 +36,10 @@ boolean Plugin_070(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number      = PLUGIN_ID_070;
-      Device[deviceCount].Type          = DEVICE_TYPE_SINGLE;
-      Device[deviceCount].VType         = Sensor_VType::SENSOR_TYPE_TRIPLE;
-      Device[deviceCount].Ports         = 0;
-      Device[deviceCount].ValueCount    = 3;
+      Device[++deviceCount].Number   = PLUGIN_ID_070;
+      Device[deviceCount].Type       = DEVICE_TYPE_SINGLE;
+      Device[deviceCount].VType      = Sensor_VType::SENSOR_TYPE_TRIPLE;
+      Device[deviceCount].ValueCount = 3;
       Device[deviceCount].setPin1Direction(gpio_direction::gpio_output);
 
       // FIXME TD-er: Not sure if access to any existing task data is needed when saving

--- a/src/_P071_Kamstrup401.ino
+++ b/src/_P071_Kamstrup401.ino
@@ -40,13 +40,14 @@ boolean Plugin_071(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_071;
-      Device[deviceCount].Type           = DEVICE_TYPE_SERIAL;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_DUAL;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 2;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_071;
+      dev.Type           = DEVICE_TYPE_SERIAL;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_DUAL;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 2;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
       break;
     }
 

--- a/src/_P071_Kamstrup401.ino
+++ b/src/_P071_Kamstrup401.ino
@@ -1,30 +1,32 @@
 #include "_Plugin_Helper.h"
 #ifdef USES_P071
-//#######################################################################################################
-//############################# Plugin 071: Kamstrup Multical 401 #######################################
-//#######################################################################################################
 
-//IR RX/TX sensor based on http://wiki.hal9k.dk/projects/kamstrup
-//schematic http://wiki.hal9k.dk/_media/projects/kamstrup/schematic.pdf
-//software based on http://elektronikforumet.com/forum/viewtopic.php?f=2&t=79853
+// #######################################################################################################
+// ############################# Plugin 071: Kamstrup Multical 401 #######################################
+// #######################################################################################################
 
-//Device pin 1 = RX
-//Device pin 2 = TX
+// IR RX/TX sensor based on http://wiki.hal9k.dk/projects/kamstrup
+// schematic http://wiki.hal9k.dk/_media/projects/kamstrup/schematic.pdf
+// software based on http://elektronikforumet.com/forum/viewtopic.php?f=2&t=79853
+
+// Device pin 1 = RX
+// Device pin 2 = TX
 
 /** Changelog:
+ * 2025-01-04 tonhuisman: Reformat source using Uncrustify, minor code optimizations
  * 2024-01-06 tonhuisman: Disable unused variables and some unused code, log optimizations
  * 2024-01-06 tonhuisman: Start changelog, newest entry on top
  */
 
-#include <ESPeasySerial.h>
+# include <ESPeasySerial.h>
 
-#include "src/ESPEasyCore/Serial.h"
+# include "src/ESPEasyCore/Serial.h"
 
-#define PLUGIN_071
-#define PLUGIN_ID_071 71
-#define PLUGIN_NAME_071 "Communication - Kamstrup Multical 401"
-#define PLUGIN_VALUENAME1_071 "Heat"
-#define PLUGIN_VALUENAME2_071 "Volume"
+# define PLUGIN_071
+# define PLUGIN_ID_071         71
+# define PLUGIN_NAME_071       "Communication - Kamstrup Multical 401"
+# define PLUGIN_VALUENAME1_071 "Heat"
+# define PLUGIN_VALUENAME2_071 "Volume"
 
 // boolean Plugin_071_init = false;
 // uint8_t PIN_KAMSER_RX = 0;
@@ -37,60 +39,56 @@ boolean Plugin_071(uint8_t function, struct EventStruct *event, String& string)
   switch (function)
   {
     case PLUGIN_DEVICE_ADD:
-      {
-        Device[++deviceCount].Number = PLUGIN_ID_071;
-        Device[deviceCount].Type = DEVICE_TYPE_SERIAL;
-        Device[deviceCount].VType = Sensor_VType::SENSOR_TYPE_DUAL;
-        Device[deviceCount].Ports = 0;
-        Device[deviceCount].PullUpOption = false;
-        Device[deviceCount].InverseLogicOption = false;
-        Device[deviceCount].FormulaOption = true;
-        Device[deviceCount].ValueCount = 2;
-        Device[deviceCount].SendDataOption = true;
-        Device[deviceCount].TimerOption = true;
-        Device[deviceCount].GlobalSyncOption = true;
-        break;
-      }
+    {
+      Device[++deviceCount].Number       = PLUGIN_ID_071;
+      Device[deviceCount].Type           = DEVICE_TYPE_SERIAL;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_DUAL;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 2;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      break;
+    }
 
     case PLUGIN_GET_DEVICENAME:
-      {
-        string = F(PLUGIN_NAME_071);
-        break;
-      }
+    {
+      string = F(PLUGIN_NAME_071);
+      break;
+    }
 
     case PLUGIN_GET_DEVICEVALUENAMES:
-      {
-        strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[0], PSTR(PLUGIN_VALUENAME1_071));
-        strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[1], PSTR(PLUGIN_VALUENAME2_071));
-        break;
-      }
+    {
+      strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[0], PSTR(PLUGIN_VALUENAME1_071));
+      strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[1], PSTR(PLUGIN_VALUENAME2_071));
+      break;
+    }
 
     case PLUGIN_GET_DEVICEGPIONAMES:
-      {
-        serialHelper_getGpioNames(event);
-        break;
-      }
+    {
+      serialHelper_getGpioNames(event);
+      break;
+    }
 
     case PLUGIN_WEBFORM_SHOW_CONFIG:
-      {
-        string += serialHelper_getSerialTypeLabel(event);
-        success = true;
-        break;
-      }
+    {
+      string += serialHelper_getSerialTypeLabel(event);
+      success = true;
+      break;
+    }
 
     case PLUGIN_INIT:
-      {
-        // Plugin_071_init = true;
+    {
+      // Plugin_071_init = true;
 
-        success = true;
-        break;
-      }
+      success = true;
+      break;
+    }
 
     case PLUGIN_WEBFORM_LOAD:
-      {
-        success = true;
-        break;
-      }
+    {
+      success = true;
+      break;
+    }
 
     case PLUGIN_WEBFORM_SAVE: {
       success = true;
@@ -98,198 +96,214 @@ boolean Plugin_071(uint8_t function, struct EventStruct *event, String& string)
     }
 
     case PLUGIN_READ:
+    {
+      // PIN_KAMSER_RX = CONFIG_PIN1;
+      // PIN_KAMSER_TX = CONFIG_PIN2;
+      const ESPEasySerialPort port = static_cast<ESPEasySerialPort>(CONFIG_PORT);
+
+      ESPeasySerial kamSer(port, CONFIG_PIN1, CONFIG_PIN2, false); // Initialize serial
+
+      pinMode(CONFIG_PIN1, INPUT);
+      pinMode(CONFIG_PIN2, OUTPUT);
+
+      // read Kamstrup
+      uint8_t sendmsg1[] = { 175, 163, 177 }; //   /#1 with even parity
+
+      uint8_t r  = 0;
+      uint8_t to = 0;
+      uint8_t i  = 0;
+      char    message[255];
+      int     parityerrors = 0;
+
+
+      kamSer.begin(300);
+
+      for (int x = 0; x < 3; ++x) {
+        kamSer.write(sendmsg1[x]);
+      }
+
+      kamSer.flush();
+
+      // kamSer.end();
+      kamSer.begin(1200);
+
+      // to = 0;
+      // r = 0;
+      // i = 0;
+      // parityerrors = 0;
+      char *tmpstr;
+      ESPEASY_RULES_FLOAT_TYPE m_energy, m_volume;
+
+      // float m_tempin, m_tempout, m_tempdiff, m_power;
+      // long m_hours, m_flow;
+
+      while (r != 0x0A)
       {
-        // PIN_KAMSER_RX = CONFIG_PIN1;
-        // PIN_KAMSER_TX = CONFIG_PIN2;
-        const ESPEasySerialPort port = static_cast<ESPEasySerialPort>(CONFIG_PORT);
+        if (kamSer.available())
+        {
+          // receive uint8_t
+          r = kamSer.read();
 
-        ESPeasySerial kamSer(port, CONFIG_PIN1, CONFIG_PIN2, false);  // Initialize serial
+          // serialPrintln(r);
+          if (parity_check(r))
+          {
+            parityerrors += 1;
+          }
+          r = r & 127; // Mask MSB to remove parity
 
-        pinMode(CONFIG_PIN1,INPUT);
-        pinMode(CONFIG_PIN2,OUTPUT);
-
-        //read Kamstrup
-        uint8_t sendmsg1[] = { 175,163,177 };            //   /#1 with even parity
-
-        uint8_t r  = 0;
-        uint8_t to = 0;
-        uint8_t i = 0;
-        char message[255];
-        int parityerrors = 0;
-
-
-        kamSer.begin(300);
-        for (int x = 0; x < 3; ++x) {
-          kamSer.write(sendmsg1[x]);
+          message[i++] = char(r);
+        }
+        else
+        {
+          to++;
+          delay(25);
         }
 
-        kamSer.flush();
-        //kamSer.end();
-        kamSer.begin(1200);
-
-        // to = 0;
-        // r = 0;
-        // i = 0;
-        // parityerrors = 0;
-        char *tmpstr;
-        ESPEASY_RULES_FLOAT_TYPE m_energy, m_volume;
-        // float m_tempin, m_tempout, m_tempdiff, m_power;
-        // long m_hours, m_flow;
-
-        while(r != 0x0A)
+        if (i >= 79)
         {
-          if (kamSer.available())
+          if (parityerrors == 0)
           {
-            // receive uint8_t
-            r = kamSer.read();
-            //serialPrintln(r);
-            if (parity_check(r))
-            {
-               parityerrors += 1;
-            }
-            r = r & 127; // Mask MSB to remove parity
+            //              serialPrint("OK: " );
+            //              serialPrintln(message);
+            message[i] = 0;
 
-            message[i++] = char(r);
+            tmpstr = strtok(message, " ");
+
+            if (tmpstr) {
+              m_energy = atol(tmpstr) / 3.6 * 1000;
+            }
+            else {
+              m_energy = 0;
+            }
+
+            tmpstr = strtok(nullptr, " ");
+
+            if (tmpstr) {
+              m_volume = atol(tmpstr);
+            }
+            else {
+              m_volume = 0;
+            }
+
+            // tmpstr = strtok(nullptr, " ");
+            // if (tmpstr)
+            //  m_hours = atol(tmpstr);
+            // else
+            //  m_hours = 0;
+
+            // tmpstr = strtok(nullptr, " ");
+            // if (tmpstr)
+            //  m_tempin = atol(tmpstr) / 100.0f;
+            // else
+            //  m_tempin = 0;
+
+            // tmpstr = strtok(nullptr, " ");
+            // if (tmpstr)
+            //  m_tempout = atol(tmpstr) / 100.0f;
+            // else
+            //  m_tempout = 0;
+
+            // tmpstr = strtok(nullptr, " ");
+            // if (tmpstr)
+            //  m_tempdiff = atol(tmpstr) / 100.0f;
+            // else
+            //  m_tempdiff = 0;
+
+            // tmpstr = strtok(nullptr, " ");
+            // if (tmpstr)
+            //  m_power = atol(tmpstr) / 10.0f;
+            // else
+            //  m_power = 0;
+
+            // tmpstr = strtok(nullptr, " ");
+            // if (tmpstr)
+            //  m_flow = atol(tmpstr);
+            // else
+            //  m_flow = 0;
+            //               {
+            //                String log = F("Kamstrup output: ");
+            //                log += m_energy;
+            //                log += F(" MJ;  ");
+            //                log += m_volume;
+            //                log += F(" L; ");
+            //                log += m_hours;
+            //                log += F(" h; ");
+            //                log += m_tempin;
+            //                log += F(" C; ");
+            //                log += m_tempout;
+            //                log += F(" C; ");
+            //                log += m_tempdiff;
+            //                log += F(" C; ");
+            //                log += m_power;
+            //                log += ' ';
+            //                log += m_flow;
+            //                log += F(" L/H");
+            // //              addLog(LOG_LEVEL_INFO, log);
+            //               }
+            UserVar.setFloat(event->TaskIndex, 0, m_energy); // gives energy in Wh
+            UserVar.setFloat(event->TaskIndex, 1, m_volume); // gives volume in liters
+
+            if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+              addLogMove(LOG_LEVEL_INFO, strformat(F("Kamstrup  : Heat value: %.3f kWh"), m_energy / 1000));
+              addLogMove(LOG_LEVEL_INFO, strformat(F("Kamstrup  : Volume value: %d Liter"), m_volume));
+            }
           }
           else
           {
-            to++;
-            delay(25);
-          }
-
-          if (i >= 79)
-          {
-            if (parityerrors == 0 )
-            {
-//              serialPrint("OK: " );
-//              serialPrintln(message);
-              message[i] = 0;
-
-              tmpstr = strtok(message, " ");
-              if (tmpstr){
-               m_energy = atol(tmpstr) / 3.6 * 1000;
-              }
-              else
-               m_energy = 0;
-
-              tmpstr = strtok(nullptr, " ");
-              if (tmpstr)
-               m_volume = atol(tmpstr);
-              else
-               m_volume = 0;
-
-              // tmpstr = strtok(nullptr, " ");
-              // if (tmpstr)
-              //  m_hours = atol(tmpstr);
-              // else
-              //  m_hours = 0;
-
-              // tmpstr = strtok(nullptr, " ");
-              // if (tmpstr)
-              //  m_tempin = atol(tmpstr) / 100.0f;
-              // else
-              //  m_tempin = 0;
-
-              // tmpstr = strtok(nullptr, " ");
-              // if (tmpstr)
-              //  m_tempout = atol(tmpstr) / 100.0f;
-              // else
-              //  m_tempout = 0;
-
-              // tmpstr = strtok(nullptr, " ");
-              // if (tmpstr)
-              //  m_tempdiff = atol(tmpstr) / 100.0f;
-              // else
-              //  m_tempdiff = 0;
-
-              // tmpstr = strtok(nullptr, " ");
-              // if (tmpstr)
-              //  m_power = atol(tmpstr) / 10.0f;
-              // else
-              //  m_power = 0;
-
-              // tmpstr = strtok(nullptr, " ");
-              // if (tmpstr)
-              //  m_flow = atol(tmpstr);
-              // else
-              //  m_flow = 0;
-//               {
-//                String log = F("Kamstrup output: ");
-//                log += m_energy;
-//                log += F(" MJ;  ");
-//                log += m_volume;
-//                log += F(" L; ");
-//                log += m_hours;
-//                log += F(" h; ");
-//                log += m_tempin;
-//                log += F(" C; ");
-//                log += m_tempout;
-//                log += F(" C; ");
-//                log += m_tempdiff;
-//                log += F(" C; ");
-//                log += m_power;
-//                log += ' ';
-//                log += m_flow;
-//                log += F(" L/H");
-// //              addLog(LOG_LEVEL_INFO, log);
-//               }
-              UserVar.setFloat(event->TaskIndex, 0, m_energy); //gives energy in Wh
-              UserVar.setFloat(event->TaskIndex, 1, m_volume); //gives volume in liters
-
-              if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-                addLogMove(LOG_LEVEL_INFO, strformat(F("Kamstrup  : Heat value: %.3f kWh"), m_energy / 1000));
-                addLogMove(LOG_LEVEL_INFO, strformat(F("Kamstrup  : Volume value: %d Liter"), m_volume));
-              }
-            }
-            else
-            {
-              message[i] = 0;
-              if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-                serialPrint("par"); // FIXME ? Why this ?
-                addLogMove(LOG_LEVEL_INFO, concat(F("ERR(PARITY):" ), String(message)));
-              }
-              //UserVar.setFloat(event->TaskIndex, 0, NAN);
-              //UserVar.setFloat(event->TaskIndex, 1, NAN);
-            }
-            break;
-          }
-          if (to > 100)
-          {
             message[i] = 0;
+
             if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-              addLogMove(LOG_LEVEL_INFO, concat(F("ERR(TIMEOUT):" ), String(message)));
+              serialPrint("par"); // FIXME ? Why this ?
+              addLogMove(LOG_LEVEL_INFO, concat(F("ERR(PARITY):"), String(message)));
             }
 
-            //UserVar.setFloat(event->TaskIndex, 0, NAN);
-            //UserVar.setFloat(event->TaskIndex, 1, NAN);
-            break;
+            // UserVar.setFloat(event->TaskIndex, 0, NAN);
+            // UserVar.setFloat(event->TaskIndex, 1, NAN);
           }
+          break;
         }
 
-        //end read Kamstrup
+        if (to > 100)
+        {
+          message[i] = 0;
 
+          if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+            addLogMove(LOG_LEVEL_INFO, concat(F("ERR(TIMEOUT):"), String(message)));
+          }
 
-        success = true;
-        break;
+          // UserVar.setFloat(event->TaskIndex, 0, NAN);
+          // UserVar.setFloat(event->TaskIndex, 1, NAN);
+          break;
+        }
       }
+
+      // end read Kamstrup
+
+
+      success = true;
+      break;
+    }
   }
   return success;
 }
 
 bool parity_check(unsigned input) {
   bool inputparity = input & 128;
-  int x = input & 127;
+  int  x           = input & 127;
 
   int parity = 0;
-  while(x != 0) {
+
+  while (x != 0) {
     parity ^= x;
-    x >>= 1;
+    x     >>= 1;
   }
 
-  if ( (parity & 0x1) != inputparity )
-    return(1);
-  else
-    return(0);
+  if ((parity & 0x1) != inputparity) {
+    return 1;
+  }
+  else {
+    return 0;
+  }
 }
 
 #endif // USES_P071

--- a/src/_P072_HDC1080.ino
+++ b/src/_P072_HDC1080.ino
@@ -6,6 +6,7 @@
 // ######################################################################################################
 
 /** Changelog:
+ * 2025-01-04 tonhuisman: Send initialization (resolution setting) only once during INIT, small code optimizations
  * 2023-02-09 tonhuisman: Fix typo in temperature calculation (was 65526.0f instead of 65536.0f (2^16))
  * 2023-02-08 tonhuisman: Add PLUGIN_I2C_GET_ADDRESS support
  * 2023-02-09 tonhuisman: Start changelog
@@ -28,19 +29,15 @@ boolean Plugin_072(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_072;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 2;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
-      Device[deviceCount].I2CNoDeviceCheck   = true;
+      Device[++deviceCount].Number         = PLUGIN_ID_072;
+      Device[deviceCount].Type             = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType            = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
+      Device[deviceCount].FormulaOption    = true;
+      Device[deviceCount].ValueCount       = 2;
+      Device[deviceCount].SendDataOption   = true;
+      Device[deviceCount].TimerOption      = true;
+      Device[deviceCount].PluginStats      = true;
+      Device[deviceCount].I2CNoDeviceCheck = true;
       break;
     }
 
@@ -74,16 +71,7 @@ boolean Plugin_072(uint8_t function, struct EventStruct *event, String& string)
 
     case PLUGIN_INIT:
     {
-      success = true;
-      break;
-    }
-
-    case PLUGIN_READ:
-    {
-      uint8_t  hdc1080_msb, hdc1080_lsb;
-      uint16_t hdc1080_rawtemp, hdc1080_rawhum;
-      float    hdc1080_temp, hdc1080_hum;
-
+      // Send only once
       Wire.beginTransmission(HDC1080_I2C_ADDRESS); // start transmission to device
       Wire.write(0x02);                            // sends HDC1080_CONFIGURATION
       Wire.write(0b00000000);                      // set resolution to 14bits both for T and H
@@ -91,14 +79,21 @@ boolean Plugin_072(uint8_t function, struct EventStruct *event, String& string)
       Wire.endTransmission();                      // end transmission
       delay(10);
 
+      success = true;
+      break;
+    }
+
+    case PLUGIN_READ:
+    {
+      uint16_t hdc1080_rawtemp, hdc1080_rawhum;
+      float    hdc1080_temp, hdc1080_hum;
+
       Wire.beginTransmission(HDC1080_I2C_ADDRESS); // start transmission to device
       Wire.write(0x00);                            // sends HDC1080_TEMPERATURE
       Wire.endTransmission();                      // end transmission
       delay(9);
       Wire.requestFrom(HDC1080_I2C_ADDRESS, 2);    // read 2 bytes for temperature
-      hdc1080_msb     = Wire.read();
-      hdc1080_lsb     = Wire.read();
-      hdc1080_rawtemp = hdc1080_msb << 8 | hdc1080_lsb;
+      hdc1080_rawtemp = Wire.read() << 8 | Wire.read();
       hdc1080_temp    = (static_cast<float>(hdc1080_rawtemp) / 65536.0f) * 165.0f - 40.0f;
 
       Wire.beginTransmission(HDC1080_I2C_ADDRESS); // start transmission to device
@@ -106,9 +101,7 @@ boolean Plugin_072(uint8_t function, struct EventStruct *event, String& string)
       Wire.endTransmission();                      // end transmission
       delay(9);
       Wire.requestFrom(HDC1080_I2C_ADDRESS, 2);    // read 2 bytes for humidity
-      hdc1080_msb    = Wire.read();
-      hdc1080_lsb    = Wire.read();
-      hdc1080_rawhum = hdc1080_msb << 8 | hdc1080_lsb;
+      hdc1080_rawhum = Wire.read() << 8 | Wire.read();
       hdc1080_hum    = (static_cast<float>(hdc1080_rawhum) / 65536.0f) * 100.0f;
 
       UserVar.setFloat(event->TaskIndex, 0, hdc1080_temp);

--- a/src/_P072_HDC1080.ino
+++ b/src/_P072_HDC1080.ino
@@ -29,15 +29,16 @@ boolean Plugin_072(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number         = PLUGIN_ID_072;
-      Device[deviceCount].Type             = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType            = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
-      Device[deviceCount].FormulaOption    = true;
-      Device[deviceCount].ValueCount       = 2;
-      Device[deviceCount].SendDataOption   = true;
-      Device[deviceCount].TimerOption      = true;
-      Device[deviceCount].PluginStats      = true;
-      Device[deviceCount].I2CNoDeviceCheck = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number           = PLUGIN_ID_072;
+      dev.Type             = DEVICE_TYPE_I2C;
+      dev.VType            = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
+      dev.FormulaOption    = true;
+      dev.ValueCount       = 2;
+      dev.SendDataOption   = true;
+      dev.TimerOption      = true;
+      dev.PluginStats      = true;
+      dev.I2CNoDeviceCheck = true;
       break;
     }
 

--- a/src/_P073_7DGT.ino
+++ b/src/_P073_7DGT.ino
@@ -87,12 +87,13 @@ boolean Plugin_073(uint8_t function, struct EventStruct *event, String& string) 
 
   switch (function) {
     case PLUGIN_DEVICE_ADD: {
-      Device[++deviceCount].Number = PLUGIN_ID_073;
-      Device[deviceCount].Type     = DEVICE_TYPE_TRIPLE;
-      Device[deviceCount].VType    = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].setPin1Direction(gpio_direction::gpio_output);
-      Device[deviceCount].setPin2Direction(gpio_direction::gpio_output);
-      Device[deviceCount].setPin3Direction(gpio_direction::gpio_output);
+      auto& dev = Device[++deviceCount];
+      dev.Number   = PLUGIN_ID_073;
+      dev.Type     = DEVICE_TYPE_TRIPLE;
+      dev.VType    = Sensor_VType::SENSOR_TYPE_NONE;
+      dev.setPin1Direction(gpio_direction::gpio_output);
+      dev.setPin2Direction(gpio_direction::gpio_output);
+      dev.setPin3Direction(gpio_direction::gpio_output);
 
       break;
     }

--- a/src/_P073_7DGT.ino
+++ b/src/_P073_7DGT.ino
@@ -87,11 +87,9 @@ boolean Plugin_073(uint8_t function, struct EventStruct *event, String& string) 
 
   switch (function) {
     case PLUGIN_DEVICE_ADD: {
-      Device[++deviceCount].Number      = PLUGIN_ID_073;
-      Device[deviceCount].Type          = DEVICE_TYPE_TRIPLE;
-      Device[deviceCount].VType         = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].Ports         = 0;
-      Device[deviceCount].ValueCount    = 0;
+      Device[++deviceCount].Number = PLUGIN_ID_073;
+      Device[deviceCount].Type     = DEVICE_TYPE_TRIPLE;
+      Device[deviceCount].VType    = Sensor_VType::SENSOR_TYPE_NONE;
       Device[deviceCount].setPin1Direction(gpio_direction::gpio_output);
       Device[deviceCount].setPin2Direction(gpio_direction::gpio_output);
       Device[deviceCount].setPin3Direction(gpio_direction::gpio_output);
@@ -119,7 +117,8 @@ boolean Plugin_073(uint8_t function, struct EventStruct *event, String& string) 
                                                    F("TM1637 - 4 digit (dots)"),
                                                    F("TM1637 - 6 digit"),
                                                    F("MAX7219 - 8 digit") };
-        addFormSelector(F("Display Type"), F("displtype"), 4, displtype, nullptr, PCONFIG(0));
+        constexpr size_t optionCount = NR_ELEMENTS(displtype);
+        addFormSelector(F("Display Type"), F("displtype"), optionCount, displtype, nullptr, PCONFIG(0));
       }
       {
         const __FlashStringHelper *displout[] = { F("Manual"),
@@ -128,7 +127,8 @@ boolean Plugin_073(uint8_t function, struct EventStruct *event, String& string) 
                                                   F("Clock 12h - Blink"),
                                                   F("Clock 12h - No Blink"),
                                                   F("Date") };
-        addFormSelector(F("Display Output"), F("displout"), 6, displout, nullptr, PCONFIG(1));
+        constexpr size_t optionCount = NR_ELEMENTS(displout);
+        addFormSelector(F("Display Output"), F("displout"), optionCount, displout, nullptr, PCONFIG(1));
       }
 
       addFormNumericBox(F("Brightness"), F("brightness"), PCONFIG(2), 0, 15);
@@ -136,11 +136,12 @@ boolean Plugin_073(uint8_t function, struct EventStruct *event, String& string) 
 
       # ifdef P073_EXTRA_FONTS
       {
-        const __FlashStringHelper *fontset[4] = { F("Default"),
-                                                  F("Siekoo"),
-                                                  F("Siekoo with uppercase 'CHNORUX'"),
-                                                  F("dSEG7") };
-        addFormSelector(F("Font set"), F("fontset"), 4, fontset, nullptr, PCONFIG(4));
+        const __FlashStringHelper *fontset[] = { F("Default"),
+                                                 F("Siekoo"),
+                                                 F("Siekoo with uppercase 'CHNORUX'"),
+                                                 F("dSEG7") };
+        constexpr size_t optionCount = NR_ELEMENTS(fontset);
+        addFormSelector(F("Font set"), F("fontset"), optionCount, fontset, nullptr, PCONFIG(4));
         addFormNote(F("Check documentation for examples of the font sets."));
       }
       # endif // P073_EXTRA_FONTS

--- a/src/_P074_TSL2591.ino
+++ b/src/_P074_TSL2591.ino
@@ -19,8 +19,8 @@
 // https://github.com/adafruit/Adafruit_TSL2591_Library/issues/17
 
 # define PLUGIN_074
-# define PLUGIN_ID_074 74
-# define PLUGIN_NAME_074 "Light/Lux - TSL2591"
+# define PLUGIN_ID_074         74
+# define PLUGIN_NAME_074       "Light/Lux - TSL2591"
 # define PLUGIN_VALUENAME1_074 "Lux"
 # define PLUGIN_VALUENAME2_074 "Full"
 # define PLUGIN_VALUENAME3_074 "Visible"
@@ -31,19 +31,14 @@ boolean Plugin_074(uint8_t function, struct EventStruct *event, String& string) 
 
   switch (function) {
     case PLUGIN_DEVICE_ADD: {
-      Device[++deviceCount].Number           = PLUGIN_ID_074;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 4;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].TimerOptional      = false;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_074;
+      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 4;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].PluginStats    = true;
       break;
     }
 
@@ -100,7 +95,8 @@ boolean Plugin_074(uint8_t function, struct EventStruct *event, String& string) 
       {
         const __FlashStringHelper *optionsMode[6] = { F("100"), F("200"), F("300"),
                                                       F("400"), F("500"), F("600") };
-        addFormSelector(F("Integration Time"), F("itime"), 6, optionsMode,
+        constexpr size_t optionCount = NR_ELEMENTS(optionsMode);
+        addFormSelector(F("Integration Time"), F("itime"), optionCount, optionsMode,
                         nullptr, PCONFIG(1));
         addUnit(F("ms"));
       }
@@ -112,7 +108,8 @@ boolean Plugin_074(uint8_t function, struct EventStruct *event, String& string) 
       {
         const __FlashStringHelper *optionsGain[4] = { F("low gain (1x)"),      F("medium gain (25x)"),
                                                       F("medium gain (428x)"), F("max gain (9876x)") };
-        addFormSelector(F("Value Mapping"), F("gain"), 4, optionsGain, nullptr,
+        constexpr size_t optionCount = NR_ELEMENTS(optionsGain);
+        addFormSelector(F("Value Mapping"), F("gain"), optionCount, optionsGain, nullptr,
                         PCONFIG(2));
       }
 

--- a/src/_P074_TSL2591.ino
+++ b/src/_P074_TSL2591.ino
@@ -31,14 +31,15 @@ boolean Plugin_074(uint8_t function, struct EventStruct *event, String& string) 
 
   switch (function) {
     case PLUGIN_DEVICE_ADD: {
-      Device[++deviceCount].Number       = PLUGIN_ID_074;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 4;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_074;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 4;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P075_Nextion.ino
+++ b/src/_P075_Nextion.ino
@@ -49,16 +49,17 @@ boolean Plugin_075(uint8_t function, struct EventStruct *event, String& string)
 
   switch (function) {
     case PLUGIN_DEVICE_ADD: {
-      Device[++deviceCount].Number       = PLUGIN_ID_075;
-      Device[deviceCount].Type           = DEVICE_TYPE_SERIAL;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_DUAL;
-      Device[deviceCount].ValueCount     = 2;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].TimerOptional  = true; // Allow user to disable interval function.
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_075;
+      dev.Type           = DEVICE_TYPE_SERIAL;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_DUAL;
+      dev.ValueCount     = 2;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.TimerOptional  = true; // Allow user to disable interval function.
 
       // FIXME TD-er: Not sure if access to any existing task data is needed when saving
-      Device[deviceCount].ExitTaskBeforeSave = false;
+      dev.ExitTaskBeforeSave = false;
 
       break;
     }

--- a/src/_P075_Nextion.ino
+++ b/src/_P075_Nextion.ino
@@ -49,18 +49,13 @@ boolean Plugin_075(uint8_t function, struct EventStruct *event, String& string)
 
   switch (function) {
     case PLUGIN_DEVICE_ADD: {
-      Device[++deviceCount].Number           = PLUGIN_ID_075;
-      Device[deviceCount].Type               = DEVICE_TYPE_SERIAL;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_DUAL;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false; // Pullup is not used.
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].ValueCount         = 2;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].TimerOptional      = true; // Allow user to disable interval function.
-      Device[deviceCount].GlobalSyncOption   = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_075;
+      Device[deviceCount].Type           = DEVICE_TYPE_SERIAL;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_DUAL;
+      Device[deviceCount].ValueCount     = 2;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].TimerOptional  = true; // Allow user to disable interval function.
 
       // FIXME TD-er: Not sure if access to any existing task data is needed when saving
       Device[deviceCount].ExitTaskBeforeSave = false;
@@ -68,19 +63,16 @@ boolean Plugin_075(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
-
     case PLUGIN_GET_DEVICENAME: {
       string = F(PLUGIN_NAME_075);
       break;
     }
-
 
     case PLUGIN_GET_DEVICEVALUENAMES: {
       strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[0], PSTR(PLUGIN_VALUENAME1_075));
       strcpy_P(ExtraTaskSettings.TaskDeviceValueNames[1], PSTR(PLUGIN_VALUENAME2_075));
       break;
     }
-
 
     case PLUGIN_GET_DEVICEGPIONAMES: {
       serialHelper_getGpioNames(event);
@@ -96,14 +88,15 @@ boolean Plugin_075(uint8_t function, struct EventStruct *event, String& string)
 
     case PLUGIN_WEBFORM_SHOW_SERIAL_PARAMS:
     {
-      const __FlashStringHelper *options[4] = {
+      const __FlashStringHelper *options[] = {
         F("9600"),
         F("38400"),
         F("57600"),
         F("115200")
       };
 
-      addFormSelector(F("Baud Rate"), F("baud"), 4, options, nullptr, P075_BaudRate);
+      constexpr size_t optionCount = NR_ELEMENTS(options);
+      addFormSelector(F("Baud Rate"), F("baud"), optionCount, options, nullptr, P075_BaudRate);
       addUnit(F("baud"));
       break;
     }
@@ -165,17 +158,9 @@ boolean Plugin_075(uint8_t function, struct EventStruct *event, String& string)
         strcpy(ExtraTaskSettings.TaskDeviceName, PLUGIN_DEFAULT_NAME); // Name missing, populate default name.
       }
 
-      //        PCONFIG(0) = isFormItemChecked(F("AdvHwSerial"));
       P075_BaudRate      = getFormItemInt(F("baud"));
       P075_IncludeValues = isFormItemChecked(F("IncludeValues"));
 
-      /* Task will be stopped and restarted, so no reason to reload the display here
-         P075_data_struct *P075_data = static_cast<P075_data_struct *>(getPluginTaskData(event->TaskIndex));
-
-         if (nullptr != P075_data) {
-         P075_data->loadDisplayLines(event->TaskIndex);
-         }
-       */
       success = true;
       break;
     }
@@ -185,8 +170,8 @@ boolean Plugin_075(uint8_t function, struct EventStruct *event, String& string)
       uint8_t BaudCode = P075_BaudRate;
 
       if (BaudCode > P075_B115200) { BaudCode = P075_B9600; }
-      const uint32_t BaudArray[4]  = { 9600UL, 38400UL, 57600UL, 115200UL };
-      const ESPEasySerialPort port = static_cast<ESPEasySerialPort>(CONFIG_PORT);
+      constexpr uint32_t BaudArray[] = { 9600UL, 38400UL, 57600UL, 115200UL };
+      const ESPEasySerialPort port   = static_cast<ESPEasySerialPort>(CONFIG_PORT);
       initPluginTaskData(event->TaskIndex, new (std::nothrow) P075_data_struct(port, CONFIG_PIN1, CONFIG_PIN2, BaudArray[BaudCode]));
       P075_data_struct *P075_data = static_cast<P075_data_struct *>(getPluginTaskData(event->TaskIndex));
 
@@ -298,7 +283,7 @@ boolean Plugin_075(uint8_t function, struct EventStruct *event, String& string)
         break;
       }
 
-      if (P075_data->rxPin < 0) {
+      if (validGpio(P075_data->rxPin)) {
         addLog(LOG_LEVEL_INFO, F("NEXTION075 : Missing RxD Pin, aborted serial receive"));
         break;
       }
@@ -383,7 +368,7 @@ boolean Plugin_075(uint8_t function, struct EventStruct *event, String& string)
               String tmpString = __buffer;
 
               # ifdef P075_DEBUG_LOG
-              addLogMove(LOG_LEVEL_INFO,  concat(F("NEXTION075 : Code = "), tmpString));
+              addLogMove(LOG_LEVEL_INFO, concat(F("NEXTION075 : Code = "), tmpString));
               # endif // ifdef P075_DEBUG_LOG
 
               int argIndex = tmpString.indexOf(F(",i"));

--- a/src/_P076_HLW8012.ino
+++ b/src/_P076_HLW8012.ino
@@ -116,15 +116,16 @@ boolean Plugin_076(uint8_t function, struct EventStruct *event, String& string) 
 
   switch (function) {
     case PLUGIN_DEVICE_ADD: {
-      Device[++deviceCount].Number       = PLUGIN_ID_076;
-      Device[deviceCount].Type           = DEVICE_TYPE_TRIPLE;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 4;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].PluginStats    = true;
-      Device[deviceCount].setPin1Direction(gpio_direction::gpio_output);
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_076;
+      dev.Type           = DEVICE_TYPE_TRIPLE;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 4;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
+      dev.setPin1Direction(gpio_direction::gpio_output);
       break;
     }
 

--- a/src/_P076_HLW8012.ino
+++ b/src/_P076_HLW8012.ino
@@ -30,9 +30,9 @@
 HLW8012 *Plugin_076_hlw = nullptr;
 
 # define PLUGIN_076
-# define PLUGIN_ID_076 76
-# define PLUGIN_076_DEBUG false // activate extra log info in the debug
-# define PLUGIN_NAME_076 "Energy (AC) - HLW8012/BL0937"
+# define PLUGIN_ID_076         76
+# define PLUGIN_076_DEBUG      false // activate extra log info in the debug
+# define PLUGIN_NAME_076       "Energy (AC) - HLW8012/BL0937"
 # define PLUGIN_VALUENAME1_076 "Voltage"
 # define PLUGIN_VALUENAME2_076 "Current"
 # define PLUGIN_VALUENAME3_076 "Power"
@@ -119,7 +119,6 @@ boolean Plugin_076(uint8_t function, struct EventStruct *event, String& string) 
       Device[++deviceCount].Number       = PLUGIN_ID_076;
       Device[deviceCount].Type           = DEVICE_TYPE_TRIPLE;
       Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].Ports          = 0;
       Device[deviceCount].FormulaOption  = true;
       Device[deviceCount].ValueCount     = 4;
       Device[deviceCount].SendDataOption = true;

--- a/src/_P077_CSE7766.ino
+++ b/src/_P077_CSE7766.ino
@@ -21,7 +21,7 @@
 # include "src/PluginStructs/P077_data_struct.h"
 
 # define PLUGIN_077
-# define PLUGIN_ID_077         77
+# define PLUGIN_ID_077            77
 # ifdef PLUGIN_SET_SONOFF_POW
   #  define PLUGIN_NAME_077       "Energy (AC) - CSE7766 (POW r2)"
 # else // ifdef PLUGIN_SET_SONOFF_POW
@@ -40,21 +40,17 @@ boolean Plugin_077(uint8_t function, struct EventStruct *event, String& string) 
 
   switch (function) {
     case PLUGIN_DEVICE_ADD: {
-      Device[++deviceCount].Number           = PLUGIN_ID_077;
-      Device[deviceCount].Type               = DEVICE_TYPE_SERIAL;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 4;
-      Device[deviceCount].OutputDataType     = Output_Data_type_t::Simple;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].TimerOptional      = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
-      Device[deviceCount].TaskLogsOwnPeaks   = true;
+      Device[++deviceCount].Number         = PLUGIN_ID_077;
+      Device[deviceCount].Type             = DEVICE_TYPE_SERIAL;
+      Device[deviceCount].VType            = Sensor_VType::SENSOR_TYPE_QUAD;
+      Device[deviceCount].FormulaOption    = true;
+      Device[deviceCount].ValueCount       = 4;
+      Device[deviceCount].OutputDataType   = Output_Data_type_t::Simple;
+      Device[deviceCount].SendDataOption   = true;
+      Device[deviceCount].TimerOption      = true;
+      Device[deviceCount].TimerOptional    = true;
+      Device[deviceCount].PluginStats      = true;
+      Device[deviceCount].TaskLogsOwnPeaks = true;
       break;
     }
 

--- a/src/_P077_CSE7766.ino
+++ b/src/_P077_CSE7766.ino
@@ -40,17 +40,18 @@ boolean Plugin_077(uint8_t function, struct EventStruct *event, String& string) 
 
   switch (function) {
     case PLUGIN_DEVICE_ADD: {
-      Device[++deviceCount].Number         = PLUGIN_ID_077;
-      Device[deviceCount].Type             = DEVICE_TYPE_SERIAL;
-      Device[deviceCount].VType            = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].FormulaOption    = true;
-      Device[deviceCount].ValueCount       = 4;
-      Device[deviceCount].OutputDataType   = Output_Data_type_t::Simple;
-      Device[deviceCount].SendDataOption   = true;
-      Device[deviceCount].TimerOption      = true;
-      Device[deviceCount].TimerOptional    = true;
-      Device[deviceCount].PluginStats      = true;
-      Device[deviceCount].TaskLogsOwnPeaks = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number           = PLUGIN_ID_077;
+      dev.Type             = DEVICE_TYPE_SERIAL;
+      dev.VType            = Sensor_VType::SENSOR_TYPE_QUAD;
+      dev.FormulaOption    = true;
+      dev.ValueCount       = 4;
+      dev.OutputDataType   = Output_Data_type_t::Simple;
+      dev.SendDataOption   = true;
+      dev.TimerOption      = true;
+      dev.TimerOptional    = true;
+      dev.PluginStats      = true;
+      dev.TaskLogsOwnPeaks = true;
       break;
     }
 

--- a/src/_P078_Eastron.ino
+++ b/src/_P078_Eastron.ino
@@ -40,16 +40,17 @@ boolean Plugin_078(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number         = PLUGIN_ID_078;
-      Device[deviceCount].Type             = DEVICE_TYPE_SERIAL_PLUS1; // connected through 3 datapins
-      Device[deviceCount].VType            = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].FormulaOption    = true;
-      Device[deviceCount].ValueCount       = P078_NR_OUTPUT_VALUES;
-      Device[deviceCount].OutputDataType   = Output_Data_type_t::Simple;
-      Device[deviceCount].SendDataOption   = true;
-      Device[deviceCount].TimerOption      = true;
-      Device[deviceCount].PluginStats      = true;
-      Device[deviceCount].TaskLogsOwnPeaks = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number           = PLUGIN_ID_078;
+      dev.Type             = DEVICE_TYPE_SERIAL_PLUS1; // connected through 3 datapins
+      dev.VType            = Sensor_VType::SENSOR_TYPE_QUAD;
+      dev.FormulaOption    = true;
+      dev.ValueCount       = P078_NR_OUTPUT_VALUES;
+      dev.OutputDataType   = Output_Data_type_t::Simple;
+      dev.SendDataOption   = true;
+      dev.TimerOption      = true;
+      dev.PluginStats      = true;
+      dev.TaskLogsOwnPeaks = true;
       break;
     }
 

--- a/src/_P078_Eastron.ino
+++ b/src/_P078_Eastron.ino
@@ -40,20 +40,16 @@ boolean Plugin_078(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_078;
-      Device[deviceCount].Type               = DEVICE_TYPE_SERIAL_PLUS1; // connected through 3 datapins
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = P078_NR_OUTPUT_VALUES;
-      Device[deviceCount].OutputDataType     = Output_Data_type_t::Simple;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
-      Device[deviceCount].TaskLogsOwnPeaks   = true;
+      Device[++deviceCount].Number         = PLUGIN_ID_078;
+      Device[deviceCount].Type             = DEVICE_TYPE_SERIAL_PLUS1; // connected through 3 datapins
+      Device[deviceCount].VType            = Sensor_VType::SENSOR_TYPE_QUAD;
+      Device[deviceCount].FormulaOption    = true;
+      Device[deviceCount].ValueCount       = P078_NR_OUTPUT_VALUES;
+      Device[deviceCount].OutputDataType   = Output_Data_type_t::Simple;
+      Device[deviceCount].SendDataOption   = true;
+      Device[deviceCount].TimerOption      = true;
+      Device[deviceCount].PluginStats      = true;
+      Device[deviceCount].TaskLogsOwnPeaks = true;
       break;
     }
 
@@ -120,9 +116,10 @@ boolean Plugin_078(uint8_t function, struct EventStruct *event, String& string)
         String options_baudrate[6];
 
         for (int i = 0; i < 6; ++i) {
-          options_baudrate[i] = String(p078_storageValueToBaudrate(i));
+          options_baudrate[i] = p078_storageValueToBaudrate(i);
         }
-        addFormSelector(F("Baud Rate"), P078_BAUDRATE_LABEL, 6, options_baudrate, nullptr, P078_BAUDRATE);
+        constexpr size_t optionCount = NR_ELEMENTS(options_baudrate);
+        addFormSelector(F("Baud Rate"), P078_BAUDRATE_LABEL, optionCount, options_baudrate, nullptr, P078_BAUDRATE);
         addUnit(F("baud"));
       }
 

--- a/src/_P079_Wemos_Motorshield.ino
+++ b/src/_P079_Wemos_Motorshield.ino
@@ -84,16 +84,9 @@ boolean Plugin_079(uint8_t function, struct EventStruct *event, String& string)
 
   switch (function) {
     case PLUGIN_DEVICE_ADD: {
-      Device[++deviceCount].Number           = PLUGIN_ID_079;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].ValueCount         = 0;
-      Device[deviceCount].SendDataOption     = false;
-      Device[deviceCount].TimerOption        = false;
+      Device[++deviceCount].Number = PLUGIN_ID_079;
+      Device[deviceCount].Type     = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType    = Sensor_VType::SENSOR_TYPE_NONE;
       break;
     }
 
@@ -130,7 +123,8 @@ boolean Plugin_079(uint8_t function, struct EventStruct *event, String& string)
           static_cast<int>(P079_BoardType::WemosMotorshield),
           static_cast<int>(P079_BoardType::LolinMotorshield)
         };
-        addFormSelector(F("Motor Shield Type"), F("shield_type"), 2, options, indices, SHIELD_VER_PCFG_P079);
+        constexpr size_t optionCount = NR_ELEMENTS(indices);
+        addFormSelector(F("Motor Shield Type"), F("shield_type"), optionCount, options, indices, SHIELD_VER_PCFG_P079);
       }
 
       if (Plugin_079_MotorShield_type == P079_BoardType::WemosMotorshield) {

--- a/src/_P079_Wemos_Motorshield.ino
+++ b/src/_P079_Wemos_Motorshield.ino
@@ -84,9 +84,10 @@ boolean Plugin_079(uint8_t function, struct EventStruct *event, String& string)
 
   switch (function) {
     case PLUGIN_DEVICE_ADD: {
-      Device[++deviceCount].Number = PLUGIN_ID_079;
-      Device[deviceCount].Type     = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType    = Sensor_VType::SENSOR_TYPE_NONE;
+      auto& dev = Device[++deviceCount];
+      dev.Number   = PLUGIN_ID_079;
+      dev.Type     = DEVICE_TYPE_I2C;
+      dev.VType    = Sensor_VType::SENSOR_TYPE_NONE;
       break;
     }
 

--- a/src/_P080_DallasIButton.ino
+++ b/src/_P080_DallasIButton.ino
@@ -36,18 +36,13 @@ boolean Plugin_080(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_080;
-      Device[deviceCount].Type               = DEVICE_TYPE_SINGLE;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].ValueCount         = 1;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].TimerOptional      = true;
-      Device[deviceCount].GlobalSyncOption   = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_080;
+      Device[deviceCount].Type           = DEVICE_TYPE_SINGLE;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      Device[deviceCount].ValueCount     = 1;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].TimerOptional  = true;
       break;
     }
 

--- a/src/_P080_DallasIButton.ino
+++ b/src/_P080_DallasIButton.ino
@@ -36,13 +36,14 @@ boolean Plugin_080(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_080;
-      Device[deviceCount].Type           = DEVICE_TYPE_SINGLE;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].ValueCount     = 1;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].TimerOptional  = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_080;
+      dev.Type           = DEVICE_TYPE_SINGLE;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      dev.ValueCount     = 1;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.TimerOptional  = true;
       break;
     }
 

--- a/src/_P081_Cron.ino
+++ b/src/_P081_Cron.ino
@@ -12,8 +12,8 @@
 # include "src/PluginStructs/P081_data_struct.h"
 
 # define PLUGIN_081
-# define PLUGIN_ID_081      81              // plugin id
-# define PLUGIN_NAME_081   "Generic - CRON" // "Plugin Name" is what will be displayed in the selection list
+# define PLUGIN_ID_081         81               // plugin id
+# define PLUGIN_NAME_081       "Generic - CRON" // "Plugin Name" is what will be displayed in the selection list
 # define PLUGIN_VALUENAME1_081 "LastExecution"
 # define PLUGIN_VALUENAME2_081 "NextExecution"
 
@@ -32,16 +32,9 @@ boolean Plugin_081(uint8_t function, struct EventStruct *event, String& string)
       Device[deviceCount].Type     = DEVICE_TYPE_DUMMY;              // how the device is connected
       Device[deviceCount].VType    = Sensor_VType::SENSOR_TYPE_NONE; // type of value the plugin will return, used only for
                                                                      // Domoticz
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].ValueCount         = 2; // number of output variables. The value should match the number of keys
-                                                  // PLUGIN_VALUENAME1_xxx
-      Device[deviceCount].SendDataOption   = false;
-      Device[deviceCount].TimerOption      = false;
-      Device[deviceCount].TimerOptional    = false;
-      Device[deviceCount].GlobalSyncOption = true;
+      Device[deviceCount].ValueCount = 2;                            // number of output variables. The value should match the number of
+                                                                     // keys
+                                                                     // PLUGIN_VALUENAME1_xxx
       Device[deviceCount].DecimalsOnly     = true;
       Device[deviceCount].HasFormatUserVar = true;
       break;

--- a/src/_P081_Cron.ino
+++ b/src/_P081_Cron.ino
@@ -28,15 +28,13 @@ boolean Plugin_081(uint8_t function, struct EventStruct *event, String& string)
     {
       // This case defines the device characteristics, edit appropriately
 
-      Device[++deviceCount].Number = PLUGIN_ID_081;
-      Device[deviceCount].Type     = DEVICE_TYPE_DUMMY;              // how the device is connected
-      Device[deviceCount].VType    = Sensor_VType::SENSOR_TYPE_NONE; // type of value the plugin will return, used only for
-                                                                     // Domoticz
-      Device[deviceCount].ValueCount = 2;                            // number of output variables. The value should match the number of
-                                                                     // keys
-                                                                     // PLUGIN_VALUENAME1_xxx
-      Device[deviceCount].DecimalsOnly     = true;
-      Device[deviceCount].HasFormatUserVar = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number           = PLUGIN_ID_081;
+      dev.Type             = DEVICE_TYPE_DUMMY;              // how the device is connected
+      dev.VType            = Sensor_VType::SENSOR_TYPE_NONE; // type of value the plugin will return, used only for Domoticz
+      dev.ValueCount       = 2;                              // number of output variables.
+      dev.DecimalsOnly     = true;
+      dev.HasFormatUserVar = true;
       break;
     }
 

--- a/src/_P082_GPS.ino
+++ b/src/_P082_GPS.ino
@@ -30,25 +30,20 @@
 # define PLUGIN_VALUENAME4_082 "Speed"
 
 
-
 boolean Plugin_082(uint8_t function, struct EventStruct *event, String& string) {
   boolean success = false;
 
   switch (function) {
     case PLUGIN_DEVICE_ADD: {
-      Device[++deviceCount].Number           = PLUGIN_ID_082;
-      Device[deviceCount].Type               = DEVICE_TYPE_SERIAL_PLUS1;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 4;
-      Device[deviceCount].OutputDataType     = Output_Data_type_t::Simple;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_082;
+      Device[deviceCount].Type           = DEVICE_TYPE_SERIAL_PLUS1;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 4;
+      Device[deviceCount].OutputDataType = Output_Data_type_t::Simple;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].PluginStats    = true;
       break;
     }
 
@@ -184,21 +179,22 @@ boolean Plugin_082(uint8_t function, struct EventStruct *event, String& string) 
       addFormSubHeader(F("U-Blox specific"));
 
       {
-        const __FlashStringHelper *options[3] = {
+        const __FlashStringHelper *options[] = {
           toString(P082_PowerMode::Max_Performance),
           toString(P082_PowerMode::Power_Save),
           toString(P082_PowerMode::Eco)
         };
-        const int indices[3] = {
+        const int indices[] = {
           static_cast<int>(P082_PowerMode::Max_Performance),
           static_cast<int>(P082_PowerMode::Power_Save),
           static_cast<int>(P082_PowerMode::Eco)
         };
-        addFormSelector(F("Power Mode"), F("pwrmode"), 3, options, indices, P082_POWER_MODE);
+        constexpr size_t optionCount = NR_ELEMENTS(indices);
+        addFormSelector(F("Power Mode"), F("pwrmode"), optionCount, options, indices, P082_POWER_MODE);
       }
 
       {
-        const __FlashStringHelper *options[10] = {
+        const __FlashStringHelper *options[] = {
           toString(P082_DynamicModel::Portable),
           toString(P082_DynamicModel::Stationary),
           toString(P082_DynamicModel::Pedestrian),
@@ -210,7 +206,7 @@ boolean Plugin_082(uint8_t function, struct EventStruct *event, String& string) 
           toString(P082_DynamicModel::Wrist),
           toString(P082_DynamicModel::Bike)
         };
-        const int indices[10] = {
+        const int indices[] = {
           static_cast<int>(P082_DynamicModel::Portable),
           static_cast<int>(P082_DynamicModel::Stationary),
           static_cast<int>(P082_DynamicModel::Pedestrian),
@@ -222,7 +218,8 @@ boolean Plugin_082(uint8_t function, struct EventStruct *event, String& string) 
           static_cast<int>(P082_DynamicModel::Wrist),
           static_cast<int>(P082_DynamicModel::Bike)
         };
-        addFormSelector(F("Dynamic Platform Model"), F("dynmodel"), 10, options, indices, P082_DYNAMIC_MODEL);
+        constexpr size_t optionCount = NR_ELEMENTS(indices);
+        addFormSelector(F("Dynamic Platform Model"), F("dynmodel"), optionCount, options, indices, P082_DYNAMIC_MODEL);
       }
 # endif // P082_USE_U_BLOX_SPECIFIC
 
@@ -289,9 +286,10 @@ boolean Plugin_082(uint8_t function, struct EventStruct *event, String& string) 
         static_cast<P082_data_struct *>(getPluginTaskData(event->TaskIndex));
 
       if (nullptr != P082_data) {
-        #if FEATURE_CHART_JS
+        #  if FEATURE_CHART_JS
         P082_data->webformLoad_show_position_scatterplot(event);
-        #endif
+        #  endif // if FEATURE_CHART_JS
+
         for (uint8_t i = 0; i < P082_NR_OUTPUT_VALUES; ++i) {
           const uint8_t pconfigIndex = i + P082_QUERY1_CONFIG_POS;
 
@@ -582,7 +580,7 @@ void P082_setOutputValue(struct EventStruct *event, uint8_t outputType, float va
     const uint8_t pconfigIndex = i + P082_QUERY1_CONFIG_POS;
 
     if (PCONFIG(pconfigIndex) == outputType) {
-      UserVar.setFloat(event->TaskIndex, i,  value);
+      UserVar.setFloat(event->TaskIndex, i, value);
     }
   }
 }
@@ -597,25 +595,16 @@ void P082_logStats(struct EventStruct *event) {
   if ((nullptr == P082_data) || !P082_data->isInitialized()) {
     return;
   }
-  String log;
 
-  if (log.reserve(128)) {
-    log  = F("GPS:");
-    log += F(" Fix: ");
-    log += P082_data->hasFix(P082_TIMEOUT) ? 1 : 0;
-    log += F(" #sat: ");
-    log += P082_data->gps->satellites.value();
-    log += F(" #SNR: ");
-    log += P082_data->gps->satellitesStats.getBestSNR();
-    log += F(" HDOP: ");
-    log += P082_data->gps->hdop.value() / 100.0f;
-    log += F(" Chksum(pass/fail): ");
-    log += P082_data->gps->passedChecksum();
-    log += '/';
-    log += P082_data->gps->failedChecksum();
-    log += F(" invalid: ");
-    log += P082_data->gps->invalidData();
-    addLogMove(LOG_LEVEL_DEBUG, log);
+  if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
+    addLogMove(LOG_LEVEL_DEBUG, strformat(F("GPS: Fix: %d #sat: %u #SNR: %u HDOP: %.3f Chksum(pass/fail): %u/%u invalid: %u"),
+                                          P082_data->hasFix(P082_TIMEOUT) ? 1 : 0,
+                                          P082_data->gps->satellites.value(),
+                                          P082_data->gps->satellitesStats.getBestSNR(),
+                                          P082_data->gps->hdop.value() / 100.0f,
+                                          P082_data->gps->passedChecksum(),
+                                          P082_data->gps->failedChecksum(),
+                                          P082_data->gps->invalidData()));
   }
   # endif // ifndef BUILD_NO_DEBUG
 }
@@ -724,6 +713,7 @@ void P082_html_show_stats(struct EventStruct *event) {
 
   addRowLabel(F("UTC Time"));
   struct tm dateTime;
+
   if (P082_data->getDateTime(dateTime)) {
     addHtml(formatDateTimeString(dateTime));
   } else {
@@ -741,22 +731,17 @@ void P082_html_show_stats(struct EventStruct *event) {
   }
 
   addRowLabel(F("Checksum (pass/fail/invalid)"));
-  {
-    String chksumStats;
+  addHtml(strformat(F("%u/%u/%u"),
+                    P082_data->gps->passedChecksum(),
+                    P082_data->gps->failedChecksum(),
+                    P082_data->gps->invalidData()));
+# ifndef BUILD_NO_DEBUG
 
-    chksumStats  = P082_data->gps->passedChecksum();
-    chksumStats += '/';
-    chksumStats += P082_data->gps->failedChecksum();
-    chksumStats += '/';
-    chksumStats += P082_data->gps->invalidData();
-    addHtml(chksumStats);
-  }
-#ifndef BUILD_NO_DEBUG
-/*
-  addRowLabel(F("SW PPS stats"));
-  addHtml(P082_data->getPPSStats());
-*/
-#endif
+  /*
+     addRowLabel(F("SW PPS stats"));
+     addHtml(P082_data->getPPSStats());
+   */
+# endif // ifndef BUILD_NO_DEBUG
 }
 
 void P082_setSystemTime(struct EventStruct *event) {

--- a/src/_P082_GPS.ino
+++ b/src/_P082_GPS.ino
@@ -35,15 +35,16 @@ boolean Plugin_082(uint8_t function, struct EventStruct *event, String& string) 
 
   switch (function) {
     case PLUGIN_DEVICE_ADD: {
-      Device[++deviceCount].Number       = PLUGIN_ID_082;
-      Device[deviceCount].Type           = DEVICE_TYPE_SERIAL_PLUS1;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 4;
-      Device[deviceCount].OutputDataType = Output_Data_type_t::Simple;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_082;
+      dev.Type           = DEVICE_TYPE_SERIAL_PLUS1;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 4;
+      dev.OutputDataType = Output_Data_type_t::Simple;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P083_SGP30.ino
+++ b/src/_P083_SGP30.ino
@@ -32,14 +32,15 @@ boolean Plugin_083(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_083;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_DUAL;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 2;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_083;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_DUAL;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 2;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P083_SGP30.ino
+++ b/src/_P083_SGP30.ino
@@ -32,18 +32,14 @@ boolean Plugin_083(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_083;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_DUAL;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 2;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_083;
+      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_DUAL;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 2;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].PluginStats    = true;
       break;
     }
 

--- a/src/_P084_VEML6070.ino
+++ b/src/_P084_VEML6070.ino
@@ -43,19 +43,14 @@ boolean Plugin_084(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_084;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 3;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].TimerOptional      = false;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_084;
+      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 3;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].PluginStats    = true;
       break;
     }
 
@@ -90,8 +85,9 @@ boolean Plugin_084(uint8_t function, struct EventStruct *event, String& string)
 
     case PLUGIN_WEBFORM_LOAD:
     {
-      const __FlashStringHelper *optionsMode[4] = { F("1/2T"), F("1T"), F("2T"), F("4T (Default)") };
-      addFormSelector(F("Refresh Time Determination"), F("itime"), 4, optionsMode, nullptr, PCONFIG(0));
+      const __FlashStringHelper *optionsMode[] = { F("1/2T"), F("1T"), F("2T"), F("4T (Default)") };
+      constexpr size_t optionCount             = NR_ELEMENTS(optionsMode);
+      addFormSelector(F("Refresh Time Determination"), F("itime"), optionCount, optionsMode, nullptr, PCONFIG(0));
 
       success = true;
       break;
@@ -160,9 +156,8 @@ uint16_t VEML6070_ReadUv(bool *status)
   uint16_t uv_raw      = 0;
   bool     wire_status = false;
 
-  uv_raw   = I2C_read8(VEML6070_ADDR_H, &wire_status);
+  uv_raw   = I2C_read8(VEML6070_ADDR_H, &wire_status) << 8;
   *status  = wire_status;
-  uv_raw <<= 8;
   uv_raw  |= I2C_read8(VEML6070_ADDR_L, &wire_status);
   *status &= wire_status;
 

--- a/src/_P084_VEML6070.ino
+++ b/src/_P084_VEML6070.ino
@@ -43,14 +43,15 @@ boolean Plugin_084(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_084;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 3;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_084;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 3;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P085_AcuDC243.ino
+++ b/src/_P085_AcuDC243.ino
@@ -27,17 +27,18 @@ boolean Plugin_085(uint8_t function, struct EventStruct *event, String& string) 
 
   switch (function) {
     case PLUGIN_DEVICE_ADD: {
-      Device[++deviceCount].Number           = PLUGIN_ID_085;
-      Device[deviceCount].Type               = DEVICE_TYPE_SERIAL_PLUS1; // connected through 3 datapins
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = P085_NR_OUTPUT_VALUES;
-      Device[deviceCount].OutputDataType     = Output_Data_type_t::Simple;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].ExitTaskBeforeSave = false;
-      Device[deviceCount].PluginStats        = true;
-      Device[deviceCount].setPin3Direction(gpio_direction::gpio_output);
+      auto& dev = Device[++deviceCount];
+      dev.Number             = PLUGIN_ID_085;
+      dev.Type               = DEVICE_TYPE_SERIAL_PLUS1; // connected through 3 datapins
+      dev.VType              = Sensor_VType::SENSOR_TYPE_QUAD;
+      dev.FormulaOption      = true;
+      dev.ValueCount         = P085_NR_OUTPUT_VALUES;
+      dev.OutputDataType     = Output_Data_type_t::Simple;
+      dev.SendDataOption     = true;
+      dev.TimerOption        = true;
+      dev.ExitTaskBeforeSave = false;
+      dev.PluginStats        = true;
+      dev.setPin3Direction(gpio_direction::gpio_output);
       break;
     }
 

--- a/src/_P085_AcuDC243.ino
+++ b/src/_P085_AcuDC243.ino
@@ -17,8 +17,8 @@
  */
 
 # define PLUGIN_085
-# define PLUGIN_ID_085 85
-# define PLUGIN_NAME_085 "Energy - AccuEnergy AcuDC24x"
+# define PLUGIN_ID_085         85
+# define PLUGIN_NAME_085       "Energy - AccuEnergy AcuDC24x"
 # define PLUGIN_VALUENAME1_085 ""
 
 
@@ -30,17 +30,14 @@ boolean Plugin_085(uint8_t function, struct EventStruct *event, String& string) 
       Device[++deviceCount].Number           = PLUGIN_ID_085;
       Device[deviceCount].Type               = DEVICE_TYPE_SERIAL_PLUS1; // connected through 3 datapins
       Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
       Device[deviceCount].FormulaOption      = true;
       Device[deviceCount].ValueCount         = P085_NR_OUTPUT_VALUES;
       Device[deviceCount].OutputDataType     = Output_Data_type_t::Simple;
       Device[deviceCount].SendDataOption     = true;
       Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
       Device[deviceCount].ExitTaskBeforeSave = false;
       Device[deviceCount].PluginStats        = true;
+      Device[deviceCount].setPin3Direction(gpio_direction::gpio_output);
       break;
     }
 
@@ -131,7 +128,7 @@ boolean Plugin_085(uint8_t function, struct EventStruct *event, String& string) 
         addRowLabel(F("Checksum (pass/fail/nodata)"));
         uint32_t reads_pass, reads_crc_failed, reads_nodata;
         P085_data->modbus.getStatistics(reads_pass, reads_crc_failed, reads_nodata);
-        addHtml(strformat(F("%d/%d/%d"), reads_pass, reads_crc_failed, reads_nodata));
+        addHtml(strformat(F("%u/%u/%u"), reads_pass, reads_crc_failed, reads_nodata));
 
         addFormSubHeader(F("Calibration"));
 

--- a/src/_P086_Homie.ino
+++ b/src/_P086_Homie.ino
@@ -42,12 +42,13 @@ boolean Plugin_086(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number     = PLUGIN_ID_086;
-      Device[deviceCount].Type         = DEVICE_TYPE_DUMMY;
-      Device[deviceCount].VType        = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].DecimalsOnly = true;
-      Device[deviceCount].ValueCount   = PLUGIN_086_VALUE_MAX;
-      Device[deviceCount].Custom       = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number       = PLUGIN_ID_086;
+      dev.Type         = DEVICE_TYPE_DUMMY;
+      dev.VType        = Sensor_VType::SENSOR_TYPE_NONE;
+      dev.DecimalsOnly = true;
+      dev.ValueCount   = PLUGIN_086_VALUE_MAX;
+      dev.Custom       = true;
       break;
     }
 

--- a/src/_P086_Homie.ino
+++ b/src/_P086_Homie.ino
@@ -45,7 +45,6 @@ boolean Plugin_086(uint8_t function, struct EventStruct *event, String& string)
       Device[++deviceCount].Number     = PLUGIN_ID_086;
       Device[deviceCount].Type         = DEVICE_TYPE_DUMMY;
       Device[deviceCount].VType        = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].Ports        = 0;
       Device[deviceCount].DecimalsOnly = true;
       Device[deviceCount].ValueCount   = PLUGIN_086_VALUE_MAX;
       Device[deviceCount].Custom       = true;

--- a/src/_P087_SerialProxy.ino
+++ b/src/_P087_SerialProxy.ino
@@ -73,17 +73,12 @@ boolean Plugin_087(uint8_t function, struct EventStruct *event, String& string) 
 
   switch (function) {
     case PLUGIN_DEVICE_ADD: {
-      Device[++deviceCount].Number           = PLUGIN_ID_087;
-      Device[deviceCount].Type               = DEVICE_TYPE_SERIAL;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_STRING;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].ValueCount         = 1;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = false;
+      Device[++deviceCount].Number       = PLUGIN_ID_087;
+      Device[deviceCount].Type           = DEVICE_TYPE_SERIAL;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_STRING;
+      Device[deviceCount].ValueCount     = 1;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
 
       // FIXME TD-er: Not sure if access to any existing task data is needed when saving
       Device[deviceCount].ExitTaskBeforeSave = false;
@@ -389,7 +384,7 @@ void P087_html_show_matchForms(struct EventStruct *event) {
           const __FlashStringHelper *options[2];
           options[P087_Filter_Comp::Equal]    = F("==");
           options[P087_Filter_Comp::NotEqual] = F("!=");
-          const int optionValues[2] = { P087_Filter_Comp::Equal, P087_Filter_Comp::NotEqual };
+          const int optionValues[] = { P087_Filter_Comp::Equal, P087_Filter_Comp::NotEqual };
           addSelector(id, 2, options, optionValues, nullptr, static_cast<int>(comparator), false, true, F(""));
           break;
         }

--- a/src/_P087_SerialProxy.ino
+++ b/src/_P087_SerialProxy.ino
@@ -73,15 +73,16 @@ boolean Plugin_087(uint8_t function, struct EventStruct *event, String& string) 
 
   switch (function) {
     case PLUGIN_DEVICE_ADD: {
-      Device[++deviceCount].Number       = PLUGIN_ID_087;
-      Device[deviceCount].Type           = DEVICE_TYPE_SERIAL;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_STRING;
-      Device[deviceCount].ValueCount     = 1;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_087;
+      dev.Type           = DEVICE_TYPE_SERIAL;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_STRING;
+      dev.ValueCount     = 1;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
 
       // FIXME TD-er: Not sure if access to any existing task data is needed when saving
-      Device[deviceCount].ExitTaskBeforeSave = false;
+      dev.ExitTaskBeforeSave = false;
       break;
     }
 

--- a/src/_P088_HeatpumpIR.ino
+++ b/src/_P088_HeatpumpIR.ino
@@ -61,10 +61,11 @@ boolean Plugin_088(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number = PLUGIN_ID_088;
-      Device[deviceCount].Type     = DEVICE_TYPE_SINGLE;
-      Device[deviceCount].VType    = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].setPin1Direction(gpio_direction::gpio_output);
+      auto& dev = Device[++deviceCount];
+      dev.Number   = PLUGIN_ID_088;
+      dev.Type     = DEVICE_TYPE_SINGLE;
+      dev.VType    = Sensor_VType::SENSOR_TYPE_NONE;
+      dev.setPin1Direction(gpio_direction::gpio_output);
 
       break;
     }

--- a/src/_P088_HeatpumpIR.ino
+++ b/src/_P088_HeatpumpIR.ino
@@ -34,7 +34,7 @@
  *
  * The parameters are (in this order)
  * * The type of the heatpump as a string, see the implementations of different models, like
- *https://github.com/ToniA/arduino-heatpumpir/blob/master/MitsubishiHeatpumpIR.cpp
+ * https://github.com/ToniA/arduino-heatpumpir/blob/master/MitsubishiHeatpumpIR.cpp
  * * power state (see https://github.com/ToniA/arduino-heatpumpir/blob/master/HeatpumpIR.h for modes)
  * * operating mode
  * * fan speed
@@ -61,11 +61,9 @@ boolean Plugin_088(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number      = PLUGIN_ID_088;
-      Device[deviceCount].Type          = DEVICE_TYPE_SINGLE;
-      Device[deviceCount].VType         = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].Ports         = 0;
-      Device[deviceCount].ValueCount    = 0;
+      Device[++deviceCount].Number = PLUGIN_ID_088;
+      Device[deviceCount].Type     = DEVICE_TYPE_SINGLE;
+      Device[deviceCount].VType    = Sensor_VType::SENSOR_TYPE_NONE;
       Device[deviceCount].setPin1Direction(gpio_direction::gpio_output);
 
       break;

--- a/src/_P089_Ping.ino
+++ b/src/_P089_Ping.ino
@@ -39,17 +39,13 @@ boolean Plugin_089(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_089;
-      Device[deviceCount].Type               = DEVICE_TYPE_CUSTOM0;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].ValueCount         = 1;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].DecimalsOnly       = true;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_089;
+      Device[deviceCount].Type           = DEVICE_TYPE_CUSTOM0;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      Device[deviceCount].ValueCount     = 1;
+      Device[deviceCount].DecimalsOnly   = true;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
       break;
     }
 
@@ -131,7 +127,7 @@ boolean Plugin_089(uint8_t function, struct EventStruct *event, String& string)
 
       if (equals(command, F("pingset")))
       {
-        String taskName       = parseString(string, 2);
+        const String taskName = parseString(string, 2);
         String param1         = parseString(string, 3);
         taskIndex_t taskIndex = findTaskIndexByName(taskName);
 
@@ -147,7 +143,7 @@ boolean Plugin_089(uint8_t function, struct EventStruct *event, String& string)
             // Avoid overflow and weird values
             if ((val_new > -1024) && (val_new < 1024)) {
               UserVar.setFloat(event->TaskIndex, 0, val_new);
-              success                      = true;
+              success = true;
             }
           }
         }

--- a/src/_P089_Ping.ino
+++ b/src/_P089_Ping.ino
@@ -39,13 +39,14 @@ boolean Plugin_089(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_089;
-      Device[deviceCount].Type           = DEVICE_TYPE_CUSTOM0;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].ValueCount     = 1;
-      Device[deviceCount].DecimalsOnly   = true;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_089;
+      dev.Type           = DEVICE_TYPE_CUSTOM0;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.ValueCount     = 1;
+      dev.DecimalsOnly   = true;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
       break;
     }
 

--- a/src/_P090_CCS811.ino
+++ b/src/_P090_CCS811.ino
@@ -77,14 +77,15 @@ boolean Plugin_090(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_090;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_DUAL;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 2;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_090;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_DUAL;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 2;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P090_CCS811.ino
+++ b/src/_P090_CCS811.ino
@@ -77,17 +77,14 @@ boolean Plugin_090(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_090;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_DUAL;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 2;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].PluginStats        = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_090;
+      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_DUAL;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 2;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].PluginStats    = true;
       break;
     }
 
@@ -111,8 +108,9 @@ boolean Plugin_090(uint8_t function, struct EventStruct *event, String& string)
 
       // I2C address choice
       if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
-        const __FlashStringHelper *options[2] = { F("0x5A (ADDR pin is LOW)"), F("0x5B (ADDR pin is HIGH)") };
-        addFormSelector(F("I2C Address"), F("i2c_addr"), 2, options, i2cAddressValues, P090_I2C_ADDR);
+        const __FlashStringHelper *options[] = { F("0x5A (ADDR pin is LOW)"), F("0x5B (ADDR pin is HIGH)") };
+        constexpr size_t optionCount         = NR_ELEMENTS(options);
+        addFormSelector(F("I2C Address"), F("i2c_addr"), optionCount, options, i2cAddressValues, P090_I2C_ADDR);
       } else {
         success = intArrayContains(2, i2cAddressValues, event->Par1);
       }
@@ -132,10 +130,11 @@ boolean Plugin_090(uint8_t function, struct EventStruct *event, String& string)
     {
       {
         // read frequency
-        int frequencyChoice                            = P090_READ_INTERVAL;
-        const __FlashStringHelper *frequencyOptions[3] = { F("1 second"), F("10 seconds"), F("60 seconds") };
-        const int frequencyValues[3]                   = { 1, 2, 3 };
-        addFormSelector(F("Take reading every"), F("temp_freq"), 3, frequencyOptions, frequencyValues, frequencyChoice);
+        const int frequencyChoice                     = P090_READ_INTERVAL;
+        const __FlashStringHelper *frequencyOptions[] = { F("1 second"), F("10 seconds"), F("60 seconds") };
+        const int frequencyValues[]                   = { 1, 2, 3 };
+        constexpr size_t optionCount                  = NR_ELEMENTS(frequencyValues);
+        addFormSelector(F("Take reading every"), F("temp_freq"), optionCount, frequencyOptions, frequencyValues, frequencyChoice);
       }
 
       addFormSeparator(2);
@@ -175,9 +174,6 @@ boolean Plugin_090(uint8_t function, struct EventStruct *event, String& string)
           }
         }
       }
-
-      //            addFormSeparator(string);
-      // addFormSeparator(2);
 
       success = true;
       break;
@@ -292,35 +288,35 @@ boolean Plugin_090(uint8_t function, struct EventStruct *event, String& string)
       if (P090_COMPENSATE_ENABLE)
       {
         // we're checking a var from another task, so calculate that basevar
-        uint8_t TaskIndex = P090_TEMPERATURE_TASK_INDEX;
+        const taskIndex_t TaskIndex = P090_TEMPERATURE_TASK_INDEX;
 
         if (validTaskIndex(TaskIndex)) {
-          uint8_t BaseVarIndex = TaskIndex * VARS_PER_TASK + P090_TEMPERATURE_TASK_VALUE;
-          float   temperature  = UserVar[BaseVarIndex]; // in degrees C
+          float temperature = UserVar.getFloat(TaskIndex, P090_TEMPERATURE_TASK_VALUE); // in degrees C
           // convert to celsius if required
-          int temperature_in_fahrenheit = P090_TEMPERATURE_SCALE;
-          String temp;
-          temp = 'C';
+          # ifndef BUILD_NO_DEBUG
+          char temp('C');
+          # endif // ifndef BUILD_NO_DEBUG
 
-          if (temperature_in_fahrenheit)
+          if (P090_TEMPERATURE_SCALE)
           {
-            temperature = ((temperature - 32) * 5.0f) / 9.0f;
-            temp        =  'F';
+            temperature = CelsiusToFahrenheit(temperature);
+            # ifndef BUILD_NO_DEBUG
+            temp = 'F';
+            # endif // ifndef BUILD_NO_DEBUG
           }
 
-          uint8_t TaskIndex2 = P090_HUMIDITY_TASK_INDEX;
+          const taskIndex_t TaskIndex2 = P090_HUMIDITY_TASK_INDEX;
 
           if (validTaskIndex(TaskIndex2)) {
-            uint8_t BaseVarIndex2 = TaskIndex2 * VARS_PER_TASK + P090_HUMIDITY_TASK_VALUE;
-            float   humidity      = UserVar[BaseVarIndex2]; // in % relative
+            const float humidity = UserVar.getFloat(TaskIndex2, P090_HUMIDITY_TASK_VALUE); // in % relative
 
-          # ifndef BUILD_NO_DEBUG
+            # ifndef BUILD_NO_DEBUG
 
             if (loglevelActiveFor(LOG_LEVEL_DEBUG)) {
-              addLogMove(LOG_LEVEL_DEBUG, strformat(F("CCS811 : Compensating for Temperature: %s%s & Humidity: %s%%"),
-                                                    toString(temperature).c_str(), temp.c_str(), toString(humidity).c_str()));
+              addLogMove(LOG_LEVEL_DEBUG, strformat(F("CCS811 : Compensating for Temperature: %s%c & Humidity: %s%%"),
+                                                    toString(temperature).c_str(), temp, toString(humidity).c_str()));
             }
-          # endif // ifndef BUILD_NO_DEBUG
+            # endif // ifndef BUILD_NO_DEBUG
 
             P090_data->myCCS811.setEnvironmentalData(humidity, temperature);
           }
@@ -335,7 +331,7 @@ boolean Plugin_090(uint8_t function, struct EventStruct *event, String& string)
       else if (P090_data->myCCS811.checkForStatusError())
       {
         // get error and also clear it
-        String errorMsg = P090_data->myCCS811.getSensorError();
+        const String errorMsg = P090_data->myCCS811.getSensorError();
 
         if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
           // If the CCS811 found an internal error, print it.

--- a/src/_P091_SerSwitch.ino
+++ b/src/_P091_SerSwitch.ino
@@ -88,13 +88,14 @@ boolean Plugin_091(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_091;
-      Device[deviceCount].Type           = DEVICE_TYPE_DUMMY;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].ValueCount     = 4;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].TimerOptional  = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_091;
+      dev.Type           = DEVICE_TYPE_DUMMY;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      dev.ValueCount     = 4;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.TimerOptional  = true;
       break;
     }
     case PLUGIN_GET_DEVICENAME:

--- a/src/_P091_SerSwitch.ino
+++ b/src/_P091_SerSwitch.ino
@@ -32,7 +32,7 @@
                                                          than return to inverse state (non-blocking)
         - ydim,[DIM_VALUE]                               Set DIM_VALUE to Tuya dimmer switch (value can be 0-255, no range check!)
                                                          Of course, only the Tuya dimmer can do it... dim value can be read from plugin
-                                                          #values.
+ #values.
                                                          There are no checks for is it state on or off.
 
    Command Examples :
@@ -88,18 +88,13 @@ boolean Plugin_091(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_091;
-      Device[deviceCount].Type               = DEVICE_TYPE_DUMMY;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].ValueCount         = 4;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].TimerOptional      = true;
-      Device[deviceCount].GlobalSyncOption   = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_091;
+      Device[deviceCount].Type           = DEVICE_TYPE_DUMMY;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      Device[deviceCount].ValueCount     = 4;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].TimerOptional  = true;
       break;
     }
     case PLUGIN_GET_DEVICENAME:
@@ -121,53 +116,57 @@ boolean Plugin_091(uint8_t function, struct EventStruct *event, String& string)
     case PLUGIN_WEBFORM_LOAD:
     {
       {
-        const __FlashStringHelper *options[4] = {
+        const __FlashStringHelper *options[] = {
           F("Yewelink/TUYA"),
           F("Sonoff Dual"),
           F("LC TECH"),
           F("Moes Wifi Dimmer")
         };
-        const int optionValues[4] = { SER_SWITCH_YEWE, SER_SWITCH_SONOFFDUAL, SER_SWITCH_LCTECH, SER_SWITCH_WIFIDIMMER };
-        addFormSelector(F("Switch Type"), F("type"), 4, options, optionValues, PCONFIG(0));
+        const int optionValues[]     = { SER_SWITCH_YEWE, SER_SWITCH_SONOFFDUAL, SER_SWITCH_LCTECH, SER_SWITCH_WIFIDIMMER };
+        constexpr size_t optionCount = NR_ELEMENTS(optionValues);
+        addFormSelector(F("Switch Type"), F("type"), optionCount, options, optionValues, PCONFIG(0));
       }
 
       if (PCONFIG(0) == SER_SWITCH_YEWE)
       {
-        const __FlashStringHelper *buttonOptions[4] = {
+        const __FlashStringHelper *buttonOptions[] = {
           F("1"),
           F("2/Dimmer#2"),
           F("3/Dimmer#3"),
           F("4"),
         };
-        const int buttonoptionValues[4] = { 1, 2, 3, 4 };
-        addFormSelector(F("Number of relays"), F("button"), 4, buttonOptions, buttonoptionValues, PCONFIG(1));
+        const int buttonoptionValues[] = { 1, 2, 3, 4 };
+        constexpr size_t optionCount   = NR_ELEMENTS(buttonoptionValues);
+        addFormSelector(F("Number of relays"), F("button"), optionCount, buttonOptions, buttonoptionValues, PCONFIG(1));
       }
 
       if (PCONFIG(0) == SER_SWITCH_SONOFFDUAL)
       {
-        const __FlashStringHelper *modeoptions[3] = {
+        const __FlashStringHelper *modeoptions[] = {
           F("Normal"),
           F("Exclude/Blinds mode"),
           F("Simultaneous mode"),
         };
-        addFormSelector(F("Relay working mode"), F("mode"), 3, modeoptions, nullptr, PCONFIG(1));
+        constexpr size_t optionCount = NR_ELEMENTS(modeoptions);
+        addFormSelector(F("Relay working mode"), F("mode"), optionCount, modeoptions, nullptr, PCONFIG(1));
       }
 
       if (PCONFIG(0) == SER_SWITCH_LCTECH)
       {
         {
-          const __FlashStringHelper *buttonOptions[4] = {
+          const __FlashStringHelper *buttonOptions[] = {
             F("1"),
             F("2"),
             F("3"),
             F("4"),
           };
-          const int buttonoptionValues[4] = { 1, 2, 3, 4 };
-          addFormSelector(F("Number of relays"), F("button"), 4, buttonOptions, buttonoptionValues, PCONFIG(1));
+          const int buttonoptionValues[] = { 1, 2, 3, 4 };
+          constexpr size_t optionCount   = NR_ELEMENTS(buttonoptionValues);
+          addFormSelector(F("Number of relays"), F("button"), optionCount, buttonOptions, buttonoptionValues, PCONFIG(1));
         }
 
         {
-          const __FlashStringHelper *speedOptions[8] = {
+          const __FlashStringHelper *speedOptions[] = {
             F("9600"),
             F("19200"),
             F("115200"),
@@ -177,7 +176,8 @@ boolean Plugin_091(uint8_t function, struct EventStruct *event, String& string)
             F("38400"),
             F("57600"),
           };
-          addFormSelector(F("Serial speed"), F("speed"), 8, speedOptions, nullptr, PCONFIG(2));
+          constexpr size_t optionCount = NR_ELEMENTS(speedOptions);
+          addFormSelector(F("Serial speed"), F("speed"), optionCount, speedOptions, nullptr, PCONFIG(2));
         }
 
         addFormCheckBox(F("Use command doubling"), F("dbl"), PCONFIG(3));
@@ -540,11 +540,11 @@ boolean Plugin_091(uint8_t function, struct EventStruct *event, String& string)
 
     case PLUGIN_WRITE:
     {
+      const String command = parseString(string, 1);
       String  log;
-      String  command = parseString(string, 1);
-      uint8_t rnum    = 0;
-      uint8_t rcmd    = 0;
-      uint8_t par3    = 0;
+      uint8_t rnum{};
+      uint8_t rcmd{};
+      uint8_t par3{};
 
       if (Plugin_091_init)
       {
@@ -578,7 +578,7 @@ boolean Plugin_091(uint8_t function, struct EventStruct *event, String& string)
 
               if ((par3 == 1) && (rcmd == 1) && (rnum < 2))
               { // exclusive on mode for Dual
-                  // FIXME TD-er: Is this a valid UserVar index?
+                // FIXME TD-er: Is this a valid UserVar index?
                 UserVar.setFloat(event->TaskIndex, 1 - rnum, 0);
               }
 
@@ -629,7 +629,7 @@ boolean Plugin_091(uint8_t function, struct EventStruct *event, String& string)
 
               if ((par3 == 1) && (rcmd == 1) && (rnum < 2))
               { // exclusive on mode for Dual
-                  // FIXME TD-er: Is this a valid UserVar index?
+                // FIXME TD-er: Is this a valid UserVar index?
                 UserVar.setFloat(event->TaskIndex, 1 - rnum, 0);
               }
 
@@ -681,7 +681,7 @@ boolean Plugin_091(uint8_t function, struct EventStruct *event, String& string)
 
               if ((par3 == 1) && (rcmd == 1) && (rnum < 2))
               { // exclusive on mode for Dual
-                  // FIXME TD-er: Is this a valid UserVar index?
+                // FIXME TD-er: Is this a valid UserVar index?
                 UserVar.setFloat(event->TaskIndex, 1 - rnum, 0);
               }
 
@@ -702,17 +702,12 @@ boolean Plugin_091(uint8_t function, struct EventStruct *event, String& string)
             addLogMove(LOG_LEVEL_INFO, strformat(F("SerSW   : SetSwitchPulse r%d:%d Pulse for %d sec"), rnum, rcmd, event->Par3));
           }
         } else
-        if (equals(command, F("ydim")))                                                                                                        //
-                                                                                                                                               // deal
-                                                                                                                                               // with
-                                                                                                                                               // dimmer
-                                                                                                                                               // command
+
+        // deal with dimmer command
+        if (equals(command, F("ydim")))
         {
-          if (((Plugin_091_globalpar0 == SER_SWITCH_YEWE) && (Plugin_091_numrelay > 1)) || (Plugin_091_globalpar0 == SER_SWITCH_WIFIDIMMER)) { //
-                                                                                                                                               // only
-                                                                                                                                               // on
-                                                                                                                                               // tuya
-                                                                                                                                               // dimmer
+          // only on tuya dimmer
+          if (((Plugin_091_globalpar0 == SER_SWITCH_YEWE) && (Plugin_091_numrelay > 1)) || (Plugin_091_globalpar0 == SER_SWITCH_WIFIDIMMER)) {
             success = true;
 
             // LoadTaskSettings(Plugin_091_ownindex); // get our own task values please
@@ -767,7 +762,7 @@ boolean Plugin_091(uint8_t function, struct EventStruct *event, String& string)
 
           if ((par3 == 1) && (rcmd == 1) && (rnum < 2))
           { // exclusive on mode for Dual
-              // FIXME TD-er: Is this a valid UserVar index?
+            // FIXME TD-er: Is this a valid UserVar index?
             UserVar.setFloat(event->TaskIndex, 1 - rnum, 0);
           }
 

--- a/src/_P092_DLbus.ino
+++ b/src/_P092_DLbus.ino
@@ -90,19 +90,14 @@ boolean Plugin_092(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_092;
-      Device[deviceCount].Type               = DEVICE_TYPE_SINGLE;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].ValueCount         = 1;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].DecimalsOnly       = true;
-      Device[deviceCount].PluginStats        = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_092;
+      Device[deviceCount].Type           = DEVICE_TYPE_SINGLE;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      Device[deviceCount].ValueCount     = 1;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].DecimalsOnly   = true;
+      Device[deviceCount].PluginStats    = true;
       break;
     }
 
@@ -145,22 +140,23 @@ boolean Plugin_092(uint8_t function, struct EventStruct *event, String& string)
         addFormSelector(F("Pin mode"), F("ppinmode"), 2, options, optionValues, choice);
       }
       {
-        const __FlashStringHelper *Devices[P092_DLbus_DeviceCount] = {
+        const __FlashStringHelper *Devices[] = {
           F("ESR21"),
           F("UVR31"),
           F("UVR42"),
           F("UVR1611"),
           F("UVR 61-3 (up to v8.2)"),
           F("UVR 61-3 (v8.3 or higher)") };
-        const int DevTypes[P092_DLbus_DeviceCount] = { 21, 31, 42, 1611, 6132, 6133 };
+        const int DevTypes[]         = { 21, 31, 42, 1611, 6132, 6133 };
+        constexpr size_t optionCount = NR_ELEMENTS(Devices);
 
-        addFormSelector(F("DL-Bus Type"), F("pdlbtype"), P092_DLbus_DeviceCount, Devices, DevTypes, nullptr, PCONFIG(0), true);
+        addFormSelector(F("DL-Bus Type"), F("pdlbtype"), optionCount, Devices, DevTypes, nullptr, PCONFIG(0), true);
       }
       {
         int P092_ValueType, P092_ValueIdx;
         P092_Last_DLB_Pin = CONFIG_PIN1;
-        const String plugin_092_DefValueName                  = F(PLUGIN_VALUENAME1_092);
-        const int    P092_OptionTypes[P092_DLbus_OptionCount] = {
+        const String plugin_092_DefValueName = F(PLUGIN_VALUENAME1_092);
+        const int    P092_OptionTypes[]      = {
           // Index der Variablen
           0, // F("None")
           1, // F("Sensor")
@@ -171,7 +167,8 @@ boolean Plugin_092(uint8_t function, struct EventStruct *event, String& string)
           6, // F("Heat power (kW)")
           7  // F("Heat meter (MWh)")
         };
-        const __FlashStringHelper *Options[P092_DLbus_OptionCount] = {
+        constexpr size_t optionCount         = NR_ELEMENTS(P092_OptionTypes);
+        const __FlashStringHelper *Options[] = {
           F("None"),
           F("Sensor"),
           F("Ext. sensor"),
@@ -182,18 +179,18 @@ boolean Plugin_092(uint8_t function, struct EventStruct *event, String& string)
           F("Heat meter (MWh)")
         };
 
-        uint8_t P092_MaxIdx[P092_DLbus_OptionCount];
-
-        // Calculation of the max indices for each sensor type
-        // default indizes for UVR31
-        P092_MaxIdx[0] = 0;      // None
-        P092_MaxIdx[1] = 3;      // Sensor
-        P092_MaxIdx[2] = 0;      // Ext. sensor
-        P092_MaxIdx[3] = 1;      // Digital output
-        P092_MaxIdx[4] = 0;      // Speed step
-        P092_MaxIdx[5] = 0;      // Analog output
-        P092_MaxIdx[6] = 0;      // Heat power (kW)
-        P092_MaxIdx[7] = 0;      // Heat meter (MWh)
+        uint8_t P092_MaxIdx[] {
+          // Calculation of the max indices for each sensor type
+          // default indizes for UVR31
+          0, // None
+          3, // Sensor
+          0, // Ext. sensor
+          1, // Digital output
+          0, // Speed step
+          0, // Analog output
+          0, // Heat power (kW)
+          0, // Heat meter (MWh)
+        };
 
         switch (PCONFIG(0)) {
           case 21:               // ESR21
@@ -240,7 +237,7 @@ boolean Plugin_092(uint8_t function, struct EventStruct *event, String& string)
 
         addFormSelector(plugin_092_DefValueName,
                         F("pValue"),
-                        P092_DLbus_OptionCount,
+                        optionCount,
                         Options,
                         P092_OptionTypes,
                         nullptr,
@@ -288,8 +285,8 @@ boolean Plugin_092(uint8_t function, struct EventStruct *event, String& string)
         P092_OptionValueDecimals[6] = 2;
       }
 
-      int OptionIdx = getFormItemInt(F("pValue"));
-      int CurIdx    = getFormItemInt(F("pIdx"));
+      const int OptionIdx = getFormItemInt(F("pValue"));
+      int CurIdx          = getFormItemInt(F("pIdx"));
 
       if (CurIdx < 1) {
         CurIdx = 1;
@@ -324,13 +321,13 @@ boolean Plugin_092(uint8_t function, struct EventStruct *event, String& string)
         String log = F("PLUGIN_WEBFORM_SAVE :");
         log += F(" DLB_Pin:");
         log += CONFIG_PIN1;
-        log += F(" DLbus_MinPulseWidth:");
+        log += F(" MinPulseWidth:");
         log += P092_data->P092_DataSettings.DLbus_MinPulseWidth;
-        log += F(" DLbus_MaxPulseWidth:");
+        log += F(" MaxPulseWidth:");
         log += P092_data->P092_DataSettings.DLbus_MaxPulseWidth;
-        log += F(" DLbus_MinDoublePulseWidth:");
+        log += F(" MinDoublePulseWidth:");
         log += P092_data->P092_DataSettings.DLbus_MinDoublePulseWidth;
-        log += F(" DLbus_MaxDoublePulseWidth:");
+        log += F(" MaxDoublePulseWidth:");
         log += P092_data->P092_DataSettings.DLbus_MaxDoublePulseWidth;
         log += F(" IdxSensor:");
         log += P092_data->P092_DataSettings.IdxSensor;

--- a/src/_P092_DLbus.ino
+++ b/src/_P092_DLbus.ino
@@ -90,14 +90,15 @@ boolean Plugin_092(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_092;
-      Device[deviceCount].Type           = DEVICE_TYPE_SINGLE;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].ValueCount     = 1;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].DecimalsOnly   = true;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_092;
+      dev.Type           = DEVICE_TYPE_SINGLE;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.ValueCount     = 1;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.DecimalsOnly   = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P093_MitsubishiHP.ino
+++ b/src/_P093_MitsubishiHP.ino
@@ -44,13 +44,14 @@ boolean Plugin_093(uint8_t function, struct EventStruct *event, String& string) 
 
   switch (function) {
     case PLUGIN_DEVICE_ADD: {
-      Device[++deviceCount].Number       = PLUGIN_ID_093;
-      Device[deviceCount].Type           = DEVICE_TYPE_SERIAL;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_STRING;
-      Device[deviceCount].ValueCount     = 1;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].TimerOptional  = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_093;
+      dev.Type           = DEVICE_TYPE_SERIAL;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_STRING;
+      dev.ValueCount     = 1;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.TimerOptional  = true;
       break;
     }
 

--- a/src/_P094_CULReader.ino
+++ b/src/_P094_CULReader.ino
@@ -53,17 +53,18 @@ boolean Plugin_094(uint8_t function, struct EventStruct *event, String& string) 
 
   switch (function) {
     case PLUGIN_DEVICE_ADD: {
-      Device[++deviceCount].Number           = PLUGIN_ID_094;
-      Device[deviceCount].Type               = DEVICE_TYPE_SERIAL;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_STRING;
-      Device[deviceCount].OutputDataType     = Output_Data_type_t::Default;
-      Device[deviceCount].ValueCount         = 1;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].DuplicateDetection = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number             = PLUGIN_ID_094;
+      dev.Type               = DEVICE_TYPE_SERIAL;
+      dev.VType              = Sensor_VType::SENSOR_TYPE_STRING;
+      dev.OutputDataType     = Output_Data_type_t::Default;
+      dev.ValueCount         = 1;
+      dev.SendDataOption     = true;
+      dev.TimerOption        = true;
+      dev.DuplicateDetection = true;
 
       // FIXME TD-er: Not sure if access to any existing task data is needed when saving
-      Device[deviceCount].ExitTaskBeforeSave = true;
+      dev.ExitTaskBeforeSave = true;
       break;
     }
 

--- a/src/_P094_CULReader.ino
+++ b/src/_P094_CULReader.ino
@@ -57,14 +57,9 @@ boolean Plugin_094(uint8_t function, struct EventStruct *event, String& string) 
       Device[deviceCount].Type               = DEVICE_TYPE_SERIAL;
       Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_STRING;
       Device[deviceCount].OutputDataType     = Output_Data_type_t::Default;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
       Device[deviceCount].ValueCount         = 1;
       Device[deviceCount].SendDataOption     = true;
       Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = false;
       Device[deviceCount].DuplicateDetection = true;
 
       // FIXME TD-er: Not sure if access to any existing task data is needed when saving
@@ -318,10 +313,8 @@ boolean Plugin_094(uint8_t function, struct EventStruct *event, String& string) 
           # endif // if P094_DEBUG_OPTIONS
 
           if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-            String log = F("CUL Reader: Sending: ");
-            log += event->String2.substring(0, 20);
-            log += F("...");
-            addLogMove(LOG_LEVEL_INFO, log);
+            addLogMove(LOG_LEVEL_INFO, strformat(F("CUL Reader: Sending: %s..."),
+                                                 event->String2.substring(0, 20).c_str()));
           }
 
           //          sendData_checkDuplicates(event, event->String2.substring(0, 22));
@@ -447,7 +440,7 @@ boolean Plugin_094(uint8_t function, struct EventStruct *event, String& string) 
 
       break;
     }
-#ifdef USES_ESPEASY_NOW
+# ifdef USES_ESPEASY_NOW
     case PLUGIN_FILTEROUT_CONTROLLER_DATA:
     {
       // event->String1 => topic;
@@ -463,7 +456,7 @@ boolean Plugin_094(uint8_t function, struct EventStruct *event, String& string) 
 
       break;
     }
-#endif
+# endif // ifdef USES_ESPEASY_NOW
   }
   return success;
 }

--- a/src/_P095_ILI9341.ino
+++ b/src/_P095_ILI9341.ino
@@ -146,18 +146,13 @@ boolean Plugin_095(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_095;
-      Device[deviceCount].Type               = DEVICE_TYPE_SPI3;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].ValueCount         = 2;
-      Device[deviceCount].SendDataOption     = false;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].TimerOptional      = true;
-      success                                = true;
+      Device[++deviceCount].Number      = PLUGIN_ID_095;
+      Device[deviceCount].Type          = DEVICE_TYPE_SPI3;
+      Device[deviceCount].VType         = Sensor_VType::SENSOR_TYPE_NONE;
+      Device[deviceCount].ValueCount    = 2;
+      Device[deviceCount].TimerOption   = true;
+      Device[deviceCount].TimerOptional = true;
+      success                           = true;
       break;
     }
 
@@ -265,9 +260,10 @@ boolean Plugin_095(uint8_t function, struct EventStruct *event, String& string)
           static_cast<int>(ILI9xxx_type_e::ILI9488_320x480),
           # endif // if P095_ENABLE_ILI948X
         };
+        constexpr size_t optionCount = NR_ELEMENTS(hardwareOptions);
         addFormSelector(F("TFT display model"),
                         F("dsptype"),
-                        NR_ELEMENTS(hardwareOptions),
+                        optionCount,
                         hardwareTypes,
                         hardwareOptions,
                         P095_CONFIG_FLAG_GET_TYPE);
@@ -314,9 +310,10 @@ boolean Plugin_095(uint8_t function, struct EventStruct *event, String& string)
           static_cast<int>(P095_CommandTrigger::ili9488),
           # endif // if P095_ENABLE_ILI948X
         };
+        constexpr size_t optionCount = NR_ELEMENTS(commandTriggerOptions);
         addFormSelector(F("Write Command trigger"),
                         F("commandtrigger"),
-                        NR_ELEMENTS(commandTriggerOptions),
+                        optionCount,
                         commandTriggers,
                         commandTriggerOptions,
                         P095_CONFIG_FLAG_GET_CMD_TRIGGER);
@@ -420,7 +417,7 @@ boolean Plugin_095(uint8_t function, struct EventStruct *event, String& string)
           strings[varNr] = webArg(getPluginCustomArgName(varNr));
         }
 
-        String error = SaveCustomTaskSettings(event->TaskIndex, strings, P095_Nlines, 0);
+        const String error = SaveCustomTaskSettings(event->TaskIndex, strings, P095_Nlines, 0);
 
         if (error.length() > 0) {
           addHtmlError(error);

--- a/src/_P095_ILI9341.ino
+++ b/src/_P095_ILI9341.ino
@@ -146,13 +146,13 @@ boolean Plugin_095(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number      = PLUGIN_ID_095;
-      Device[deviceCount].Type          = DEVICE_TYPE_SPI3;
-      Device[deviceCount].VType         = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].ValueCount    = 2;
-      Device[deviceCount].TimerOption   = true;
-      Device[deviceCount].TimerOptional = true;
-      success                           = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number        = PLUGIN_ID_095;
+      dev.Type          = DEVICE_TYPE_SPI3;
+      dev.VType         = Sensor_VType::SENSOR_TYPE_NONE;
+      dev.ValueCount    = 2;
+      dev.TimerOption   = true;
+      dev.TimerOptional = true;
       break;
     }
 

--- a/src/_P096_eInk.ino
+++ b/src/_P096_eInk.ino
@@ -114,13 +114,13 @@
 
 # ifndef P096_USE_ADA_GRAPHICS
 
-// declare functions for using default value parameters
-void Plugin_096_printText(const char    *string,
-                          int            X,
-                          int            Y,
-                          unsigned int   textSize = 1,
-                          unsigned short color    = EPD_WHITE,
-                          unsigned short bkcolor  = EPD_BLACK);
+// // declare functions for using default value parameters
+// void Plugin_096_printText(const char    *string,
+//                           int            X,
+//                           int            Y,
+//                           unsigned int   textSize = 1,
+//                           unsigned short color    = EPD_WHITE,
+//                           unsigned short bkcolor  = EPD_BLACK);
 # endif // ifndef P096_USE_ADA_GRAPHICS
 
 // Define the default values for both ESP32/lolin32 and D1 Mini
@@ -135,8 +135,8 @@ void Plugin_096_printText(const char    *string,
 # else // ifdef ESP32
 
 // for D1 Mini with shield connection
-  #  define EPD_CS  16 // D0
-  #  define EPD_DC  15 // D8
+  #  define EPD_CS  16  // D0
+  #  define EPD_DC  15  // D8
   #  define EPD_RST -1  // can set to -1 and share with microcontroller Reset!
   #  define EPD_BUSY -1 // can set to -1 to not use a pin (will wait a fixed delay)
 # endif // ifdef ESP32
@@ -175,22 +175,14 @@ boolean Plugin_096(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_096;
-      Device[deviceCount].Type               = DEVICE_TYPE_SPI3;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
+      Device[++deviceCount].Number = PLUGIN_ID_096;
+      Device[deviceCount].Type     = DEVICE_TYPE_SPI3;
+      Device[deviceCount].VType    = Sensor_VType::SENSOR_TYPE_NONE;
       # if P096_USE_EXTENDED_SETTINGS
       Device[deviceCount].ValueCount    = 2;
       Device[deviceCount].TimerOption   = true;
       Device[deviceCount].TimerOptional = true;
-      # else // if P096_USE_EXTENDED_SETTINGS
-      Device[deviceCount].ValueCount  = 0;
-      Device[deviceCount].TimerOption = false;
       # endif // if P096_USE_EXTENDED_SETTINGS
-      Device[deviceCount].SendDataOption = false;
 
       success = true;
       break;
@@ -248,8 +240,7 @@ boolean Plugin_096(uint8_t function, struct EventStruct *event, String& string)
 
     case PLUGIN_WEBFORM_SHOW_GPIO_DESCR:
     {
-      string  = F("EPD BUSY: ");
-      string += formatGpioLabel(PIN(3), false);
+      string  = concat(F("EPD BUSY: "), formatGpioLabel(PIN(3), false));
       success = true;
       break;
     }
@@ -282,9 +273,10 @@ boolean Plugin_096(uint8_t function, struct EventStruct *event, String& string)
           static_cast<int>(EPD_type_e::EPD_WS2IN7)
           #  endif // if P096_USE_WAVESHARE_2IN7
         };
+        constexpr size_t optionCount = NR_ELEMENTS(optionValues4);
         addFormSelector(F("eInk display model"),
                         F("_type"),
-                        static_cast<int>(EPD_type_e::EPD_MAX),
+                        optionCount,
                         options4,
                         optionValues4,
                         P096_CONFIG_FLAG_GET_DISPLAYTYPE);
@@ -297,9 +289,10 @@ boolean Plugin_096(uint8_t function, struct EventStruct *event, String& string)
       AdaGFXFormRotation(F("_rotate"), P096_CONFIG_ROTATION);
       # else // ifdef P096_USE_ADA_GRAPHICS
       {
-        const __FlashStringHelper *options2[4] = { F("Normal"), F("+90&deg;"), F("+180&deg;"), F("+270&deg;") };
-        int optionValues2[4]                   = { 0, 1, 2, 3 };
-        addFormSelector(F("Rotation"), F("_rotate"), 4, options2, optionValues2, P096_CONFIG_ROTATION);
+        const __FlashStringHelper *options2[] = { F("Normal"), F("+90&deg;"), F("+180&deg;"), F("+270&deg;") };
+        int optionValues2[]                   = { 0, 1, 2, 3 };
+        constexpr size_t optionCount          = NR_ELEMENTS(optionValues2);
+        addFormSelector(F("Rotation"), F("_rotate"), optionCount, options2, optionValues2, P096_CONFIG_ROTATION);
       }
       # endif // ifdef P096_USE_ADA_GRAPHICS
 
@@ -340,14 +333,15 @@ boolean Plugin_096(uint8_t function, struct EventStruct *event, String& string)
           #  endif // if ADAGFX_SUPPORT_7COLOR
         };
 
-        if (P096_CONFIG_FLAG_GET_COLORDEPTH == 0) { // Enum doesn't have 0
+        if (P096_CONFIG_FLAG_GET_COLORDEPTH == 0) {                                                                // Enum doesn't have 0
           uint32_t lSettings = 0;
           set4BitToUL(lSettings, P096_CONFIG_FLAG_COLORDEPTH, static_cast<uint8_t>(AdaGFXColorDepth::Monochrome)); // Bit 20..23 Color depth
           P096_CONFIG_FLAGS = lSettings;
         }
+        constexpr size_t optionCount = NR_ELEMENTS(colorDepthOptions);
         addFormSelector(F("Greyscale levels"),
                         F("_colorDepth"),
-                        ADAGFX_MONOCOLORS_COUNT,
+                        optionCount,
                         colorDepths,
                         colorDepthOptions,
                         P096_CONFIG_FLAG_GET_COLORDEPTH);
@@ -355,9 +349,9 @@ boolean Plugin_096(uint8_t function, struct EventStruct *event, String& string)
 
       AdaGFXFormTextPrintMode(F("_mode"), P096_CONFIG_FLAG_GET_MODE);
 
-      # if ADAGFX_FONTS_INCLUDED
+      #  if ADAGFX_FONTS_INCLUDED
       AdaGFXFormDefaultFont(F("deffont"), P096_CONFIG_DEFAULT_FONT);
-      # endif // if ADAGFX_FONTS_INCLUDED
+      #  endif // if ADAGFX_FONTS_INCLUDED
 
       AdaGFXFormFontScaling(F("_fontscale"), P096_CONFIG_FLAG_GET_FONTSCALE);
 
@@ -384,9 +378,10 @@ boolean Plugin_096(uint8_t function, struct EventStruct *event, String& string)
           static_cast<int>(P096_CommandTrigger::ws2in7)
           #  endif // if P096_USE_WAVESHARE_2IN7
         };
+        constexpr size_t optionCount = NR_ELEMENTS(commandTriggerOptions);
         addFormSelector(F("Write Command trigger"),
                         F("_commandtrigger"),
-                        static_cast<int>(P096_CommandTrigger::MAX),
+                        optionCount,
                         commandTriggers,
                         commandTriggerOptions,
                         P096_CONFIG_FLAG_GET_CMD_TRIGGER);
@@ -576,7 +571,6 @@ boolean Plugin_096(uint8_t function, struct EventStruct *event, String& string)
       }
       break;
     }
-
   }
 
   return success;
@@ -584,26 +578,26 @@ boolean Plugin_096(uint8_t function, struct EventStruct *event, String& string)
 
 # ifndef P096_USE_ADA_GRAPHICS
 
-// Print some text
-// param [in] string : The text to display
-// param [in] X : The left position (X)
-// param [in] Y : The top position (Y)
-// param [in] textSize : The text size (default 1)
-// param [in] color : The fore color (default ILI9341_WHITE)
-// param [in] bkcolor : The background color (default ILI9341_BLACK)
-void Plugin_096_printText(const char *string, int X, int Y, unsigned int textSize, unsigned short color, unsigned short bkcolor)
-{
-  eInkScreen->clearBuffer();
-  eInkScreen->clearDisplay();
-  eInkScreen->setCursor(X, Y);
-  eInkScreen->setTextColor(color, bkcolor);
-  eInkScreen->setTextSize(textSize);
-  String fixString = string;
+// // Print some text
+// // param [in] string : The text to display
+// // param [in] X : The left position (X)
+// // param [in] Y : The top position (Y)
+// // param [in] textSize : The text size (default 1)
+// // param [in] color : The fore color (default ILI9341_WHITE)
+// // param [in] bkcolor : The background color (default ILI9341_BLACK)
+// void Plugin_096_printText(const char *string, int X, int Y, unsigned int textSize, unsigned short color, unsigned short bkcolor)
+// {
+//   eInkScreen->clearBuffer();
+//   eInkScreen->clearDisplay();
+//   eInkScreen->setCursor(X, Y);
+//   eInkScreen->setTextColor(color, bkcolor);
+//   eInkScreen->setTextSize(textSize);
+//   String fixString = string;
 
-  Plugin_096_FixText(fixString);
-  eInkScreen->println(fixString);
-  eInkScreen->display();
-}
+//   Plugin_096_FixText(fixString);
+//   eInkScreen->println(fixString);
+//   eInkScreen->display();
+// }
 
 # endif // ifndef P096_USE_ADA_GRAPHICS
 

--- a/src/_P096_eInk.ino
+++ b/src/_P096_eInk.ino
@@ -175,16 +175,15 @@ boolean Plugin_096(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number = PLUGIN_ID_096;
-      Device[deviceCount].Type     = DEVICE_TYPE_SPI3;
-      Device[deviceCount].VType    = Sensor_VType::SENSOR_TYPE_NONE;
+      auto& dev = Device[++deviceCount];
+      dev.Number = PLUGIN_ID_096;
+      dev.Type   = DEVICE_TYPE_SPI3;
+      dev.VType  = Sensor_VType::SENSOR_TYPE_NONE;
       # if P096_USE_EXTENDED_SETTINGS
-      Device[deviceCount].ValueCount    = 2;
-      Device[deviceCount].TimerOption   = true;
-      Device[deviceCount].TimerOptional = true;
+      dev.ValueCount    = 2;
+      dev.TimerOption   = true;
+      dev.TimerOptional = true;
       # endif // if P096_USE_EXTENDED_SETTINGS
-
-      success = true;
       break;
     }
 

--- a/src/_P097_Esp32Touch.ino
+++ b/src/_P097_Esp32Touch.ino
@@ -56,13 +56,14 @@ boolean Plugin_097(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_097;
-      Device[deviceCount].Type           = DEVICE_TYPE_ANALOG;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 1;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOptional  = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_097;
+      dev.Type           = DEVICE_TYPE_ANALOG;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 1;
+      dev.SendDataOption = true;
+      dev.TimerOptional  = true;
       break;
     }
 

--- a/src/_P097_Esp32Touch.ino
+++ b/src/_P097_Esp32Touch.ino
@@ -56,19 +56,13 @@ boolean Plugin_097(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_097;
-      Device[deviceCount].Type               = DEVICE_TYPE_ANALOG;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 1;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].DecimalsOnly       = false;
-      Device[deviceCount].TimerOption        = false;
-      Device[deviceCount].TimerOptional      = true;
-      Device[deviceCount].GlobalSyncOption   = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_097;
+      Device[deviceCount].Type           = DEVICE_TYPE_ANALOG;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 1;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOptional  = true;
       break;
     }
 

--- a/src/_P098_PWM_motor.ino
+++ b/src/_P098_PWM_motor.ino
@@ -51,17 +51,13 @@ boolean Plugin_098(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_098;
-      Device[deviceCount].Type               = DEVICE_TYPE_CUSTOM0;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].ValueCount         = 4;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].TimerOptional      = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_098;
+      Device[deviceCount].Type           = DEVICE_TYPE_CUSTOM0;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      Device[deviceCount].ValueCount     = 4;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].TimerOptional  = true;
       break;
     }
 
@@ -92,7 +88,7 @@ boolean Plugin_098(uint8_t function, struct EventStruct *event, String& string)
         F("Lim A"),
         F("Lim B")
       };
-      int values[] = {
+      const int values[] = {
         CONFIG_PIN1,
         CONFIG_PIN2,
         CONFIG_PIN3,
@@ -102,7 +98,7 @@ boolean Plugin_098(uint8_t function, struct EventStruct *event, String& string)
         P098_LIMIT_SWA_GPIO,
         P098_LIMIT_SWB_GPIO
       };
-      constexpr size_t nrElements = sizeof(values) / sizeof(values[0]);
+      constexpr size_t nrElements = NR_ELEMENTS(values);
 
       for (size_t i = 0; i < nrElements; ++i) {
         if (i != 0) { addHtml(event->String1); }
@@ -250,8 +246,8 @@ boolean Plugin_098(uint8_t function, struct EventStruct *event, String& string)
       CONFIG_PIN2 = getFormItemInt(F("taskdevicepin2"));
       CONFIG_PIN3 = getFormItemInt(F("taskdevicepin3"));
 
-      P098_ENC_TIMEOUT = getFormItemInt(F("enc_timeout"));
-      P098_VIRTUAL_SPEED = getFormItemInt(F("virtual_speed"));
+      P098_ENC_TIMEOUT      = getFormItemInt(F("enc_timeout"));
+      P098_VIRTUAL_SPEED    = getFormItemInt(F("virtual_speed"));
       P098_POS_0_SUPPLEMENT = getFormItemInt(F("pos0_supplement"));
 
       P098_LIMIT_SWA_GPIO     = getFormItemInt(F("limit_a"));

--- a/src/_P098_PWM_motor.ino
+++ b/src/_P098_PWM_motor.ino
@@ -51,13 +51,14 @@ boolean Plugin_098(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_098;
-      Device[deviceCount].Type           = DEVICE_TYPE_CUSTOM0;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].ValueCount     = 4;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].TimerOptional  = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_098;
+      dev.Type           = DEVICE_TYPE_CUSTOM0;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      dev.ValueCount     = 4;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.TimerOptional  = true;
       break;
     }
 

--- a/src/_P099_XPT2046Touch.ino
+++ b/src/_P099_XPT2046Touch.ino
@@ -50,17 +50,11 @@ boolean Plugin_099(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_099;
-      Device[deviceCount].Type               = DEVICE_TYPE_SPI;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TRIPLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].ValueCount         = 3;
-      Device[deviceCount].SendDataOption     = false;
-      Device[deviceCount].TimerOption        = false;
-      success                                = true;
+      Device[++deviceCount].Number   = PLUGIN_ID_099;
+      Device[deviceCount].Type       = DEVICE_TYPE_SPI;
+      Device[deviceCount].VType      = Sensor_VType::SENSOR_TYPE_TRIPLE;
+      Device[deviceCount].ValueCount = 3;
+      success                        = true;
       break;
     }
 
@@ -129,37 +123,37 @@ boolean Plugin_099(uint8_t function, struct EventStruct *event, String& string)
       addFormNumericBox(F("Screen Height (px) (y)"), F("pheight"), height_, 1, 65535);
 
       {
-        uint8_t choice2                        = P099_CONFIG_ROTATION;
-        const __FlashStringHelper *options2[4] = { F("Normal"), F("+90&deg;"), F("+180&deg;"), F("+270&deg;") }; // Avoid unicode
-        int optionValues2[4]                   = { 0, 1, 2, 3 };                                                 // Rotation similar to the
-                                                                                                                 // TFT ILI9341 rotation
-        addFormSelector(F("Rotation"), F("protate"), 4, options2, optionValues2, choice2);
+        const uint8_t choice2                 = P099_CONFIG_ROTATION;
+        const __FlashStringHelper *options2[] = { F("Normal"), F("+90&deg;"), F("+180&deg;"), F("+270&deg;") }; // Avoid unicode
+        const int optionValues2[]             = { 0, 1, 2, 3 };                                                 // Rotation similar to the
+                                                                                                                // TFT ILI9341 rotation
+        constexpr size_t optionCount = NR_ELEMENTS(optionValues2);
+        addFormSelector(F("Rotation"), F("protate"), optionCount, options2, optionValues2, choice2);
       }
 
-      bool bRotationFlipped = bitRead(P099_CONFIG_FLAGS, P099_FLAGS_ROTATION_FLIPPED);
+      const bool bRotationFlipped = bitRead(P099_CONFIG_FLAGS, P099_FLAGS_ROTATION_FLIPPED);
       addFormCheckBox(F("Flip rotation 180&deg;"), F("protation_flipped"), bRotationFlipped);
       addFormNote(F("Some touchscreens are mounted 180&deg; rotated on the display."));
 
       addFormSubHeader(F("Touch configuration"));
 
-      uint8_t treshold = P099_CONFIG_TRESHOLD;
-      addFormNumericBox(F("Touch minimum pressure"), F("ptreshold"), treshold, 0, 255);
+      addFormNumericBox(F("Touch minimum pressure"), F("ptreshold"), P099_CONFIG_TRESHOLD, 0, 255);
 
-      #define P099_EVENTS_OPTIONS 6
       uint8_t choice3 = 0;
       bitWrite(choice3, P099_FLAGS_SEND_XY,         bitRead(P099_CONFIG_FLAGS, P099_FLAGS_SEND_XY));
       bitWrite(choice3, P099_FLAGS_SEND_Z,          bitRead(P099_CONFIG_FLAGS, P099_FLAGS_SEND_Z));
       bitWrite(choice3, P099_FLAGS_SEND_OBJECTNAME, bitRead(P099_CONFIG_FLAGS, P099_FLAGS_SEND_OBJECTNAME));
       {
-        const __FlashStringHelper *options3[P099_EVENTS_OPTIONS] =
+        const __FlashStringHelper *options3[] =
         { F("None"),
           F("X and Y"),
           F("X, Y and Z"),
           F("Objectnames only"),
           F("Objectnames, X and Y"),
           F("Objectnames, X, Y and Z") };
-        int optionValues3[P099_EVENTS_OPTIONS] = { 0, 1, 3, 4, 5, 7 }; // Already used as a bitmap!
-        addFormSelector(F("Events"), F("pevents"), P099_EVENTS_OPTIONS, options3, optionValues3, choice3);
+        const int optionValues3[]    = { 0, 1, 3, 4, 5, 7 }; // Already used as a bitmap!
+        constexpr size_t optionCount = NR_ELEMENTS(optionValues3);
+        addFormSelector(F("Events"), F("pevents"), optionCount, options3, optionValues3, choice3);
       }
 
       if (!Settings.UseRules) {
@@ -176,7 +170,7 @@ boolean Plugin_099(uint8_t function, struct EventStruct *event, String& string)
 
         addFormSubHeader(F("Calibration"));
 
-        bool tbUseCalibration = bitRead(P099_CONFIG_FLAGS, P099_FLAGS_USE_CALIBRATION);
+        const bool tbUseCalibration = bitRead(P099_CONFIG_FLAGS, P099_FLAGS_USE_CALIBRATION);
         addFormSelector_YesNo(F("Calibrate to screen resolution"), F("puse_calibration"), tbUseCalibration ? 1 : 0, true);
 
         if (tbUseCalibration) {
@@ -205,7 +199,7 @@ boolean Plugin_099(uint8_t function, struct EventStruct *event, String& string)
           html_end_table();
           addFormNote(F("All x/y values must be <> 0 to enable calibration."));
         }
-        bool bEnableCalibrationLog = bitRead(P099_CONFIG_FLAGS, P099_FLAGS_LOG_CALIBRATION);
+        const bool bEnableCalibrationLog = bitRead(P099_CONFIG_FLAGS, P099_FLAGS_LOG_CALIBRATION);
         addFormCheckBox(F("Enable logging for calibration"), F("plog_calibration"), bEnableCalibrationLog);
 
         addFormSubHeader(F("Touch objects"));
@@ -217,11 +211,11 @@ boolean Plugin_099(uint8_t function, struct EventStruct *event, String& string)
           if (choice5 == 0) { // Uninitialized, so use default
             choice5 = P099_CONFIG_OBJECTCOUNT = P099_INIT_OBJECTCOUNT;
           }
-          #define P099_OBJECTCOUNT_OPTIONS 6
           {
-            const __FlashStringHelper *options5[P099_OBJECTCOUNT_OPTIONS] = { F("None"), F("8"), F("16"), F("24"), F("32"), F("40") };
-            int optionValues5[P099_OBJECTCOUNT_OPTIONS]                   = { -1, 8, 16, 24, 32, 40 };
-            addFormSelector(F("# of objects"), F("pobjectcount"), P099_OBJECTCOUNT_OPTIONS, options5, optionValues5, choice5, true);
+            const __FlashStringHelper *options5[] = { F("None"), F("8"), F("16"), F("24"), F("32"), F("40") };
+            const int optionValues5[]             = { -1, 8, 16, 24, 32, 40 };
+            constexpr size_t optionCount          = NR_ELEMENTS(optionValues5);
+            addFormSelector(F("# of objects"), F("pobjectcount"), optionCount, options5, optionValues5, choice5, true);
           }
         }
 
@@ -237,7 +231,7 @@ boolean Plugin_099(uint8_t function, struct EventStruct *event, String& string)
           html_table_header(F("On/Off button"),  150);
           html_table_header(F("Inverted"),       120);
 
-          for (int objectNr = 0; objectNr < P099_CONFIG_OBJECTCOUNT; objectNr++) {
+          for (int objectNr = 0; objectNr < P099_CONFIG_OBJECTCOUNT; ++objectNr) {
             html_TR_TD();
             addHtml(F("&nbsp;"));
             addHtmlInt(objectNr + 1);
@@ -264,7 +258,7 @@ boolean Plugin_099(uint8_t function, struct EventStruct *event, String& string)
           html_end_table();
           addFormNote(F("Start objectname with '_' to ignore/disable the object (temporarily)."));
 
-          uint8_t debounce = P099_CONFIG_DEBOUNCE_MS;
+          const uint8_t debounce = P099_CONFIG_DEBOUNCE_MS;
           addFormNumericBox(F("Debounce delay for On/Off buttons"), F("pdebounce"), debounce, 0, 255);
           addUnit(F("0-255 msec."));
         }
@@ -311,17 +305,14 @@ boolean Plugin_099(uint8_t function, struct EventStruct *event, String& string)
                           P099_MaxObjectNameLength)) {
           error += getCustomTaskSettingsError(objectNr);
         }
-        P099_data->StoredSettings.TouchObjects[objectNr].objectname[P099_MaxObjectNameLength - 1] = 0;                     // Terminate in
-                                                                                                                           // case of
-                                                                                                                           // uninitalized
-                                                                                                                           // data
+        P099_data->StoredSettings.TouchObjects[objectNr]
+        .objectname[P099_MaxObjectNameLength - 1] = 0;                            // Terminate in case of uninitalized data
 
-        if (!ExtraTaskSettings.checkInvalidCharInNames(&P099_data->StoredSettings.TouchObjects[objectNr].objectname[0])) { // Check for
-                                                                                                                           // invalid
-                                                                                                                           // characters in
-                                                                                                                           // objectname
-          error += concat(F("Invalid character in objectname #"), objectNr + 1);
-          error += F(". Do not use ',-+/*=^%!#[]{}()' or space.\n");
+        if (!ExtraTaskSettings.checkInvalidCharInNames(
+              &P099_data->StoredSettings.TouchObjects[objectNr].objectname[0])) { // Check for invalid characters in objectname
+          error += strformat(F("Invalid character in objectname #%d. "
+                               "Do not use ',-+/*=^%!#[]{}()' or space.\n"),
+                             objectNr + 1);
         }
         P099_data->StoredSettings.TouchObjects[objectNr].top_left.x     = getFormItemIntCustomArgName(objectNr + 100);
         P099_data->StoredSettings.TouchObjects[objectNr].top_left.y     = getFormItemIntCustomArgName(objectNr + 200);
@@ -404,7 +395,7 @@ boolean Plugin_099(uint8_t function, struct EventStruct *event, String& string)
       if (P099_data->isInitialized()) {
         if (P099_data->touched()) {
           uint16_t x, y, rx, ry;
-          uint8_t z;
+          uint8_t  z;
           P099_data->readData(&x, &y, &z);
 
           if (!((x >= P099_TOUCH_X_INVALID) || (y >= P099_TOUCH_Y_INVALID) || (z == P099_TOUCH_Z_INVALID) || (z <= P099_CONFIG_TRESHOLD))) {

--- a/src/_P099_XPT2046Touch.ino
+++ b/src/_P099_XPT2046Touch.ino
@@ -50,11 +50,11 @@ boolean Plugin_099(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number   = PLUGIN_ID_099;
-      Device[deviceCount].Type       = DEVICE_TYPE_SPI;
-      Device[deviceCount].VType      = Sensor_VType::SENSOR_TYPE_TRIPLE;
-      Device[deviceCount].ValueCount = 3;
-      success                        = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number     = PLUGIN_ID_099;
+      dev.Type       = DEVICE_TYPE_SPI;
+      dev.VType      = Sensor_VType::SENSOR_TYPE_TRIPLE;
+      dev.ValueCount = 3;
       break;
     }
 

--- a/src/_P100_DS2423_counter.ino
+++ b/src/_P100_DS2423_counter.ino
@@ -22,13 +22,14 @@ boolean Plugin_100(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_100;
-      Device[deviceCount].Type           = DEVICE_TYPE_SINGLE;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 1;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_100;
+      dev.Type           = DEVICE_TYPE_SINGLE;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 1;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
       break;
     }
 

--- a/src/_P100_DS2423_counter.ino
+++ b/src/_P100_DS2423_counter.ino
@@ -22,17 +22,13 @@ boolean Plugin_100(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_100;
-      Device[deviceCount].Type               = DEVICE_TYPE_SINGLE;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 1;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_100;
+      Device[deviceCount].Type           = DEVICE_TYPE_SINGLE;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 1;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
       break;
     }
 
@@ -65,9 +61,9 @@ boolean Plugin_100(uint8_t function, struct EventStruct *event, String& string)
         Dallas_addr_selector_webform_load(event->TaskIndex, Plugin_100_DallasPin, Plugin_100_DallasPin);
 
         // Counter select
-        const __FlashStringHelper * resultsOptions[2]      = { F("A"), F("B") };
-        int    resultsOptionValues[2] = { 0, 1 };
-        addFormSelector(F("Counter"), F("counter"), 2, resultsOptions, resultsOptionValues, PCONFIG(0));
+        const __FlashStringHelper *resultsOptions[] = { F("A"), F("B") };
+        constexpr size_t optionCount                = NR_ELEMENTS(resultsOptions);
+        addFormSelector(F("Counter"), F("counter"), optionCount, resultsOptions, nullptr, PCONFIG(0));
         addFormNote(F("Counter value is incremental"));
       }
       success = true;
@@ -142,7 +138,7 @@ boolean Plugin_100(uint8_t function, struct EventStruct *event, String& string)
             } else {
               log += F("Error!");
             }
-            log += concat(F(" (%s)"), Dallas_format_address(addr).c_str());
+            log += strformat(F(" (%s)"), Dallas_format_address(addr).c_str());
             addLogMove(LOG_LEVEL_INFO, log);
           }
         }
@@ -152,6 +148,5 @@ boolean Plugin_100(uint8_t function, struct EventStruct *event, String& string)
   }
   return success;
 }
-
 
 #endif // USES_P100

--- a/src/_P101_WakeOnLan.ino
+++ b/src/_P101_WakeOnLan.ino
@@ -113,9 +113,10 @@ boolean Plugin_101(uint8_t function, struct EventStruct *event, String& string)
 
   switch (function) {
     case PLUGIN_DEVICE_ADD: {
-      Device[++deviceCount].Number = PLUGIN_ID_101;
-      Device[deviceCount].Type     = DEVICE_TYPE_DUMMY;
-      Device[deviceCount].VType    = Sensor_VType::SENSOR_TYPE_NONE;
+      auto& dev = Device[++deviceCount];
+      dev.Number   = PLUGIN_ID_101;
+      dev.Type     = DEVICE_TYPE_DUMMY;
+      dev.VType    = Sensor_VType::SENSOR_TYPE_NONE;
       break;
     }
 

--- a/src/_P101_WakeOnLan.ino
+++ b/src/_P101_WakeOnLan.ino
@@ -113,16 +113,9 @@ boolean Plugin_101(uint8_t function, struct EventStruct *event, String& string)
 
   switch (function) {
     case PLUGIN_DEVICE_ADD: {
-      Device[++deviceCount].Number           = PLUGIN_ID_101;
-      Device[deviceCount].Type               = DEVICE_TYPE_DUMMY;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].ValueCount         = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].SendDataOption     = false;
-      Device[deviceCount].TimerOption        = false;
+      Device[++deviceCount].Number = PLUGIN_ID_101;
+      Device[deviceCount].Type     = DEVICE_TYPE_DUMMY;
+      Device[deviceCount].VType    = Sensor_VType::SENSOR_TYPE_NONE;
       break;
     }
 
@@ -167,7 +160,7 @@ boolean Plugin_101(uint8_t function, struct EventStruct *event, String& string)
       String errorStr;
 
       // Check Task Name.
-      uint8_t nameCode = safeName(event->TaskIndex);
+      const uint8_t nameCode = safeName(event->TaskIndex);
 
       if ((nameCode == NAME_MISSING) || (nameCode == NAME_UNSAFE)) {        // Check to see if user submitted safe device name.
         strcpy(ExtraTaskSettings.TaskDeviceName, PSTR(DEF_TASK_NAME_P101)); // Use default name.
@@ -237,7 +230,7 @@ boolean Plugin_101(uint8_t function, struct EventStruct *event, String& string)
     }
 
     case PLUGIN_READ: {
-      success = false;
+      // Do nothing on purpose
       break;
     }
 
@@ -362,11 +355,13 @@ bool validateIp(const String& ipStr) {
   if ((length < IP_MIN_SIZE_P101) || (length > IP_ADDR_SIZE_P101)) {
     return false;
   }
-  else if (ip.fromString(ipStr) == false) { // ThomasTech's Trick to Check IP for valid formatting.
-    return false;
-  }
 
-  return true;
+  // else if (ip.fromString(ipStr) == false) { // ThomasTech's Trick to Check IP for valid formatting.
+  //   return false;
+  // }
+
+  // return true;
+  return ip.fromString(ipStr); // Trick is nice, code not so readable :-)
 }
 
 // ************************************************************************************************
@@ -405,19 +400,9 @@ bool validateMac(const String& macStr) {
 // Arg: Port Number String (decimal).
 // Return true if Port string appears legit.
 bool validatePort(const String& portStr) {
-  bool pass = true;
-  long portNumber;
+  uint32_t portNumber{};
 
-  portNumber = portStr.toInt();
-
-  if ((portNumber < 0) || (portNumber > PORT_MAX_P101)) {
-    pass = false;
-  }
-  else if (!isDigit(portStr.charAt(0))) {
-    pass = false;
-  }
-
-  return pass;
+  return validUIntFromString(portStr, portNumber) && portNumber <= PORT_MAX_P101;
 }
 
 // ************************************************************************************************

--- a/src/_P102_PZEM004Tv3.ino
+++ b/src/_P102_PZEM004Tv3.ino
@@ -58,14 +58,15 @@ boolean                    Plugin_102(uint8_t function, struct EventStruct *even
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_102;
-      Device[deviceCount].Type           = DEVICE_TYPE_SERIAL;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 4;
-      Device[deviceCount].OutputDataType = Output_Data_type_t::Simple;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_102;
+      dev.Type           = DEVICE_TYPE_SERIAL;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 4;
+      dev.OutputDataType = Output_Data_type_t::Simple;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
       break;
     }
 

--- a/src/_P102_PZEM004Tv3.ino
+++ b/src/_P102_PZEM004Tv3.ino
@@ -58,18 +58,14 @@ boolean                    Plugin_102(uint8_t function, struct EventStruct *even
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_102;
-      Device[deviceCount].Type               = DEVICE_TYPE_SERIAL;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 4;
-      Device[deviceCount].OutputDataType     = Output_Data_type_t::Simple;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = false;
+      Device[++deviceCount].Number       = PLUGIN_ID_102;
+      Device[deviceCount].Type           = DEVICE_TYPE_SERIAL;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 4;
+      Device[deviceCount].OutputDataType = Output_Data_type_t::Simple;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
       break;
     }
 
@@ -147,21 +143,24 @@ boolean                    Plugin_102(uint8_t function, struct EventStruct *even
       if (P102_PZEM_FIRST == event->TaskIndex)                               // If first PZEM, serial config available
       {
         addHtml(F("<br><B>This PZEM is the first. Its configuration of serial Pins will affect next PZEM. </B>"));
-        addHtml(F(
-                  "<span style=\"color:red\"> <br><B>If several PZEMs foreseen, don't use HW serial (or invert Tx and Rx to configure as SW serial).</B></span>"));
+        addHtml(F("<span style=\"color:red\"> <br><B>If several PZEMs foreseen, "
+                  "don't use HW serial (or invert Tx and Rx to configure as SW serial).</B></span>"));
         addFormSubHeader(F("PZEM actions"));
         {
-          const __FlashStringHelper *options_model[3] = { F("Read_value"), F("Reset_Energy"), F("Program_adress") };
-          addFormSelector(F("PZEM Mode"), F("PZEM_mode"), 3, options_model, nullptr, P102_PZEM_mode);
+          const __FlashStringHelper *options_model[] = { F("Read_value"), F("Reset_Energy"), F("Program_adress") };
+          constexpr size_t optionCount               = NR_ELEMENTS(options_model);
+          addFormSelector(F("PZEM Mode"), F("PZEM_mode"), optionCount, options_model, nullptr, P102_PZEM_mode);
         }
 
         if (P102_PZEM_mode == 2)
         {
-          addHtml(F(
-                    "<span style=\"color:red\"> <br>When programming an address, only one PZEMv30 must be connected. Otherwise, all connected PZEMv30s will get the same address, which would cause a conflict during reading.</span>"));
+          addHtml(F("<span style=\"color:red\"> <br>When programming an address, only one PZEMv30 must be connected. "
+                    "Otherwise, all connected PZEMv30s will get the same address, which would cause a conflict during reading.</span>"));
           {
-            const __FlashStringHelper *options_confirm[2] = { F("NO"), F("YES") };
-            addFormSelector(F("Confirm address programming ?"), F("PZEM_addr_set"), 2, options_confirm, nullptr, P102_PZEM_ADDR_SET);
+            const __FlashStringHelper *options_confirm[] = { F("NO"), F("YES") };
+            constexpr size_t optionCount                 = NR_ELEMENTS(options_confirm);
+            addFormSelector(F("Confirm address programming ?"), F("PZEM_addr_set"), optionCount, options_confirm, nullptr,
+                            P102_PZEM_ADDR_SET);
           }
           addFormNumericBox(F("Address of PZEM"), F("PZEM_addr"), (P102_PZEM_ADDR < 1) ? 1 : P102_PZEM_ADDR, 1, 247);
           addHtml(F("Select the address to set PZEM. Programming address 0 is forbidden."));
@@ -182,8 +181,9 @@ boolean                    Plugin_102(uint8_t function, struct EventStruct *even
       {
         addFormSubHeader(F("PZEM actions"));
         {
-          const __FlashStringHelper *options_model[2] = { F("Read_value"), F("Reset_Energy") };
-          addFormSelector(F("PZEM Mode"), F("PZEM_mode"), 2, options_model, nullptr, P102_PZEM_mode);
+          const __FlashStringHelper *options_model[] = { F("Read_value"), F("Reset_Energy") };
+          constexpr size_t optionCount               = NR_ELEMENTS(options_model);
+          addFormSelector(F("PZEM Mode"), F("PZEM_mode"), optionCount, options_model, nullptr, P102_PZEM_mode);
         }
         addHtml(F(" Tx/Rx Pins config disabled: Configuration is available in the first PZEM plugin.<br>"));
         addFormNumericBox(F("Address of PZEM"), F("PZEM_addr"), P102_PZEM_ADDR, 1, 247);
@@ -223,8 +223,8 @@ boolean                    Plugin_102(uint8_t function, struct EventStruct *even
       // FIXME TD-er: This will fail if the set to be first taskindex is no longer enabled
       if (P102_PZEM_FIRST == event->TaskIndex) // If first PZEM, serial config available
       {
-        int rxPin                    = CONFIG_PIN1;
-        int txPin                    = CONFIG_PIN2;
+        const int rxPin              = CONFIG_PIN1;
+        const int txPin              = CONFIG_PIN2;
         const ESPEasySerialPort port = static_cast<ESPEasySerialPort>(CONFIG_PORT);
 
         if (P102_PZEM_sensor != nullptr) {
@@ -349,7 +349,7 @@ boolean                    Plugin_102(uint8_t function, struct EventStruct *even
     {
       if (Plugin_102_init)
       {
-        String command = parseString(string, 1);
+        const String command = parseString(string, 1);
 
         if ((equals(command, F("resetenergy"))) && (P102_PZEM_FIRST == event->TaskIndex))
         {

--- a/src/_P103_Atlas_EZO_pH_ORP_EC_DO.ino
+++ b/src/_P103_Atlas_EZO_pH_ORP_EC_DO.ino
@@ -72,13 +72,14 @@ boolean Plugin_103(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_103;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_DUAL;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 2;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_103;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_DUAL;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 2;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
       break;
     }
 

--- a/src/_P103_Atlas_EZO_pH_ORP_EC_DO.ino
+++ b/src/_P103_Atlas_EZO_pH_ORP_EC_DO.ino
@@ -51,14 +51,14 @@ boolean Plugin_103(uint8_t function, struct EventStruct *event, String& string)
 {
   boolean success = false;
 
-  AtlasEZO_Sensors_e board_type    = AtlasEZO_Sensors_e::UNKNOWN;
-  const uint8_t i2cAddressValues[] = { 0x63, 0x62, 0x64, 0x61, 0x6F
-                                       # if P103_USE_RTD
-                                       ,     0x66
-                                       # endif // if P103_USE_RTD
-                                       # if P103_USE_FLOW
-                                       ,     0x68
-                                       # endif // if P103_USE_FLOW
+  AtlasEZO_Sensors_e board_type         = AtlasEZO_Sensors_e::UNKNOWN;
+  constexpr uint8_t  i2cAddressValues[] = { 0x63, 0x62, 0x64, 0x61, 0x6F,
+                                            # if P103_USE_RTD
+                                            0x66,
+                                            # endif // if P103_USE_RTD
+                                            # if P103_USE_FLOW
+                                            0x68,
+                                            # endif // if P103_USE_FLOW
   };
   constexpr int i2c_nr_elements = NR_ELEMENTS(i2cAddressValues);
 
@@ -75,7 +75,6 @@ boolean Plugin_103(uint8_t function, struct EventStruct *event, String& string)
       Device[++deviceCount].Number       = PLUGIN_ID_103;
       Device[deviceCount].Type           = DEVICE_TYPE_I2C;
       Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_DUAL;
-      Device[deviceCount].Ports          = 0;
       Device[deviceCount].FormulaOption  = true;
       Device[deviceCount].ValueCount     = 2;
       Device[deviceCount].SendDataOption = true;
@@ -503,8 +502,8 @@ boolean Plugin_103(uint8_t function, struct EventStruct *event, String& string)
       if ((AtlasEZO_Sensors_e::PH == board_type) ||
           (AtlasEZO_Sensors_e::EC == board_type) ||
           (AtlasEZO_Sensors_e::DO == board_type)) {
-        char   deviceTemperatureTemplate[40]{};
-        String tmpString = webArg(F("_template"));
+        char deviceTemperatureTemplate[40]{};
+        const String tmpString = webArg(F("_template"));
         safe_strncpy(deviceTemperatureTemplate, tmpString.c_str(), sizeof(deviceTemperatureTemplate) - 1);
         ZERO_TERMINATE(deviceTemperatureTemplate); // be sure that our string ends with a \0
 
@@ -585,7 +584,7 @@ boolean Plugin_103(uint8_t function, struct EventStruct *event, String& string)
       UserVar.setFloat(event->TaskIndex, 0, -1);
 
       if (P103_send_I2C_command(P103_I2C_ADDRESS, readCommand, boarddata)) {
-        String sensorString(boarddata);
+        const String sensorString(boarddata);
         addLog(LOG_LEVEL_INFO, concat(F("P103: READ result: "), sensorString));
 
         float sensor_f{};
@@ -625,8 +624,8 @@ boolean Plugin_103(uint8_t function, struct EventStruct *event, String& string)
       UserVar.setFloat(event->TaskIndex, 1, -1);
 
       if (P103_send_I2C_command(P103_I2C_ADDRESS, F("Status"), boarddata)) {
-        String voltage(boarddata);
-        float  volt_f{};
+        const String voltage(boarddata);
+        float volt_f{};
         string2float(voltage.substring(voltage.lastIndexOf(',') + 1), volt_f);
         UserVar.setFloat(event->TaskIndex, 1, volt_f);
       }

--- a/src/_P104_max7219_Dotmatrix.ino
+++ b/src/_P104_max7219_Dotmatrix.ino
@@ -140,15 +140,6 @@ boolean Plugin_104(uint8_t function, struct EventStruct *event, String& string) 
       Device[++deviceCount].Number           = PLUGIN_ID_104;
       Device[deviceCount].Type               = DEVICE_TYPE_SPI;
       Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].ValueCount         = 0;
-      Device[deviceCount].SendDataOption     = false;
-      Device[deviceCount].TimerOption        = false;
-      Device[deviceCount].TimerOptional      = false;
-      Device[deviceCount].GlobalSyncOption   = true;
       Device[deviceCount].ExitTaskBeforeSave = false;
       break;
     }

--- a/src/_P104_max7219_Dotmatrix.ino
+++ b/src/_P104_max7219_Dotmatrix.ino
@@ -137,10 +137,11 @@ boolean Plugin_104(uint8_t function, struct EventStruct *event, String& string) 
 
   switch (function) {
     case PLUGIN_DEVICE_ADD: {
-      Device[++deviceCount].Number           = PLUGIN_ID_104;
-      Device[deviceCount].Type               = DEVICE_TYPE_SPI;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].ExitTaskBeforeSave = false;
+      auto& dev = Device[++deviceCount];
+      dev.Number             = PLUGIN_ID_104;
+      dev.Type               = DEVICE_TYPE_SPI;
+      dev.VType              = Sensor_VType::SENSOR_TYPE_NONE;
+      dev.ExitTaskBeforeSave = false;
       break;
     }
 

--- a/src/_P105_AHT.ino
+++ b/src/_P105_AHT.ino
@@ -56,14 +56,15 @@ boolean Plugin_105(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_105;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 2;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_105;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 2;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P105_AHT.ino
+++ b/src/_P105_AHT.ino
@@ -59,7 +59,6 @@ boolean Plugin_105(uint8_t function, struct EventStruct *event, String& string)
       Device[++deviceCount].Number       = PLUGIN_ID_105;
       Device[deviceCount].Type           = DEVICE_TYPE_I2C;
       Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
-      Device[deviceCount].Ports          = 0;
       Device[deviceCount].FormulaOption  = true;
       Device[deviceCount].ValueCount     = 2;
       Device[deviceCount].SendDataOption = true;
@@ -84,7 +83,7 @@ boolean Plugin_105(uint8_t function, struct EventStruct *event, String& string)
     case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      const uint8_t i2cAddressValues[2] = { 0x38, 0x39 };
+      const uint8_t i2cAddressValues[] = { 0x38, 0x39 };
 
       if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
         addFormSelectorI2C(F("i2c_addr"), 2, i2cAddressValues, PCONFIG(0));
@@ -129,6 +128,7 @@ boolean Plugin_105(uint8_t function, struct EventStruct *event, String& string)
                   )
               ) {
             hasOtherI2CDevices = true;
+            break;
           }
         }
 
@@ -143,7 +143,8 @@ boolean Plugin_105(uint8_t function, struct EventStruct *event, String& string)
         const int indices[]                  = { static_cast<int>(AHTx_device_type::AHT10_DEVICE),
                                                  static_cast<int>(AHTx_device_type::AHT20_DEVICE),
                                                  static_cast<int>(AHTx_device_type::AHT21_DEVICE) };
-        addFormSelector(F("Sensor model"), F("ahttype"), 3, options, indices, PCONFIG(1), true);
+        constexpr size_t optionCount = NR_ELEMENTS(indices);
+        addFormSelector(F("Sensor model"), F("ahttype"), optionCount, options, indices, PCONFIG(1), true);
         addFormNote(F("Changing Sensor model will reload the page."));
 
         if (static_cast<int>(AHTx_device_type::AHT10_DEVICE) == PCONFIG(1)) {

--- a/src/_P106_BME680.ino
+++ b/src/_P106_BME680.ino
@@ -44,18 +44,14 @@ boolean Plugin_106(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_106;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 4;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_106;
+      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 4;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].PluginStats    = true;
       break;
     }
 

--- a/src/_P106_BME680.ino
+++ b/src/_P106_BME680.ino
@@ -44,14 +44,15 @@ boolean Plugin_106(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_106;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 4;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_106;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 4;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P107_SI1145.ino
+++ b/src/_P107_SI1145.ino
@@ -22,18 +22,14 @@ boolean Plugin_107(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_107;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 3;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_107;
+      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 3;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].PluginStats    = true;
       break;
     }
 

--- a/src/_P107_SI1145.ino
+++ b/src/_P107_SI1145.ino
@@ -22,14 +22,15 @@ boolean Plugin_107(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_107;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 3;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_107;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 3;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P108_DDS238.ino
+++ b/src/_P108_DDS238.ino
@@ -37,19 +37,16 @@ boolean Plugin_108(uint8_t function, struct EventStruct *event, String& string) 
 
   switch (function) {
     case PLUGIN_DEVICE_ADD: {
-      Device[++deviceCount].Number           = PLUGIN_ID_108;
-      Device[deviceCount].Type               = DEVICE_TYPE_SERIAL_PLUS1; // connected through 3 datapins
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = P108_NR_OUTPUT_VALUES;
-      Device[deviceCount].OutputDataType     = Output_Data_type_t::Simple;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_108;
+      Device[deviceCount].Type           = DEVICE_TYPE_SERIAL_PLUS1; // connected through 3 datapins
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = P108_NR_OUTPUT_VALUES;
+      Device[deviceCount].OutputDataType = Output_Data_type_t::Simple;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].PluginStats    = true;
+      Device[deviceCount].setPin3Direction(gpio_direction::gpio_output);
       break;
     }
 
@@ -62,7 +59,7 @@ boolean Plugin_108(uint8_t function, struct EventStruct *event, String& string) 
       for (uint8_t i = 0; i < VARS_PER_TASK; ++i) {
         if (i < P108_NR_OUTPUT_VALUES) {
           const uint8_t pconfigIndex = i + P108_QUERY1_CONFIG_POS;
-          uint8_t choice             = PCONFIG(pconfigIndex);
+          const uint8_t choice       = PCONFIG(pconfigIndex);
           ExtraTaskSettings.setTaskDeviceValueName(i, Plugin_108_valuename(choice, false));
         } else {
           ExtraTaskSettings.clearTaskDeviceValueName(i);

--- a/src/_P108_DDS238.ino
+++ b/src/_P108_DDS238.ino
@@ -37,16 +37,17 @@ boolean Plugin_108(uint8_t function, struct EventStruct *event, String& string) 
 
   switch (function) {
     case PLUGIN_DEVICE_ADD: {
-      Device[++deviceCount].Number       = PLUGIN_ID_108;
-      Device[deviceCount].Type           = DEVICE_TYPE_SERIAL_PLUS1; // connected through 3 datapins
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = P108_NR_OUTPUT_VALUES;
-      Device[deviceCount].OutputDataType = Output_Data_type_t::Simple;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].PluginStats    = true;
-      Device[deviceCount].setPin3Direction(gpio_direction::gpio_output);
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_108;
+      dev.Type           = DEVICE_TYPE_SERIAL_PLUS1; // connected through 3 datapins
+      dev.VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = P108_NR_OUTPUT_VALUES;
+      dev.OutputDataType = Output_Data_type_t::Simple;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
+      dev.setPin3Direction(gpio_direction::gpio_output);
       break;
     }
 

--- a/src/_P109_ThermOLED.ino
+++ b/src/_P109_ThermOLED.ino
@@ -85,15 +85,13 @@ boolean Plugin_109(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number         = PLUGIN_ID_109;
-      Device[deviceCount].Type             = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType            = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].Ports            = 0;
-      Device[deviceCount].FormulaOption    = true;
-      Device[deviceCount].ValueCount       = 4;
-      Device[deviceCount].SendDataOption   = true;
-      Device[deviceCount].TimerOption      = true;
-      Device[deviceCount].GlobalSyncOption = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_109;
+      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 4;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
       break;
     }
 
@@ -138,16 +136,16 @@ boolean Plugin_109(uint8_t function, struct EventStruct *event, String& string)
     # ifndef LIMIT_BUILD_SIZE
     case PLUGIN_WEBFORM_SHOW_GPIO_DESCR:
     {
-      const char* separator = event->String1.c_str();
+      const char*separator = event->String1.c_str();
       string = strformat(
         F("Btn L: %s%sBtn R: %s%sBtn M: %s%sRelay: %s"),
-       formatGpioLabel(CONFIG_PIN1, false).c_str(),
-       separator,
-       formatGpioLabel(CONFIG_PIN2, false).c_str(),
-       separator,
-       formatGpioLabel(CONFIG_PIN3, false).c_str(),
-       separator,
-       formatGpioLabel(P109_CONFIG_RELAYPIN, false).c_str());
+        formatGpioLabel(CONFIG_PIN1,          false).c_str(),
+        separator,
+        formatGpioLabel(CONFIG_PIN2,          false).c_str(),
+        separator,
+        formatGpioLabel(CONFIG_PIN3,          false).c_str(),
+        separator,
+        formatGpioLabel(P109_CONFIG_RELAYPIN, false).c_str());
       success = true;
       break;
     }
@@ -181,7 +179,8 @@ boolean Plugin_109(uint8_t function, struct EventStruct *event, String& string)
       {
         const __FlashStringHelper *options4[] = { F("0.2"), F("0.5"), F("1") };
         const int optionValues4[]             = { 2, 5, 10 };
-        addFormSelector(F("Hysteresis"), F("hyst"), 3, options4, optionValues4, static_cast<int>(P109_CONFIG_HYSTERESIS * 10.0f));
+        constexpr size_t optionCount          = NR_ELEMENTS(optionValues4);
+        addFormSelector(F("Hysteresis"), F("hyst"), optionCount, options4, optionValues4, static_cast<int>(P109_CONFIG_HYSTERESIS * 10.0f));
       }
 
       {

--- a/src/_P109_ThermOLED.ino
+++ b/src/_P109_ThermOLED.ino
@@ -85,13 +85,14 @@ boolean Plugin_109(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_109;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 4;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_109;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 4;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
       break;
     }
 

--- a/src/_P110_VL53L0X.ino
+++ b/src/_P110_VL53L0X.ino
@@ -40,19 +40,15 @@ boolean Plugin_110(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_110;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 2;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].TimerOptional      = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      Device[++deviceCount].Number       = PLUGIN_ID_110;
+      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
+      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      Device[deviceCount].FormulaOption  = true;
+      Device[deviceCount].ValueCount     = 2;
+      Device[deviceCount].SendDataOption = true;
+      Device[deviceCount].TimerOption    = true;
+      Device[deviceCount].TimerOptional  = true;
+      Device[deviceCount].PluginStats    = true;
       break;
     }
 
@@ -97,20 +93,21 @@ boolean Plugin_110(uint8_t function, struct EventStruct *event, String& string)
     case PLUGIN_WEBFORM_LOAD:
     {
       {
-        const __FlashStringHelper *optionsMode2[3] = {
+        const __FlashStringHelper *optionsMode2[] = {
           F("Normal"),
           F("Fast"),
           F("Accurate") };
-        const int optionValuesMode2[3] = { 80, 20, 320 };
-        addFormSelector(F("Timing"), F("ptiming"), 3, optionsMode2, optionValuesMode2, P110_TIMING);
+        const int optionValuesMode2[] = { 80, 20, 320 };
+        constexpr size_t optionCount  = NR_ELEMENTS(optionValuesMode2);
+        addFormSelector(F("Timing"), F("ptiming"), optionCount, optionsMode2, optionValuesMode2, P110_TIMING);
       }
 
       {
-        const __FlashStringHelper *optionsMode3[2] = {
+        const __FlashStringHelper *optionsMode3[] = {
           F("Normal"),
           F("Long") };
-        const int optionValuesMode3[2] = { 0, 1 };
-        addFormSelector(F("Range"), F("prange"), 2, optionsMode3, optionValuesMode3, P110_RANGE);
+        constexpr size_t optionCount = NR_ELEMENTS(optionsMode3);
+        addFormSelector(F("Range"), F("prange"), optionCount, optionsMode3, nullptr, P110_RANGE);
       }
       addFormCheckBox(F("Send event when value unchanged"), F("notchanged"), P110_SEND_ALWAYS == 1);
       addFormNote(F("When checked, 'Trigger delta' setting is ignored!"));

--- a/src/_P110_VL53L0X.ino
+++ b/src/_P110_VL53L0X.ino
@@ -40,15 +40,16 @@ boolean Plugin_110(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_110;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 2;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].TimerOptional  = true;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_110;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 2;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.TimerOptional  = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P111_RC522_RFID.ino
+++ b/src/_P111_RC522_RFID.ino
@@ -73,24 +73,20 @@ boolean Plugin_111(uint8_t function, struct EventStruct *event, String& string)
       addFormSubHeader(F("Options"));
 
       {
-        # ifdef P111_USE_REMOVAL
-        #  define P111_removaltypes 3
-        # else // ifdef P111_USE_REMOVAL
-        #  define P111_removaltypes 2
-        # endif // ifdef P111_USE_REMOVAL
-        const __FlashStringHelper *removaltype[P111_removaltypes] = {
+        const __FlashStringHelper *removaltype[] = {
           F("None"),
           F("Autoremove after Time-out"),
           # ifdef P111_USE_REMOVAL
           F("Tag removal detection + Time-out")
           # endif // ifdef P111_USE_REMOVAL
         };
-        const int removalopts[P111_removaltypes] = { // A-typical order for logical order and backward compatibility
+        const int removalopts[] = { // A-typical order for logical order and backward compatibility
           1, 0,
           # ifdef P111_USE_REMOVAL
           2
           # endif // P111_USE_REMOVAL
         };
+        constexpr size_t P111_removaltypes = NR_ELEMENTS(removalopts);
         addFormSelector(F("Tag removal mode"), F("autotagremoval"), P111_removaltypes, removaltype, removalopts, P111_TAG_AUTOREMOVAL);
       }
 

--- a/src/_P111_RC522_RFID.ino
+++ b/src/_P111_RC522_RFID.ino
@@ -34,16 +34,12 @@ boolean Plugin_111(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_111;
-      Device[deviceCount].Type               = DEVICE_TYPE_SPI2;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_ULONG;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].ValueCount         = 1;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = false;
-      Device[deviceCount].GlobalSyncOption   = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_111;
+      dev.Type           = DEVICE_TYPE_SPI2;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_ULONG;
+      dev.ValueCount     = 1;
+      dev.SendDataOption = true;
       break;
     }
 
@@ -89,7 +85,7 @@ boolean Plugin_111(uint8_t function, struct EventStruct *event, String& string)
           F("Tag removal detection + Time-out")
           # endif // ifdef P111_USE_REMOVAL
         };
-        const int    removalopts[P111_removaltypes] = { // A-typical order for logical order and backward compatibility
+        const int removalopts[P111_removaltypes] = { // A-typical order for logical order and backward compatibility
           1, 0,
           # ifdef P111_USE_REMOVAL
           2

--- a/src/_P112_AS7265x.ino
+++ b/src/_P112_AS7265x.ino
@@ -32,20 +32,16 @@ boolean Plugin_112(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_112;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TRIPLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].ValueCount         = 3;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].DecimalsOnly       = true;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].OutputDataType     = Output_Data_type_t::All;
-      Device[deviceCount].PluginStats        = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_112;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_TRIPLE;
+      dev.ValueCount     = 3;
+      dev.DecimalsOnly   = true;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.OutputDataType = Output_Data_type_t::All;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P112_AS7265x.ino
+++ b/src/_P112_AS7265x.ino
@@ -116,7 +116,8 @@ boolean Plugin_112(uint8_t function, struct EventStruct *event, String& string)
           AS7265X_GAIN_16X,
           AS7265X_GAIN_64X,
         };
-        addFormSelector(F("Gain"), F("Gain"), 4, optionsMode, optionValuesMode, PCONFIG_LONG(0));
+        constexpr size_t optionCount = NR_ELEMENTS(optionValuesMode);
+        addFormSelector(F("Gain"), F("Gain"), optionCount, optionsMode, optionValuesMode, PCONFIG_LONG(0));
       }
       {
         // Integration cycles from 0 (2.78ms) to 255 (711ms)
@@ -138,7 +139,8 @@ boolean Plugin_112(uint8_t function, struct EventStruct *event, String& string)
           99,
           254,
         };
-        addFormSelector(F("Integration Time"), F("IntegrationTime"), 6, optionsMode2, optionValuesMode2, PCONFIG_LONG(1));
+        constexpr size_t optionCount = NR_ELEMENTS(optionValuesMode2);
+        addFormSelector(F("Integration Time"), F("IntegrationTime"), optionCount, optionsMode2, optionValuesMode2, PCONFIG_LONG(1));
       }
       # ifndef BUILD_NO_DEBUG
       addFormNote(F("Raw Readings shall not reach the upper limit of 65535 (Sensor Saturation)."));
@@ -164,7 +166,8 @@ boolean Plugin_112(uint8_t function, struct EventStruct *event, String& string)
           AS7265X_INDICATOR_CURRENT_LIMIT_4MA,
           AS7265X_INDICATOR_CURRENT_LIMIT_8MA,
         };
-        addFormSelector(EMPTY_STRING, PCONFIG_LABEL(1), 4, optionsMode3, optionValuesMode3, PCONFIG(1));
+        constexpr size_t optionCount = NR_ELEMENTS(optionValuesMode3);
+        addFormSelector(EMPTY_STRING, PCONFIG_LABEL(1), optionCount, optionsMode3, optionValuesMode3, PCONFIG(1));
       }
       addHtml(F(" Current Limit"));
       # ifndef BUILD_NO_DEBUG
@@ -189,7 +192,8 @@ boolean Plugin_112(uint8_t function, struct EventStruct *event, String& string)
           AS7265X_LED_CURRENT_LIMIT_50MA,
           AS7265X_LED_CURRENT_LIMIT_100MA,
         };
-        addFormSelector(F("White"), PCONFIG_LABEL(2), 4, optionsMode4, optionValuesMode4, PCONFIG(2));
+        constexpr size_t optionCount = NR_ELEMENTS(optionValuesMode4);
+        addFormSelector(F("White"), PCONFIG_LABEL(2), optionCount, optionsMode4, optionValuesMode4, PCONFIG(2));
       }
       addHtml(F(" Current Limit"));
 
@@ -209,7 +213,8 @@ boolean Plugin_112(uint8_t function, struct EventStruct *event, String& string)
           AS7265X_LED_CURRENT_LIMIT_25MA,
           AS7265X_LED_CURRENT_LIMIT_50MA,
         };
-        addFormSelector(F("IR"), PCONFIG_LABEL(3), 3, optionsMode5, optionValuesMode5, PCONFIG(3));
+        constexpr size_t optionCount = NR_ELEMENTS(optionValuesMode5);
+        addFormSelector(F("IR"), PCONFIG_LABEL(3), optionCount, optionsMode5, optionValuesMode5, PCONFIG(3));
       }
 
       {
@@ -220,7 +225,8 @@ boolean Plugin_112(uint8_t function, struct EventStruct *event, String& string)
         // sensor.setBulbCurrent(AS7265X_LED_CURRENT_LIMIT_100MA, AS7265x_LED_UV-bad); //Not allowed
         const __FlashStringHelper *optionsMode6[] = { F("12.5 mA (default)") };
         const int optionValuesMode6[]             = { AS7265X_LED_CURRENT_LIMIT_12_5MA };
-        addFormSelector(F("UV"), PCONFIG_LABEL(4), 1, optionsMode6, optionValuesMode6, PCONFIG(4));
+        constexpr size_t optionCount              = NR_ELEMENTS(optionValuesMode6);
+        addFormSelector(F("UV"), PCONFIG_LABEL(4), optionCount, optionsMode6, optionValuesMode6, PCONFIG(4));
       }
       addFormNote(F("Control Gain and Integration Time after any change to avoid Sensor Saturation!"));
 

--- a/src/_P113_VL53L1X.ino
+++ b/src/_P113_VL53L1X.ino
@@ -110,7 +110,8 @@ boolean Plugin_113(uint8_t function, struct EventStruct *event, String& string)
           F("500ms"),
         };
         const int optionValuesMode2[] = { 100, 20, 33, 50, 200, 500 };
-        addFormSelector(F("Timing"), F("timing"), 6, optionsMode2, optionValuesMode2, P113_TIMING);
+        constexpr size_t optionCount  = NR_ELEMENTS(optionValuesMode2);
+        addFormSelector(F("Timing"), F("timing"), optionCount, optionsMode2, optionValuesMode2, P113_TIMING);
       }
 
       {
@@ -119,7 +120,8 @@ boolean Plugin_113(uint8_t function, struct EventStruct *event, String& string)
           F("Long (~400cm)"),
         };
         const int optionValuesMode3[2] = { 0, 1 };
-        addFormSelector(F("Range"), F("range"), 2, optionsMode3, optionValuesMode3, P113_RANGE);
+        constexpr size_t optionCount = NR_ELEMENTS(optionValuesMode3);
+        addFormSelector(F("Range"), F("range"), optionCount, optionsMode3, optionValuesMode3, P113_RANGE);
       }
       addFormCheckBox(F("Send event when value unchanged"), F("notchanged"), P113_SEND_ALWAYS == 1);
       addFormNote(F("When checked, 'Trigger delta' setting is ignored!"));
@@ -180,9 +182,9 @@ boolean Plugin_113(uint8_t function, struct EventStruct *event, String& string)
       html_add_script(false);
       addHtml(F("document.addEventListener('DOMContentLoaded', p113_main);"));
       const __FlashStringHelper *_fmt = F("document.getElementById('%s').onchange=function(){p113_main.upDsp()};");
-      addHtml(strformat(_fmt, String(F("roix")).c_str()));
-      addHtml(strformat(_fmt, String(F("roiy")).c_str()));
-      addHtml(strformat(_fmt, String(F("optc")).c_str()));
+      addHtml(strformat(_fmt, FsP(F("roix"))));
+      addHtml(strformat(_fmt, FsP(F("roiy"))));
+      addHtml(strformat(_fmt, FsP(F("optc"))));
       html_add_script_end();
       # endif // if P113_USE_ROI
 
@@ -267,11 +269,11 @@ boolean Plugin_113(uint8_t function, struct EventStruct *event, String& string)
 
 # if P113_USE_ROI
 void P113_CheckMinMaxValues(struct EventStruct *event) {
-  if (0 == P113_ROI_X) { P113_ROI_X = 16; } // Default
+  if (0 == P113_ROI_X) { P113_ROI_X = 16; }                              // Default
 
-  if (0 == P113_ROI_Y) { P113_ROI_Y = 16; } // Default
+  if (0 == P113_ROI_Y) { P113_ROI_Y = 16; }                              // Default
 
-  if (0 == P113_OPT_CENTER) { P113_OPT_CENTER = 199; } // Optical Center @ Center of sensor. See matrix in documentation
+  if (0 == P113_OPT_CENTER) { P113_OPT_CENTER = 199; }                   // Optical Center @ Center of sensor. See matrix in documentation
 
   if ((P113_ROI_X > 10) || (P113_ROI_Y > 10)) { P113_OPT_CENTER = 199; } // Driver behavior
 }

--- a/src/_P113_VL53L1X.ino
+++ b/src/_P113_VL53L1X.ino
@@ -40,16 +40,16 @@ boolean Plugin_113(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_113;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].Ports          = 0;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 3;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].TimerOptional  = true;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_113;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 3;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.TimerOptional  = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P114_VEML6075.ino
+++ b/src/_P114_VEML6075.ino
@@ -27,18 +27,15 @@ boolean Plugin_114(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_114;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TRIPLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 3;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_114;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_TRIPLE;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 3;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P114_VEML6075.ino
+++ b/src/_P114_VEML6075.ino
@@ -93,7 +93,8 @@ boolean Plugin_114(uint8_t function, struct EventStruct *event, String& string)
           P114_IT_400,
           P114_IT_800,
         };
-        addFormSelector(F("Integration Time"), F("it"), 5, optionsMode2, optionValuesMode2, PCONFIG(1));
+        constexpr size_t optionCount = NR_ELEMENTS(optionValuesMode2);
+        addFormSelector(F("Integration Time"), F("it"), optionCount, optionsMode2, optionValuesMode2, PCONFIG(1));
       }
 
       {
@@ -101,7 +102,8 @@ boolean Plugin_114(uint8_t function, struct EventStruct *event, String& string)
           F("Normal Dynamic"),
           F("High Dynamic") }
         ;
-        addFormSelector(F("Dynamic Setting"), F("hd"), 2, optionsMode3, nullptr, PCONFIG(2));
+        constexpr size_t optionCount = NR_ELEMENTS(optionsMode3);
+        addFormSelector(F("Dynamic Setting"), F("hd"), optionCount, optionsMode3, nullptr, PCONFIG(2));
       }
 
       success = true;
@@ -133,9 +135,9 @@ boolean Plugin_114(uint8_t function, struct EventStruct *event, String& string)
         return success;
       }
 
-      float UVA     = 0.0f;
-      float UVB     = 0.0f;
-      float UVIndex = 0.0f;
+      float UVA{};
+      float UVB{};
+      float UVIndex{};
 
       if (P114_data->read_sensor(UVA, UVB, UVIndex)) {
         UserVar.setFloat(event->TaskIndex, 0, UVA);

--- a/src/_P115_MAX1704x_v2.ino
+++ b/src/_P115_MAX1704x_v2.ino
@@ -106,7 +106,8 @@ boolean Plugin_115(uint8_t function, struct EventStruct *event, String& string)
           MAX1704X_MAX17044,
           MAX1704X_MAX17048,
           MAX1704X_MAX17049 };
-        addFormSelector(F("Device"), F("device"), 4, options, optionValues, choice);
+        constexpr size_t optionCount = NR_ELEMENTS(optionValues);
+        addFormSelector(F("Device"), F("device"), optionCount, options, optionValues, choice);
       }
 
       addFormNumericBox(F("Alert threshold"), F("threshold"), P115_THRESHOLD, 1, 32);

--- a/src/_P115_MAX1704x_v2.ino
+++ b/src/_P115_MAX1704x_v2.ino
@@ -37,19 +37,16 @@ boolean Plugin_115(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_115;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;                  // how the device is connected
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TRIPLE; // type of value the plugin will return
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 4;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].DecimalsOnly       = true;
-      Device[deviceCount].PluginStats        = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_115;
+      dev.Type           = DEVICE_TYPE_I2C;                  // how the device is connected
+      dev.VType          = Sensor_VType::SENSOR_TYPE_TRIPLE; // type of value the plugin will return
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 4;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.DecimalsOnly   = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P116_ST77xx.ino
+++ b/src/_P116_ST77xx.ino
@@ -51,17 +51,13 @@ boolean Plugin_116(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_116;
-      Device[deviceCount].Type               = DEVICE_TYPE_SPI3;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].ValueCount         = 2;
-      Device[deviceCount].SendDataOption     = false;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].TimerOptional      = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number        = PLUGIN_ID_116;
+      dev.Type          = DEVICE_TYPE_SPI3;
+      dev.VType         = Sensor_VType::SENSOR_TYPE_NONE;
+      dev.ValueCount    = 2;
+      dev.TimerOption   = true;
+      dev.TimerOptional = true;
       break;
     }
 

--- a/src/_P117_SCD30.ino
+++ b/src/_P117_SCD30.ino
@@ -45,19 +45,16 @@ boolean Plugin_117(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_117;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 4;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
-      Device[deviceCount].I2CMax100kHz       = true; // Max 100 kHz allowed/supported
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_117;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 4;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
+      dev.I2CMax100kHz   = true; // Max 100 kHz allowed/supported
       break;
     }
 

--- a/src/_P117_SCD30.ino
+++ b/src/_P117_SCD30.ino
@@ -128,23 +128,15 @@ boolean Plugin_117(uint8_t function, struct EventStruct *event, String& string)
       P117_SENSOR_ALTITUDE    = alt;
       P117_TEMPERATURE_OFFSET = getFormItemFloat(F("tmp"));
       P117_AUTO_CALIBRATION   = isFormItemChecked(F("abc")) ? 1 : 0;
-      uint16_t interval = getFormItemInt(F("pinterval"));
-
-      if (interval < 2) { interval = 2; }
-
-      if (interval > 1800) { interval = 1800; }
-      P117_MEASURE_INTERVAL = interval;
+      const uint16_t interval = getFormItemInt(F("pinterval"));
+      P117_MEASURE_INTERVAL = constrain(interval, 2, 1800);
       success               = true;
       break;
     }
     case PLUGIN_INIT:
     {
-      uint16_t interval = P117_MEASURE_INTERVAL;
-
-      if (interval < 2) { interval = 2; }
-
-      if (interval > 1800) { interval = 1800; }
-      P117_MEASURE_INTERVAL = interval;
+      const uint16_t interval = P117_MEASURE_INTERVAL;
+      P117_MEASURE_INTERVAL = constrain(interval, 2, 1800);
       initPluginTaskData(event->TaskIndex,
                          new (std::nothrow) P117_data_struct(P117_SENSOR_ALTITUDE, P117_TEMPERATURE_OFFSET, P117_AUTO_CALIBRATION == 1,
                                                              P117_MEASURE_INTERVAL));
@@ -162,10 +154,10 @@ boolean Plugin_117(uint8_t function, struct EventStruct *event, String& string)
         return success;
       }
 
-      uint16_t scd30_CO2     = 0u;
-      uint16_t scd30_CO2EAvg = 0u;
-      float    scd30_Humid   = 0.0f;
-      float    scd30_Temp    = 0.0f;
+      uint16_t scd30_CO2{};
+      uint16_t scd30_CO2EAvg{};
+      float    scd30_Humid{};
+      float    scd30_Temp{};
 
       switch (P117_data->read_sensor(&scd30_CO2, &scd30_CO2EAvg, &scd30_Temp, &scd30_Humid))
       {
@@ -222,7 +214,7 @@ boolean Plugin_117(uint8_t function, struct EventStruct *event, String& string)
         log                  += concat(F("Calibration: "), event->Par1 == 1 ? F("auto") : F("manual"));
         success               = true;
       } else if (equals(command, F("scdsetfrc")) && (event->Par1 >= 400) && (event->Par1 <= 2000)) {
-        int res = P117_data->setForcedRecalibrationFactor(event->Par1);
+        const int res = P117_data->setForcedRecalibrationFactor(event->Par1);
         log    += strformat(F("SCD30 Forced calibration: %d, result: %d"), event->Par1, res);
         success = true;
       } else if (equals(command, F("scdgetinterval"))) {
@@ -230,7 +222,7 @@ boolean Plugin_117(uint8_t function, struct EventStruct *event, String& string)
         log    += concat(F("Interval: "), value);
         success = true;
       } else if (equals(command, F("scdsetinterval")) && (event->Par1 >= 2) && (event->Par1 <= 1800)) {
-        int res = P117_data->setMeasurementInterval(event->Par1);
+        const int res = P117_data->setMeasurementInterval(event->Par1);
         P117_MEASURE_INTERVAL = event->Par1; // Update device configuration
         log                  += strformat(F("SCD30 Measurement Interval: %d, result: %d"),
                                           event->Par1, res);

--- a/src/_P118_Itho.ino
+++ b/src/_P118_Itho.ino
@@ -124,18 +124,12 @@ boolean Plugin_118(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_118;
-      Device[deviceCount].Type               = DEVICE_TYPE_SPI2;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TRIPLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].ValueCount         = 3;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = false;
-      Device[deviceCount].TimerOptional      = true;
-      Device[deviceCount].GlobalSyncOption   = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_118;
+      dev.Type           = DEVICE_TYPE_SPI2;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_TRIPLE;
+      dev.ValueCount     = 3;
+      dev.SendDataOption = true;
       break;
     }
 

--- a/src/_P119_ITG3205_Gyro.ino
+++ b/src/_P119_ITG3205_Gyro.ino
@@ -122,8 +122,9 @@ boolean Plugin_119(uint8_t function, struct EventStruct *event, String& string)
       const __FlashStringHelper *frequencyOptions[] = {
         F("10"),
         F("50") };
-      const int frequencyValues[] = { P119_FREQUENCY_10, P119_FREQUENCY_50 };
-      addFormSelector(F("Measuring frequency"), F("frequency"), 2, frequencyOptions, frequencyValues, P119_FREQUENCY);
+      const int frequencyValues[]  = { P119_FREQUENCY_10, P119_FREQUENCY_50 };
+      constexpr size_t optionCount = NR_ELEMENTS(frequencyValues);
+      addFormSelector(F("Measuring frequency"), F("frequency"), optionCount, frequencyOptions, frequencyValues, P119_FREQUENCY);
       addUnit(F("Hz"));
 
       success = true;

--- a/src/_P119_ITG3205_Gyro.ino
+++ b/src/_P119_ITG3205_Gyro.ino
@@ -47,16 +47,16 @@ boolean Plugin_119(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_119;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_TRIPLE;
-      Device[deviceCount].Ports          = 0;
-      Device[deviceCount].ValueCount     = 3;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].TimerOptional  = true;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_119;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_TRIPLE;
+      dev.ValueCount     = 3;
+      dev.FormulaOption  = true;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.TimerOptional  = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P120_ADXL345_Accelerometer.ino
+++ b/src/_P120_ADXL345_Accelerometer.ino
@@ -40,17 +40,17 @@ boolean Plugin_120(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_120;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_TRIPLE;
-      Device[deviceCount].Ports          = 0;
-      Device[deviceCount].ValueCount     = 3;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].TimerOptional  = true;
-      Device[deviceCount].PluginStats    = true;
-      Device[deviceCount].OutputDataType = Output_Data_type_t::Simple;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_120;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_TRIPLE;
+      dev.ValueCount     = 3;
+      dev.FormulaOption  = true;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.TimerOptional  = true;
+      dev.PluginStats    = true;
+      dev.OutputDataType = Output_Data_type_t::Simple;
 
       break;
     }

--- a/src/_P121_HMC5883L.ino
+++ b/src/_P121_HMC5883L.ino
@@ -42,19 +42,16 @@ boolean Plugin_121(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_121;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 4;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
-      success                                = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_121;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 4;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
+      success            = true;
       break;
     }
 

--- a/src/_P121_HMC5883L.ino
+++ b/src/_P121_HMC5883L.ino
@@ -22,9 +22,6 @@
  */
 
 # include "src/PluginStructs/P121_data_struct.h"
-# include <Adafruit_Sensor.h>
-# include <Adafruit_HMC5883_U.h>
-# include <math.h>
 
 # define PLUGIN_121
 # define PLUGIN_ID_121          121

--- a/src/_P122_SHT2x.ino
+++ b/src/_P122_SHT2x.ino
@@ -125,8 +125,6 @@ boolean Plugin_122(uint8_t function, struct EventStruct *event, String& string)
       // The user's selection will be stored in
       // PCONFIG(x) (custom configuration)
 
-      # define P122_RESOLUTION_OPTIONS 4
-
       const __FlashStringHelper *options[] = {
         F("Temp 14 bits / RH 12 bits"),
         F("Temp 13 bits / RH 10 bits"),
@@ -139,7 +137,8 @@ boolean Plugin_122(uint8_t function, struct EventStruct *event, String& string)
         P122_RESOLUTION_12T_08RH,
         P122_RESOLUTION_11T_11RH,
       };
-      addFormSelector(F("Resolution"), P122_RESOLUTION_LABEL, P122_RESOLUTION_OPTIONS, options, optionValues, P122_RESOLUTION);
+      constexpr size_t optionCount = NR_ELEMENTS(optionValues);
+      addFormSelector(F("Resolution"), P122_RESOLUTION_LABEL, optionCount, options, optionValues, P122_RESOLUTION);
 
 # ifndef LIMIT_BUILD_SIZE
       P122_data_struct *P122_data = static_cast<P122_data_struct *>(getPluginTaskData(event->TaskIndex));
@@ -150,17 +149,18 @@ boolean Plugin_122(uint8_t function, struct EventStruct *event, String& string)
         uint32_t eidb;
         uint8_t  firmware;
         P122_data->getEID(eida, eidb, firmware);
-        String txt = F("CHIP ID:");
-        txt += formatToHex(eida);
-        txt += ',';
-        txt += formatToHex(eidb);
-        txt += F(" firmware=");
-        txt += String(firmware);
-#  ifdef PLUGIN_122_DEBUG
-        txt += F(" userReg= ");
-        txt += formatToHex(P122_data->getUserReg());
-#  endif // ifdef PLUGIN_122_DEBUG
-        addFormNote(txt);
+        addFormNote(strformat(F("CHIP ID:%s,%s firmware=%d"
+                              #  ifdef PLUGIN_122_DEBUG
+                                " userReg= %s"
+                              #  endif // ifdef PLUGIN_122_DEBUG
+                                ),
+                              formatToHex(eida).c_str(),
+                              formatToHex(eidb).c_str(),
+                              firmware
+                              #  ifdef PLUGIN_122_DEBUG
+                              , formatToHex(P122_data->getUserReg()).c_str()
+                              #  endif // ifdef PLUGIN_122_DEBUG
+                              ));
       }
 # endif // ifndef LIMIT_BUILD_SIZE
       success = true;

--- a/src/_P122_SHT2x.ino
+++ b/src/_P122_SHT2x.ino
@@ -51,21 +51,19 @@ boolean Plugin_122(uint8_t function, struct EventStruct *event, String& string)
     case PLUGIN_DEVICE_ADD:
     {
       // This case defines the device characteristics
-      Device[++deviceCount].Number           = PLUGIN_ID_122;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 2;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].I2CNoDeviceCheck   = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number           = PLUGIN_ID_122;
+      dev.Type             = DEVICE_TYPE_I2C;
+      dev.VType            = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
+      dev.FormulaOption    = true;
+      dev.ValueCount       = 2;
+      dev.SendDataOption   = true;
+      dev.TimerOption      = true;
+      dev.I2CNoDeviceCheck = true;
 
-      // Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats    = true;
-      Device[deviceCount].OutputDataType = Output_Data_type_t::Default;
+      // dev.GlobalSyncOption   = true;
+      dev.PluginStats    = true;
+      dev.OutputDataType = Output_Data_type_t::Default;
       break;
     }
 
@@ -251,4 +249,4 @@ boolean Plugin_122(uint8_t function, struct EventStruct *event, String& string)
   return success;
 }   // function
 
-#endif  //USES_P122
+#endif  // USES_P122

--- a/src/_P123_I2CTouch.ino
+++ b/src/_P123_I2CTouch.ino
@@ -71,19 +71,13 @@ boolean Plugin_123(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_123;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TRIPLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].ValueCount         = 3;
-      Device[deviceCount].SendDataOption     = false;
-      Device[deviceCount].TimerOption        = false;
-      Device[deviceCount].ExitTaskBeforeSave = false;
-      Device[deviceCount].I2CNoDeviceCheck   = true;
-      success                                = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number             = PLUGIN_ID_123;
+      dev.Type               = DEVICE_TYPE_I2C;
+      dev.VType              = Sensor_VType::SENSOR_TYPE_TRIPLE;
+      dev.ValueCount         = 3;
+      dev.ExitTaskBeforeSave = false;
+      dev.I2CNoDeviceCheck   = true;
       break;
     }
 

--- a/src/_P123_I2CTouch.ino
+++ b/src/_P123_I2CTouch.ino
@@ -200,9 +200,10 @@ boolean Plugin_123(uint8_t function, struct EventStruct *event, String& string)
             static_cast<int>(P123_TouchType_e::CHSC5816),
             static_cast<int>(P123_TouchType_e::Automatic),
           };
+          constexpr size_t optionCount = NR_ELEMENTS(touchTypeOptions);
           addFormSelector(F("Touchscreen type (address)"),
                           F("ttype"),
-                          NR_ELEMENTS(touchTypeOptions),
+                          optionCount,
                           touchTypes,
                           touchTypeOptions,
                           P123_GET_TOUCH_TYPE);

--- a/src/_P124_MultiRelay.ino
+++ b/src/_P124_MultiRelay.ino
@@ -110,7 +110,8 @@ boolean Plugin_124(uint8_t function, struct EventStruct *event, String& string)
         F("4"),
         F("8") };
       const int optionValuesMode2[] { 2, 4, 8 };
-      addFormSelector(F("Number of relays"), F("relays"), 3, optionsMode2, optionValuesMode2, P124_CONFIG_RELAY_COUNT, true);
+      constexpr size_t optionCount = NR_ELEMENTS(optionValuesMode2);
+      addFormSelector(F("Number of relays"), F("relays"), optionCount, optionsMode2, optionValuesMode2, P124_CONFIG_RELAY_COUNT, true);
 
       addFormSelector_YesNo(F("Initialize relays on startup"),
                             getPluginCustomArgName(P124_FLAGS_INIT_RELAYS),
@@ -123,7 +124,7 @@ boolean Plugin_124(uint8_t function, struct EventStruct *event, String& string)
         addFormNote(F("Disabled: Applied once per restart, Enabled: Applied on every plugin start, like on Submit of this page"));
 
         for (int i = 0; i < P124_CONFIG_RELAY_COUNT; ++i) {
-          const String label = strformat(F("Relay %d initial state (on/off)"), i + 1);
+          const String label = strformat(F("Relay %d %sstate (on/off)"), i + 1, FsP(F("initial ")));
           addFormCheckBox(label, getPluginCustomArgName(i), bitRead(P124_CONFIG_FLAGS, i));
         }
       }
@@ -134,7 +135,7 @@ boolean Plugin_124(uint8_t function, struct EventStruct *event, String& string)
 
       if (bitRead(P124_CONFIG_FLAGS, P124_FLAGS_EXIT_RELAYS)) {
         for (int i = 0; i < P124_CONFIG_RELAY_COUNT; ++i) {
-          const String label = strformat(F("Relay %d exit-state (on/off)"), i + 1);
+          const String label = strformat(F("Relay %d %sstate (on/off)"), i + 1, FsP(F("exit-")));
           addFormCheckBox(label, getPluginCustomArgName(i + P124_FLAGS_EXIT_OFFSET), bitRead(P124_CONFIG_FLAGS, i + P124_FLAGS_EXIT_OFFSET));
         }
         addFormNote(F("ATTENTION: These Relay states will be set when the task is enabled and the settings are saved!"));

--- a/src/_P124_MultiRelay.ino
+++ b/src/_P124_MultiRelay.ino
@@ -40,17 +40,15 @@ boolean Plugin_124(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_124;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 3;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].TimerOptional      = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_124;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 3;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.TimerOptional  = true;
 
       break;
     }

--- a/src/_P125_ADXL345_SPI.ino
+++ b/src/_P125_ADXL345_SPI.ino
@@ -38,17 +38,17 @@ boolean Plugin_125(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_125;
-      Device[deviceCount].Type           = DEVICE_TYPE_SPI;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_TRIPLE;
-      Device[deviceCount].Ports          = 0;
-      Device[deviceCount].ValueCount     = 3;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].TimerOptional  = true;
-      Device[deviceCount].PluginStats    = true;
-      Device[deviceCount].OutputDataType = Output_Data_type_t::Simple;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_125;
+      dev.Type           = DEVICE_TYPE_SPI;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_TRIPLE;
+      dev.ValueCount     = 3;
+      dev.FormulaOption  = true;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.TimerOptional  = true;
+      dev.PluginStats    = true;
+      dev.OutputDataType = Output_Data_type_t::Simple;
 
       break;
     }

--- a/src/_P126_74HC595.ino
+++ b/src/_P126_74HC595.ino
@@ -79,11 +79,11 @@ boolean Plugin_126(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number   = PLUGIN_ID_126;
-      Device[deviceCount].Type       = DEVICE_TYPE_TRIPLE;
-      Device[deviceCount].VType      = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].Ports      = 0;
-      Device[deviceCount].ValueCount =
+      auto& dev = Device[++deviceCount];
+      dev.Number     = PLUGIN_ID_126;
+      dev.Type       = DEVICE_TYPE_TRIPLE;
+      dev.VType      = Sensor_VType::SENSOR_TYPE_QUAD;
+      dev.ValueCount =
       # if P126_MAX_CHIP_COUNT <= 4
         1
       # elif P126_MAX_CHIP_COUNT <= 8
@@ -94,13 +94,13 @@ boolean Plugin_126(uint8_t function, struct EventStruct *event, String& string)
         4
       # endif // if P126_MAX_CHIP_COUNT <= 4
       ;
-      Device[deviceCount].SendDataOption   = true;
-      Device[deviceCount].TimerOption      = true;
-      Device[deviceCount].TimerOptional    = true;
-      Device[deviceCount].HasFormatUserVar = true;
-      Device[deviceCount].setPin1Direction(gpio_direction::gpio_output);
-      Device[deviceCount].setPin2Direction(gpio_direction::gpio_output);
-      Device[deviceCount].setPin3Direction(gpio_direction::gpio_output);
+      dev.SendDataOption   = true;
+      dev.TimerOption      = true;
+      dev.TimerOptional    = true;
+      dev.HasFormatUserVar = true;
+      dev.setPin1Direction(gpio_direction::gpio_output);
+      dev.setPin2Direction(gpio_direction::gpio_output);
+      dev.setPin3Direction(gpio_direction::gpio_output);
 
       break;
     }

--- a/src/_P126_74HC595.ino
+++ b/src/_P126_74HC595.ino
@@ -165,8 +165,9 @@ boolean Plugin_126(uint8_t function, struct EventStruct *event, String& string)
         F("Decimal &amp; hex/bin"),
         F("Decimal only"),
         F("Hex/bin only") };
-      const int outputValues[] = { P126_OUTPUT_BOTH, P126_OUTPUT_DEC_ONLY, P126_OUTPUT_HEXBIN };
-      addFormSelector(F("Output selection"), F("output"), 3, outputOptions, outputValues, P126_CONFIG_FLAGS_GET_OUTPUT_SELECTION);
+      const int outputValues[]     = { P126_OUTPUT_BOTH, P126_OUTPUT_DEC_ONLY, P126_OUTPUT_HEXBIN };
+      constexpr size_t optionCount = NR_ELEMENTS(outputValues);
+      addFormSelector(F("Output selection"), F("output"), optionCount, outputOptions, outputValues, P126_CONFIG_FLAGS_GET_OUTPUT_SELECTION);
 
       addFormCheckBox(F("Restore Values on warm boot"), F("valrestore"), P126_CONFIG_FLAGS_GET_VALUES_RESTORE);
 

--- a/src/_P127_CDM7160.ino
+++ b/src/_P127_CDM7160.ino
@@ -35,18 +35,16 @@ boolean Plugin_127(uint8_t function, struct EventStruct *event, String& string)
   switch (function) {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_127;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 1;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number           = PLUGIN_ID_127;
+      dev.Type             = DEVICE_TYPE_I2C;
+      dev.VType            = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.FormulaOption    = true;
+      dev.ValueCount       = 1;
+      dev.SendDataOption   = true;
+      dev.TimerOption      = true;
+      dev.GlobalSyncOption = true;
+      dev.PluginStats      = true;
       break;
     }
 
@@ -151,8 +149,8 @@ boolean Plugin_127(uint8_t function, struct EventStruct *event, String& string)
 
       if (loglevelActiveFor(LOG_LEVEL_INFO)) {
         addLogMove(LOG_LEVEL_INFO, strformat(F("CDM7160: Address: 0x%02x: CO2 ppm: %d, alt: %d, comp: %d"),
-                                             P127_CONFIG_I2C_ADDRESS, 
-                                             UserVar[event->BaseVarIndex], 
+                                             P127_CONFIG_I2C_ADDRESS,
+                                             UserVar[event->BaseVarIndex],
                                              P127_data->getAltitude(),
                                              P127_data->getCompensation()));
       }

--- a/src/_P128_NeoPixelBusFX.ino
+++ b/src/_P128_NeoPixelBusFX.ino
@@ -147,21 +147,21 @@ boolean Plugin_128(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number = PLUGIN_ID_128;
+      auto& dev = Device[++deviceCount];
+      dev.Number = PLUGIN_ID_128;
       # if defined(ESP32)
-      Device[deviceCount].Type = DEVICE_TYPE_SINGLE;
+      dev.Type = DEVICE_TYPE_SINGLE;
       # endif // if defined(ESP32)
       # if defined(ESP8266)
-      Device[deviceCount].Type = DEVICE_TYPE_DUMMY;
+      dev.Type = DEVICE_TYPE_DUMMY;
       # endif // if defined(ESP8266)
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].Custom         = true;
-      Device[deviceCount].Ports          = 0;
-      Device[deviceCount].ValueCount     = 4;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].TimerOptional  = true;
-      Device[deviceCount].setPin1Direction(gpio_direction::gpio_output);
+      dev.VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      dev.Custom         = true;
+      dev.ValueCount     = 4;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.TimerOptional  = true;
+      dev.setPin1Direction(gpio_direction::gpio_output);
       break;
     }
 

--- a/src/_P129_74HC165.ino
+++ b/src/_P129_74HC165.ino
@@ -62,11 +62,11 @@ boolean Plugin_129(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number   = PLUGIN_ID_129;
-      Device[deviceCount].Type       = DEVICE_TYPE_TRIPLE;
-      Device[deviceCount].VType      = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].Ports      = 0;
-      Device[deviceCount].ValueCount =
+      auto& dev = Device[++deviceCount];
+      dev.Number     = PLUGIN_ID_129;
+      dev.Type       = DEVICE_TYPE_TRIPLE;
+      dev.VType      = Sensor_VType::SENSOR_TYPE_QUAD;
+      dev.ValueCount =
       # if P129_MAX_CHIP_COUNT <= 4
         1
       # elif P129_MAX_CHIP_COUNT <= 8
@@ -77,12 +77,12 @@ boolean Plugin_129(uint8_t function, struct EventStruct *event, String& string)
         4
       # endif // if P129_MAX_CHIP_COUNT <= 4
       ;
-      Device[deviceCount].SendDataOption   = true; // No use in sending the Values to a controller
-      Device[deviceCount].TimerOption      = true; // Used to update the Devices page
-      Device[deviceCount].TimerOptional    = true;
-      Device[deviceCount].HasFormatUserVar = true;
-      Device[deviceCount].setPin2Direction(gpio_direction::gpio_output);
-      Device[deviceCount].setPin3Direction(gpio_direction::gpio_output);
+      dev.SendDataOption   = true; // No use in sending the Values to a controller
+      dev.TimerOption      = true; // Used to update the Devices page
+      dev.TimerOptional    = true;
+      dev.HasFormatUserVar = true;
+      dev.setPin2Direction(gpio_direction::gpio_output);
+      dev.setPin3Direction(gpio_direction::gpio_output);
 
       break;
     }

--- a/src/_P129_74HC165.ino
+++ b/src/_P129_74HC165.ino
@@ -178,8 +178,14 @@ boolean Plugin_129(uint8_t function, struct EventStruct *event, String& string)
       const __FlashStringHelper *frequencyOptions[] = {
         F("10/sec (100 msec)"),
         F("50/sec (20 msec)") };
-      const int frequencyValues[] = { P129_FREQUENCY_10, P129_FREQUENCY_50 };
-      addFormSelector(F("Sample frequency"), F("frequency"), 2, frequencyOptions, frequencyValues, P129_CONFIG_FLAGS_GET_READ_FREQUENCY);
+      const int frequencyValues[]  = { P129_FREQUENCY_10, P129_FREQUENCY_50 };
+      constexpr size_t optionCount = NR_ELEMENTS(frequencyValues);
+      addFormSelector(F("Sample frequency"),
+                      F("frequency"),
+                      optionCount,
+                      frequencyOptions,
+                      frequencyValues,
+                      P129_CONFIG_FLAGS_GET_READ_FREQUENCY);
 
       addFormSubHeader(F("Display and output"));
 
@@ -191,8 +197,10 @@ boolean Plugin_129(uint8_t function, struct EventStruct *event, String& string)
         F("Decimal &amp; hex/bin"),
         F("Decimal only"),
         F("Hex/bin only") };
-      const int outputValues[] = { P129_OUTPUT_BOTH, P129_OUTPUT_DEC_ONLY, P129_OUTPUT_HEXBIN };
-      addFormSelector(F("Output selection"), F("outputsel"), 3, outputOptions, outputValues, P129_CONFIG_FLAGS_GET_OUTPUT_SELECTION);
+      const int outputValues[]     = { P129_OUTPUT_BOTH, P129_OUTPUT_DEC_ONLY, P129_OUTPUT_HEXBIN };
+      constexpr size_t outputCount = NR_ELEMENTS(outputValues);
+      addFormSelector(F("Output selection"), F("outputsel"), outputCount, outputOptions, outputValues,
+                      P129_CONFIG_FLAGS_GET_OUTPUT_SELECTION);
 
       addFormCheckBox(F("Separate events per pin"), F("separate_events"), P129_CONFIG_FLAGS_GET_SEPARATE_EVENTS == 1);
 
@@ -292,13 +300,10 @@ boolean Plugin_129(uint8_t function, struct EventStruct *event, String& string)
         # ifndef P129_DEBUG_LOG
 
         if (loglevelActiveFor(LOG_LEVEL_INFO) && ((i % 4 == 3) || (i == P129_CONFIG_CHIP_COUNT))) {
-          String log = F("74HC165 Writing to: ");
-          log += (i / 4);
-          log += F(", offset: ");
-          log += (off * 8);
-          log += F(", bits: ");
-          log += P129_ul2stringFixed(bits, BIN);
-          addLog(LOG_LEVEL_INFO, log);
+          addLog(LOG_LEVEL_INFO, strformat(F("74HC165 Writing to: %d, offset: %d, bits: %s"),
+                                           i / 4,
+                                           off * 8,
+                                           P129_ul2stringFixed(bits, BIN).c_str()));
         }
         # endif // ifndef P129_DEBUG_LOG
         off++;

--- a/src/_P131_NeoPixelMatrix.ino
+++ b/src/_P131_NeoPixelMatrix.ino
@@ -42,14 +42,13 @@ boolean Plugin_131(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number      = PLUGIN_ID_131;
-      Device[deviceCount].Type          = DEVICE_TYPE_SINGLE;
-      Device[deviceCount].VType         = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].Ports         = 0;
-      Device[deviceCount].ValueCount    = 0;
-      Device[deviceCount].TimerOption   = true;
-      Device[deviceCount].TimerOptional = true;
-      Device[deviceCount].setPin1Direction(gpio_direction::gpio_output);
+      auto& dev = Device[++deviceCount];
+      dev.Number        = PLUGIN_ID_131;
+      dev.Type          = DEVICE_TYPE_SINGLE;
+      dev.VType         = Sensor_VType::SENSOR_TYPE_NONE;
+      dev.TimerOption   = true;
+      dev.TimerOptional = true;
+      dev.setPin1Direction(gpio_direction::gpio_output);
 
       break;
     }
@@ -271,7 +270,8 @@ boolean Plugin_131(uint8_t function, struct EventStruct *event, String& string)
 
           if ((P131_CONFIG_TILE_HEIGHT > 1) && (varNr == P131_CONFIG_TILE_HEIGHT - 1)) {
             html_TD();
-            addUnit(concat(F("Remaining: "), static_cast<int>(remain)));
+            addUnit(concat(F("Remaining: "),
+                           static_cast<int>(remain)));
           }
         }
         html_end_table();
@@ -378,8 +378,9 @@ boolean Plugin_131(uint8_t function, struct EventStruct *event, String& string)
                                                                                  P131_CONFIG_FLAG_GET_ROTATION,
                                                                                  P131_CONFIG_FLAG_GET_FONTSCALE,
                                                                                  static_cast<AdaGFXTextPrintMode>(P131_CONFIG_FLAG_GET_MODE),
-                                                                                 P131_CommandTrigger_toString(static_cast<P131_CommandTrigger>(
-                                                                                                                P131_CONFIG_FLAG_GET_CMD_TRIGGER)),
+                                                                                 P131_CommandTrigger_toString(
+                                                                                   static_cast<P131_CommandTrigger>(
+                                                                                     P131_CONFIG_FLAG_GET_CMD_TRIGGER)),
                                                                                  P131_CONFIG_FLAG_GET_BRIGHTNESS,
                                                                                  P131_CONFIG_FLAG_GET_MAXBRIGHT,
                                                                                  P131_CONFIG_GET_COLOR_FOREGROUND,

--- a/src/_P131_NeoPixelMatrix.ino
+++ b/src/_P131_NeoPixelMatrix.ino
@@ -350,7 +350,7 @@ boolean Plugin_131(uint8_t function, struct EventStruct *event, String& string)
 
       error += SaveCustomTaskSettings(event->TaskIndex, strings, P131_Nlines, 0);
 
-      if (error.length() > 0) {
+      if (!error.isEmpty()) {
         addHtmlError(error);
       }
 

--- a/src/_P132_INA3221.ino
+++ b/src/_P132_INA3221.ino
@@ -34,18 +34,15 @@ boolean Plugin_132(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_132;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 4;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_132;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 4;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P132_INA3221.ino
+++ b/src/_P132_INA3221.ino
@@ -100,7 +100,6 @@ boolean Plugin_132(uint8_t function, struct EventStruct *event, String& string)
 
     case PLUGIN_WEBFORM_LOAD:
     {
-      #define INA3221_var_OPTION 6
       {
         const __FlashStringHelper *varOptions[] = {
           F("Current channel 1"),
@@ -110,31 +109,31 @@ boolean Plugin_132(uint8_t function, struct EventStruct *event, String& string)
           F("Current channel 3"),
           F("Voltage channel 3")
         };
+        constexpr size_t optionCount = NR_ELEMENTS(varOptions);
 
         for (uint8_t r = 0; r < VARS_PER_TASK; ++r) {
           addFormSelector(concat(F("Power value "), r + 1),
-                          getPluginCustomArgName(r), INA3221_var_OPTION, varOptions, NULL, PCONFIG(P132_CONFIG_BASE + r));
+                          getPluginCustomArgName(r), optionCount, varOptions, NULL, PCONFIG(P132_CONFIG_BASE + r));
         }
       }
 
 
       addFormSubHeader(F("Hardware"));
 
-      #define INA3221_shunt_OPTION 3
       {
         const __FlashStringHelper *varshuntptions[] = {
           F("0.1 ohm"),
           F("0.01 ohm"),
           F("0.005 ohm"),
         };
-        const int shuntvalue[] = { 1, 10, 20 };
-        addFormSelector(F("Shunt resistor"), F("shunt"), INA3221_shunt_OPTION, varshuntptions, shuntvalue, P132_SHUNT);
+        const int shuntvalue[]       = { 1, 10, 20 };
+        constexpr size_t optionCount = NR_ELEMENTS(shuntvalue);
+        addFormSelector(F("Shunt resistor"), F("shunt"), optionCount, varshuntptions, shuntvalue, P132_SHUNT);
         addFormNote(F("Select as is installed on the board."));
       }
 
       addFormSubHeader(F("Measurement"));
 
-      #define INA3221_average_OPTION 8
       {
         const __FlashStringHelper *averagingSamples[] = {
           F("1 (default)"),
@@ -146,17 +145,17 @@ boolean Plugin_132(uint8_t function, struct EventStruct *event, String& string)
           F("512"),
           F("1024"),
         };
-        const int averageValue[] = { 0b000, 0b001, 0b010, 0b011, 0b100, 0b101, 0b110, 0b111 };
+        const int averageValue[]     = { 0b000, 0b001, 0b010, 0b011, 0b100, 0b101, 0b110, 0b111 };
+        constexpr size_t optionCount = NR_ELEMENTS(averageValue);
         addFormSelector(F("Averaging samples"),
                         F("average"),
-                        INA3221_average_OPTION,
+                        optionCount,
                         averagingSamples,
                         averageValue,
                         P132_GET_AVERAGE);
         addFormNote(F("Samples &gt; 16 then min. Interval: 64= 4, 128= 7, 256= 14, 512= 26, 1024= 52 seconds!"));
       }
 
-      #define INA3221_conversion_OPTION 8
       {
         const __FlashStringHelper *conversionRates[] = {
           F("140 &micro;sec"),
@@ -171,16 +170,17 @@ boolean Plugin_132(uint8_t function, struct EventStruct *event, String& string)
 
         //                               140us  204us  332us  588us  1.1ms  2.1ms  4.1ms  8.2ms
         const int conversionValues[] = { 0b000, 0b001, 0b010, 0b011, 0b100, 0b101, 0b110, 0b111 };
+        constexpr size_t optionCount = NR_ELEMENTS(conversionValues);
         addFormSelector(F("Conversion rate Voltage"),
                         F("conv_v"),
-                        INA3221_conversion_OPTION,
+                        optionCount,
                         conversionRates,
                         conversionValues,
                         P132_GET_CONVERSION_B);
 
         addFormSelector(F("Conversion rate Current"),
                         F("conv_c"),
-                        INA3221_conversion_OPTION,
+                        optionCount,
                         conversionRates,
                         conversionValues,
                         P132_GET_CONVERSION_S);
@@ -230,11 +230,9 @@ boolean Plugin_132(uint8_t function, struct EventStruct *event, String& string)
         return success;
       }
 
-      uint8_t reg;
-
       for (uint8_t r = 0; r < VARS_PER_TASK; ++r) {
         // VALUES 1..4
-        reg = static_cast<uint8_t>(PCONFIG(P132_CONFIG_BASE + r) + 1);
+        const uint8_t reg = static_cast<uint8_t>(PCONFIG(P132_CONFIG_BASE + r) + 1);
 
         if ((reg == 2) || (reg == 4) || (reg == 6)) {
           UserVar.setFloat(event->TaskIndex, r,

--- a/src/_P133_LTR390.ino
+++ b/src/_P133_LTR390.ino
@@ -96,7 +96,8 @@ boolean Plugin_133(uint8_t function, struct EventStruct *event, String& string)
           static_cast<int>(P133_selectMode_e::UVMode),
           static_cast<int>(P133_selectMode_e::ALSMode)
         };
-        addFormSelector(F("Read mode"), F("mode"), 3, selectModeOptions, selectModeValues, P133_SELECT_MODE, true);
+        constexpr size_t optionCount = NR_ELEMENTS(selectModeValues);
+        addFormSelector(F("Read mode"), F("mode"), optionCount, selectModeOptions, selectModeValues, P133_SELECT_MODE, true);
       }
 
       const __FlashStringHelper *gainOptions[] = { F("1x"), F("3x"), F("6x"), F("9x"), F("18x") };
@@ -107,6 +108,7 @@ boolean Plugin_133(uint8_t function, struct EventStruct *event, String& string)
         LTR390_GAIN_9,
         LTR390_GAIN_18
       };
+      constexpr size_t gainCount = NR_ELEMENTS(gainValues);
 
       const __FlashStringHelper *resolutionOptions[] = {
         F("20 bit"),
@@ -124,15 +126,16 @@ boolean Plugin_133(uint8_t function, struct EventStruct *event, String& string)
         LTR390_RESOLUTION_16BIT,
         LTR390_RESOLUTION_13BIT,
       };
+      constexpr size_t resolutionCount = NR_ELEMENTS(resolutionValues);
 
       if (static_cast<P133_selectMode_e>(P133_SELECT_MODE) != P133_selectMode_e::ALSMode) {
-        addFormSelector(F("UV Gain"),       F("uvgain"), 5, gainOptions,       gainValues,       P133_UVGAIN);
-        addFormSelector(F("UV Resolution"), F("uvres"),  6, resolutionOptions, resolutionValues, P133_UVRESOLUTION);
+        addFormSelector(F("UV Gain"),       F("uvgain"), gainCount,       gainOptions,       gainValues,       P133_UVGAIN);
+        addFormSelector(F("UV Resolution"), F("uvres"),  resolutionCount, resolutionOptions, resolutionValues, P133_UVRESOLUTION);
       }
 
       if (static_cast<P133_selectMode_e>(P133_SELECT_MODE) != P133_selectMode_e::UVMode) {
-        addFormSelector(F("Ambient Gain"),       F("alsgain"), 5, gainOptions,       gainValues,       P133_ALSGAIN);
-        addFormSelector(F("Ambient Resolution"), F("alsres"),  6, resolutionOptions, resolutionValues, P133_ALSRESOLUTION);
+        addFormSelector(F("Ambient Gain"),       F("alsgain"), gainCount,       gainOptions,       gainValues,       P133_ALSGAIN);
+        addFormSelector(F("Ambient Resolution"), F("alsres"),  resolutionCount, resolutionOptions, resolutionValues, P133_ALSRESOLUTION);
       }
 
       addFormCheckBox(F("Reset sensor on init"), F("initreset"), P133_INITRESET == 1);

--- a/src/_P133_LTR390.ino
+++ b/src/_P133_LTR390.ino
@@ -27,18 +27,15 @@ boolean Plugin_133(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_133;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 4;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_133;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 4;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P134_A02YYUW.ino
+++ b/src/_P134_A02YYUW.ino
@@ -28,17 +28,14 @@ boolean Plugin_134(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_134;
-      Device[deviceCount].Type               = DEVICE_TYPE_SERIAL;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 1;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_134;
+      dev.Type           = DEVICE_TYPE_SERIAL;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 1;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
 
       break;
     }

--- a/src/_P135_SCD4x.ino
+++ b/src/_P135_SCD4x.ino
@@ -42,19 +42,16 @@ boolean Plugin_135(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_135;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TRIPLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 3;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
-      Device[deviceCount].I2CMax100kHz       = true; // Max 100 kHz allowed/supported
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_135;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_TRIPLE;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 3;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
+      dev.I2CMax100kHz   = true; // Max 100 kHz allowed/supported
 
       break;
     }

--- a/src/_P135_SCD4x.ino
+++ b/src/_P135_SCD4x.ino
@@ -104,7 +104,8 @@ boolean Plugin_135(uint8_t function, struct EventStruct *event, String& string)
           static_cast<int>(scd4x_sensor_type_e::SCD4x_SENSOR_SCD40),
           static_cast<int>(scd4x_sensor_type_e::SCD4x_SENSOR_SCD41),
         };
-        addFormSelector(F("Sensor model"), F("ptype"), 2, sensorTypes, sensorTypeOptions, P135_SENSOR_TYPE, true);
+        constexpr size_t optionCount = NR_ELEMENTS(sensorTypeOptions);
+        addFormSelector(F("Sensor model"), F("ptype"), optionCount, sensorTypes, sensorTypeOptions, P135_SENSOR_TYPE, true);
         # ifndef LIMIT_BUILD_SIZE
         addFormNote(F("Page will reload on change."));
         # endif // ifndef LIMIT_BUILD_SIZE

--- a/src/_P137_AXP192.ino
+++ b/src/_P137_AXP192.ino
@@ -81,17 +81,18 @@ boolean Plugin_137(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_137;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].OutputDataType = Output_Data_type_t::Simple;
-      Device[deviceCount].PowerManager   = true; // So it can be started before SPI is initialized
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 4;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].TimerOptional  = true;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_137;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      dev.OutputDataType = Output_Data_type_t::Simple;
+      dev.PowerManager   = true; // So it can be started before SPI is initialized
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 4;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.TimerOptional  = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P137_AXP192.ino
+++ b/src/_P137_AXP192.ino
@@ -189,8 +189,9 @@ boolean Plugin_137(uint8_t function, struct EventStruct *event, String& string)
           static_cast<int>(P137_PredefinedDevices_e::M5Stack_Core2),
           static_cast<int>(P137_PredefinedDevices_e::LilyGO_TBeam),
           static_cast<int>(P137_PredefinedDevices_e::UserDefined) }; // keep last and at 99 !!
+        constexpr size_t optionCount = NR_ELEMENTS(predefinedValues);
         addFormSelector(F("Predefined device configuration"), F("predef"),
-                        sizeof(predefinedValues) / sizeof(int),
+                        optionCount,
                         predefinedNames, predefinedValues, 0, !Settings.isPowerManagerTask(event->TaskIndex));
 
         if (!Settings.isPowerManagerTask(event->TaskIndex)) {
@@ -265,11 +266,12 @@ boolean Plugin_137(uint8_t function, struct EventStruct *event, String& string)
           F("disabled"),
           F("disabled"),
         };
+        constexpr size_t optionCount = NR_ELEMENTS(bootStateValues);
 
         for (int i = 0; i < 5; ++i) { // GPIO0..4
           const String id = concat(F("pgpio"), i);
           addRowLabel(concat(F("Initial state GPIO"), i));
-          addSelector(id, sizeof(bootStateValues) / sizeof(int),
+          addSelector(id, optionCount,
                       bootStates, bootStateValues, bootStateAttributes,
                       get3BitFromUL(P137_CONFIG_FLAGS, i * 3),
                       false, !bitRead(P137_CONFIG_DISABLEBITS, i + 3), F("")
@@ -334,12 +336,13 @@ boolean Plugin_137(uint8_t function, struct EventStruct *event, String& string)
         static_cast<int>(P137_valueOptions_e::DCDC2),
         static_cast<int>(P137_valueOptions_e::DCDC3),
       };
+      constexpr size_t optionCount = NR_ELEMENTS(valValues);
 
       for (uint8_t i = 0; i < P137_NR_OUTPUT_VALUES; ++i) {
         sensorTypeHelper_loadOutputSelector(event,
                                             P137_CONFIG_BASE + i,
                                             i,
-                                            sizeof(valValues) / sizeof(int),
+                                            optionCount,
                                             valOptions,
                                             valValues);
       }

--- a/src/_P138_IP5306.ino
+++ b/src/_P138_IP5306.ino
@@ -144,12 +144,13 @@ boolean Plugin_138(uint8_t function, struct EventStruct *event, String& string)
           static_cast<int>(P138_valueOptions_e::ChargeLevel),
           static_cast<int>(P138_valueOptions_e::PowerSource),
         };
+        constexpr size_t optionCount = NR_ELEMENTS(valValues);
 
         for (uint8_t i = 0; i < P138_NR_OUTPUT_VALUES; i++) {
           sensorTypeHelper_loadOutputSelector(event,
                                               P138_CONFIG_BASE + i,
                                               i,
-                                              sizeof(valValues) / sizeof(int),
+                                              optionCount,
                                               valOptions,
                                               valValues);
         }

--- a/src/_P138_IP5306.ino
+++ b/src/_P138_IP5306.ino
@@ -48,16 +48,17 @@ boolean Plugin_138(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_138;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].OutputDataType = Output_Data_type_t::Simple;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 4;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].TimerOptional  = true;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_138;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      dev.OutputDataType = Output_Data_type_t::Simple;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 4;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.TimerOptional  = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P141_PCD8544_Nokia5110.ino
+++ b/src/_P141_PCD8544_Nokia5110.ino
@@ -43,19 +43,16 @@ boolean Plugin_141(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_141;
-      Device[deviceCount].Type               = DEVICE_TYPE_SPI3;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
+      auto& dev = Device[++deviceCount];
+      dev.Number = PLUGIN_ID_141;
+      dev.Type   = DEVICE_TYPE_SPI3;
+      dev.VType  = Sensor_VType::SENSOR_TYPE_NONE;
       # if P141_FEATURE_CURSOR_XY_VALUES
-      Device[deviceCount].ValueCount = 2;
+      dev.ValueCount = 2;
       # endif // if P141_FEATURE_CURSOR_XY_VALUES
-      Device[deviceCount].SendDataOption = false;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].TimerOptional  = true;
+      dev.SendDataOption = false;
+      dev.TimerOption    = true;
+      dev.TimerOptional  = true;
       break;
     }
 

--- a/src/_P141_PCD8544_Nokia5110.ino
+++ b/src/_P141_PCD8544_Nokia5110.ino
@@ -147,9 +147,10 @@ boolean Plugin_141(uint8_t function, struct EventStruct *event, String& string)
           static_cast<int>(P141_CommandTrigger::pcd8544),
           static_cast<int>(P141_CommandTrigger::lcd),
         };
+        constexpr size_t optionCount = NR_ELEMENTS(commandTriggerOptions);
         addFormSelector(F("Write Command trigger"),
                         F("pcmdtrigger"),
-                        NR_ELEMENTS(commandTriggerOptions),
+                        optionCount,
                         commandTriggers,
                         commandTriggerOptions,
                         P141_CONFIG_FLAG_GET_CMD_TRIGGER);
@@ -222,13 +223,12 @@ boolean Plugin_141(uint8_t function, struct EventStruct *event, String& string)
       P141_CONFIG_FLAGS = lSettings;
 
       String strings[P141_Nlines];
-      String error;
 
       for (uint8_t varNr = 0; varNr < P141_Nlines; ++varNr) {
         strings[varNr] = web_server.arg(getPluginCustomArgName(varNr));
       }
 
-      error = SaveCustomTaskSettings(event->TaskIndex, strings, P141_Nlines, 0);
+      const String error = SaveCustomTaskSettings(event->TaskIndex, strings, P141_Nlines, 0);
 
       if (!error.isEmpty()) {
         addHtmlError(error);

--- a/src/_P142_AS5600.ino
+++ b/src/_P142_AS5600.ino
@@ -172,9 +172,10 @@ boolean Plugin_142(uint8_t function, struct EventStruct *event, String& string)
           AS5600_MODE_DEGREES,
           AS5600_MODE_RADIANS,
         };
+        constexpr size_t optionCount = NR_ELEMENTS(configurationOptions);
         addFormSelector(F("Output range"),
                         F("range"),
-                        NR_ELEMENTS(configurationOptions),
+                        optionCount,
                         configurations,
                         configurationOptions,
                         P142_GET_OUTPUT_MODE);
@@ -210,9 +211,10 @@ boolean Plugin_142(uint8_t function, struct EventStruct *event, String& string)
           AS5600_POWERMODE_LOW2,
           AS5600_POWERMODE_LOW3,
         };
+        constexpr size_t optionCount = NR_ELEMENTS(configurationOptions);
         addFormSelector(F("Power mode"),
                         F("pow"),
-                        NR_ELEMENTS(configurationOptions),
+                        optionCount,
                         configurations,
                         configurationOptions,
                         P142_GET_POWER_MODE);
@@ -234,9 +236,10 @@ boolean Plugin_142(uint8_t function, struct EventStruct *event, String& string)
           AS5600_HYST_LSB2,
           AS5600_HYST_LSB3,
         };
+        constexpr size_t optionCount = NR_ELEMENTS(configurationOptions);
         addFormSelector(F("Hysteresis"),
                         F("hyst"),
-                        NR_ELEMENTS(configurationOptions),
+                        optionCount,
                         configurations,
                         configurationOptions,
                         P142_GET_HYSTERESIS);
@@ -254,9 +257,10 @@ boolean Plugin_142(uint8_t function, struct EventStruct *event, String& string)
           AS5600_SLOW_FILT_4X,
           AS5600_SLOW_FILT_2X,
         };
+        constexpr size_t optionCount = NR_ELEMENTS(configurationOptions);
         addFormSelector(F("Slow filter"),
                         F("sflt"),
-                        NR_ELEMENTS(configurationOptions),
+                        optionCount,
                         configurations,
                         configurationOptions,
                         P142_GET_SLOW_FILTER);
@@ -282,9 +286,10 @@ boolean Plugin_142(uint8_t function, struct EventStruct *event, String& string)
           AS5600_FAST_FILT_LSB24,
           AS5600_FAST_FILT_LSB10,
         };
+        constexpr size_t optionCount = NR_ELEMENTS(configurationOptions);
         addFormSelector(F("Fast filter"),
                         F("fflt"),
-                        NR_ELEMENTS(configurationOptions),
+                        optionCount,
                         configurations,
                         configurationOptions,
                         P142_GET_FAST_FILTER);

--- a/src/_P142_AS5600.ino
+++ b/src/_P142_AS5600.ino
@@ -44,18 +44,17 @@ boolean Plugin_142(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number         = PLUGIN_ID_142;
-      Device[deviceCount].Type             = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType            = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].Ports            = 0;
-      Device[deviceCount].OutputDataType   = Output_Data_type_t::Simple;
-      Device[deviceCount].FormulaOption    = true;
-      Device[deviceCount].ValueCount       = 4;
-      Device[deviceCount].SendDataOption   = true;
-      Device[deviceCount].TimerOption      = true;
-      Device[deviceCount].TimerOptional    = true;
-      Device[deviceCount].GlobalSyncOption = true;
-      Device[deviceCount].PluginStats      = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_142;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      dev.OutputDataType = Output_Data_type_t::Simple;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 4;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.TimerOptional  = true;
+      dev.PluginStats    = true;
 
       break;
     }

--- a/src/_P143_I2C_Rotary.ino
+++ b/src/_P143_I2C_Rotary.ino
@@ -48,18 +48,13 @@ boolean Plugin_143(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_143;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_DUAL;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 2;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = false;
-      Device[deviceCount].TimerOptional      = true;
-      Device[deviceCount].GlobalSyncOption   = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_143;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_DUAL;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 2;
+      dev.SendDataOption = true;
       break;
     }
 

--- a/src/_P143_I2C_Rotary.ino
+++ b/src/_P143_I2C_Rotary.ino
@@ -171,9 +171,10 @@ boolean Plugin_143(uint8_t function, struct EventStruct *event, String& string)
           static_cast<int>(P143_DeviceType_e::DFRobotEncoder)
           # endif // if P143_FEATURE_INCLUDE_DFROBOT
         };
+        constexpr size_t optionCount = NR_ELEMENTS(selectModeValues);
         addFormSelector(F("Encoder type"),
                         F("pdevice"),
-                        sizeof(selectModeValues) / sizeof(int),
+                        optionCount,
                         selectModeOptions,
                         selectModeValues,
                         P143_ENCODER_TYPE,
@@ -239,9 +240,10 @@ boolean Plugin_143(uint8_t function, struct EventStruct *event, String& string)
               static_cast<int>(P143_M5StackLed_e::Led1Only),
               static_cast<int>(P143_M5StackLed_e::Led2Only),
             };
+            constexpr size_t optionCount = NR_ELEMENTS(selectLedModeValues);
             addFormSelector(F("Color map Leds"),
                             F("pledsel"),
-                            sizeof(selectLedModeValues) / sizeof(int),
+                            optionCount,
                             selectLedModeOptions,
                             selectLedModeValues,
                             P143_M5STACK_SELECTION);
@@ -284,9 +286,10 @@ boolean Plugin_143(uint8_t function, struct EventStruct *event, String& string)
           static_cast<int>(P143_ButtonAction_e::PushButtonInverted),
           static_cast<int>(P143_ButtonAction_e::ToggleSwitch),
         };
+        constexpr size_t optionCount = NR_ELEMENTS(selectButtonValues);
         addFormSelector(F("Button action"),
                         F("pbutton"),
-                        sizeof(selectButtonValues) / sizeof(int),
+                        optionCount,
                         selectButtonOptions,
                         selectButtonValues,
                         P143_PLUGIN_BUTTON_ACTION);
@@ -326,9 +329,10 @@ boolean Plugin_143(uint8_t function, struct EventStruct *event, String& string)
             static_cast<int>(P143_CounterMapping_e::ColorMapping),
             static_cast<int>(P143_CounterMapping_e::ColorGradient),
           };
+          constexpr size_t optionCount = NR_ELEMENTS(selectCounterValues);
           addFormSelector(F("Counter color mapping"),
                           F("pmap"),
-                          sizeof(selectCounterValues) / sizeof(int),
+                          optionCount,
                           selectCounterOptions,
                           selectCounterValues,
                           P143_PLUGIN_COUNTER_MAPPING);

--- a/src/_P144_Vindriktning.ino
+++ b/src/_P144_Vindriktning.ino
@@ -1,31 +1,32 @@
-//#######################################################################################################
-//################################## Plugin 144: Dust Sensor Ikea Vindriktning ##########################
-//#######################################################################################################
-/*
-  Plugin is based upon various open sources on the internet. Plugin uses the serial lib to access a serial port
-  This plugin was written by flashmark
+// #######################################################################################################
+// ################################## Plugin 144: Dust Sensor Ikea Vindriktning ##########################
+// #######################################################################################################
 
-  This plugin reads the particle concentration from the PM1006 sensor in the Ikea Vindriktning
-  The original Ikea processor is controlling the PM1006 sensor, the plugin is eavesdropping the responses
-  DevicePin1 - RX on ESP, TX on PM1006
-  DevicePin2 - TX on ESP, RX on PM1006 (optional, currently not accessed by the plugin)
-  This plugin is intended to be extended with stand alone support for the PM1006 and PM1006K sensors
-  The stand alone support is not implemented yet
-*/
+/*
+   Plugin is based upon various open sources on the internet. Plugin uses the serial lib to access a serial port
+   This plugin was written by flashmark
+
+   This plugin reads the particle concentration from the PM1006 sensor in the Ikea Vindriktning
+   The original Ikea processor is controlling the PM1006 sensor, the plugin is eavesdropping the responses
+   DevicePin1 - RX on ESP, TX on PM1006
+   DevicePin2 - TX on ESP, RX on PM1006 (optional, currently not accessed by the plugin)
+   This plugin is intended to be extended with stand alone support for the PM1006 and PM1006K sensors
+   The stand alone support is not implemented yet
+ */
 
 // #include section
 #include "_Plugin_Helper.h"
 #ifdef USES_P144
-#include "src/PluginStructs/P144_data_struct.h"  // Sensor abstraction for P144
+# include "src/PluginStructs/P144_data_struct.h" // Sensor abstraction for P144
 
 // Standard plugin defines
-#define PLUGIN_144
-#define PLUGIN_ID_144     144                               // plugin id
-#define PLUGIN_NAME_144   "Dust - PM1006(K) (Vindriktning)" // "Plugin Name" is what will be dislpayed in the selection list
-#define PLUGIN_VALUENAME1_144 "PM2.5"                       // variable output of the plugin. The label is in quotation marks
+# define PLUGIN_144
+# define PLUGIN_ID_144     144                               // plugin id
+# define PLUGIN_NAME_144   "Dust - PM1006(K) (Vindriktning)" // "Plugin Name" is what will be dislpayed in the selection list
+# define PLUGIN_VALUENAME1_144 "PM2.5"                       // variable output of the plugin. The label is in quotation marks
 
 //   PIN/port configuration is stored in the following:
-//   CONFIG_PIN1 - Used by plugin_Helper_serial (RX pin) 
+//   CONFIG_PIN1 - Used by plugin_Helper_serial (RX pin)
 //   CONFIG_PIN2 - Used by plugin_Helper_serial (TX pin)
 //   CONFIG_PIN3 - Not used
 //   CONFIG_PORT - Used by the plugin_Helper_serial (serialType)
@@ -37,7 +38,7 @@
 //   N.B. these are aliases for a longer less readable amount of code. See _Plugin_Helper.h
 //
 //
-//   PCONFIG_LABEL(x) is a function to generate a unique label used as HTML id to be able to match 
+//   PCONFIG_LABEL(x) is a function to generate a unique label used as HTML id to be able to match
 //                    returned values when saving a configuration.
 
 
@@ -56,21 +57,15 @@ boolean Plugin_144(uint8_t function, struct EventStruct *event, String& string)
     {
       // This case defines the device characteristics
 
-      Device[++deviceCount].Number           = PLUGIN_ID_144;                    // Plugin ID number.   (PLUGIN_ID_xxx)
-      Device[deviceCount].Type               = DEVICE_TYPE_SERIAL;               // How the device is connected. e.g. DEVICE_TYPE_SINGLE => connected through 1 datapin
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SINGLE; // Type of value the plugin will return. e.g. SENSOR_TYPE_STRING
-      Device[deviceCount].Ports              = 0;                                // Port to use when device has multiple I/O pins  (N.B. not used much)
-      Device[deviceCount].ValueCount         = 1;                                // The number of output values of a plugin. The value should match the number of keys PLUGIN_VALUENAME1_xxx
-      Device[deviceCount].OutputDataType     = Output_Data_type_t::Default;      // Subset of selectable output data types  (Default = no selection)
-      Device[deviceCount].PullUpOption       = false;                            // Allow to set internal pull-up resistors.
-      Device[deviceCount].InverseLogicOption = false;                            // Allow to invert the boolean state (e.g. a switch)
-      Device[deviceCount].FormulaOption      = true;                             // Allow to enter a formula to convert values during read. (not possible with Custom enabled)
-      Device[deviceCount].Custom             = false;
-      Device[deviceCount].SendDataOption     = true;                             // Allow to send data to a controller.
-      Device[deviceCount].GlobalSyncOption   = true;                             // No longer used. Was used for ESPeasy values sync between nodes
-      Device[deviceCount].TimerOption        = true;                             // Allow to set the "Interval" timer for the plugin.
-      Device[deviceCount].TimerOptional      = false;                            // When taskdevice timer is not set and not optional, use default "Interval" delay (Settings.Delay)
-      Device[deviceCount].DecimalsOnly       = false;                            // Allow to set the number of decimals (otherwise treated a 0 decimals)
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_144;
+      dev.Type           = DEVICE_TYPE_SERIAL;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.ValueCount     = 1;
+      dev.OutputDataType = Output_Data_type_t::Default;
+      dev.FormulaOption  = true;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
       break;
     }
 
@@ -103,7 +98,7 @@ boolean Plugin_144(uint8_t function, struct EventStruct *event, String& string)
       success = true;
       break;
     }
-    
+
     case PLUGIN_SET_DEFAULTS:
     {
       // Set a default config here, which will be called when a plugin is assigned to a task.
@@ -136,7 +131,7 @@ boolean Plugin_144(uint8_t function, struct EventStruct *event, String& string)
       /// addFormNumericBox(string, F("description"), F("plugin_144_description"), PCONFIG(1), min - value, max - value);
 
       // after the form has been loaded, set success and break
-      //serialHelper_serialconfig_webformLoad(event, true);
+      // serialHelper_serialconfig_webformLoad(event, true);
       success = true;
       break;
     }
@@ -146,7 +141,7 @@ boolean Plugin_144(uint8_t function, struct EventStruct *event, String& string)
       // this case defines the code to be executed when the form is submitted
       // the plugin settings should be saved to PCONFIG(x)
       // ping configuration should be read from CONFIG_PIN1 and stored
-      //serialHelper_webformSave(event);
+      // serialHelper_webformSave(event);
 
       // after the form has been saved successfuly, set success and break
       success = true;
@@ -155,18 +150,18 @@ boolean Plugin_144(uint8_t function, struct EventStruct *event, String& string)
     case PLUGIN_INIT:
     {
       // this case defines code to be executed when the plugin is initialised
-      const int8_t rxPin = serialHelper_getRxPin(event);
-      const int8_t txPin = serialHelper_getTxPin(event);
-      const ESPEasySerialPort portType = serialHelper_getSerialType(event); 
+      const int8_t rxPin               = serialHelper_getRxPin(event);
+      const int8_t txPin               = serialHelper_getTxPin(event);
+      const ESPEasySerialPort portType = serialHelper_getSerialType(event);
 
       // Create the P144_data_struct object that will do all the sensor interaction
       initPluginTaskData(event->TaskIndex, new (std::nothrow) P144_data_struct());
       P144_data_struct *P144_data =
         static_cast<P144_data_struct *>(getPluginTaskData(event->TaskIndex));
 
-      if (P144_data != nullptr) 
+      if (P144_data != nullptr)
       {
-        success = P144_data->setSerial(portType, rxPin, txPin);    // Initialize with existing task data
+        success = P144_data->setSerial(portType, rxPin, txPin); // Initialize with existing task data
       }
       break;
     }
@@ -179,13 +174,14 @@ boolean Plugin_144(uint8_t function, struct EventStruct *event, String& string)
         static_cast<P144_data_struct *>(getPluginTaskData(event->TaskIndex));
 
       if (P144_data != nullptr) {
-        UserVar.setFloat(event->TaskIndex, 0, P144_data->getValue()); 
-        #ifdef PLUGIN_144_DEBUG
+        UserVar.setFloat(event->TaskIndex, 0, P144_data->getValue());
+        # ifdef PLUGIN_144_DEBUG
+
         if (loglevelActiveFor(LOG_LEVEL_INFO))
         {
           addLogMove(LOG_LEVEL_INFO, concat(F("P144 : READ "), UserVar[event->BaseVarIndex]));
         }
-        #endif
+        # endif // ifdef PLUGIN_144_DEBUG
       }
       success = true;
       break;
@@ -204,9 +200,10 @@ boolean Plugin_144(uint8_t function, struct EventStruct *event, String& string)
     case PLUGIN_EXIT:
     {
       // perform cleanup tasks here. For example, free memory
-      
+
       P144_data_struct *P144_data =
         static_cast<P144_data_struct *>(getPluginTaskData(event->TaskIndex));
+
       if (P144_data != nullptr) {
         P144_data->disconnectSerial();
       }
@@ -227,15 +224,15 @@ boolean Plugin_144(uint8_t function, struct EventStruct *event, String& string)
       // be careful on what is added here. Heavy processing will result in slowing the module down!
       P144_data_struct *P144_data =
         static_cast<P144_data_struct *>(getPluginTaskData(event->TaskIndex));
+
       if (P144_data != nullptr)
       {
         success = P144_data->processSensor();
       }
       break;
     }
-
   } // switch
   return success;
 }   // function
 
-#endif
+#endif // ifdef USES_P144

--- a/src/_P145_MQxxx.ino
+++ b/src/_P145_MQxxx.ino
@@ -1,7 +1,7 @@
-//#######################################################################################################
-//#################################### Plugin 145: MQ-xx ################################################
-//#################################### by flashmark      ################################################
-//#######################################################################################################
+// #######################################################################################################
+// #################################### Plugin 145: MQ-xx ################################################
+// #################################### by flashmark      ################################################
+// #######################################################################################################
 // Analog gas sensors based upon electro-chemical resistance changes like the cheap MQ-xxx series
 //
 // References:
@@ -11,11 +11,16 @@
 //   http://davidegironi.blogspot.com/2014/01/cheap-co2-meter-using-mq135-sensor-with.html
 //   https://hackaday.io/project/3475-sniffing-trinket/log/12363-mq135-arduino-library
 //
-//#################################### Change log        ###############################################
-// 2020-05-21 Refactored and extended by flashmark
-// 2022-07-11 Refactored, first attempt for calibration
-// 2023-01-06 Reworked after review
-//#################################### Description       ################################################
+// #################################### Change log        ###############################################
+
+/** Changelog:
+ * 2025-01-06 tonhuisman: Formatted source uing Uncrustify and small cleanups
+ * 2023-01-06 Reworked after review
+ * 2022-07-11 Refactored, first attempt for calibration
+ * 2020-05-21 Refactored and extended by flashmark
+ */
+
+// #################################### Description       ################################################
 // This plugin supports some gas sensors for which the resistance depends on a gas concentration (MQ-xxx)
 // Conversion depends on the sensor type. Main property is the logarithmic Rsensor/Rzero curve
 // It expects a measurement circuit measuring the voltage over a load resistance Rload using an analog in
@@ -34,7 +39,7 @@
 // Reference:Reference value expected when calibrating Rzero (configuration P145_PCONFIG_REF)
 // Rcal:     Computed Rzero as if the current measurement value is at Reference level
 //
-// Temperature/humidity  compensation is supported for some sensors. 
+// Temperature/humidity  compensation is supported for some sensors.
 // In these cases the value will be read from another task.
 // temperature: Read from task/value configured in P145_PCONFIG_TEMP_TASK/P145_PCONFIG_TEMP_VAL
 // humidity:    Read from task/value configured in P145_PCONFIG_HUM_TASK/P145_PCONFIG_HUM_VAL
@@ -47,16 +52,16 @@
 // Sensor resistance is logaritmic to the concentration of a gas. Sensors are not specific to a single
 // gas. Key is the ratio between the measured Rs and a reference resistor Rzero (Rs/Rzero).
 // For each specific gas a somewhat linear relation between gas concentration and the ratio (Rs/Rzero) is
-// shown on a log-log chart. Various algorithms are described in above mentioned literature. 
+// shown on a log-log chart. Various algorithms are described in above mentioned literature.
 // This plugin supports 3, almost similar, algorithms to make it easier to copy a parameter set from the
 // internet for a specific sensor/gas combination.
-// 
+//
 // Calibration algorithm:
 // Each measurement calculate Rcal assuming the concentration is at the reference level
-// Remember the lowest value of Rcal assuming it belongs to measuring the lowest concentration 
-//################################### Configuration data ###############################################
-// This plugin uses the following predefined static data storage 
-// P145_PCONFIG_RLOAD  PCONFIG_FLOAT(0)  RLOAD   [Ohm] 
+// Remember the lowest value of Rcal assuming it belongs to measuring the lowest concentration
+// ################################### Configuration data ###############################################
+// This plugin uses the following predefined static data storage
+// P145_PCONFIG_RLOAD  PCONFIG_FLOAT(0)  RLOAD   [Ohm]
 // P145_PCONFIG_RZERO  PCONFIG_FLOAT(1)  RZERO   [Ohm]
 // P145_PCONFIG_REF    PCONFIG_FLOAT(2)  REF. level [ppm]
 // P145_PCONFIG_FLAGS        PCONFIG(0)  Enable compensation & Enable Calibration & use low Vcc
@@ -65,51 +70,51 @@
 // P145_PCONFIG_HUM_TASK     PCONFIG(3)  Humidity compensation task
 // P145_PCONFIG_HUM_VAL      PCONFIG(4)  Humidity compensation value
 // P145_PCONFIG_SENSORT      PCONFIG(5)  Sensor type
-//#######################################################################################################
+// #######################################################################################################
 
 #include "_Plugin_Helper.h"
 #ifdef USES_P145
-#include "src/PluginStructs/P145_data_struct.h"  // MQ-xxx sensor specific data
+# include "src/PluginStructs/P145_data_struct.h"                    // MQ-xxx sensor specific data
 
-#define PLUGIN_145
-#define PLUGIN_ID_145     145           // plugin id
-#define PLUGIN_NAME_145   "Gases - MQxxx (MQ135 CO2, MQ3 Alcohol)" // "Plugin Name" is what will be displayed in the selection list
-#define PLUGIN_VALUENAME1_145 "level"   // variable output of the plugin. The label is in quotation marks
-#define PLUGIN_145_DEBUG  false         // set to true for extra log info in the debug
+# define PLUGIN_145
+# define PLUGIN_ID_145     145                                      // plugin id
+# define PLUGIN_NAME_145   "Gases - MQxxx (MQ135 CO2, MQ3 Alcohol)" // "Plugin Name" is what will be displayed in the selection list
+# define PLUGIN_VALUENAME1_145 "level"                              // variable output of the plugin. The label is in quotation marks
+# define PLUGIN_145_DEBUG  false                                    // set to true for extra log info in the debug
 
 // Static, per plugin instance, data stored in the generic ESPeasy structures see usage defined above
 // PCONFIG(n)    : stores an integer (8)
 // PCONFIG_FLOAT : stors a float (4)
 // PCONFIG_LONG  : stores a long (4, shared with PCONFIG_ULONG)
 // PCONFIG_ULONG : stores an unsigned long (4, shared with PCONFIG_LONG)
-#define P145_PCONFIG_RLOAD       PCONFIG_FLOAT(0)
-#define P145_PCONFIG_RZERO       PCONFIG_FLOAT(1)
-#define P145_PCONFIG_REF         PCONFIG_FLOAT(2)
-#define P145_PCONFIG_FLAGS       PCONFIG(0)
-#define P145_PCONFIG_TEMP_TASK   PCONFIG(1)
-#define P145_PCONFIG_TEMP_VAL    PCONFIG(2)
-#define P145_PCONFIG_HUM_TASK    PCONFIG(3)
-#define P145_PCONFIG_HUM_VAL     PCONFIG(4)
-#define P145_PCONFIG_SENSORT     PCONFIG(5)
+# define P145_PCONFIG_RLOAD       PCONFIG_FLOAT(0)
+# define P145_PCONFIG_RZERO       PCONFIG_FLOAT(1)
+# define P145_PCONFIG_REF         PCONFIG_FLOAT(2)
+# define P145_PCONFIG_FLAGS       PCONFIG(0)
+# define P145_PCONFIG_TEMP_TASK   PCONFIG(1)
+# define P145_PCONFIG_TEMP_VAL    PCONFIG(2)
+# define P145_PCONFIG_HUM_TASK    PCONFIG(3)
+# define P145_PCONFIG_HUM_VAL     PCONFIG(4)
+# define P145_PCONFIG_SENSORT     PCONFIG(5)
 
 // PIN/port configuration is stored in the following:
-#define P145_CONFIG_PIN_AIN      CONFIG_PIN1
-#define P145_CONFIG_PIN_HEATER   CONFIG_PIN2
+# define P145_CONFIG_PIN_AIN      CONFIG_PIN1
+# define P145_CONFIG_PIN_HEATER   CONFIG_PIN2
 
 // Form IDs used on the device setup page. Should be a short unique string.
-#define P145_GUID_TYPE       "f01"
-#define P145_GUID_RLOAD      "f02"
-#define P145_GUID_RZERO      "f03"
-#define P145_GUID_RREFLEVEL  "f04"
-#define P145_GUID_CAL        "f05"
-#define P145_GUID_COMP       "f06"
-#define P145_GUID_LOWVCC     "f07"
-#define P145_GUID_TEMP_T     "f08"
-#define P145_GUID_TEMP_V     "f09"
-#define P145_GUID_HUM_T      "f10"
-#define P145_GUID_HUM_V      "f11"
-#define P145_GUID_AINPIN     "f12"
-#define P145_GUID_HEATPIN    "f13"
+# define P145_GUID_TYPE       "f01"
+# define P145_GUID_RLOAD      "f02"
+# define P145_GUID_RZERO      "f03"
+# define P145_GUID_RREFLEVEL  "f04"
+# define P145_GUID_CAL        "f05"
+# define P145_GUID_COMP       "f06"
+# define P145_GUID_LOWVCC     "f07"
+# define P145_GUID_TEMP_T     "f08"
+# define P145_GUID_TEMP_V     "f09"
+# define P145_GUID_HUM_T      "f10"
+# define P145_GUID_HUM_V      "f11"
+# define P145_GUID_AINPIN     "f12"
+# define P145_GUID_HEATPIN    "f13"
 
 // A plugin has to implement the following function
 // ------------------------------------------------
@@ -122,20 +127,17 @@ boolean Plugin_145(byte function, struct EventStruct *event, String& string)
     // Make the plugin known with its options
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number = PLUGIN_ID_145;
-      Device[deviceCount].Type = DEVICE_TYPE_CUSTOM0;
-      Device[deviceCount].VType = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].Ports = 0;
-      Device[deviceCount].PullUpOption = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption = true;
-      Device[deviceCount].ValueCount = 1;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption = true;
-      Device[deviceCount].GlobalSyncOption = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_145;
+      dev.Type           = DEVICE_TYPE_CUSTOM0;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 1;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
       break;
     }
-    
+
     // Return the DEVICENAME for this plugin
     case PLUGIN_GET_DEVICENAME:
     {
@@ -153,12 +155,13 @@ boolean Plugin_145(byte function, struct EventStruct *event, String& string)
     // Add custom GPIO description on device overview page
     case PLUGIN_WEBFORM_SHOW_GPIO_DESCR:
     {
-      string  = F("AIN: ");
+      string = F("AIN: ");
 # ifdef ESP32
       string += formatGpioLabel(P145_CONFIG_PIN_AIN, false);
-#else
+# else // ifdef ESP32
       string += F("ADC (TOUT)");
-#endif
+# endif // ifdef ESP32
+
       if (validGpio(P145_CONFIG_PIN_HEATER))
       {
         string += F("<BR>HEAT: ");
@@ -172,32 +175,38 @@ boolean Plugin_145(byte function, struct EventStruct *event, String& string)
     case PLUGIN_WEBFORM_LOAD:
     {
       const bool compensate = P145_PCONFIG_FLAGS & 0x0001;        // Compensation enable flag
-      const bool calibrate = (P145_PCONFIG_FLAGS >> 1) & 0x0001;  // Calibration enable flag
-      const bool lowvcc = (P145_PCONFIG_FLAGS >> 2) & 0x0001;     // Low voltage power supply indicator
-      
+      const bool calibrate  = (P145_PCONFIG_FLAGS >> 1) & 0x0001; // Calibration enable flag
+      const bool lowvcc     = (P145_PCONFIG_FLAGS >> 2) & 0x0001; // Low voltage power supply indicator
+
       // FormSelector with all predefined "Sensor - Gas" options
       String options[P145_MAXTYPES] = {};
-      int x = P145_data_struct::getNbrOfTypes();
-      if (x > P145_MAXTYPES) 
+      int    x                      = P145_data_struct::getNbrOfTypes();
+
+      if (x > P145_MAXTYPES)
       {
-        x = P145_MAXTYPES;    // Clip to prevent array boundary out of range access
+        x = P145_MAXTYPES; // Clip to prevent array boundary out of range access
       }
-      for (int i=0; i<x; ++i)
+
+      for (int i = 0; i < x; ++i)
       {
         options[i] = concat(concat(P145_data_struct::getTypeName(i), F(" - ")), P145_data_struct::getGasName(i));
       }
       addFormSelector(F("Sensor type"), F(P145_GUID_TYPE), x, options, nullptr, P145_PCONFIG_SENSORT);
 
 # ifdef ESP32
+
       // Analog input selection
       addRowLabel(formatGpioName_input(F("Analog Pin ")));
-#if HAS_HALL_EFFECT_SENSOR
+#  if HAS_HALL_EFFECT_SENSOR
       addADC_PinSelect(AdcPinSelectPurpose::ADC_Touch_HallEffect, F(P145_GUID_AINPIN), P145_CONFIG_PIN_AIN);
-#else
-      addADC_PinSelect(AdcPinSelectPurpose::ADC_Touch, F(P145_GUID_AINPIN), P145_CONFIG_PIN_AIN);
-#endif
+#  else // if HAS_HALL_EFFECT_SENSOR
+      addADC_PinSelect(AdcPinSelectPurpose::ADC_Touch,            F(P145_GUID_AINPIN), P145_CONFIG_PIN_AIN);
+#  endif // if HAS_HALL_EFFECT_SENSOR
 # endif // ifdef ESP32
-      addFormPinSelect( PinSelectPurpose::Generic_output, formatGpioName_output_optional(F("Heater Pin ")), F(P145_GUID_HEATPIN), P145_CONFIG_PIN_HEATER);
+      addFormPinSelect(PinSelectPurpose::Generic_output,
+                       formatGpioName_output_optional(F("Heater Pin ")),
+                       F(P145_GUID_HEATPIN),
+                       P145_CONFIG_PIN_HEATER);
 
       addFormFloatNumberBox(F("Load Resistance"), F(P145_GUID_RLOAD), P145_PCONFIG_RLOAD, 0.0f, 10e6f, 2U);
       addUnit(F("Ohm"));
@@ -206,10 +215,12 @@ boolean Plugin_145(byte function, struct EventStruct *event, String& string)
       addFormFloatNumberBox(F("Reference Level"), F(P145_GUID_RREFLEVEL), P145_PCONFIG_REF, 0.0f, 10e6f, 2U);
       addUnit(F("ppm"));
       P145_data_struct *P145_data = static_cast<P145_data_struct *>(getPluginTaskData(event->TaskIndex));
+
       if (P145_data != nullptr)
       {
         float calVal = P145_data->getCalibrationValue();
-        if (definitelyGreaterThan(calVal, 0.0f)) 
+
+        if (definitelyGreaterThan(calVal, 0.0f))
         {
           addFormNote(concat(F("Current measurement suggests Rzero= "), calVal));
         }
@@ -217,26 +228,32 @@ boolean Plugin_145(byte function, struct EventStruct *event, String& string)
       addFormCheckBox(F("Low sensor supply voltage"), F(P145_GUID_LOWVCC), lowvcc);
 
       addFormSeparator(2);
+
       // Auto calibration and Temp/hum compensation flags are bitfields in P145_PCONFIG_FLAGS
       addFormCheckBox(F("Enable automatic calibration"), F(P145_GUID_CAL), calibrate);
       addFormSelector_YesNo(F("Enable temp/humid compensation"), F(P145_GUID_COMP), compensate, true);
+
       // Above selector will fore reloading the page and thus updating the compensate flag
       // Show the compensation details only when compensation is enabled
       if (compensate)
       {
         addFormNote(F("If compensation is enabled, the Temperature and Humidity values below need to be configured."));
+
         // temperature
         addRowLabel(F("Temperature"));
         addTaskSelect(F(P145_GUID_TEMP_T), P145_PCONFIG_TEMP_TASK);
+
         if (validTaskIndex(P145_PCONFIG_TEMP_TASK))
         {
           LoadTaskSettings(P145_PCONFIG_TEMP_TASK); // we need to load the values from another task for selection!
           addRowLabel(F("Temperature Value"));
           addTaskValueSelect(F(P145_GUID_TEMP_V), P145_PCONFIG_TEMP_VAL, P145_PCONFIG_TEMP_TASK);
         }
+
         // humidity
         addRowLabel(F("Humidity"));
         addTaskSelect(F(P145_GUID_HUM_T), P145_PCONFIG_HUM_TASK);
+
         if (validTaskIndex(P145_PCONFIG_HUM_TASK))
         {
           LoadTaskSettings(P145_PCONFIG_HUM_TASK); // we need to load the values from another task for selection!
@@ -253,27 +270,29 @@ boolean Plugin_145(byte function, struct EventStruct *event, String& string)
     // Save setting from web form for the task
     case PLUGIN_WEBFORM_SAVE:
     {
-      P145_PCONFIG_SENSORT   = getFormItemInt(F(P145_GUID_TYPE));
-      P145_PCONFIG_RLOAD     = getFormItemFloat(F(P145_GUID_RLOAD));
-      P145_PCONFIG_RZERO     = getFormItemFloat(F(P145_GUID_RZERO));
-      P145_PCONFIG_REF       = getFormItemFloat(F(P145_GUID_RREFLEVEL));
-      const bool compensate  = (getFormItemInt(F(P145_GUID_COMP)) == 1);
-      const bool calibrate   = isFormItemChecked(F(P145_GUID_CAL));
-      const bool lowvcc      = isFormItemChecked(F(P145_GUID_LOWVCC));
+      P145_PCONFIG_SENSORT = getFormItemInt(F(P145_GUID_TYPE));
+      P145_PCONFIG_RLOAD   = getFormItemFloat(F(P145_GUID_RLOAD));
+      P145_PCONFIG_RZERO   = getFormItemFloat(F(P145_GUID_RZERO));
+      P145_PCONFIG_REF     = getFormItemFloat(F(P145_GUID_RREFLEVEL));
+      const bool compensate = (getFormItemInt(F(P145_GUID_COMP)) == 1);
+      const bool calibrate  = isFormItemChecked(F(P145_GUID_CAL));
+      const bool lowvcc     = isFormItemChecked(F(P145_GUID_LOWVCC));
       P145_PCONFIG_FLAGS     = compensate + (calibrate << 1) + (lowvcc << 2);
       P145_PCONFIG_TEMP_TASK = getFormItemInt(F(P145_GUID_TEMP_T));
       P145_PCONFIG_TEMP_VAL  = getFormItemInt(F(P145_GUID_TEMP_V));
       P145_PCONFIG_HUM_TASK  = getFormItemInt(F(P145_GUID_HUM_T));
       P145_PCONFIG_HUM_VAL   = getFormItemInt(F(P145_GUID_HUM_V));
 # ifdef ESP32
-      P145_CONFIG_PIN_AIN    = getFormItemInt(F(P145_GUID_AINPIN));
-#endif
+      P145_CONFIG_PIN_AIN = getFormItemInt(F(P145_GUID_AINPIN));
+# endif // ifdef ESP32
       P145_CONFIG_PIN_HEATER = getFormItemInt(F(P145_GUID_HEATPIN));
 
       P145_data_struct *P145_data = static_cast<P145_data_struct *>(getPluginTaskData(event->TaskIndex));
+
       if (P145_data != nullptr)
       {
-        P145_data->setSensorData(P145_PCONFIG_SENSORT, compensate, calibrate, lowvcc, P145_PCONFIG_RLOAD, P145_PCONFIG_RZERO, P145_PCONFIG_REF);
+        P145_data->setSensorData(P145_PCONFIG_SENSORT, compensate, calibrate, lowvcc, P145_PCONFIG_RLOAD, P145_PCONFIG_RZERO,
+                                 P145_PCONFIG_REF);
         P145_data->setSensorPins(P145_CONFIG_PIN_AIN, P145_CONFIG_PIN_HEATER);
         P145_data->dump();
       }
@@ -285,14 +304,17 @@ boolean Plugin_145(byte function, struct EventStruct *event, String& string)
     case PLUGIN_INIT:
     {
       P145_data_struct *P145_data = static_cast<P145_data_struct *>(getPluginTaskData(event->TaskIndex));
+
       if (P145_data == nullptr)
       {
         P145_data = new (std::nothrow) P145_data_struct();
         initPluginTaskData(event->TaskIndex, P145_data);
+
         if (P145_data != nullptr)
         {
           P145_data->plugin_init();
-          P145_data->setSensorData(P145_PCONFIG_SENSORT, P145_PCONFIG_FLAGS & 0x0001, (P145_PCONFIG_FLAGS >> 1) & 0x0001, (P145_PCONFIG_FLAGS >> 2) & 0x0001, P145_PCONFIG_RLOAD, P145_PCONFIG_RZERO, P145_PCONFIG_REF);
+          P145_data->setSensorData(P145_PCONFIG_SENSORT, P145_PCONFIG_FLAGS & 0x0001, (P145_PCONFIG_FLAGS >> 1) & 0x0001,
+                                   (P145_PCONFIG_FLAGS >> 2) & 0x0001, P145_PCONFIG_RLOAD, P145_PCONFIG_RZERO, P145_PCONFIG_REF);
           P145_data->setSensorPins(P145_CONFIG_PIN_AIN, P145_CONFIG_PIN_HEATER);
           P145_data->dump();
         }
@@ -305,6 +327,7 @@ boolean Plugin_145(byte function, struct EventStruct *event, String& string)
     case PLUGIN_TEN_PER_SECOND:
     {
       P145_data_struct *P145_data = static_cast<P145_data_struct *>(getPluginTaskData(event->TaskIndex));
+
       if (P145_data != nullptr)
       {
         success = P145_data->plugin_ten_per_second();
@@ -316,16 +339,18 @@ boolean Plugin_145(byte function, struct EventStruct *event, String& string)
     case PLUGIN_READ:
     {
       P145_data_struct *P145_data = static_cast<P145_data_struct *>(getPluginTaskData(event->TaskIndex));
+
       if (P145_data != nullptr)
       {
-        float temperature = 20.0f;  // A reasonable value in case temperature source task is invalid
-        float humidity = 60.0f;     // A reasonable value in case humidity source task is invalid
+        float temperature     = 20.0f; // A reasonable value in case temperature source task is invalid
+        float humidity        = 60.0f; // A reasonable value in case humidity source task is invalid
         const bool compensate = P145_PCONFIG_FLAGS & 0x0001;
+
         if (compensate && validTaskIndex(P145_PCONFIG_TEMP_TASK) && validTaskIndex(P145_PCONFIG_HUM_TASK))
         {
           // we're checking a var from another task, so calculate that basevar
           temperature = UserVar.getFloat(P145_PCONFIG_TEMP_TASK, P145_PCONFIG_TEMP_VAL); // in degrees C
-          humidity = UserVar.getFloat(P145_PCONFIG_HUM_TASK, P145_PCONFIG_HUM_VAL);    // in % relative
+          humidity    = UserVar.getFloat(P145_PCONFIG_HUM_TASK, P145_PCONFIG_HUM_VAL);   // in % relative
         }
         UserVar.setFloat(event->TaskIndex, 0, P145_data->readValue(temperature, humidity));
         success = true;
@@ -337,19 +362,21 @@ boolean Plugin_145(byte function, struct EventStruct *event, String& string)
     case PLUGIN_ONCE_A_SECOND:
     {
       P145_data_struct *P145_data = static_cast<P145_data_struct *>(getPluginTaskData(event->TaskIndex));
+
       if (P145_data != nullptr)
       {
-        if ((P145_PCONFIG_FLAGS >> 1) & 0x0001)   // Calibration flag
+        if ((P145_PCONFIG_FLAGS >> 1) & 0x0001) // Calibration flag
         {
           // Update Rzero in case of autocalibration
           // TODO is there an event to signal the plugin code that the value has been updated to prevent polling?
-          P145_PCONFIG_RZERO = P145_data->getAutoCalibrationValue();    // Store autocalibration value 
+          P145_PCONFIG_RZERO = P145_data->getAutoCalibrationValue(); // Store autocalibration value
         }
-        P145_data->heaterControl();   // Execute heater control algorithm
+        P145_data->heaterControl();                                  // Execute heater control algorithm
       }
       break;
     }
   }
   return success;
-}  // function Plugin_145()
+} // function Plugin_145()
+
 #endif  // USES_P145

--- a/src/_P146_CacheControllerReader.ino
+++ b/src/_P146_CacheControllerReader.ino
@@ -220,7 +220,8 @@ boolean Plugin_146(uint8_t function, struct EventStruct *event, String& string)
           ',',
           ';'
         };
-        addFormSelector(F("Separator"), F("separator"), 3, separatorLabels, separatorOptions, P146_SEPARATOR_CHARACTER);
+        constexpr size_t optionCount = NR_ELEMENTS(separatorOptions);
+        addFormSelector(F("Separator"), F("separator"), optionCount, separatorLabels, separatorOptions, P146_SEPARATOR_CHARACTER);
       }
       addFormCheckBox(F("Join Samples with same Timestamp"), F("jointimestamp"), P146_GET_JOIN_TIMESTAMP);
       addFormCheckBox(F("Export only enabled tasks"),        F("onlysettasks"),  P146_GET_ONLY_SET_TASKS);
@@ -268,13 +269,12 @@ boolean Plugin_146(uint8_t function, struct EventStruct *event, String& string)
       P146_SEPARATOR_CHARACTER = getFormItemInt(F("separator"));
 
       String strings[P146_Nlines];
-      String error;
 
       for (uint8_t varNr = 0; varNr < P146_Nlines; varNr++) {
         strings[varNr] = webArg(getPluginCustomArgName(varNr));
       }
 
-      error = SaveCustomTaskSettings(event->TaskIndex, strings, P146_Nlines, 0);
+      const String error = SaveCustomTaskSettings(event->TaskIndex, strings, P146_Nlines, 0);
 
       if (!error.isEmpty()) {
         addHtmlError(error);

--- a/src/_P146_CacheControllerReader.ino
+++ b/src/_P146_CacheControllerReader.ino
@@ -41,20 +41,13 @@ boolean Plugin_146(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_146;
-      Device[deviceCount].Type               = DEVICE_TYPE_DUMMY;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_DUAL;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].DecimalsOnly       = false;
-      Device[deviceCount].ValueCount         = 2;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = false;
-      Device[deviceCount].TimerOptional      = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].OutputDataType     = Output_Data_type_t::Default;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_146;
+      dev.Type           = DEVICE_TYPE_DUMMY;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_DUAL;
+      dev.ValueCount     = 2;
+      dev.SendDataOption = true;
+      dev.OutputDataType = Output_Data_type_t::Default;
       break;
     }
 
@@ -136,7 +129,7 @@ boolean Plugin_146(uint8_t function, struct EventStruct *event, String& string)
 
             if (P146_GET_ERASE_BINFILES) {
               // Check whether we must delete the oldest file
-              if (P146_TASKVALUE_FILENR != 0 && P146_TASKVALUE_FILENR  < readFileNr) {
+              if ((P146_TASKVALUE_FILENR != 0) && (P146_TASKVALUE_FILENR  < readFileNr)) {
                 ControllerCache.deleteCacheBlock(P146_TASKVALUE_FILENR);
               }
             }
@@ -174,7 +167,8 @@ boolean Plugin_146(uint8_t function, struct EventStruct *event, String& string)
             if (P146_GET_ERASE_BINFILES) {
               // Check whether we must delete the oldest file
               const int filenr = P146_TASKVALUE_FILENR;
-              if (filenr != 0 && filenr  < readFileNr) {
+
+              if ((filenr != 0) && (filenr  < readFileNr)) {
                 ControllerCache.deleteCacheBlock(filenr);
               }
             }
@@ -229,7 +223,7 @@ boolean Plugin_146(uint8_t function, struct EventStruct *event, String& string)
         addFormSelector(F("Separator"), F("separator"), 3, separatorLabels, separatorOptions, P146_SEPARATOR_CHARACTER);
       }
       addFormCheckBox(F("Join Samples with same Timestamp"), F("jointimestamp"), P146_GET_JOIN_TIMESTAMP);
-      addFormCheckBox(F("Export only enabled tasks"),            F("onlysettasks"),  P146_GET_ONLY_SET_TASKS);
+      addFormCheckBox(F("Export only enabled tasks"),        F("onlysettasks"),  P146_GET_ONLY_SET_TASKS);
 
       addFormNote(F("Download button link only updated after saving"));
 

--- a/src/_P147_SGP4x.ino
+++ b/src/_P147_SGP4x.ino
@@ -118,7 +118,8 @@ boolean Plugin_147(uint8_t function, struct EventStruct *event, String& string)
           static_cast<int>(P147_sensor_e::SGP40),
           static_cast<int>(P147_sensor_e::SGP41),
         };
-        addFormSelector(F("Sensor model"), F("ptype"), 2, sensorTypes, sensorTypeOptions, P147_SENSOR_TYPE, true);
+        constexpr size_t optionCount = NR_ELEMENTS(sensorTypeOptions);
+        addFormSelector(F("Sensor model"), F("ptype"), optionCount, sensorTypes, sensorTypeOptions, P147_SENSOR_TYPE, true);
         # ifndef BUILD_NO_DEBUG
         addFormNote(F("Page will reload on change."));
         # endif // ifndef BUILD_NO_DEBUG
@@ -162,7 +163,7 @@ boolean Plugin_147(uint8_t function, struct EventStruct *event, String& string)
 
     case PLUGIN_WEBFORM_SAVE:
     {
-      int prevSensor = P147_SENSOR_TYPE;
+      const int prevSensor = P147_SENSOR_TYPE;
       P147_SENSOR_TYPE       = getFormItemInt(F("ptype"));
       P147_LOW_POWER_MEASURE = isFormItemChecked(F("plow")) ? 1 : 0;
       P147_SET_USE_COMPENSATION(getFormItemInt(F("comp")));

--- a/src/_P147_SGP4x.ino
+++ b/src/_P147_SGP4x.ino
@@ -50,18 +50,15 @@ boolean Plugin_147(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_147;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 2;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_147;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 2;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
 
       break;
     }

--- a/src/_P148_POWRxxD_THR3xxD.ino
+++ b/src/_P148_POWRxxD_THR3xxD.ino
@@ -39,18 +39,12 @@ boolean Plugin_148(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_148;
-      Device[deviceCount].Type               = DEVICE_TYPE_CUSTOM0;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = false;
-      Device[deviceCount].ValueCount         = 0;
-      Device[deviceCount].SendDataOption     = false;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].TimerOptional      = true;
-      Device[deviceCount].GlobalSyncOption   = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number        = PLUGIN_ID_148;
+      dev.Type          = DEVICE_TYPE_CUSTOM0;
+      dev.VType         = Sensor_VType::SENSOR_TYPE_NONE;
+      dev.TimerOption   = true;
+      dev.TimerOptional = true;
       break;
     }
 
@@ -147,9 +141,9 @@ boolean Plugin_148(uint8_t function, struct EventStruct *event, String& string)
       html_TR_TD();
 
       addHtml(F("<label class='nosave'>&nbsp;<input "));
-      addHtmlAttribute(F("type"), F("checkbox"));
-      addHtmlAttribute(F("id"),   F("nosave"));
-      addHtmlAttribute(F("name"), F("nosave"));
+      addHtmlAttribute(F("type"),  F("checkbox"));
+      addHtmlAttribute(F("id"),    F("nosave"));
+      addHtmlAttribute(F("name"),  F("nosave"));
       addHtmlAttribute(F("style"), F("display:none"));
       addHtml(F("><span class='checkmark'></span></label>"));
 

--- a/src/_P150_TMP117.ino
+++ b/src/_P150_TMP117.ino
@@ -134,7 +134,8 @@ boolean Plugin_150(uint8_t function, struct EventStruct *event, String& string)
           P150_AVERAGING_32_SAMPLES,
           P150_AVERAGING_64_SAMPLES,
         };
-        addFormSelector(F("Averaging"), F("avg"), 4, averagingCaptions, averagingOptions, P150_GET_CONF_AVERAGING);
+        constexpr size_t optionCount = NR_ELEMENTS(averagingOptions);
+        addFormSelector(F("Averaging"), F("avg"), optionCount, averagingCaptions, averagingOptions, P150_GET_CONF_AVERAGING);
       }
 
       {
@@ -146,7 +147,14 @@ boolean Plugin_150(uint8_t function, struct EventStruct *event, String& string)
           P150_CONVERSION_CONTINUOUS,
           P150_CONVERSION_ONE_SHOT,
         };
-        addFormSelector(F("Conversion mode"), F("conv"), 2, conversionCaptions, conversionOptions, P150_GET_CONF_CONVERSION_MODE, true);
+        constexpr size_t optionCount = NR_ELEMENTS(conversionOptions);
+        addFormSelector(F("Conversion mode"),
+                        F("conv"),
+                        optionCount,
+                        conversionCaptions,
+                        conversionOptions,
+                        P150_GET_CONF_CONVERSION_MODE,
+                        true);
         # ifndef BUILD_NO_DEBUG
         addFormNote(F("Changing this setting will save and reload this page."));
         # endif // ifndef BUILD_NO_DEBUG
@@ -173,7 +181,9 @@ boolean Plugin_150(uint8_t function, struct EventStruct *event, String& string)
           P150_CYCLE_8_SEC,
           P150_CYCLE_16_SEC,
         };
-        addFormSelector(F("Continuous conversion cycle time"), F("cycle"), 8, cycleCaptions, cycleOptions, P150_GET_CONF_CYCLE_BITS);
+        constexpr size_t optionCount = NR_ELEMENTS(cycleOptions);
+        addFormSelector(F("Continuous conversion cycle time"), F("cycle"), optionCount, cycleCaptions, cycleOptions,
+                        P150_GET_CONF_CYCLE_BITS);
       }
 
       addFormSubHeader(F("Output"));

--- a/src/_P150_TMP117.ino
+++ b/src/_P150_TMP117.ino
@@ -32,18 +32,15 @@ boolean Plugin_150(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_150;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_DUAL;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 2;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_150;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_DUAL;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 2;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
 
       break;
     }

--- a/src/_P151_Honeywell_pressure.ino
+++ b/src/_P151_Honeywell_pressure.ino
@@ -71,7 +71,7 @@ boolean Plugin_151(uint8_t function, struct EventStruct *event, String& string)
         0x88,
         0x98
       };
-      constexpr size_t addrCount = sizeof(i2cAddressValues) / sizeof(uint8_t);
+      constexpr size_t addrCount = NR_ELEMENTS(i2cAddressValues);
 
       if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS) {
         addFormSelectorI2C(F("pi2c"), addrCount, i2cAddressValues, P151_I2C_ADDR);

--- a/src/_P151_Honeywell_pressure.ino
+++ b/src/_P151_Honeywell_pressure.ino
@@ -22,19 +22,16 @@ boolean Plugin_151(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_151;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_DUAL;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 2;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].TimerOptional      = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;      
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_151;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_DUAL;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 2;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.TimerOptional  = true;
+      dev.PluginStats    = true;
       break;
     }
 
@@ -65,14 +62,14 @@ boolean Plugin_151(uint8_t function, struct EventStruct *event, String& string)
       // 136 (88 hex)
       // 152 (98 hex)
       const uint8_t i2cAddressValues[] = {
-        0x28 ,
-        0x38 ,
-        0x48 ,
-        0x58 ,
-        0x68 ,
-        0x78 ,
-        0x88 ,
-        0x98 
+        0x28,
+        0x38,
+        0x48,
+        0x58,
+        0x68,
+        0x78,
+        0x88,
+        0x98
       };
       constexpr size_t addrCount = sizeof(i2cAddressValues) / sizeof(uint8_t);
 
@@ -155,29 +152,30 @@ boolean Plugin_151(uint8_t function, struct EventStruct *event, String& string)
 
       break;
     }
-/*
-    case PLUGIN_TEN_PER_SECOND:
-    {
-      P151_data_struct *P151_data = static_cast<P151_data_struct *>(getPluginTaskData(event->TaskIndex));
 
-      if (nullptr != P151_data) {
-        success = P151_data->plugin_ten_per_second(event);
-      }
+      /*
+          case PLUGIN_TEN_PER_SECOND:
+          {
+            P151_data_struct *P151_data = static_cast<P151_data_struct *>(getPluginTaskData(event->TaskIndex));
 
-      break;
-    }
+            if (nullptr != P151_data) {
+              success = P151_data->plugin_ten_per_second(event);
+            }
 
-    case PLUGIN_FIFTY_PER_SECOND:
-    {
-      P151_data_struct *P151_data = static_cast<P151_data_struct *>(getPluginTaskData(event->TaskIndex));
+            break;
+          }
 
-      if (nullptr != P151_data) {
-        success = P151_data->plugin_fifty_per_second(event);
-      }
+          case PLUGIN_FIFTY_PER_SECOND:
+          {
+            P151_data_struct *P151_data = static_cast<P151_data_struct *>(getPluginTaskData(event->TaskIndex));
 
-      break;
-    }
-*/
+            if (nullptr != P151_data) {
+              success = P151_data->plugin_fifty_per_second(event);
+            }
+
+            break;
+          }
+       */
   }
   return success;
 }

--- a/src/_P152_DAC.ino
+++ b/src/_P152_DAC.ino
@@ -15,13 +15,13 @@
 
 #if defined(SOC_DAC_SUPPORTED) && SOC_DAC_SUPPORTED
 
-#define PLUGIN_152
-#define PLUGIN_ID_152         152
-#define PLUGIN_NAME_152       "Output - ESP32 DAC"
-#define PLUGIN_VALUENAME1_152 "Output"
+# define PLUGIN_152
+# define PLUGIN_ID_152         152
+# define PLUGIN_NAME_152       "Output - ESP32 DAC"
+# define PLUGIN_VALUENAME1_152 "Output"
 
-#define P152_DAC_VALUE        UserVar[event->BaseVarIndex]
-#define P152_SET_DAC_VALUE(x) UserVar.setFloat(event->TaskIndex, 0, x)
+# define P152_DAC_VALUE        UserVar[event->BaseVarIndex]
+# define P152_SET_DAC_VALUE(x) UserVar.setFloat(event->TaskIndex, 0, x)
 
 
 boolean Plugin_152(uint8_t function, struct EventStruct *event, String& string)
@@ -32,14 +32,13 @@ boolean Plugin_152(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_152;
-      Device[deviceCount].Type               = DEVICE_TYPE_SINGLE;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].Custom             = true;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 1;
+      auto& dev = Device[++deviceCount];
+      dev.Number        = PLUGIN_ID_152;
+      dev.Type          = DEVICE_TYPE_SINGLE;
+      dev.VType         = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.Custom        = true;
+      dev.FormulaOption = true;
+      dev.ValueCount    = 1;
       break;
     }
 
@@ -121,6 +120,6 @@ boolean Plugin_152(uint8_t function, struct EventStruct *event, String& string)
   return success;
 }
 
-#endif
+#endif // if defined(SOC_DAC_SUPPORTED) && SOC_DAC_SUPPORTED
 
 #endif // USES_P152

--- a/src/_P153_SHT4x.ino
+++ b/src/_P153_SHT4x.ino
@@ -146,9 +146,10 @@ boolean Plugin_153(uint8_t function, struct EventStruct *event, String& string)
           static_cast<int>(P153_configuration_e::HighResolution20mW1000msec),
           static_cast<int>(P153_configuration_e::HighResolution20mW100msec),
         };
+        constexpr size_t optionCount = NR_ELEMENTS(configurationOptions);
         addFormSelector(F("Startup Configuration"),
                         F("startup"),
-                        sizeof(configurationOptions) / sizeof(configurationOptions[0]),
+                        optionCount,
                         configurations,
                         configurationOptions,
                         P153_STARTUP_CONFIGURATION);

--- a/src/_P153_SHT4x.ino
+++ b/src/_P153_SHT4x.ino
@@ -54,18 +54,15 @@ boolean Plugin_153(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_153;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 2;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_153;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 2;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
 
       break;
     }

--- a/src/_P154_BMP3xx.ino
+++ b/src/_P154_BMP3xx.ino
@@ -21,18 +21,15 @@ boolean Plugin_154(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_154;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TEMP_BARO;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 2;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_154;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_TEMP_BARO;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 2;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P159_LD2410.ino
+++ b/src/_P159_LD2410.ino
@@ -77,18 +77,18 @@ boolean Plugin_159(uint8_t function, struct EventStruct *event, String& string)
     {
       // This case defines the device characteristics
 
-      Device[++deviceCount].Number           = PLUGIN_ID_159;
-      Device[deviceCount].Type               = DEVICE_TYPE_SERIAL;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].ValueCount         = 4;
-      Device[deviceCount].OutputDataType     = Output_Data_type_t::Simple;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].TimerOptional      = true;
-      Device[deviceCount].PluginStats        = true;
-      Device[deviceCount].ExitTaskBeforeSave = false; // Enable calling PLUGIN_WEBFORM_SAVE on the instantiated object
+      auto& dev = Device[++deviceCount];
+      dev.Number             = PLUGIN_ID_159;
+      dev.Type               = DEVICE_TYPE_SERIAL;
+      dev.VType              = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.ValueCount         = 4;
+      dev.OutputDataType     = Output_Data_type_t::Simple;
+      dev.FormulaOption      = true;
+      dev.SendDataOption     = true;
+      dev.TimerOption        = true;
+      dev.TimerOptional      = true;
+      dev.PluginStats        = true;
+      dev.ExitTaskBeforeSave = false; // Enable calling PLUGIN_WEBFORM_SAVE on the instantiated object
 
       break;
     }

--- a/src/_P162_MCP42xxx.ino
+++ b/src/_P162_MCP42xxx.ino
@@ -29,17 +29,16 @@ boolean Plugin_162(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number         = PLUGIN_ID_162;
-      Device[deviceCount].Type             = DEVICE_TYPE_SPI3;
-      Device[deviceCount].VType            = Sensor_VType::SENSOR_TYPE_DUAL;
-      Device[deviceCount].Ports            = 0;
-      Device[deviceCount].ValueCount       = 2;
-      Device[deviceCount].SendDataOption   = true;
-      Device[deviceCount].TimerOption      = true;
-      Device[deviceCount].TimerOptional    = true;
-      Device[deviceCount].GlobalSyncOption = true;
-      Device[deviceCount].FormulaOption    = true;
-      Device[deviceCount].PluginStats      = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_162;
+      dev.Type           = DEVICE_TYPE_SPI3;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_DUAL;
+      dev.ValueCount     = 2;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.TimerOptional  = true;
+      dev.FormulaOption  = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P163_RadSens.ino
+++ b/src/_P163_RadSens.ino
@@ -37,17 +37,16 @@ boolean Plugin_163(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number         = PLUGIN_ID_163;
-      Device[deviceCount].Type             = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType            = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].Ports            = 0;
-      Device[deviceCount].FormulaOption    = true;
-      Device[deviceCount].ValueCount       = 4;
-      Device[deviceCount].SendDataOption   = true;
-      Device[deviceCount].TimerOption      = true;
-      Device[deviceCount].TimerOptional    = true;
-      Device[deviceCount].GlobalSyncOption = true;
-      Device[deviceCount].PluginStats      = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_163;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 4;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.TimerOptional  = true;
+      dev.PluginStats    = true;
 
       break;
     }

--- a/src/_P164_gases_ens160.ino
+++ b/src/_P164_gases_ens160.ino
@@ -6,7 +6,7 @@
 // #######################################################################################################
 // P164 "GASES - ENS16x (TVOC, eCO2)"
 // Plugin for ENS160 & ENS161 TVOC and eCO2 sensor with I2C interface from ScioSense
-// For documentation of the ENS160 hardware device see 
+// For documentation of the ENS160 hardware device see
 // https://www.sciosense.com/wp-content/uploads/documents/SC-001224-DS-9-ENS160-Datasheet.pdf
 //
 // PLugin code:
@@ -29,18 +29,15 @@ boolean Plugin_164(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_164;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_DUAL;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 2;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_164;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_DUAL;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 2;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
       break;
     }
 
@@ -85,7 +82,7 @@ boolean Plugin_164(uint8_t function, struct EventStruct *event, String& string)
     case PLUGIN_SET_DEFAULTS:
     {
       P164_PCONFIG_I2C_ADDR = P164_ENS160_I2CADDR_1;
-      success = true;
+      success               = true;
       break;
     }
 
@@ -107,10 +104,10 @@ boolean Plugin_164(uint8_t function, struct EventStruct *event, String& string)
         break;
       }
 
-      float temperature = 20.0f;  // A reasonable value in case temperature source task is invalid
-      float humidity = 50.0f;     // A reasonable value in case humidity source task is invalid
-      float tvoc = 0.0f;          // tvoc value to be retrieved from device
-      float eco2 = 0.0f;          // eCO2 value to be retrieved from device
+      float temperature = 20.0f; // A reasonable value in case temperature source task is invalid
+      float humidity    = 50.0f; // A reasonable value in case humidity source task is invalid
+      float tvoc        = 0.0f;  // tvoc value to be retrieved from device
+      float eco2        = 0.0f;  // eCO2 value to be retrieved from device
 
       if (validTaskIndex(P164_PCONFIG_TEMP_TASK) && validTaskIndex(P164_PCONFIG_HUM_TASK))
       {
@@ -140,6 +137,7 @@ boolean Plugin_164(uint8_t function, struct EventStruct *event, String& string)
     {
       P164_data_struct *P164_data =
         static_cast<P164_data_struct *>(getPluginTaskData(event->TaskIndex));
+
       if (nullptr == P164_data) {
         break;
       }

--- a/src/_P165_7SegNeopixel.ino
+++ b/src/_P165_7SegNeopixel.ino
@@ -54,10 +54,11 @@ boolean Plugin_165(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number      = PLUGIN_ID_165;
-      Device[deviceCount].Type          = DEVICE_TYPE_SINGLE;
-      Device[deviceCount].VType         = Sensor_VType::SENSOR_TYPE_NONE;
-      Device[deviceCount].setPin1Direction(gpio_direction::gpio_output);
+      auto& dev = Device[++deviceCount];
+      dev.Number = PLUGIN_ID_165;
+      dev.Type   = DEVICE_TYPE_SINGLE;
+      dev.VType  = Sensor_VType::SENSOR_TYPE_NONE;
+      dev.setPin1Direction(gpio_direction::gpio_output);
       break;
     }
 

--- a/src/_P166_GP8403.ino
+++ b/src/_P166_GP8403.ino
@@ -53,19 +53,16 @@ boolean Plugin_166(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_166;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_DUAL;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 2;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].TimerOptional      = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true; // FIXME: Is this useful?
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_166;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_DUAL;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 2;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.TimerOptional  = true;
+      dev.PluginStats    = true; // FIXME: Is this useful?
 
       break;
     }

--- a/src/_P166_GP8403.ino
+++ b/src/_P166_GP8403.ino
@@ -126,9 +126,10 @@ boolean Plugin_166(uint8_t function, struct EventStruct *event, String& string)
           static_cast<int>(DFRobot_GP8403::eOutPutRange_t::eOutputRange5V),
           static_cast<int>(DFRobot_GP8403::eOutPutRange_t::eOutputRange10V),
         };
+        constexpr size_t optionCount = NR_ELEMENTS(configurationOptions);
         addFormSelector(F("Output range"),
                         F("range"),
-                        sizeof(configurationOptions) / sizeof(configurationOptions[0]),
+                        optionCount,
                         configurations,
                         configurationOptions,
                         P166_MAX_VOLTAGE);

--- a/src/_P167_Vindstyrka.ino
+++ b/src/_P167_Vindstyrka.ino
@@ -32,21 +32,18 @@ boolean Plugin_167(uint8_t function, struct EventStruct *event, String& string) 
     case PLUGIN_DEVICE_ADD:
     {
       // This case defines the device characteristics
-      Device[++deviceCount].Number           = PLUGIN_ID_167;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 4;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].I2CNoDeviceCheck   = true;
-      Device[deviceCount].I2CMax100kHz       = true; // SEN5x only supports up to 100 kHz
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
-      Device[deviceCount].OutputDataType     = Output_Data_type_t::Simple;
+      auto& dev = Device[++deviceCount];
+      dev.Number           = PLUGIN_ID_167;
+      dev.Type             = DEVICE_TYPE_I2C;
+      dev.VType            = Sensor_VType::SENSOR_TYPE_QUAD;
+      dev.FormulaOption    = true;
+      dev.ValueCount       = 4;
+      dev.SendDataOption   = true;
+      dev.TimerOption      = true;
+      dev.I2CNoDeviceCheck = true;
+      dev.I2CMax100kHz     = true; // SEN5x only supports up to 100 kHz
+      dev.PluginStats      = true;
+      dev.OutputDataType   = Output_Data_type_t::Simple;
       break;
     }
 

--- a/src/_P168_VEML6030_7700.ino
+++ b/src/_P168_VEML6030_7700.ino
@@ -29,16 +29,15 @@ boolean Plugin_168(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number         = PLUGIN_ID_168;
-      Device[deviceCount].Type             = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType            = Sensor_VType::SENSOR_TYPE_SINGLE;
-      Device[deviceCount].Ports            = 0;
-      Device[deviceCount].FormulaOption    = true;
-      Device[deviceCount].ValueCount       = 3;
-      Device[deviceCount].SendDataOption   = true;
-      Device[deviceCount].TimerOption      = true;
-      Device[deviceCount].GlobalSyncOption = true;
-      Device[deviceCount].PluginStats      = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_168;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_SINGLE;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 3;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
 
       break;
     }

--- a/src/_P168_VEML6030_7700.ino
+++ b/src/_P168_VEML6030_7700.ino
@@ -113,9 +113,10 @@ boolean Plugin_168(uint8_t function, struct EventStruct *event, String& string)
           VEML_LUX_NORMAL_NOWAIT,
           VEML_LUX_CORRECTED_NOWAIT,
         };
+        constexpr size_t optionCount = NR_ELEMENTS(readMethodOptions);
         addFormSelector(F("Lux Read-method"),
                         F("rmth"),
-                        NR_ELEMENTS(readMethodOptions),
+                        optionCount,
                         readMethod,
                         readMethodOptions,
                         P168_READLUX_MODE);
@@ -134,9 +135,10 @@ boolean Plugin_168(uint8_t function, struct EventStruct *event, String& string)
           0b10,
           0b11,
         };
+        constexpr size_t optionCount = NR_ELEMENTS(alsGainOptions);
         addFormSelector(F("Gain factor"),
                         F("gain"),
-                        NR_ELEMENTS(alsGainOptions),
+                        optionCount,
                         alsGain,
                         alsGainOptions,
                         P168_ALS_GAIN);
@@ -158,9 +160,10 @@ boolean Plugin_168(uint8_t function, struct EventStruct *event, String& string)
           0b0010,
           0b0011,
         };
+        constexpr size_t optionCount = NR_ELEMENTS(alsIntegrationOptions);
         addFormSelector(F("Integration time"),
                         F("int"),
-                        NR_ELEMENTS(alsIntegrationOptions),
+                        optionCount,
                         alsIntegration,
                         alsIntegrationOptions,
                         P168_ALS_INTEGRATION);
@@ -181,9 +184,10 @@ boolean Plugin_168(uint8_t function, struct EventStruct *event, String& string)
           static_cast<int>(P168_power_save_mode_e::Mode3),
           static_cast<int>(P168_power_save_mode_e::Mode4),
         };
+        constexpr size_t optionCount = NR_ELEMENTS(psmModeOptions);
         addFormSelector(F("Power Save Mode"),
                         F("psm"),
-                        NR_ELEMENTS(psmModeOptions),
+                        optionCount,
                         psmMode,
                         psmModeOptions,
                         P168_PSM_MODE);

--- a/src/_P169_AS3935_LightningDetector.ino
+++ b/src/_P169_AS3935_LightningDetector.ino
@@ -88,17 +88,18 @@ boolean Plugin_169(uint8_t function, struct EventStruct *event, String& string)
     case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      const uint8_t i2cAddressValues[] = { 0x01, 0x02, 0x03 };
+      constexpr uint8_t i2cAddressValues[] = { 0x01, 0x02, 0x03 };
+      constexpr size_t  i2cOptionCount     = NR_ELEMENTS(i2cAddressValues);
 
       if (function == PLUGIN_WEBFORM_SHOW_I2C_PARAMS)
       {
         // addFormSelectorI2C(P169_I2C_ADDRESS_LABEL, 3, i2cAddressValues, P169_I2C_ADDRESS);
-        addFormSelectorI2C(F("i2c_addr"), NR_ELEMENTS(i2cAddressValues), i2cAddressValues, P169_I2C_ADDRESS);
+        addFormSelectorI2C(F("i2c_addr"), i2cOptionCount, i2cAddressValues, P169_I2C_ADDRESS);
         addFormNote(F("Addr: 0-0-0-0-0-A1-A0. Both A0 & A1 low is not valid."));
       }
       else
       {
-        success = intArrayContains(NR_ELEMENTS(i2cAddressValues), i2cAddressValues, event->Par1);
+        success = intArrayContains(i2cOptionCount, i2cAddressValues, event->Par1);
       }
       break;
     }
@@ -125,9 +126,10 @@ boolean Plugin_169(uint8_t function, struct EventStruct *event, String& string)
           AS3935MI::AS3935_MNL_5,
           AS3935MI::AS3935_MNL_9,
           AS3935MI::AS3935_MNL_16 };
+        constexpr size_t optionCount = NR_ELEMENTS(optionValues);
         addFormSelector(F("Lightning Threshold"),
                         P169_LIGHTNING_THRESHOLD_LABEL,
-                        NR_ELEMENTS(optionValues),
+                        optionCount,
                         options,
                         optionValues,
                         P169_LIGHTNING_THRESHOLD);
@@ -156,8 +158,9 @@ boolean Plugin_169(uint8_t function, struct EventStruct *event, String& string)
           17,
           18
         };
-        addFormSelector(F("AFE Gain Min"), P169_AFE_GAIN_LOW_LABEL,  NR_ELEMENTS(optionValues), options, optionValues, P169_AFE_GAIN_LOW);
-        addFormSelector(F("AFE Gain Max"), P169_AFE_GAIN_HIGH_LABEL, NR_ELEMENTS(optionValues), options, optionValues, P169_AFE_GAIN_HIGH);
+        constexpr size_t optionCount = NR_ELEMENTS(optionValues);
+        addFormSelector(F("AFE Gain Min"), P169_AFE_GAIN_LOW_LABEL,  optionCount, options, optionValues, P169_AFE_GAIN_LOW);
+        addFormSelector(F("AFE Gain Max"), P169_AFE_GAIN_HIGH_LABEL, optionCount, options, optionValues, P169_AFE_GAIN_HIGH);
         addFormNote(F("Lower and upper limit for the Analog Frond-End auto gain to use."));
       }
 

--- a/src/_P169_AS3935_LightningDetector.ino
+++ b/src/_P169_AS3935_LightningDetector.ino
@@ -24,19 +24,16 @@ boolean Plugin_169(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_169;
-      Device[deviceCount].Type               = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TRIPLE;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 4;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].I2CNoDeviceCheck   = true; // Sensor may sometimes not respond immediately
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number           = PLUGIN_ID_169;
+      dev.Type             = DEVICE_TYPE_I2C;
+      dev.VType            = Sensor_VType::SENSOR_TYPE_TRIPLE;
+      dev.FormulaOption    = true;
+      dev.ValueCount       = 4;
+      dev.SendDataOption   = true;
+      dev.TimerOption      = true;
+      dev.I2CNoDeviceCheck = true; // Sensor may sometimes not respond immediately
+      dev.PluginStats      = true;
       break;
     }
 

--- a/src/_P170_Waterlevel.ino
+++ b/src/_P170_Waterlevel.ino
@@ -30,17 +30,16 @@ boolean Plugin_170(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number         = PLUGIN_ID_170;
-      Device[deviceCount].Type             = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType            = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].Ports            = 0;
-      Device[deviceCount].FormulaOption    = true;
-      Device[deviceCount].ValueCount       = 2;
-      Device[deviceCount].SendDataOption   = true;
-      Device[deviceCount].TimerOption      = true;
-      Device[deviceCount].TimerOptional    = true;
-      Device[deviceCount].GlobalSyncOption = true;
-      Device[deviceCount].PluginStats      = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_170;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 2;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.TimerOptional  = true;
+      dev.PluginStats    = true;
 
       break;
     }

--- a/src/_P172_BMP3xx_SPI.ino
+++ b/src/_P172_BMP3xx_SPI.ino
@@ -25,18 +25,15 @@ boolean Plugin_172(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number           = PLUGIN_ID_172;
-      Device[deviceCount].Type               = DEVICE_TYPE_SPI;
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TEMP_BARO;
-      Device[deviceCount].Ports              = 0;
-      Device[deviceCount].PullUpOption       = false;
-      Device[deviceCount].InverseLogicOption = false;
-      Device[deviceCount].FormulaOption      = true;
-      Device[deviceCount].ValueCount         = 2;
-      Device[deviceCount].SendDataOption     = true;
-      Device[deviceCount].TimerOption        = true;
-      Device[deviceCount].GlobalSyncOption   = true;
-      Device[deviceCount].PluginStats        = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_172;
+      dev.Type           = DEVICE_TYPE_SPI;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_TEMP_BARO;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 2;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
       break;
     }
 

--- a/src/_P173_SHTC3.ino
+++ b/src/_P173_SHTC3.ino
@@ -26,15 +26,15 @@ boolean Plugin_173(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_173;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
-      Device[deviceCount].Ports          = 0;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 2;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_173;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_TEMP_HUM;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 2;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
 
       break;
     }

--- a/src/_P175_PMSx003i.ino
+++ b/src/_P175_PMSx003i.ino
@@ -21,23 +21,24 @@
 boolean Plugin_175(uint8_t function, struct EventStruct *event, String& string)
 {
   boolean success = false;
+
   P053_for_P175 = true; // Ignore this error, compiler can see it as all .ino files are smart-copied into ESPEasy.ino
 
   switch (function)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_175;
-      Device[deviceCount].Type           = DEVICE_TYPE_I2C;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].Ports          = 0;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 4;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].PluginStats    = true;
-      Device[deviceCount].I2CMax100kHz   = true; // Max I2C Clock speed 100 kHz
-      success                            = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_175;
+      dev.Type           = DEVICE_TYPE_I2C;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 4;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.PluginStats    = true;
+      dev.I2CMax100kHz   = true; // Max I2C Clock speed 100 kHz
+
       break;
     }
 

--- a/src/_P176_VE_Direct.ino
+++ b/src/_P176_VE_Direct.ino
@@ -6,7 +6,8 @@
 // #######################################################################################################
 
 /** Changelog:
- * 2024-11-24 tonhuisman: Add setting "Events only on updated data" to not generate events/Controller output if no new packets have been received
+ * 2024-11-24 tonhuisman: Add setting "Events only on updated data" to not generate events/Controller output if no new packets have been
+ *received
  *                        This check is independent from the Updated GetConfig value.
  * 2024-11-10 tonhuisman: Renamed GetConfig ischanged to updated.
  * 2024-11-08 tonhuisman: Add successcount, errorcount and ischanged values for GetConfig. IsChanged will reset the state on each call, so
@@ -43,16 +44,16 @@ boolean Plugin_176(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      Device[++deviceCount].Number       = PLUGIN_ID_176;
-      Device[deviceCount].Type           = DEVICE_TYPE_SERIAL;
-      Device[deviceCount].VType          = Sensor_VType::SENSOR_TYPE_QUAD;
-      Device[deviceCount].Ports          = 0;
-      Device[deviceCount].FormulaOption  = true;
-      Device[deviceCount].ValueCount     = 4;
-      Device[deviceCount].SendDataOption = true;
-      Device[deviceCount].TimerOption    = true;
-      Device[deviceCount].TimerOptional  = true;
-      Device[deviceCount].PluginStats    = true;
+      auto& dev = Device[++deviceCount];
+      dev.Number         = PLUGIN_ID_176;
+      dev.Type           = DEVICE_TYPE_SERIAL;
+      dev.VType          = Sensor_VType::SENSOR_TYPE_QUAD;
+      dev.FormulaOption  = true;
+      dev.ValueCount     = 4;
+      dev.SendDataOption = true;
+      dev.TimerOption    = true;
+      dev.TimerOptional  = true;
+      dev.PluginStats    = true;
 
       break;
     }

--- a/src/_Pxxx_PluginTemplate.ino
+++ b/src/_Pxxx_PluginTemplate.ino
@@ -104,22 +104,24 @@ boolean Plugin_xxx(uint8_t function, struct EventStruct *event, String& string)
     case PLUGIN_DEVICE_ADD:
     {
       // This case defines the device characteristics, edit appropriately
+      // Attention: dev Values set to 0 or false should be removed to save a few bytes (unneeded assignments)
 
-      Device[++deviceCount].Number           = PLUGIN_ID_xxx;                    // Plugin ID number.   (PLUGIN_ID_xxx)
-      Device[deviceCount].Type               = DEVICE_TYPE_SINGLE;               // How the device is connected. e.g. DEVICE_TYPE_SINGLE => connected through 1 datapin
-      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_SWITCH; // Type of value the plugin will return. e.g. SENSOR_TYPE_STRING
-      Device[deviceCount].Ports              = 0;                                // Port to use when device has multiple I/O pins  (N.B. not used much)
-      Device[deviceCount].ValueCount         = 0;                                // The number of output values of a plugin. The value should match the number of keys PLUGIN_VALUENAME1_xxx
-      Device[deviceCount].OutputDataType     = Output_Data_type_t::Default;      // Subset of selectable output data types  (Default = no selection)
-      Device[deviceCount].PullUpOption       = false;                            // Allow to set internal pull-up resistors.
-      Device[deviceCount].InverseLogicOption = false;                            // Allow to invert the boolean state (e.g. a switch)
-      Device[deviceCount].FormulaOption      = false;                            // Allow to enter a formula to convert values during read. (not possible with Custom enabled)
-      Device[deviceCount].Custom             = false;
-      Device[deviceCount].SendDataOption     = false;                            // Allow to send data to a controller.
-      Device[deviceCount].GlobalSyncOption   = true;                             // No longer used. Was used for ESPeasy values sync between nodes
-      Device[deviceCount].TimerOption        = false;                            // Allow to set the "Interval" timer for the plugin.
-      Device[deviceCount].TimerOptional      = false;                            // When taskdevice timer is not set and not optional, use default "Interval" delay (Settings.Delay)
-      Device[deviceCount].DecimalsOnly       = true;                             // Allow to set the number of decimals (otherwise treated a 0 decimals)
+      auto& dev = Device[++deviceCount];
+      dev.Number             = PLUGIN_ID_xxx;                    // Plugin ID number.   (PLUGIN_ID_xxx)
+      dev.Type               = DEVICE_TYPE_SINGLE;               // How the device is connected. e.g. DEVICE_TYPE_SINGLE => connected through 1 datapin
+      dev.VType              = Sensor_VType::SENSOR_TYPE_SWITCH; // Type of value the plugin will return. e.g. SENSOR_TYPE_STRING
+      dev.Ports              = 0;                                // Port to use when device has multiple I/O pins  (N.B. not used much)
+      dev.ValueCount         = 0;                                // The number of output values of a plugin. The value should match the number of keys PLUGIN_VALUENAME1_xxx
+      dev.OutputDataType     = Output_Data_type_t::Default;      // Subset of selectable output data types  (Default = no selection)
+      dev.PullUpOption       = false;                            // Allow to set internal pull-up resistors.
+      dev.InverseLogicOption = false;                            // Allow to invert the boolean state (e.g. a switch)
+      dev.FormulaOption      = false;                            // Allow to enter a formula to convert values during read. (not possible with Custom enabled)
+      dev.Custom             = false;
+      dev.SendDataOption     = false;                            // Allow to send data to a controller.
+      dev.GlobalSyncOption   = true;                             // No longer used. Was used for ESPeasy values sync between nodes
+      dev.TimerOption        = false;                            // Allow to set the "Interval" timer for the plugin.
+      dev.TimerOptional      = false;                            // When taskdevice timer is not set and not optional, use default "Interval" delay (Settings.Delay)
+      dev.DecimalsOnly       = true;                             // Allow to set the number of decimals (otherwise treated a 0 decimals)
       break;
     }
 
@@ -177,7 +179,7 @@ boolean Plugin_xxx(uint8_t function, struct EventStruct *event, String& string)
 
     case PLUGIN_GET_DEVICEVALUECOUNT:
     {
-      // This is only called when Device[deviceCount].OutputDataType is not Output_Data_type_t::Default
+      // This is only called when dev.OutputDataType is not Output_Data_type_t::Default
       // The position in the config parameters used in this example is PCONFIG(Pxxx_OUTPUT_TYPE_INDEX)
       // Must match the one used in case PLUGIN_GET_DEVICEVTYPE  (best to use a define for it)
       // see P026_Sysinfo.ino for more examples.
@@ -188,7 +190,7 @@ boolean Plugin_xxx(uint8_t function, struct EventStruct *event, String& string)
 
     case PLUGIN_GET_DEVICEVTYPE:
     {
-      // This is only called when Device[deviceCount].OutputDataType is not Output_Data_type_t::Default
+      // This is only called when dev.OutputDataType is not Output_Data_type_t::Default
       // The position in the config parameters used in this example is PCONFIG(Pxxx_OUTPUT_TYPE_INDEX)
       // Must match the one used in case PLUGIN_GET_DEVICEVALUECOUNT  (best to use a define for it)
       // IDX is used here to mark the PCONFIG position used to store the Device VType.

--- a/src/src/Helpers/AdafruitGFX_helper.cpp
+++ b/src/src/Helpers/AdafruitGFX_helper.cpp
@@ -2176,7 +2176,7 @@ bool AdafruitGFX_helper::processCommand(const String& string) {
         #  if ADAGFX_ARGUMENT_VALIDATION
         const int16_t curWin = getWindow();
 
-        if (curWin != 0) { selectWindow(0); } // Validate against raw window coordinates
+        if (curWin != 0) { selectWindow(0); }           // Validate against raw window coordinates
 
         if (argCount == 6) { setRotation(nParams[5]); } // Use requested rotation
 
@@ -2313,10 +2313,15 @@ bool AdafruitGFX_helper::pluginGetConfigValue(String& string) {
     case adagfx_getcommands_e::textheight:
       // length/textheight: get text length or height
     {
-      int16_t  x1, y1;
-      uint16_t w1, h1;
-      String   newString = AdaGFXparseTemplate(parseStringToEndKeepCaseNoTrim(string, 2), 0);
-      _display->getTextBounds(newString, 0, 0, &x1, &y1, &w1, &h1); // Count length and height
+      int16_t  x1{}, y1{};
+      uint16_t w1{}, h1{};
+      String   newString = parseStringToEndKeepCaseNoTrim(string, 2, sep);
+
+      if (!newString.isEmpty()) {
+        newString = AdaGFXparseTemplate(newString, 0);
+
+        _display->getTextBounds(newString, 0, 0, &x1, &y1, &w1, &h1); // Count length and height
+      }
 
       if (adagfx_getcommands_e::length == cmd) {
         string = w1;
@@ -3358,12 +3363,13 @@ bool AdafruitGFX_helper::showBmp(const String& filename,
               }
 
               constexpr size_t errorcode = (size_t)-1;
-              size_t pos = file.position();
+              size_t pos                 = file.position();
+
               if (pos == errorcode) {
                 pos = 0;
               }
 
-              if (pos != bmpPos) {        // Need seek?
+              if (pos != bmpPos) {                    // Need seek?
                 if (transact && canTransact) {
                   _tft->dmaWait();
                   _tft->endWrite();                   // End TFT SPI transaction

--- a/src/src/PluginStructs/P016_data_struct.h
+++ b/src/src/PluginStructs/P016_data_struct.h
@@ -123,11 +123,11 @@ private:
                     decode_type_t DecodeType,
                     uint16_t      CodeFlags);
 
-  uint64_t      iLastCmd        = 0;                      // last command send
-  uint32_t      iLastCmdTime    = 0;                      // time while last command was send
-  decode_type_t iLastDecodeType = decode_type_t::UNUSED;  // last decode_type sent
-  uint16_t      iCmdInhibitTime = 0;                      // inhibit time for sending the same command again
-  uint16_t      iLastCodeFlags  = 0;                      // last flags sent
+  uint64_t      iLastCmd        = 0;                     // last command send
+  uint32_t      iLastCmdTime    = 0;                     // time while last command was send
+  decode_type_t iLastDecodeType = decode_type_t::UNUSED; // last decode_type sent
+  uint16_t      iCmdInhibitTime = 0;                     // inhibit time for sending the same command again
+  uint16_t      iLastCodeFlags  = 0;                     // last flags sent
   # endif // if P016_FEATURE_COMMAND_HANDLING
   # ifdef P016_CHECK_HEAP
   void CheckHeap(String dbgtxt);

--- a/src/src/PluginStructs/P050_data_struct.cpp
+++ b/src/src/PluginStructs/P050_data_struct.cpp
@@ -1,4 +1,4 @@
-// Needed also here for PlatformIO's library finder as the .h file 
+// Needed also here for PlatformIO's library finder as the .h file
 // is in a directory which is excluded in the src_filter
 
 #include "../PluginStructs/P050_data_struct.h"
@@ -6,12 +6,9 @@
 
 #ifdef USES_P050
 
-# include "../Helpers/ESPEasy_Storage.h"
-
 # include <Adafruit_TCS34725.h>
 
 P050_data_struct::P050_data_struct(uint16_t integrationSetting, uint16_t gainSetting) {
-
   // Map integration time setting (uint16_t to enum)
   _integrationTime = static_cast<tcs34725IntegrationTime_t>(integrationSetting);
 
@@ -30,12 +27,12 @@ P050_data_struct::P050_data_struct(uint16_t integrationSetting, uint16_t gainSet
 
 /**
  * resetTransformation
- * Effectgively sets matrix[0][0], matrix[1][1] and matrix[2][2] to 1.0f, all other fields to 0.0f 
+ * Effectgively sets matrix[0][0], matrix[1][1] and matrix[2][2] to 1.0f, all other fields to 0.0f
  */
 void P050_data_struct::resetTransformation() {
   // Initialize Transformationn defaults
-  for (int i = 0; i < 3; i++) {
-    for (int j = 0; j < 3; j++) {
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
       TransformationSettings.matrix[i][j] = i == j ? 1.0f : 0.0f;
     }
   }
@@ -45,23 +42,27 @@ void P050_data_struct::resetTransformation() {
  * applyTransformation : calibrate r/g/b inputs (uint16_t) to rc/gc/bc outputs (float, by reference)
  */
 void P050_data_struct::applyTransformation(uint16_t r, uint16_t g, uint16_t b, float *rc, float *gc, float *bc) {
-  *rc = TransformationSettings.matrix[0][0] * static_cast<float>(r) + TransformationSettings.matrix[0][1] * static_cast<float>(g) + TransformationSettings.matrix[0][2] * static_cast<float>(b);
-  *gc = TransformationSettings.matrix[1][0] * static_cast<float>(r) + TransformationSettings.matrix[1][1] * static_cast<float>(g) + TransformationSettings.matrix[1][2] * static_cast<float>(b);
-  *bc = TransformationSettings.matrix[2][0] * static_cast<float>(r) + TransformationSettings.matrix[2][1] * static_cast<float>(g) + TransformationSettings.matrix[2][2] * static_cast<float>(b);
+  applyTransformation(static_cast<float>(r), static_cast<float>(g), static_cast<float>(b), rc, gc, bc);
 }
 
 /**
  * applyTransformation : calibrate normalized r/g/b inputs (float) to rc/gc/bc outputs (float, by reference)
  */
 void P050_data_struct::applyTransformation(float nr, float ng, float nb, float *rc, float *gc, float *bc) {
-  *rc = TransformationSettings.matrix[0][0] * static_cast<float>(nr) + TransformationSettings.matrix[0][1] * static_cast<float>(ng) + TransformationSettings.matrix[0][2] * static_cast<float>(nb);
-  *gc = TransformationSettings.matrix[1][0] * static_cast<float>(nr) + TransformationSettings.matrix[1][1] * static_cast<float>(ng) + TransformationSettings.matrix[1][2] * static_cast<float>(nb);
-  *bc = TransformationSettings.matrix[2][0] * static_cast<float>(nr) + TransformationSettings.matrix[2][1] * static_cast<float>(ng) + TransformationSettings.matrix[2][2] * static_cast<float>(nb);
+  *rc = TransformationSettings.matrix[0][0] * nr +
+        TransformationSettings.matrix[0][1] * ng +
+        TransformationSettings.matrix[0][2] * nb;
+  *gc = TransformationSettings.matrix[1][0] * nr +
+        TransformationSettings.matrix[1][1] * ng +
+        TransformationSettings.matrix[1][2] * nb;
+  *bc = TransformationSettings.matrix[2][0] * nr +
+        TransformationSettings.matrix[2][1] * ng +
+        TransformationSettings.matrix[2][2] * nb;
 }
 
 bool P050_data_struct::loadSettings(taskIndex_t taskIndex) {
   LoadCustomTaskSettings(taskIndex, reinterpret_cast<uint8_t *>(&TransformationSettings), sizeof(TransformationSettings));
-  return  true;
+  return true;
 }
 
 bool P050_data_struct::saveSettings(taskIndex_t taskIndex) {
@@ -72,6 +73,5 @@ bool P050_data_struct::saveSettings(taskIndex_t taskIndex) {
 String P050_data_struct::generate_cal_id(int i, int j) {
   return strformat(F("cal_%c_%d"), static_cast<char>('a' + i), j);
 }
-
 
 #endif // ifdef USES_P050

--- a/src/src/PluginStructs/P050_data_struct.h
+++ b/src/src/PluginStructs/P050_data_struct.h
@@ -7,32 +7,44 @@
 # include <Adafruit_TCS34725.h>
 
 typedef struct {
-  float matrix[3][3]={};
+  float matrix[3][3] = {};
 } tcsTransformationSettings_t;
 
 struct P050_data_struct : public PluginTaskData_base {
-
 public:
 
-  P050_data_struct(uint16_t integrationSetting, uint16_t gainSetting);
-  P050_data_struct() = delete;
+  P050_data_struct(uint16_t integrationSetting,
+                   uint16_t gainSetting);
+  P050_data_struct()          = delete;
   virtual ~P050_data_struct() = default;
 
   bool loadSettings(taskIndex_t taskIndex);
   bool saveSettings(taskIndex_t taskIndex);
   void resetTransformation();
-  void applyTransformation(uint16_t r, uint16_t g, uint16_t b, float *rc, float *gc, float *bc);
-  void applyTransformation(float nr, float ng, float nb, float *rc, float *gc, float *bc);
+  void applyTransformation(uint16_t r,
+                           uint16_t g,
+                           uint16_t b,
+                           float   *rc,
+                           float   *gc,
+                           float   *bc);
+  void applyTransformation(float  nr,
+                           float  ng,
+                           float  nb,
+                           float *rc,
+                           float *gc,
+                           float *bc);
 
-  static String generate_cal_id(int i, int j);
+  static String generate_cal_id(int i,
+                                int j);
 
-  Adafruit_TCS34725           tcs;
+  Adafruit_TCS34725 tcs;
 
   tcsTransformationSettings_t TransformationSettings;
 
 private:
-  tcs34725IntegrationTime_t   _integrationTime;
-  tcs34725Gain_t              _gain;
+
+  tcs34725IntegrationTime_t _integrationTime;
+  tcs34725Gain_t            _gain;
 };
 
 #endif // ifdef USES_P050

--- a/src/src/PluginStructs/P110_data_struct.cpp
+++ b/src/src/PluginStructs/P110_data_struct.cpp
@@ -162,7 +162,7 @@ int16_t P110_data_struct::readDistance() {
     addLog(LOG_LEVEL_DEBUG, F("VL53L0X: TIMEOUT"));
 # endif // P110_DEBUG_LOG
     return P110_DISTANCE_READ_TIMEOUT;
-  } else if (dist >= 8190u) {
+  } else if (dist >= 8190) {
 # ifdef P110_DEBUG_LOG
     addLog(LOG_LEVEL_DEBUG, concat(F("VL53L0X: NO MEASUREMENT: "), dist));
 # endif // P110_DEBUG_LOG

--- a/src/src/WebServer/SysInfoPage.cpp
+++ b/src/src/WebServer/SysInfoPage.cpp
@@ -746,19 +746,19 @@ void handle_sysinfo_Storage() {
     static_cast<int>(RTC.flashCounter)));
 
   {
-    // FIXME TD-er: Must also add this for ESP32.
-    addRowLabel(LabelType::SKETCH_SIZE);
-    addHtml(strformat(
-      F("%d [kB] (%d kB free)"),
-      getSketchSize() / 1024,
-      getFreeSketchSpace() / 1024));
-
     uint32_t maxSketchSize;
     bool     use2step;
     # if defined(ESP8266)
     bool otaEnabled =
     # endif // if defined(ESP8266)
     OTA_possible(maxSketchSize, use2step);
+
+    addRowLabel(LabelType::SKETCH_SIZE);
+    addHtml(strformat(
+      F("%d [kB] (%d kB not used)"),
+      getSketchSize() / 1024,
+      (maxSketchSize - getSketchSize()) / 1024));
+
     addRowLabel(LabelType::MAX_OTA_SKETCH_SIZE);
     addHtml(strformat(
       F("%d [kB] (%d bytes)"),


### PR DESCRIPTION
Features:
- Another round of code optimizations, this time so we can fit in bug-fixes and improvements

Most reductions are from String and log statement optimizations, but also from deleting unneeded `Device[]` initializations.
Updates to `.ino` files.
- Round 1: ca. 1.7 .. 1.9kB reduction for ESP8266 and 2.2kB for ESP32 (MAX) ([P001]..[P053])
- Round 2: up to 800 more bytes reduction for ESP8266 and 1.2kB more for ESP32 (MAX) ([P054]..[P091])
- Round 3: up to 250 more bytes reduction for ESP8266 and 512 more bytes for ESP32 (MAX) ([P092]..[P110])
- Round 4: cleanup `PLUGIN_DEVICE_ADD` function (as suggested by TD-er) reduces most ESP8266 builds by 1..2kB, and ESP32 builds by up to 4kB
- Round 5: cleanup remaining .ino files ({P111]..[P176])
- Bugfix: AdaGFX_helper: Handling of arguments for `[<taskname>#length."some text"]` (and also textheight) would only accept a comma separator, but should also accept a period.

Total gain for the most challenging build ESP8266 Display: 3992 bytes, And an ESP32-S3 MAX build: 9788 bytes.

Further optimizations to other parts of plugin code are planned in the somewhat near future.

TODO:
- [x] More optimizations