### PR TITLE
[HWL8012] Fix stability issues on ESP8266 with high current load

### DIFF
--- a/lib/HLW8012_1.1.1/src/HLW8012_sample.cpp
+++ b/lib/HLW8012_1.1.1/src/HLW8012_sample.cpp
@@ -9,19 +9,16 @@
 #endif
 #endif
 
-bool HLW8012_finished_sample::getPulseFreq(float &pulseFreq) const
+bool HLW8012_finished_sample::getPulseFreq(float &pulseFreq)
 {
     // Copy volatile values first before checking
     const int32_t dur = duration_usec;
     const uint32_t cnt = count;
-    if (dur == 0 || cnt == 0)
-    {
-        pulseFreq = 0.0f;
-        return false;
-    }
-    pulseFreq = cnt;
-    pulseFreq /= dur;
-    return true;
+    valid = (dur != 0 && cnt != 0);
+    pulseFreq = valid
+      ? static_cast<float>(cnt) / static_cast<float>(dur)
+      : 0.0f;
+    return valid;
 }
 
 void HLW8012_sample::reset()
@@ -34,6 +31,7 @@ void HLW8012_sample::reset()
     {
         finished.duration_usec = timeDiff(prev, next);
         finished.count = cnt;
+        finished.updated = true;
     }
     else
     {
@@ -48,29 +46,29 @@ void HLW8012_sample::reset()
 HLW8012_sample::result_e HLW8012_sample::add()
 {
     const uint32_t now = micros();
-    ++count;
-    last_pulse_usec = now;
-
-    const auto res = getState();
-    if (res == HLW8012_sample::result_e::NoisePeriod ||
-        first_pulse_usec == 0)
-    {
-        count = 0;
-        first_pulse_usec =
-            (res == HLW8012_sample::result_e::NoisePeriod)
-                ? 0
-                : now;
+    const int32_t duration_since_start_usec(timeDiff(start_usec, now));
+    if (duration_since_start_usec < HLW8012_UNSTABLE_SAMPLE_DURATION_USEC) {
         return HLW8012_sample::result_e::NotEnough;
     }
-    return res;
+    if (first_pulse_usec == 0) {
+        first_pulse_usec = now;
+        return HLW8012_sample::result_e::NotEnough;
+    }
+    ++count;
+    last_pulse_usec = now;
+    if (timeDiff(first_pulse_usec, now) > HLW8012_MINIMUM_SAMPLE_DURATION_USEC)
+    {
+        return HLW8012_sample::result_e::Enough;
+    }
+    if (duration_since_start_usec >= HLW8012_MAXIMUM_SAMPLE_DURATION_USEC)
+    {
+        return HLW8012_sample::result_e::Expired;
+    }
+    return HLW8012_sample::result_e::NotEnough;
 }
 
 HLW8012_sample::result_e HLW8012_sample::getState() const
 {
-    if (last_pulse_usec == 0)
-    {
-        return HLW8012_sample::result_e::Cleared;
-    }
     const int32_t duration_since_start_usec(timeDiff(start_usec, last_pulse_usec));
     if (duration_since_start_usec < HLW8012_UNSTABLE_SAMPLE_DURATION_USEC && count == 0)
     {
@@ -88,11 +86,18 @@ HLW8012_sample::result_e HLW8012_sample::getState() const
     return HLW8012_sample::result_e::NotEnough;
 }
 
-HLW8012_sample::result_e HLW8012_sample::getPulseFreq(float &pulsefreq) const
+bool HLW8012_sample::getPulseFreq(float &pulsefreq)
 {
-    if (finished.getPulseFreq(pulsefreq))
-    {
-        return HLW8012_sample::result_e::Enough;
+    return finished.getPulseFreq(pulsefreq);
+}
+
+bool HLW8012_sample::updated(bool& valid)
+{
+    const bool res = finished.updated == 1;
+    valid = finished.valid;
+    if (res) {
+      // Do not try to clear the volatile value if it was not set
+      finished.updated = 0;
     }
-    return HLW8012_sample::result_e::Expired;
+    return res;
 }


### PR DESCRIPTION
The CF and CF1 pulses are correlated with energy consumption. So at high load, the ESP8266 had issues keeping up with the 1000's of ISR calls per sec.

Added some caching so we don't need to do as many floating point operations and access volatile variables. Also the ISR functions are more simplified.

Test run heating up a laminating device drawing 380 Watt while heating up, mainly a resistive load, though the paper feed motor is an inductive load.
![image](https://github.com/user-attachments/assets/c925fa12-2866-4abd-9e4a-6d2f6e6a42dd)
