### PR TITLE
[Build] Revert platform build to before shorten path commit

### DIFF
--- a/platformio_core_defs.ini
+++ b/platformio_core_defs.ini
@@ -197,7 +197,8 @@ lib_extra_dirs            =
 
 ; ESP_IDF 5.3.1
 [core_esp32_IDF5_3_2__3_1_0_LittleFS]
-platform                    = https://github.com/Jason2866/platform-espressif32.git
+platform = https://github.com/Jason2866/platform-espressif32.git#44cb91bd1171b854c5055aef91b3819913ff7f02
+;platform                    = https://github.com/Jason2866/platform-espressif32.git
 platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/3203/framework-arduinoespressif32-all-release_v5.3-ddc10306.zip
 build_flags                 = -DESP32_STAGE
                               -DESP_IDF_VERSION_MAJOR=5

--- a/platformio_esp32_solo1.ini
+++ b/platformio_esp32_solo1.ini
@@ -2,7 +2,8 @@
 ; IDF 5.3.1
 [esp32_solo1_common_LittleFS]
 extends                   = esp32_base_idf5
-platform                  = https://github.com/Jason2866/platform-espressif32.git#Arduino/IDF53
+platform = https://github.com/Jason2866/platform-espressif32.git#44cb91bd1171b854c5055aef91b3819913ff7f02
+;platform                  = https://github.com/Jason2866/platform-espressif32.git#Arduino/IDF53
 platform_packages         = framework-arduino-solo1 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/3204/framework-arduinoespressif32-solo1-release_v5.3-ddc10306.zip
 build_flags               = ${esp32_base_idf5.build_flags}
                             -DFEATURE_ARDUINO_OTA=1

--- a/src/src/WebServer/Chart_JS.cpp
+++ b/src/src/WebServer/Chart_JS.cpp
@@ -95,28 +95,14 @@ void add_ChartJS_chart_header(
   if (enableZoom) {
     plugins = F(
       "\"zoom\":"
-      "{"
-      "\"limits\":{"
-      "\"x\":{\"min\":\"original\",\"max\":\"original\",\"minRange\":1000}," // 1 sec min range
-      "},"
-      "\"pan\":{"
-      "\"enabled\":true,"
-      "\"mode\":\"x\","
-      "\"modifierKey\":\"ctrl\","
-      "},"
+      "{\"limits\":{"
+      "\"x\":{\"min\":\"original\",\"max\":\"original\",\"minRange\":1000}},"
+      "\"pan\":{\"enabled\":true,\"mode\":\"x\",\"modifierKey\":\"ctrl\"},"
       "\"zoom\":{"
-      "\"wheel\":{"
-      "\"enabled\":true,"
-      "},"
-      "\"drag\":{"
-      "\"enabled\":true,"
-      "},"
-      "\"pinch\":{"
-      "\"enabled\":true"
-      "},"
-      "\"mode\":\"x\","
-      "}"
-      "}"
+      "\"wheel\":{\"enabled\":true},"
+      "\"drag\":{\"enabled\":true},"
+      "\"pinch\":{\"enabled\":true},"
+      "\"mode\":\"x\"}}"
       );
   }
   add_ChartJS_chart_JSON_header(


### PR DESCRIPTION
This new feature of the build environment is not compatible (yet) with the compile-time-defined.cpp used in ESPEasy