### PR TITLE
[Console] Support Backspace to correct typos

### DIFF
--- a/docs/source/Tools/Tools.rst
+++ b/docs/source/Tools/Tools.rst
@@ -351,6 +351,10 @@ See also: `Serial Helper <../Plugin/SerialHelper.html>`__
 
 .. note:: Make sure to either uncheck "Enable Serial Port Console" or configure another serial port for the console, when either HW Serial0 or its pins are used in a task or on the hardware page for I2C, SPI, SD-card or Ethernet.
 
+Correct typing errors: (added: 2025-01-21)
+
+When typing commands in the console (nothing you type is visible until you press <Enter>), typos can be corrected using the backspace key (ctrl-H). Some terminal configurations may use a different key code for backspace, then this can be re-configured in your terminal software, or you can use ``<ctrl-H>`` for correcting typos.
+
 Special notes on Software Serial
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/src/ESPEasyCore/ESPEasy_Console_Port.cpp
+++ b/src/src/ESPEasyCore/ESPEasy_Console_Port.cpp
@@ -138,6 +138,10 @@ bool EspEasy_Console_Port::process_consoleInput(uint8_t SerialInByte)
     }
   }
 
+  if ((SerialInByte == '\b') && (SerialInByteCounter > 0)) // Correct a typo using BackSpace
+  {
+    --SerialInByteCounter;
+  } else
   if ((SerialInByte == '\r') || (SerialInByte == '\n'))
   {
     // Ignore empty command


### PR DESCRIPTION
Features:
- Use the backspace key in the console to correct typos (hmm, who doesn't have those... 🤔)
- Updated documentation
- Tested :)