### PR TITLE
[Memory] Allow use of PSRAM + free unused strings

### DIFF
--- a/src/_C008.cpp
+++ b/src/_C008.cpp
@@ -49,7 +49,7 @@ bool CPlugin_008(CPlugin::Function function, struct EventStruct *event, String& 
 
     case CPlugin::Function::CPLUGIN_PROTOCOL_TEMPLATE:
     {
-      event->String1 = String();
+      free_string(event->String1);
       event->String2 = F("demo.php?name=%sysname%&task=%tskname%&valuename=%valname%&value=%value%");
       break;
     }

--- a/src/_C010.cpp
+++ b/src/_C010.cpp
@@ -35,7 +35,7 @@ bool CPlugin_010(CPlugin::Function function, struct EventStruct *event, String& 
 
     case CPlugin::Function::CPLUGIN_PROTOCOL_TEMPLATE:
     {
-      event->String1 = String();
+      free_string(event->String1);
       event->String2 = F("%sysname%_%tskname%_%valname%=%value%");
       break;
     }

--- a/src/_C015.cpp
+++ b/src/_C015.cpp
@@ -202,7 +202,7 @@ bool CPlugin_015(CPlugin::Function function, struct EventStruct *event, String& 
 
           if (!isvalid) {
             // send empty string to Blynk in case of error
-            formattedValue = String();
+            free_string(formattedValue);
           }
 
           const String valueName = Cache.getTaskDeviceValueName(event->TaskIndex, x);

--- a/src/_C016.cpp
+++ b/src/_C016.cpp
@@ -104,8 +104,8 @@ bool CPlugin_016(CPlugin::Function function, struct EventStruct *event, String& 
 
     case CPlugin::Function::CPLUGIN_PROTOCOL_TEMPLATE:
     {
-      event->String1 = String();
-      event->String2 = String();
+      free_string(event->String1);
+      free_string(event->String2);
       break;
     }
 

--- a/src/_P055_Chiming.ino
+++ b/src/_P055_Chiming.ino
@@ -529,7 +529,7 @@ uint8_t Plugin_055_ReadChime(const String& name, String& tokens)
     log = strformat(F("Chime: read %s "), fileName.c_str());
   }
 
-  tokens = String();
+  free_string(tokens);
   fs::File f = tryOpenFile(fileName, "r");
 
   if (f)

--- a/src/src/Commands/InternalCommands.cpp
+++ b/src/src/Commands/InternalCommands.cpp
@@ -173,7 +173,7 @@ bool do_command_case_check(command_case_data         & data,
   // The data struct is re-used on each attempt to process an internal command.
   // Re-initialize the only two members that may have been altered by a previous call.
   data.retval = false;
-  data.status = String();
+  free_string(data.status);
 
   if (!checkSourceFlags(data.event->Source, group)) {
     data.status = return_incorrect_source();

--- a/src/src/Controller_struct/C018_data_struct.cpp
+++ b/src/src/Controller_struct/C018_data_struct.cpp
@@ -25,9 +25,9 @@ void C018_data_struct::reset() {
     delete C018_easySerial;
     C018_easySerial = nullptr;
   }
-  cacheDevAddr     = String();
-  cacheHWEUI       = String();
-  cacheSysVer      = String();
+  free_string(cacheDevAddr);
+  free_string(cacheHWEUI);
+  free_string(cacheSysVer);
   autobaud_success = false;
 }
 
@@ -157,7 +157,7 @@ bool C018_data_struct::initOTAA(const String& AppEUI, const String& AppKey, cons
   if (myLora == nullptr) { return false; }
   bool success = myLora->initOTAA(AppEUI, AppKey, DevEUI);
 
-  cacheDevAddr = String();
+  free_string(cacheDevAddr);
 
   C018_logError(F("initOTAA()"));
   updateCacheOnInit();
@@ -334,7 +334,7 @@ void C018_data_struct::updateCacheOnInit() {
       cacheDevAddr = myLora->sendRawCommand(F("mac get devaddr"));
 
       if (cacheDevAddr == F("00000000")) {
-        cacheDevAddr = String();
+        free_string(cacheDevAddr);
       }
     }
   }

--- a/src/src/DataStructs/EventQueue.cpp
+++ b/src/src/DataStructs/EventQueue.cpp
@@ -11,18 +11,21 @@
 void EventQueueStruct::add(const String& event, bool deduplicate)
 {
   if (!deduplicate || !isDuplicate(event)) {
-    #ifdef USE_SECOND_HEAP
+#if defined(USE_SECOND_HEAP) || defined(ESP32)
     String tmp;
     reserve_special(tmp, event.length());
     tmp = event;
 
+#ifdef USE_SECOND_HEAP
     // Do not add to the list while on 2nd heap
     HeapSelectDram ephemeral;
+#endif
+
 
     _eventQueue.emplace_back(std::move(tmp));
-    #else
+#else
     _eventQueue.push_back(event);
-    #endif // ifdef USE_SECOND_HEAP
+#endif
   }
 }
 
@@ -38,12 +41,14 @@ void EventQueueStruct::addMove(String&& event, bool deduplicate)
   if (!event.length()) { return; }
 
   if (!deduplicate || !isDuplicate(event)) {
-    #ifdef USE_SECOND_HEAP
+    #if defined(USE_SECOND_HEAP) || defined(ESP32)
     String tmp;
     move_special(tmp, std::move(event));
 
+    #ifdef USE_SECOND_HEAP
     // Do not add to the list while on 2nd heap
     HeapSelectDram ephemeral;
+    #endif
     _eventQueue.emplace_back(std::move(tmp));
     #else
     _eventQueue.emplace_back(std::move(event));

--- a/src/src/DataStructs/ExtendedControllerCredentialsStruct.cpp
+++ b/src/src/DataStructs/ExtendedControllerCredentialsStruct.cpp
@@ -1,6 +1,7 @@
 #include "../DataStructs/ExtendedControllerCredentialsStruct.h"
 
 #include "../Helpers/ESPEasy_Storage.h"
+#include "../Helpers/StringConverter.h"
 
 #define EXT_CONTR_CRED_USER_OFFSET 0
 #define EXT_CONTR_CRED_PASS_OFFSET 1
@@ -24,7 +25,7 @@ bool ExtendedControllerCredentialsStruct::validateChecksum() const
 
 void ExtendedControllerCredentialsStruct::clear() {
   for (size_t i = 0; i < CONTROLLER_MAX * 2; ++i) {
-    _strings[i] = String();
+    free_string(_strings[i]);
   }
 }
 

--- a/src/src/DataStructs/LogEntry.cpp
+++ b/src/src/DataStructs/LogEntry.cpp
@@ -26,8 +26,9 @@ bool LogEntry_t::add(const uint8_t loglevel, const String& line)
     #endif // ifdef USE_SECOND_HEAP
 
     if (line.length() > LOG_STRUCT_MESSAGE_SIZE - 1) {
-      _message = std::move(line.substring(0, LOG_STRUCT_MESSAGE_SIZE - 1));
+      move_special(_message, line.substring(0, LOG_STRUCT_MESSAGE_SIZE - 1));
     } else {
+      reserve_special(_message, line.length());
       _message = line;
     }
   }
@@ -48,7 +49,7 @@ bool LogEntry_t::add(const uint8_t loglevel, String&& line)
     // Need to make a substring, which is a new allocation, on the 2nd heap
     HeapSelectIram ephemeral;
       #endif // ifdef USE_SECOND_HEAP
-    _message = move_special(line.substring(0, LOG_STRUCT_MESSAGE_SIZE - 1));
+    move_special(_message, line.substring(0, LOG_STRUCT_MESSAGE_SIZE - 1));
   } else {
     move_special(_message, std::move(line));
   }
@@ -59,7 +60,7 @@ bool LogEntry_t::add(const uint8_t loglevel, String&& line)
 
 void LogEntry_t::clear()
 {
-  _message   = String();
+  free_string(_message);
   _timestamp = 0;
   _loglevel  = 0;
 }

--- a/src/src/DataStructs/LogEntry.cpp
+++ b/src/src/DataStructs/LogEntry.cpp
@@ -48,7 +48,7 @@ bool LogEntry_t::add(const uint8_t loglevel, String&& line)
     // Need to make a substring, which is a new allocation, on the 2nd heap
     HeapSelectIram ephemeral;
       #endif // ifdef USE_SECOND_HEAP
-    _message = std::move(line.substring(0, LOG_STRUCT_MESSAGE_SIZE - 1));
+    _message = move_special(line.substring(0, LOG_STRUCT_MESSAGE_SIZE - 1));
   } else {
     move_special(_message, std::move(line));
   }

--- a/src/src/DataStructs/LogStruct.h
+++ b/src/src/DataStructs/LogStruct.h
@@ -10,7 +10,7 @@
  * LogStruct
 \*********************************************************************************************/
 #ifdef ESP32
-  #define LOG_STRUCT_MESSAGE_LINES 60
+  #define LOG_STRUCT_MESSAGE_LINES 120
 #else
   #ifdef USE_SECOND_HEAP
     #define LOG_STRUCT_MESSAGE_LINES 60

--- a/src/src/DataStructs/Modbus.cpp
+++ b/src/src/DataStructs/Modbus.cpp
@@ -4,6 +4,7 @@
 
 #include "../DataStructs/ControllerSettingsStruct.h"
 #include "../ESPEasyCore/ESPEasy_Log.h"
+#include "../Helpers/StringConverter.h"
 
 
 Modbus::Modbus() : ModbusClient(nullptr), errcnt(0), timeout(0),
@@ -108,7 +109,7 @@ bool Modbus::handle() {
   unsigned int RXavailable = 0;
 
   #ifndef BUILD_NO_DEBUG
-  LogString = String();
+  free_string(LogString);
   #endif
   int64_t rxValue = 0;
 

--- a/src/src/DataStructs/RulesEventCache.cpp
+++ b/src/src/DataStructs/RulesEventCache.cpp
@@ -41,6 +41,10 @@ bool RulesEventCache::addLine(const String& line, const String& filename, size_t
     # ifdef USE_SECOND_HEAP
     HeapSelectDram ephemeral;
     # endif // ifdef USE_SECOND_HEAP
+    #ifdef ESP32
+    reserve_special(event, event.length());
+    reserve_special(action, action.length());
+    #endif
 
     _eventCache.emplace_back(filename, pos, std::move(event), std::move(action));
     return true;

--- a/src/src/DataStructs/Web_StreamingBuffer.cpp
+++ b/src/src/DataStructs/Web_StreamingBuffer.cpp
@@ -336,7 +336,7 @@ void Web_StreamingBuffer::sendContentBlocking(String& data) {
   web_server.sendContent(data);
 
   if (data.length() > (CHUNKED_BUFFER_SIZE + 1)) {
-    data = String(); // Clear also allocated memory
+    free_string(data); // Clear also allocated memory
   } else {
     data.clear();
   }

--- a/src/src/Globals/RamTracker.cpp
+++ b/src/src/Globals/RamTracker.cpp
@@ -156,7 +156,7 @@ RamTracker::RamTracker(void) {
   writePtr = 0;
 
   for (int i = 0; i < TRACES; i++) {
-    traces[i] = String();
+    free_string(traces[i]);
     tracesMemory[i] = 0xffffffff; // init with best case memory values, so they get replaced if memory goes lower
   }
 
@@ -172,7 +172,7 @@ void RamTracker::registerRamState(const String& s) {   // store function
   int bestCase = bestCaseTrace();                      // find best case memory trace
 
   if (ESP.getFreeHeap() < tracesMemory[bestCase]) {    // compare to current memory value
-    traces[bestCase] = String();
+    free_string(traces[bestCase]);
     readPtr          = writePtr + 1;                   // read out buffer, oldest value first
 
     if (readPtr >= TRACEENTRIES) { 
@@ -210,7 +210,7 @@ void RamTracker::getTraceBuffer() {
       retval += ' ';
       retval += traces[i];
       addLogMove(LOG_LEVEL_DEBUG_DEV, retval);
-      retval = String();
+      retval.clear();
     }
   }
 #endif // ifndef BUILD_NO_DEBUG

--- a/src/src/Helpers/Audio.cpp
+++ b/src/src/Helpers/Audio.cpp
@@ -5,6 +5,7 @@
 #include "../Globals/RamTracker.h"
 #include "../Helpers/Hardware_GPIO.h"
 #include "../Helpers/Hardware_PWM.h"
+#include "../Helpers/StringConverter.h"
 
 
 /********************************************************************************************\
@@ -53,7 +54,7 @@ void clear_rtttl_melody() {
     #   endif // if FEATURE_RTTTL_EVENTS
   }
 
-  rtttlMelody = String();
+  free_string(rtttlMelody);
 }
 
 void set_rtttl_melody(String& melody) {

--- a/src/src/Helpers/ESPEasy_checks.cpp
+++ b/src/src/Helpers/ESPEasy_checks.cpp
@@ -211,7 +211,7 @@ String ReportOffsetErrorInStruct(const String& structname, size_t offset) {
 *  Not a member function to be able to use the F-macro
 \*********************************************************************************************/
 bool SettingsCheck(String& error) {
-  error = String();
+  free_string(error);
   #ifndef LIMIT_BUILD_SIZE
 #ifdef esp8266
   size_t offset = offsetof(SettingsStruct, ResetFactoryDefaultPreference);

--- a/src/src/Helpers/Memory.h
+++ b/src/src/Helpers/Memory.h
@@ -58,4 +58,8 @@ void *special_realloc(void *ptr, size_t size);
 void *special_calloc(size_t num, size_t size);
 
 
+// Perform a special memory allocate for the buffer pointer in the String object
+// Allocation is tried either on 2nd heap (ESP8266) or PSRAM (ESP32)
+// when possible.
 bool String_reserve_special(String& str, size_t size);
+

--- a/src/src/Helpers/Memory.h
+++ b/src/src/Helpers/Memory.h
@@ -56,3 +56,6 @@ unsigned long getMaxFreeBlock();
 void *special_malloc(uint32_t size);
 void *special_realloc(void *ptr, size_t size);
 void *special_calloc(size_t num, size_t size);
+
+
+bool String_reserve_special(String& str, size_t size);

--- a/src/src/Helpers/Modbus_RTU.cpp
+++ b/src/src/Helpers/Modbus_RTU.cpp
@@ -19,7 +19,7 @@ void ModbusRTU_struct::reset() {
     delete easySerial;
     easySerial = nullptr;
   }
-  detected_device_description = String();
+  free_string(detected_device_description);
 
   for (int i = 0; i < 8; ++i) {
     _sendframe[i] = 0;

--- a/src/src/Helpers/StringConverter.cpp
+++ b/src/src/Helpers/StringConverter.cpp
@@ -90,6 +90,9 @@ void move_special(String& dest, String&& source) {
   }
   #endif // ifdef USE_SECOND_HEAP
   dest = std::move(source);
+  #ifdef ESP32
+  reserve_special(dest, dest.length());
+  #endif
 }
 
 String move_special(String&& source) {
@@ -100,23 +103,7 @@ String move_special(String&& source) {
 
 
 bool reserve_special(String& str, size_t size) {
-  if (str.length() >= size) {
-    // Nothing needs to be done
-    return true;
-  }
-  // FIXME TD-er: Should also use this for ESP32 with PSRAM to allocate on PSRAM
-  #ifdef USE_SECOND_HEAP
-  if (size >= 32) {
-    // Only try to store larger strings here as those tend to be kept for a longer period.
-    HeapSelectIram ephemeral;
-    // String does round up to nearest multiple of 16 bytes, so no need to round up to multiples of 32 bit here
-    if (str.reserve(size)) {
-      return true;
-    }
-  }
-  #endif
-  return str.reserve(size);
-  // TD-er: should we also log here?
+  return String_reserve_special(str, size);
 }
 
 

--- a/src/src/Helpers/StringConverter.cpp
+++ b/src/src/Helpers/StringConverter.cpp
@@ -83,7 +83,7 @@ void move_special(String& dest, String&& source) {
     HeapSelectIram ephemeral;
     if (dest.reserve(source.length())) {
       dest = source;
-      source = String();
+      free_string(source);
       return;
     }
     // Could not allocate on 2nd heap, so just move existing string
@@ -106,6 +106,12 @@ bool reserve_special(String& str, size_t size) {
   return String_reserve_special(str, size);
 }
 
+void free_string(String& str) {
+  // This is a call specifically tailored to what is done in:
+  //  void String::move(String &rhs)
+  
+  String tmp(std::move(str));
+}
 
 /********************************************************************************************\
    Format string using vsnprintf
@@ -1515,7 +1521,7 @@ bool GetArgv(const char *string, String& argvString, unsigned int argc, char sep
   int  pos_begin, pos_end;
   bool hasArgument = GetArgvBeginEnd(string, argc, pos_begin, pos_end, separator);
 
-  argvString = String();
+  free_string(argvString);
 
   if (!hasArgument) { return false; }
 

--- a/src/src/Helpers/StringConverter.cpp
+++ b/src/src/Helpers/StringConverter.cpp
@@ -109,7 +109,8 @@ bool reserve_special(String& str, size_t size) {
 void free_string(String& str) {
   // This is a call specifically tailored to what is done in:
   //  void String::move(String &rhs)
-  
+
+  str.clear(); // Prevent any unneeded copying  
   String tmp(std::move(str));
 }
 

--- a/src/src/Helpers/StringConverter.h
+++ b/src/src/Helpers/StringConverter.h
@@ -58,6 +58,10 @@ String move_special(String&& source);
 // Try to reserve on the heap with the most space available
 bool reserve_special(String& str, size_t size);
 
+// Arduino String does not have a function to de-allocate its internal buffer
+// This is a special trick to de-allocate its internal buffer and thus free up memory.
+void free_string(String& str);
+
 /*
 template <typename T>
 bool equals(const String& str, const T &val) {

--- a/src/src/Helpers/StringParser.cpp
+++ b/src/src/Helpers/StringParser.cpp
@@ -420,7 +420,7 @@ void transformValue(
               }
 
               if (equals(value, '0')) {
-                value = String();
+                free_string(value);
               } else {
                 const int valueLength = value.length();
 
@@ -769,7 +769,7 @@ bool findNextDevValNameInString(const String& input, int& startpos, int& endpos,
     move_special(format,    valueName.substring(hashpos + 1));
     move_special(valueName, valueName.substring(0, hashpos));
   } else {
-    format = String();
+    free_string(format);
   }
   deviceName.toLowerCase();
   valueName.toLowerCase();

--- a/src/src/Helpers/WebServer_commandHelper.cpp
+++ b/src/src/Helpers/WebServer_commandHelper.cpp
@@ -23,7 +23,7 @@ HandledWebCommand_result handle_command_from_web(EventValueSource::Enum source, 
 
   bool handledCmd = false;
   bool sendOK     = false;
-  printWebString = String();
+  free_string(printWebString);
   printToWeb     = false;
   printToWebJSON = false;
 

--- a/src/src/Helpers/_CPlugin_Helper.cpp
+++ b/src/src/Helpers/_CPlugin_Helper.cpp
@@ -42,7 +42,8 @@ bool safeReadStringUntil(Stream     & input,
   const unsigned long timer           = start + timeout;
   unsigned long backgroundtasks_timer = start + 10;
 
-  str = String();
+  // FIXME TD-er: Should this also de-allocate internal buffer?
+  str.clear();
 
   do {
     // read character

--- a/src/src/PluginStructs/P020_data_struct.cpp
+++ b/src/src/PluginStructs/P020_data_struct.cpp
@@ -136,7 +136,7 @@ void P020_Task::discardClientIn() {
 }
 
 void P020_Task::clearBuffer() {
-  serial_buffer    = String();
+  free_string(serial_buffer);
   _maxDataGramSize = serial_processing == P020_Events::P1WiFiGateway
                     ? P020_P1_DATAGRAM_MAX_SIZE
                     : P020_DATAGRAM_MAX_SIZE;

--- a/src/src/PluginStructs/P044_data_struct.cpp
+++ b/src/src/PluginStructs/P044_data_struct.cpp
@@ -154,7 +154,7 @@ void P044_Task::clearBuffer() {
     maxMessageSize = _min(serial_buffer.length(), P044_DATAGRAM_MAX_SIZE);
   }
 
-  serial_buffer = String();
+  free_string(serial_buffer);
   serial_buffer.reserve(maxMessageSize);
 }
 

--- a/src/src/PluginStructs/P073_data_struct.cpp
+++ b/src/src/PluginStructs/P073_data_struct.cpp
@@ -498,7 +498,7 @@ bool P073_data_struct::NextScroll() {
 }
 
 void P073_data_struct::setTextToScroll(const String& text) {
-  _textToScroll = String();
+  free_string(_textToScroll);
 
   if (!text.isEmpty()) {
     const int bufToFill = getBufferLength(displayModel);

--- a/src/src/PluginStructs/P082_data_struct.cpp
+++ b/src/src/PluginStructs/P082_data_struct.cpp
@@ -342,7 +342,7 @@ bool P082_data_struct::loop() {
           // Full sentence received
 # ifdef P082_SEND_GPS_TO_LOG
           _lastSentence    = _currentSentence;
-          _currentSentence = String();
+          free_string(_currentSentence);
 # endif // ifdef P082_SEND_GPS_TO_LOG
           completeSentence = true;
           available        = easySerial->available();

--- a/src/src/PluginStructs/P094_data_struct.cpp
+++ b/src/src/PluginStructs/P094_data_struct.cpp
@@ -594,7 +594,7 @@ bool P094_data_struct::loop() {
 
           for (size_t i = 0; i < length && valid; ++i) {
             if ((sentence_part[i] > 127) || (sentence_part[i] < 32)) {
-              sentence_part = String();
+              free_string(sentence_part);
               ++sentences_received_error;
               valid = false;
             }
@@ -653,7 +653,6 @@ const String& P094_data_struct::peekSentence() const {
 
 void P094_data_struct::getSentence(String& string, bool appendSysTime) {
   string        = std::move(sentence_part);
-  sentence_part = String(); // FIXME TD-er: Should not be needed as move already cleared it.
 
   if (appendSysTime) {
     // Unix timestamp = 10 decimals + separator

--- a/src/src/PluginStructs/P104_data_struct.cpp
+++ b/src/src/PluginStructs/P104_data_struct.cpp
@@ -268,7 +268,7 @@ void P104_data_struct::loadSettings() {
         # endif // ifdef P104_DEBUG
       }
 
-      buffer = String();     // Free some memory
+      free_string(buffer);     // Free some memory
     }
 
     delete[] settingsBuffer; // Release allocated buffer
@@ -1676,7 +1676,7 @@ void P104_data_struct::checkRepeatTimer(uint8_t z) {
  * saveSettings gather the zones data from the UI and store in customsettings
  **************************************/
 bool P104_data_struct::saveSettings() {
-  error = String(); // Clear
+  free_string(error); // Clear
 
   # ifdef P104_DEBUG_DEV
 

--- a/src/src/PluginStructs/P165_data_struct.cpp
+++ b/src/src/PluginStructs/P165_data_struct.cpp
@@ -2220,7 +2220,7 @@ bool P165_data_struct::nextScroll() {
  * Set up the string to scroll across the display, with optional prefixed spaces
  **********************************************************************************/
 void P165_data_struct::setTextToScroll(const String& text) {
-  _textToScroll = String();
+  free_string(_textToScroll);
 
   if (!text.isEmpty()) {
     const int bufToFill = calculateDisplayDigits();

--- a/src/src/WebServer/ControlPage.cpp
+++ b/src/src/WebServer/ControlPage.cpp
@@ -41,7 +41,7 @@ void handle_control() {
 
   TXBuffer.endStream();
 
-  printWebString = String();
+  free_string(printWebString);
   printToWeb     = false;
   printToWebJSON = false;
 }

--- a/src/src/WebServer/RootPage.cpp
+++ b/src/src/WebServer/RootPage.cpp
@@ -274,7 +274,7 @@ void handle_root() {
         addHtml(F("<TR><TD colspan='2'>Command Output<BR><textarea readonly rows='10' wrap='on'>"));
         addHtml(printWebString);
         addHtml(F("</textarea>"));
-        printWebString = String();
+        free_string(printWebString);
       }
     }
     html_end_table();
@@ -460,7 +460,7 @@ void handle_root() {
   # endif // if FEATURE_ESPEASY_P2P
     html_end_form();
 
-    printWebString = String();
+    free_string(printWebString);
     printToWeb     = false;
     sendHeadandTail_stdtemplate(_TAIL);
   }

--- a/src/src/WebServer/ToolsPage.cpp
+++ b/src/src/WebServer/ToolsPage.cpp
@@ -56,7 +56,7 @@ void handle_tools() {
     addHtml(F("<TR><TD colspan='2'>Command Output<BR><textarea readonly rows='10' wrap='on'>"));
     addHtml(printWebString);
     addHtml(F("</textarea>"));
-    printWebString = String();
+    free_string(printWebString);
   }
 
 
@@ -198,7 +198,7 @@ void handle_tools() {
   html_end_form();
   sendHeadandTail_stdtemplate(_TAIL);
   TXBuffer.endStream();
-  printWebString = String();
+  free_string(printWebString);
   printToWeb     = false;
 }
 

--- a/src/src/WebServer/UploadPage.cpp
+++ b/src/src/WebServer/UploadPage.cpp
@@ -35,7 +35,7 @@ void handle_upload() {
             "<form enctype='multipart/form-data' method='post'><p>Upload settings file:<br><input type='file' name='datafile' size='40'></p><div><input class='button link' type='submit' value='Upload'></div><input type='hidden' name='edit' value='1'></form>"));
   sendHeadandTail_stdtemplate(_TAIL);
   TXBuffer.endStream();
-  printWebString = String();
+  free_string(printWebString);
   printToWeb     = false;
 }
 
@@ -87,7 +87,7 @@ void handle_upload_post() {
   addHtml(F("Upload finished"));
   sendHeadandTail_stdtemplate(_TAIL);
   TXBuffer.endStream();
-  printWebString = String();
+  free_string(printWebString);
   printToWeb     = false;
 }
 

--- a/src/src/WebServer/WebTemplateParser.cpp
+++ b/src/src/WebServer/WebTemplateParser.cpp
@@ -159,7 +159,7 @@ bool WebTemplateParser::process(const char c) {
           } else if (Tail == contentVarFound) {
             processVarName();
           }
-          varName = String();
+          free_string(varName);
         }
       }
       break;


### PR DESCRIPTION
Apparently a previous fix to free up allocated buffers in String objects was broken again due to changes in the `String` class.

This caused the web log to keep its memory for the once largest logs allocated when no longer viewing the web log. (or never viewed the web log, but having its log level not set to 'None')


As a bonus, I also added the possibility to use PSRAM if available for temporary strings like those used in controller queue elements, cached rules and (web) log messages.