### PR TITLE
[N001] Use a non-TLS client for SMTP on port 25

### DIFF
--- a/docs/source/Notify/N001.rst
+++ b/docs/source/Notify/N001.rst
@@ -79,7 +79,7 @@ From the *Notifications* page, press *Edit* on an available *Nr* option. Next, C
 * SMTP Server Settings
 
   * **Domain :** Mail provider domain.
-  * **Server :** Mail server address (DNS or IP number). Must support non-secure SMTP.
+  * **Server :** Mail server address (DNS or IP number).
   * **Port :** Server port number. (see note below)
   * **Timeout :** Maximum allowed time for server reply. Increase value if server timeouts occur.
 
@@ -114,6 +114,8 @@ ESP8266 simply doesn't have enough free memory available to setup a SSL connecti
 
 Only SSL port 465 is supported, as for using port 587 (typically named "TLS") extra steps are required to make a connection.
 This may be added later.
+
+ESP32: (With TLS enabled in the build) To use the basic SMTP protocol (not SMTPS), configure port ``25`` or ``2525``. For other port numbers, a secure SMTP connection will be attempted.
 |
 
 Email Server Requirements with SSL

--- a/src/src/NotifierStructs/N001_data_struct.cpp
+++ b/src/src/NotifierStructs/N001_data_struct.cpp
@@ -22,8 +22,9 @@
 
 bool NPlugin_001_send(const NotificationSettingsStruct& notificationsettings, String& subject, String& body)
 {
-  bool myStatus = false;
-  bool failFlag = false;
+  bool myStatus     = false;
+  bool failFlag     = false;
+  bool deleteClient = true;
 
   WiFiClient *client = nullptr;
 
@@ -39,7 +40,8 @@ bool NPlugin_001_send(const NotificationSettingsStruct& notificationsettings, St
     secureClient.setCfgTime_fcn(get_build_unixtime);
     secureClient.setTrustAnchor(Tasmota_TA, Tasmota_TA_size);
     secureClient.setInsecure();
-    client = &secureClient;
+    client       = &secureClient;
+    deleteClient = false;
   } else {
     client = new (std::nothrow) WiFiClient();
 
@@ -369,7 +371,8 @@ bool NPlugin_001_send(const NotificationSettingsStruct& notificationsettings, St
   }
 
   client->stop();
-  delete client;
+
+  if (deleteClient) { delete client; }
 
   return myStatus;
 }

--- a/src/src/NotifierStructs/N001_data_struct.cpp
+++ b/src/src/NotifierStructs/N001_data_struct.cpp
@@ -33,7 +33,7 @@ bool NPlugin_001_send(const NotificationSettingsStruct& notificationsettings, St
 
   BearSSL::WiFiClientSecure_light secureClient(4096, 4096);
 
-  if (notificationsettings.Port != 25) { // Port 25 is a standard WiFiClient, all else is a secure client...
+  if ((notificationsettings.Port != 25) && (notificationsettings.Port != 2525)) { // Port 25 or 2525 is a standard WiFiClient, all else is a secure client...
     secureClient.setUtcTime_fcn(getUnixTime);
     secureClient.setCfgTime_fcn(get_build_unixtime);
     secureClient.setTrustAnchor(Tasmota_TA, Tasmota_TA_size);

--- a/src/src/NotifierStructs/N001_data_struct.cpp
+++ b/src/src/NotifierStructs/N001_data_struct.cpp
@@ -41,13 +41,17 @@ bool NPlugin_001_send(const NotificationSettingsStruct& notificationsettings, St
     secureClient.setInsecure();
     client = &secureClient;
   } else {
-    client = new WiFiClient();
+    client = new (std::nothrow) WiFiClient();
+
+    if (!client) { return false; }
   }
 
 # else // if FEATURE_EMAIL_TLS
 
   // Use WiFiClient class to create TCP connections
-  client = new WiFiClient();
+  client = new (std::nothrow) WiFiClient();
+
+  if (!client) { return false; }
 # endif // if FEATURE_EMAIL_TLS
 
   # ifdef MUSTFIX_CLIENT_TIMEOUT_IN_SECONDS
@@ -355,11 +359,7 @@ bool NPlugin_001_send(const NotificationSettingsStruct& notificationsettings, St
       }
     }
 
-    //    client.PR_9453_FLUSH_TO_CLEAR();
-    client->stop();
-    delete client;
-
-    if (myStatus == true) {
+    if (myStatus) {
       addLog(LOG_LEVEL_INFO, F("Email: Connection Closed Successfully"));
     } else {
       if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
@@ -367,6 +367,10 @@ bool NPlugin_001_send(const NotificationSettingsStruct& notificationsettings, St
       }
     }
   }
+
+  client->stop();
+  delete client;
+
   return myStatus;
 }
 

--- a/src/src/NotifierStructs/N001_data_struct.cpp
+++ b/src/src/NotifierStructs/N001_data_struct.cpp
@@ -33,7 +33,8 @@ bool NPlugin_001_send(const NotificationSettingsStruct& notificationsettings, St
 
   BearSSL::WiFiClientSecure_light secureClient(4096, 4096);
 
-  if ((notificationsettings.Port != 25) && (notificationsettings.Port != 2525)) { // Port 25 or 2525 is a standard WiFiClient, all else is a secure client...
+  // Port 25 or 2525 is a standard WiFiClient, all else is a secure client...
+  if ((notificationsettings.Port != 25) && (notificationsettings.Port != 2525)) {
     secureClient.setUtcTime_fcn(getUnixTime);
     secureClient.setCfgTime_fcn(get_build_unixtime);
     secureClient.setTrustAnchor(Tasmota_TA, Tasmota_TA_size);
@@ -356,6 +357,7 @@ bool NPlugin_001_send(const NotificationSettingsStruct& notificationsettings, St
 
     //    client.PR_9453_FLUSH_TO_CLEAR();
     client->stop();
+    delete client;
 
     if (myStatus == true) {
       addLog(LOG_LEVEL_INFO, F("Email: Connection Closed Successfully"));


### PR DESCRIPTION
Resolves #5237 

Bugfix:
- Even when using port 25 a secure client was started for the mail-server connection. Now when using port 25, or port 2525, a default WiFiClient is used, instead of a secure client.
- Close & destroy client also when server-connection (login?/network?) fails.
- Documentation updated about the use of ports 25 and 2525 for ESP32 builds with TLS included.

TODO:
- [x] testing by requester ([confirmed](https://github.com/letscontrolit/ESPEasy/issues/5237#issuecomment-2628921164))