### PR TITLE
[Build] Add Power management plugins to ESP32 Climate builds

### DIFF
--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -1989,6 +1989,12 @@ To create/register a plugin, you have to :
   #ifndef USES_P135
     #define USES_P135 // SCD4x
   #endif
+  #if !defined(USES_P137) && defined(ESP32)
+    #define USES_P137   // AXP192
+  #endif
+  #if !defined(USES_P139) && defined(ESP32)
+    #define USES_P139   // AXP2101
+  #endif
   #ifndef USES_P144
     #define USES_P144   // Dust - PM1006(K) (Vindriktning)
   #endif


### PR DESCRIPTION
Feature:
- Add P137 and P139 Power management plugins to ESP32 Climate builds, as these where missing for unknown reasons.