### PR TITLE
[NeoPixel] Fix issue running addressable LEDs on ESP32S3 with OPI PSRAM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,15 @@ docs/source/Plugin/_plugin_sets_overview.repl
 
 .platformio/
 .pio/
+
+managed_components/
+
+CMakeLists.txt
+
+sdkconfig.max_ESP32s3_16M8M_LittleFS_OPI_PSRAM_CDC_ETH
+
+sdkconfig.defaults
+
+dependencies.lock
+
+.dummy/

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,5 @@ sdkconfig.defaults
 dependencies.lock
 
 .dummy/
+
+.cache/

--- a/lib/NeoPixelBus/src/internal/NeoEsp32RmtMethod_idf5.cpp
+++ b/lib/NeoPixelBus/src/internal/NeoEsp32RmtMethod_idf5.cpp
@@ -2,7 +2,7 @@
 #include "../internal/NeoEsp32RmtMethod_idf5.h"
 
 
-size_t rmt_encode_led_strip(rmt_encoder_t *encoder, rmt_channel_handle_t channel, const void *primary_data, size_t data_size, rmt_encode_state_t *ret_state)
+size_t IRAM_ATTR rmt_encode_led_strip(rmt_encoder_t *encoder, rmt_channel_handle_t channel, const void *primary_data, size_t data_size, rmt_encode_state_t *ret_state)
 {
     rmt_led_strip_encoder_t *led_encoder = __containerof(encoder, rmt_led_strip_encoder_t, base);
     rmt_encoder_handle_t bytes_encoder = led_encoder->bytes_encoder;

--- a/lib/NeoPixelBus/src/internal/NeoEsp32RmtMethod_idf5.h
+++ b/lib/NeoPixelBus/src/internal/NeoEsp32RmtMethod_idf5.h
@@ -455,7 +455,10 @@ public:
         config.gpio_num = static_cast<gpio_num_t>(_pin);
         config.mem_block_symbols = NEOESP32_RMT_MEM_BLOCK_SYMBOLS;          // memory block size, 64 * 4 = 256 Bytes
         config.resolution_hz = RMT_LED_STRIP_RESOLUTION_HZ; // 1 MHz tick resolution, i.e., 1 tick = 1 µs
-        config.trans_queue_depth = 4;           // set the number of transactions that can pend in the background
+        config.trans_queue_depth = 2;           // set the number of transactions that can pend in the background
+        config.intr_priority = 0;
+        config.flags.io_loop_back = 0;
+        config.flags.io_od_mode = 0;
         config.flags.invert_out = false;        // do not invert output signal
         config.flags.with_dma = NEOESP32_RMT_FLAGS_WITH_DMA; 
 
@@ -464,6 +467,8 @@ public:
         encoder_config.resolution = RMT_LED_STRIP_RESOLUTION_HZ;
 
         _tx_config.loop_count = 0; //no loop
+        _tx_config.flags.eot_level = 0; // Low level for end-of-transaction
+        _tx_config.flags.queue_nonblocking = 1; // May block
 
         ret += rmt_new_led_strip_encoder(&encoder_config, &_led_encoder, T_SPEED::RmtBit0, T_SPEED::RmtBit1);
 

--- a/lib/NeoPixelBus/src/internal/NeoEsp32RmtMethod_idf5.h
+++ b/lib/NeoPixelBus/src/internal/NeoEsp32RmtMethod_idf5.h
@@ -476,10 +476,10 @@ public:
     {
         // AddLog(2,"..");
         // wait for not actively sending data
-        // this will time out at 10 seconds, an arbitrarily long period of time
+        // this will time out at 100 ms, an arbitrarily long period of time
         // and do nothing if this happens
 
-        if (ESP_OK == ESP_ERROR_CHECK_WITHOUT_ABORT(rmt_tx_wait_all_done(_channel.RmtChannelNumber, 10000 / portTICK_PERIOD_MS)))
+        if (ESP_OK == ESP_ERROR_CHECK_WITHOUT_ABORT(rmt_tx_wait_all_done(_channel.RmtChannelNumber, 100 / portTICK_PERIOD_MS)))
         {
             // AddLog(2,"__ %u", _sizeData);
             // now start the RMT transmit with the editing buffer before we swap
@@ -530,10 +530,15 @@ private:
     void construct()
     {
         // AddLog(2,"RMT:construct");
-        _dataEditing = static_cast<uint8_t*>(malloc(_sizeData));
+//        _dataEditing = static_cast<uint8_t*>(malloc(_sizeData));
+        _dataEditing = static_cast<uint8_t*>(
+            heap_caps_malloc(_sizeData, MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA)
+        );
         // data cleared later in Begin()
 
-        _dataSending = static_cast<uint8_t*>(malloc(_sizeData));
+        _dataSending = static_cast<uint8_t*>(
+            heap_caps_malloc(_sizeData, MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA)
+            );
         // no need to initialize it, it gets overwritten on every send
     }
 };

--- a/platformio.ini
+++ b/platformio.ini
@@ -100,7 +100,7 @@ upload_speed              = 115200
 monitor_speed             = 115200
 ;targets                   = size, checkprogsize
 targets                   =
-src_filter                = +<*> -<.git/> -<.svn/> -<example/> -<examples/> -<test/> -<tests/> -<*/Commands_tmp/> -<*/ControllerQueue_tmp/> -<*/DataStructs_tmp/> -<*/DataTypes_tmp/>  -<*/ESPEasyCore_tmp/>  -<*/Globals_tmp/> -<*/Helpers_tmp/> -<*/PluginStructs_tmp/>  -<*/WebServer_tmp/>
+;src_filter                = +<*> -<.git/> -<.svn/> -<example/> -<examples/> -<test/> -<tests/> -<*/Commands_tmp/> -<*/ControllerQueue_tmp/> -<*/DataStructs_tmp/> -<*/DataTypes_tmp/>  -<*/ESPEasyCore_tmp/>  -<*/Globals_tmp/> -<*/Helpers_tmp/> -<*/PluginStructs_tmp/>  -<*/WebServer_tmp/>
 
 ; Backwards compatibility: https://github.com/platformio/platformio-core/issues/4270
 ;build_src_filter  = +<*> -<.git/> -<.svn/> -<example/> -<examples/> -<test/> -<tests/> -<*/Commands/> -<*/ControllerQueue/> -<*/DataStructs/> -<*/DataTypes/> -<*/Globals/> -<*/Helpers/> -<*/PluginStructs/>  -<*/WebServer/>

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,11 +11,12 @@
 ; *********************************************************************;
 
 [platformio]
-core_dir = .platformio
-description   = Firmware for ESP82xx/ESP32/ESP32-S2/ESP32-S3/ESP32-C3 for easy IoT deployment of sensors.
-boards_dir    = boards
-lib_dir       = lib
-extra_configs =
+core_dir        = .platformio
+description     = Firmware for ESP82xx/ESP32/ESP32-S2/ESP32-S3/ESP32-C3 for easy IoT deployment of sensors.
+boards_dir      = boards
+lib_dir         = lib
+build_cache_dir = .cache
+extra_configs   =
   platformio_core_defs.ini
   platformio_esp82xx_base.ini
   platformio_esp82xx_envs.ini

--- a/platformio_core_defs.ini
+++ b/platformio_core_defs.ini
@@ -174,7 +174,7 @@ build_flags                 = -DESP32_STAGE
                               -DESP_IDF_VERSION_MAJOR=5
                               -DLIBRARIES_NO_LOG=1
                               -DDISABLE_SC16IS752_SPI
-                              -DCONFIG_PM_ENABLE
+                              -DCONFIG_PM_ENABLE=0
                               -DESP_IDF_STILL_NEEDS_SPI_REGISTERS_FIXED
                               -DPR_9453_FLUSH_TO_CLEAR=clear
 
@@ -203,7 +203,7 @@ build_flags                 = -DESP32_STAGE
                               -DESP_IDF_VERSION_MAJOR=5
                               -DLIBRARIES_NO_LOG=1
                               -DDISABLE_SC16IS752_SPI
-                              -DCONFIG_PM_ENABLE
+;                              -DCONFIG_PM_ENABLE=0
                               -DETH_TYPE_JL1101_SUPPORTED
                               ; PR_9453_FLUSH_TO_CLEAR_REVERTED
                               -DPR_9453_FLUSH_TO_CLEAR=clear
@@ -217,7 +217,7 @@ build_flags                 = -DESP32_STAGE
                               -include "sdkconfig.h"
                               -include "ESPEasy_config.h"
                               -include "esp32x_fixes.h"
-                              -Wnull-dereference
+;                              -Wnull-dereference
 lib_ignore                = 
 lib_extra_dirs            =
                             lib/lib_ssl

--- a/platformio_esp32_envs.ini
+++ b/platformio_esp32_envs.ini
@@ -10,7 +10,8 @@ extends                   = common, core_esp32_IDF5_1_4__3_1_0_SPIFFS
 upload_speed              = 460800
 upload_before_reset       = default_reset
 upload_after_reset        = hard_reset
-extra_scripts             = post:tools/pio/post_esp32.py
+extra_scripts             = pre:tools/pio/pre_esp32.py
+                            post:tools/pio/post_esp32.py
                             ${extra_scripts_default.extra_scripts}
 ; you can disable debug linker flag to reduce binary size (comment out line below), but the backtraces will become less readable
 ;                            tools/pio/extra_linker_flags.py
@@ -38,7 +39,8 @@ extends                   = common, core_esp32_IDF5_3_2__3_1_0_LittleFS
 upload_speed              = 460800
 upload_before_reset       = default_reset
 upload_after_reset        = hard_reset
-extra_scripts             = post:tools/pio/post_esp32.py
+extra_scripts             = pre:tools/pio/pre_esp32.py
+                            post:tools/pio/post_esp32.py
                             ${extra_scripts_default.extra_scripts}
 ; you can disable debug linker flag to reduce binary size (comment out line below), but the backtraces will become less readable
 ;                            tools/pio/extra_linker_flags.py

--- a/platformio_esp32s3_envs.ini
+++ b/platformio_esp32s3_envs.ini
@@ -215,6 +215,11 @@ build_flags               = ${esp32s3_common_LittleFS.build_flags}
                             -DFEATURE_ARDUINO_OTA=1
                             -DPLUGIN_BUILD_MAX_ESP32
                             -DPLUGIN_BUILD_IR_EXTENDED
+                            -DCONFIG_PM_LIGHTSLEEP_RTC_OSC_CAL_INTERVAL=1
 extra_scripts             = ${esp32s3_common_LittleFS.extra_scripts}
+custom_sdkconfig            =
+                              CONFIG_RMT_ISR_CACHE_SAFE=y
+                              CONFIG_PM_LIGHTSLEEP_RTC_OSC_CAL_INTERVAL=1
+
 
 

--- a/tools/pio/pre_esp32.py
+++ b/tools/pio/pre_esp32.py
@@ -1,0 +1,39 @@
+# Part of ESPEasy build toolchain.
+#
+# ESP8266 builds need to concatenate the files to a single .cpp file.
+# However for ESP32 we should ignore this file.
+# So when building for ESP32, we simply delete this temporary file.
+
+Import("env")
+
+platform = env.PioPlatform()
+
+import os
+import glob
+import filecmp
+
+
+def delete_concat_cpp_files(paths_to_concat):
+    cpp_files = []
+
+    cpp_path = paths_to_concat[0]
+
+    cpp_path_out = '{}_tmp'.format(cpp_path)
+
+    tmp_cpp_file = os.path.join(cpp_path_out, '__tmpfile.cpp')
+    tmp2_cpp_file = os.path.join(cpp_path_out, '__tmpfile.cpp.test')
+    if os.path.exists(tmp_cpp_file):
+        os.remove(tmp_cpp_file)
+    if os.path.exists(tmp2_cpp_file):
+        os.remove(tmp2_cpp_file)
+
+
+delete_concat_cpp_files(['./src/src/Commands',
+                        './src/src/ControllerQueue',
+                        './src/src/DataStructs',
+                        './src/src/DataTypes',
+                        './src/src/ESPEasyCore',
+                        './src/src/Globals',
+                        './src/src/Helpers',
+                        './src/src/PluginStructs',
+                        './src/src/WebServer'])


### PR DESCRIPTION
Fixes: #5253

For builds with "OPI PSRAM", the entire sketch is uploaded from flash to PSRAM at boot as PSRAM is way faster than flash. (about 3x faster) This is also why the reported PSRAM size is about 5 MB while you have 8 MB PSRAM.

Another side-effect is that there is another threshold for allocating memory to internal or PSRAM based on size. So starting from 64 LEDs, the malloc switches to use PSRAM instead of internal RAM.

Problem is that we can't use DMA from PSRAM while we have read- and write-access to it. So the change in this test build is to force allocating memory on internal RAM and use a flag to make sure it is DMA accessible.

Timeout is set  to 100 msec, which is  enough for not really blocking the ESP, but should still not happen anyway as it allows for roughly 2000 LEDs to be updated in that period.