### PR TITLE
[SD-card] Bugfix: Reading a bmp file from SD-Card didn't work as expected

### DIFF
--- a/src/src/Helpers/ESPEasy_Storage.cpp
+++ b/src/src/Helpers/ESPEasy_Storage.cpp
@@ -135,22 +135,41 @@ bool fileExists(const __FlashStringHelper *fname)
   return fileExists(String(fname));
 }
 
+bool fileExists(const __FlashStringHelper *fname, FileDestination_e& destination)
+{
+  return fileExists(String(fname), destination);
+}
+
 bool fileExists(const String& fname) {
+  FileDestination_e dummy;
+  return fileExists(fname, dummy);
+}
+
+bool fileExists(const String& fname, FileDestination_e& destination) {
   #ifdef USE_SECOND_HEAP
   HeapSelectDram ephemeral;
   #endif // ifdef USE_SECOND_HEAP
 
   const String patched_fname = patch_fname(fname);
   auto search                = Cache.fileExistsMap.find(patched_fname);
+  destination                = FileDestination_e::ANY;
 
   if (search != Cache.fileExistsMap.end()) {
-    return search->second;
+    destination = static_cast<FileDestination_e>(search->second - 1);
+    return search->second != 0;
   }
   bool res = ESPEASY_FS.exists(patched_fname);
+  if (res) {
+    destination = FileDestination_e::FLASH;
+  }
+
   #if FEATURE_SD
 
   if (!res) {
     res = SD.exists(patched_fname);
+    if (res) {
+      destination = FileDestination_e::SD;
+    }
   }
   #endif // if FEATURE_SD
 
@@ -164,7 +183,7 @@ bool fileExists(const String& fname) {
     Cache.fileExistsMap.emplace(
       std::make_pair(
         patched_fname,
-        res));
+        res ? (static_cast<uint8_t>(destination) + 1) : 0));
   }
 
   if (Cache.fileCacheClearMoment == 0) {
@@ -180,13 +199,14 @@ bool fileExists(const String& fname) {
 
 fs::File tryOpenFile(const String& fname, const String& mode, FileDestination_e destination) {
   START_TIMER;
-  fs::File f;
+  fs::File f{};
 
   if (fname.isEmpty() || equals(fname, '/')) {
     return f;
   }
 
-  bool exists = fileExists(fname);
+  FileDestination_e where = FileDestination_e::ANY;
+  bool exists = fileExists(fname, where);
 
   if (!exists) {
     if (equals(mode, 'r')) {
@@ -195,13 +215,15 @@ fs::File tryOpenFile(const String& fname, const String& mode, FileDestination_e 
     clearFileCaches();
   }
 
-  if ((destination == FileDestination_e::ANY) || (destination == FileDestination_e::FLASH)) {
+  if (where != FileDestination_e::SD && ((destination == FileDestination_e::ANY) || (destination == FileDestination_e::FLASH))) {
     f = ESPEASY_FS.open(patch_fname(fname), mode.c_str());
+    addLog(LOG_LEVEL_INFO, strformat(F("Accessing on Flash: %s (0x%x)"), patch_fname(fname).c_str(), f));
   }
   #if FEATURE_SD
 
-  if (!f && ((destination == FileDestination_e::ANY) || (destination == FileDestination_e::SD))) {
+  if ((!f || where == FileDestination_e::SD) && ((destination == FileDestination_e::ANY) || (destination == FileDestination_e::SD))) {
     f = SD.open(patch_fname(fname).c_str(), mode.c_str());
+    addLog(LOG_LEVEL_INFO, strformat(F("Accessing on SD-card: %s (0x%x)"), patch_fname(fname).c_str(), f));
   }
   #endif // if FEATURE_SD
 

--- a/src/src/Helpers/ESPEasy_Storage.cpp
+++ b/src/src/Helpers/ESPEasy_Storage.cpp
@@ -217,13 +217,11 @@ fs::File tryOpenFile(const String& fname, const String& mode, FileDestination_e 
 
   if (where != FileDestination_e::SD && ((destination == FileDestination_e::ANY) || (destination == FileDestination_e::FLASH))) {
     f = ESPEASY_FS.open(patch_fname(fname), mode.c_str());
-    addLog(LOG_LEVEL_INFO, strformat(F("Accessing on Flash: %s (0x%x)"), patch_fname(fname).c_str(), f));
   }
   #if FEATURE_SD
 
   if ((!f || where == FileDestination_e::SD) && ((destination == FileDestination_e::ANY) || (destination == FileDestination_e::SD))) {
     f = SD.open(patch_fname(fname).c_str(), mode.c_str());
-    addLog(LOG_LEVEL_INFO, strformat(F("Accessing on SD-card: %s (0x%x)"), patch_fname(fname).c_str(), f));
   }
   #endif // if FEATURE_SD
 

--- a/src/src/Helpers/ESPEasy_Storage.cpp
+++ b/src/src/Helpers/ESPEasy_Storage.cpp
@@ -199,14 +199,14 @@ bool fileExists(const String& fname, FileDestination_e& destination) {
 
 fs::File tryOpenFile(const String& fname, const String& mode, FileDestination_e destination) {
   START_TIMER;
-  fs::File f{};
+  fs::File f;
 
   if (fname.isEmpty() || equals(fname, '/')) {
     return f;
   }
 
   FileDestination_e where = FileDestination_e::ANY;
-  bool exists = fileExists(fname, where);
+  const bool exists = fileExists(fname, where);
 
   if (!exists) {
     if (equals(mode, 'r')) {

--- a/src/src/Helpers/ESPEasy_Storage.h
+++ b/src/src/Helpers/ESPEasy_Storage.h
@@ -33,16 +33,18 @@ String appendLineToFile(const String& fname, const String& line);
 
 String appendToFile(const String& fname, const uint8_t *data, unsigned int size);
 
-bool fileExists(const __FlashStringHelper * fname);
-bool fileExists(const String& fname);
-
-int fileSize(const String& fname);
-
 enum class FileDestination_e : uint8_t {
   ANY   = 0,
   FLASH = 1,
   SD    = 2,
 };
+
+bool fileExists(const __FlashStringHelper * fname);
+bool fileExists(const __FlashStringHelper *fname, FileDestination_e& destination);
+bool fileExists(const String& fname, FileDestination_e& destination);
+bool fileExists(const String& fname);
+
+int fileSize(const String& fname);
 
 fs::File tryOpenFile(const String& fname, const String& mode, FileDestination_e destination = FileDestination_e::ANY);
 


### PR DESCRIPTION
Resolves #5255 

Features:
- Fix displaying .bmp files on a TFT display when read from SD-Card
- Implement workaround for `file.position()` not returning for an SD-located file 😮
- Tested:
  - Displaying .bmp files from local storage on TFT display
  - Loading .bmp files from SD-Card and display them on TFT display
  - Uploading files to local Flash storage
  - Uploading files to SD-Card storage

TODO:
- [x] More testing ([confirmed](https://github.com/letscontrolit/ESPEasy/issues/5255#issuecomment-2661330520))
- [x] Find other similar use-cases in the code