### PR TITLE
[Memory] Improve memory usage

### DIFF
--- a/platformio_esp32s3_envs.ini
+++ b/platformio_esp32s3_envs.ini
@@ -217,9 +217,9 @@ build_flags               = ${esp32s3_common_LittleFS.build_flags}
                             -DPLUGIN_BUILD_IR_EXTENDED
                             -DCONFIG_PM_LIGHTSLEEP_RTC_OSC_CAL_INTERVAL=1
 extra_scripts             = ${esp32s3_common_LittleFS.extra_scripts}
-custom_sdkconfig            =
-                              CONFIG_RMT_ISR_CACHE_SAFE=y
-                              CONFIG_PM_LIGHTSLEEP_RTC_OSC_CAL_INTERVAL=1
+;custom_sdkconfig            =
+;                              CONFIG_RMT_ISR_CACHE_SAFE=y
+;                              CONFIG_PM_LIGHTSLEEP_RTC_OSC_CAL_INTERVAL=1
 
 
 

--- a/platformio_esp82xx_base.ini
+++ b/platformio_esp82xx_base.ini
@@ -107,6 +107,14 @@ build_flags               = ${beta_platform.build_flags}
 lib_ignore                = ${beta_platform.lib_ignore}
                             ${no_ir.lib_ignore}
 
+[normal_beta_2ndheap]
+platform                  = ${beta_platform_2ndheap.platform}
+platform_packages         = ${beta_platform_2ndheap.platform_packages}
+build_flags               = ${beta_platform_2ndheap.build_flags}
+                            -DBUILD_NO_DEBUG
+lib_ignore                = ${beta_platform.lib_ignore}
+                            ${no_ir.lib_ignore}
+
 ;;; COLLECTION  ********************************************************
 ; additional plugins (and dependend code) that is marked as COLLECTION ;
 ; Includes "normal" + "collection" plugins                             ;

--- a/platformio_esp82xx_envs.ini
+++ b/platformio_esp82xx_envs.ini
@@ -300,6 +300,26 @@ build_flags               = ${normal.build_flags}
                             -D NO_LIMIT_BUILD_SIZE
 lib_ignore                = ${normal.lib_ignore}
 
+[env:normal_beta_2ndheap_ESP8266_4M1M]
+extends                   = esp8266_4M1M
+platform                  = ${normal_beta_2ndheap.platform}
+platform_packages         = ${normal_beta_2ndheap.platform_packages}
+build_flags               = ${normal_beta_2ndheap.build_flags}
+                            ${esp8266_4M1M.build_flags}
+                            -D NO_LIMIT_BUILD_SIZE
+lib_ignore                = ${normal_beta_2ndheap.lib_ignore}
+
+
+[env:normal_beta_2ndheap_ESP8266_4M1M_VCC]
+extends                   = esp8266_4M1M
+platform                  = ${normal_beta_2ndheap.platform}
+platform_packages         = ${normal_beta_2ndheap.platform_packages}
+build_flags               = ${normal_beta_2ndheap.build_flags}
+                            ${esp8266_4M1M.build_flags}
+                            -D FEATURE_ADC_VCC=1
+                            -D NO_LIMIT_BUILD_SIZE
+lib_ignore                = ${normal_beta_2ndheap.lib_ignore}
+
 
 ; NORMAL: 16M version --- LittleFS --------------
 ; LittleFS is determined by using "LittleFS" in the pio env name

--- a/src/_C001.cpp
+++ b/src/_C001.cpp
@@ -100,9 +100,14 @@ bool CPlugin_001(CPlugin::Function function, struct EventStruct *event, String& 
           url += mapVccToDomoticz();
             # endif // if FEATURE_ADC_VCC
 
-          std::unique_ptr<C001_queue_element> element(new (std::nothrow) C001_queue_element(event->ControllerIndex, event->TaskIndex, std::move(url)));
+          constexpr unsigned size = sizeof(C001_queue_element);
+          void *ptr               = special_calloc(1, size);
+    
+          if (ptr != nullptr) {
+            std::unique_ptr<C001_queue_element> element(new (ptr) C001_queue_element(event->ControllerIndex, event->TaskIndex, std::move(url)));
 
-          success = C001_DelayHandler->addToQueue(std::move(element));
+            success = C001_DelayHandler->addToQueue(std::move(element));
+          }
           Scheduler.scheduleNextDelayQueue(SchedulerIntervalTimer_e::TIMER_C001_DELAY_QUEUE,
                                            C001_DelayHandler->getNextScheduleTime());
         }

--- a/src/_C004.cpp
+++ b/src/_C004.cpp
@@ -48,7 +48,8 @@ bool CPlugin_004(CPlugin::Function function, struct EventStruct *event, String& 
     {
       success = true;
 
-      switch (event->idx) {
+      switch (event->idx)
+      {
         case ControllerSettingsStruct::CONTROLLER_USER:
           string = F("ThingHTTP Name");
           break;
@@ -72,9 +73,14 @@ bool CPlugin_004(CPlugin::Function function, struct EventStruct *event, String& 
         break;
       }
 
-      std::unique_ptr<C004_queue_element> element(new (std::nothrow) C004_queue_element(event));
+      constexpr unsigned size = sizeof(C004_queue_element);
+      void *ptr               = special_calloc(1, size);
 
-      success = C004_DelayHandler->addToQueue(std::move(element));
+      if (ptr != nullptr) {
+        std::unique_ptr<C004_queue_element> element(new (ptr) C004_queue_element(event));
+
+        success = C004_DelayHandler->addToQueue(std::move(element));
+      }
       Scheduler.scheduleNextDelayQueue(SchedulerIntervalTimer_e::TIMER_C004_DELAY_QUEUE, C004_DelayHandler->getNextScheduleTime());
 
       break;

--- a/src/_C009.cpp
+++ b/src/_C009.cpp
@@ -1,9 +1,9 @@
 #include "src/Helpers/_CPlugin_Helper.h"
 #ifdef USES_C009
 
-#include "src/DataTypes/NodeTypeID.h"
-#include "src/Helpers/StringProvider.h"
-#include "src/CustomBuild/ESPEasy_buildinfo.h"
+# include "src/DataTypes/NodeTypeID.h"
+# include "src/Helpers/StringProvider.h"
+# include "src/CustomBuild/ESPEasy_buildinfo.h"
 
 // #######################################################################################################
 // ########################### Controller Plugin 009: FHEM HTTP ##########################################
@@ -80,8 +80,13 @@ bool CPlugin_009(CPlugin::Function function, struct EventStruct *event, String& 
           break;
         }
 
-        std::unique_ptr<C009_queue_element> element(new (std::nothrow) C009_queue_element(event));
-        success = C009_DelayHandler->addToQueue(std::move(element));
+        constexpr unsigned size = sizeof(C009_queue_element);
+        void *ptr               = special_calloc(1, size);
+
+        if (ptr != nullptr) {
+          std::unique_ptr<C009_queue_element> element(new (ptr) C009_queue_element(event));
+          success = C009_DelayHandler->addToQueue(std::move(element));
+        }
         Scheduler.scheduleNextDelayQueue(SchedulerIntervalTimer_e::TIMER_C009_DELAY_QUEUE, C009_DelayHandler->getNextScheduleTime());
       }
       break;
@@ -109,109 +114,110 @@ bool CPlugin_009(CPlugin::Function function, struct EventStruct *event, String& 
 bool do_process_c009_delay_queue(cpluginID_t cpluginID, const Queue_element_base& element_base, ControllerSettingsStruct& ControllerSettings) {
   const C009_queue_element& element = static_cast<const C009_queue_element&>(element_base);
 // *INDENT-ON*
-  String jsonString;
-  // Make an educated guess on the actual length, based on earlier requests.
-  static size_t expectedJsonLength = 100;
-  {
-    // Reserve on the heap with most space
-    if (!reserve_special(jsonString, expectedJsonLength)) {
-      // Not enough free memory
-      return false;
-    }
+String jsonString;
+
+// Make an educated guess on the actual length, based on earlier requests.
+static size_t expectedJsonLength = 100;
+{
+  // Reserve on the heap with most space
+  if (!reserve_special(jsonString, expectedJsonLength)) {
+    // Not enough free memory
+    return false;
   }
+}
+{
+  jsonString += '{';
   {
-    jsonString += '{';
+    jsonString += to_json_object_value(F("module"),  F("ESPEasy"));
+    jsonString += ',';
+    jsonString += to_json_object_value(F("version"), F("1.04"));
+
+    // Create nested object "ESP" inside "data"
+    jsonString += ',';
+    jsonString += F("\"data\":{");
     {
-      jsonString += to_json_object_value(F("module"),  F("ESPEasy"));
-      jsonString += ',';
-      jsonString += to_json_object_value(F("version"), F("1.04"));
-
-      // Create nested object "ESP" inside "data"
-      jsonString += ',';
-      jsonString += F("\"data\":{");
+      jsonString += F("\"ESP\":{");
       {
-        jsonString += F("\"ESP\":{");
-        {
-          // Create nested objects in "ESP":
-          jsonString += to_json_object_value(F("name"), Settings.getName());
-          jsonString += ',';
-          jsonString += to_json_object_value(F("unit"), static_cast<int>(Settings.Unit));
-          jsonString += ',';
-          jsonString += to_json_object_value(F("version"), static_cast<int>(Settings.Version));
-          jsonString += ',';
-          jsonString += to_json_object_value(F("build"), static_cast<int>(Settings.Build));
-          jsonString += ',';
-          jsonString += to_json_object_value(F("build_notes"), F(BUILD_NOTES));
-          jsonString += ',';
-          jsonString += to_json_object_value(F("build_git"), getValue(LabelType::GIT_BUILD));
-          jsonString += ',';
-          jsonString += to_json_object_value(F("node_type_id"), static_cast<int>(NODE_TYPE_ID));
-          jsonString += ',';
-          jsonString += to_json_object_value(F("sleep"), static_cast<int>(Settings.deepSleep_wakeTime));
-
-          // embed IP, important if there is NAT/PAT
-          // char ipStr[20];
-          // IPAddress ip = NetworkLocalIP();
-          // sprintf_P(ipStr, PSTR("%u.%u.%u.%u"), ip[0], ip[1], ip[2], ip[3]);
-          jsonString += ',';
-          jsonString += to_json_object_value(F("ip"), formatIP(NetworkLocalIP()));
-        }
-        jsonString += '}'; // End "ESP"
-
+        // Create nested objects in "ESP":
+        jsonString += to_json_object_value(F("name"), Settings.getName());
         jsonString += ',';
+        jsonString += to_json_object_value(F("unit"), static_cast<int>(Settings.Unit));
+        jsonString += ',';
+        jsonString += to_json_object_value(F("version"), static_cast<int>(Settings.Version));
+        jsonString += ',';
+        jsonString += to_json_object_value(F("build"), static_cast<int>(Settings.Build));
+        jsonString += ',';
+        jsonString += to_json_object_value(F("build_notes"), F(BUILD_NOTES));
+        jsonString += ',';
+        jsonString += to_json_object_value(F("build_git"), getValue(LabelType::GIT_BUILD));
+        jsonString += ',';
+        jsonString += to_json_object_value(F("node_type_id"), static_cast<int>(NODE_TYPE_ID));
+        jsonString += ',';
+        jsonString += to_json_object_value(F("sleep"), static_cast<int>(Settings.deepSleep_wakeTime));
 
-        // Create nested object "SENSOR" json object inside "data"
-        jsonString += F("\"SENSOR\":{");
-        {
-          // char itemNames[valueCount][2];
-          for (uint8_t x = 0; x < element.valueCount; x++)
-          {
-            // Each sensor value get an own object (0..n)
-            // sprintf(itemNames[x],"%d",x);
-            if (x != 0) {
-              jsonString += ',';
-            }
-
-            jsonString += '"';
-            jsonString += x;
-            jsonString += F("\":{");
-            {
-              jsonString += to_json_object_value(F("deviceName"), getTaskDeviceName(element._taskIndex));
-              jsonString += ',';
-              jsonString += to_json_object_value(F("valueName"), Cache.getTaskDeviceValueName(element._taskIndex, x));
-              jsonString += ',';
-              jsonString += to_json_object_value(F("type"), static_cast<int>(element.sensorType));
-              jsonString += ',';
-              jsonString += to_json_object_value(F("value"), element.txt[x]);
-            }
-            jsonString += '}'; // End "sensor value N"
-          }
-        }
-        jsonString += '}';     // End "SENSOR"
+        // embed IP, important if there is NAT/PAT
+        // char ipStr[20];
+        // IPAddress ip = NetworkLocalIP();
+        // sprintf_P(ipStr, PSTR("%u.%u.%u.%u"), ip[0], ip[1], ip[2], ip[3]);
+        jsonString += ',';
+        jsonString += to_json_object_value(F("ip"), formatIP(NetworkLocalIP()));
       }
-      jsonString += '}';       // End "data"
+      jsonString += '}'; // End "ESP"
+
+      jsonString += ',';
+
+      // Create nested object "SENSOR" json object inside "data"
+      jsonString += F("\"SENSOR\":{");
+      {
+        // char itemNames[valueCount][2];
+        for (uint8_t x = 0; x < element.valueCount; x++)
+        {
+          // Each sensor value get an own object (0..n)
+          // sprintf(itemNames[x],"%d",x);
+          if (x != 0) {
+            jsonString += ',';
+          }
+
+          jsonString += '"';
+          jsonString += x;
+          jsonString += F("\":{");
+          {
+            jsonString += to_json_object_value(F("deviceName"), getTaskDeviceName(element._taskIndex));
+            jsonString += ',';
+            jsonString += to_json_object_value(F("valueName"), Cache.getTaskDeviceValueName(element._taskIndex, x));
+            jsonString += ',';
+            jsonString += to_json_object_value(F("type"), static_cast<int>(element.sensorType));
+            jsonString += ',';
+            jsonString += to_json_object_value(F("value"), element.txt[x]);
+          }
+          jsonString += '}'; // End "sensor value N"
+        }
+      }
+      jsonString += '}';     // End "SENSOR"
     }
-    jsonString += '}';         // End JSON structure
+    jsonString += '}';       // End "data"
   }
+  jsonString += '}';         // End JSON structure
+}
 
-  if (expectedJsonLength < jsonString.length()) {
-    expectedJsonLength = jsonString.length();
-  }
+if (expectedJsonLength < jsonString.length()) {
+  expectedJsonLength = jsonString.length();
+}
 
-  // addLog(LOG_LEVEL_INFO, F("C009 Test JSON:"));
-  // addLog(LOG_LEVEL_INFO, jsonString);
+// addLog(LOG_LEVEL_INFO, F("C009 Test JSON:"));
+// addLog(LOG_LEVEL_INFO, jsonString);
 
-  int httpCode = -1;
-  send_via_http(
-    cpluginID,
-    ControllerSettings,
-    element._controller_idx,
-    F("/ESPEasy"),
-    F("POST"),
-    EMPTY_STRING,
-    jsonString,
-    httpCode);
-  return (httpCode >= 100) && (httpCode < 300);
+int httpCode = -1;
+send_via_http(
+  cpluginID,
+  ControllerSettings,
+  element._controller_idx,
+  F("/ESPEasy"),
+  F("POST"),
+  EMPTY_STRING,
+  jsonString,
+  httpCode);
+return (httpCode >= 100) && (httpCode < 300);
 }
 
 #endif // ifdef USES_C009

--- a/src/_C012.cpp
+++ b/src/_C012.cpp
@@ -59,7 +59,15 @@ bool CPlugin_012(CPlugin::Function function, struct EventStruct *event, String& 
 
       // Collect the values at the same run, to make sure all are from the same sample
       uint8_t valueCount = getValueCountForTask(event->TaskIndex);
-      std::unique_ptr<C012_queue_element> element(new (std::nothrow) C012_queue_element(event, valueCount));
+
+      constexpr unsigned size = sizeof(C012_queue_element);
+      void *ptr               = special_calloc(1, size);
+    
+      if (ptr == nullptr) {
+        break;
+      }
+    
+      std::unique_ptr<C012_queue_element> element(new (ptr) C012_queue_element(event, valueCount));
 
       for (uint8_t x = 0; x < valueCount; x++)
       {

--- a/src/_C017.cpp
+++ b/src/_C017.cpp
@@ -67,8 +67,13 @@ bool CPlugin_017(CPlugin::Function function, struct EventStruct *event, String& 
         break;
       }
 
-      std::unique_ptr<C017_queue_element> element(new (std::nothrow) C017_queue_element(event));
-      success = C017_DelayHandler->addToQueue(std::move(element));
+      constexpr unsigned size = sizeof(C017_queue_element);
+      void *ptr               = special_calloc(1, size);
+    
+      if (ptr != nullptr) {
+        std::unique_ptr<C017_queue_element> element(new (ptr) C017_queue_element(event));
+        success = C017_DelayHandler->addToQueue(std::move(element));
+      }
       Scheduler.scheduleNextDelayQueue(SchedulerIntervalTimer_e::TIMER_C017_DELAY_QUEUE, C017_DelayHandler->getNextScheduleTime());
       break;
     }

--- a/src/_C018.cpp
+++ b/src/_C018.cpp
@@ -127,7 +127,14 @@ bool CPlugin_018(CPlugin::Function function, struct EventStruct *event, String& 
 
       {
         // Keep this object in a small scope so we can destruct it as soon as possible again.
-        std::shared_ptr<C018_ConfigStruct> customConfig(new (std::nothrow) C018_ConfigStruct);
+
+        constexpr unsigned size = sizeof(C018_ConfigStruct);
+        void *ptr               = special_calloc(1, size);
+      
+        if (ptr == nullptr) {
+          break;
+        }
+        std::shared_ptr<C018_ConfigStruct> customConfig(new (ptr) C018_ConfigStruct);
 
         if (!customConfig) {
           break;
@@ -140,7 +147,13 @@ bool CPlugin_018(CPlugin::Function function, struct EventStruct *event, String& 
     }
     case CPlugin::Function::CPLUGIN_WEBFORM_SAVE:
     {
-      std::shared_ptr<C018_ConfigStruct> customConfig(new (std::nothrow) C018_ConfigStruct);
+      constexpr unsigned size = sizeof(C018_ConfigStruct);
+      void *ptr               = special_calloc(1, size);
+    
+      if (ptr == nullptr) {
+        break;
+      }
+      std::shared_ptr<C018_ConfigStruct> customConfig(new (ptr) C018_ConfigStruct);
 
       if (customConfig) {
         customConfig->webform_save();
@@ -186,7 +199,14 @@ bool CPlugin_018(CPlugin::Function function, struct EventStruct *event, String& 
 
       if (C018_data != nullptr) {
         {
-          std::unique_ptr<C018_queue_element> element(new (std::nothrow) C018_queue_element(event, C018_data->getSampleSetCount(event->TaskIndex)));
+          constexpr unsigned size = sizeof(C018_queue_element);
+          void *ptr               = special_calloc(1, size);
+        
+          if (ptr == nullptr) {
+            break;
+          }
+    
+          std::unique_ptr<C018_queue_element> element(new (ptr) C018_queue_element(event, C018_data->getSampleSetCount(event->TaskIndex)));
           success = C018_DelayHandler->addToQueue(std::move(element));
           Scheduler.scheduleNextDelayQueue(SchedulerIntervalTimer_e::TIMER_C018_DELAY_QUEUE,
                                            C018_DelayHandler->getNextScheduleTime());
@@ -274,11 +294,19 @@ bool C018_init(struct EventStruct *event) {
     C018_data = nullptr;
   }
 
+  {
+    constexpr unsigned size = sizeof(C018_data_struct);
+    void *ptr               = special_calloc(1, size);
 
-  C018_data = new (std::nothrow) C018_data_struct;
+    if (ptr == nullptr) {
+      return false;
+    }
 
-  if (C018_data == nullptr) {
-    return false;
+    C018_data = new (ptr) C018_data_struct;
+
+    if (C018_data == nullptr) {
+      return false;
+    }
   }
   {
     // Allocate ControllerSettings object in a scope, so we can destruct it as soon as possible.
@@ -296,7 +324,13 @@ bool C018_init(struct EventStruct *event) {
     Port               = ControllerSettings->Port;
   }
 
-  std::shared_ptr<C018_ConfigStruct> customConfig(new (std::nothrow) C018_ConfigStruct);
+  constexpr unsigned size = sizeof(C018_ConfigStruct);
+  void *ptr               = special_calloc(1, size);
+
+  if (ptr == nullptr) {
+    return false;
+  }
+  std::shared_ptr<C018_ConfigStruct> customConfig(new (ptr) C018_ConfigStruct);
 
   if (!customConfig) {
     return false;

--- a/src/_N001_Email.cpp
+++ b/src/_N001_Email.cpp
@@ -56,9 +56,9 @@ bool NPlugin_001(NPlugin::Function function, struct EventStruct *event, String& 
     //     if (command == F("email"))
     //     {
     //       MakeNotificationSettings(NotificationSettings);
-    //       LoadNotificationSettings(event->NotificationIndex, (uint8_t*)&NotificationSettings, sizeof(NotificationSettingsStruct));
-    //       NPlugin_001_send(NotificationSettings.Domain, NotificationSettings.Receiver, NotificationSettings.Sender,
-    // NotificationSettings.Subject, NotificationSettings.Body, NotificationSettings.Server, NotificationSettings.Port);
+    //       LoadNotificationSettings(event->NotificationIndex, (uint8_t *)NotificationSettings.get(), sizeof(NotificationSettingsStruct));
+    //       NPlugin_001_send(NotificationSettings->Domain, NotificationSettings->Receiver, NotificationSettings->Sender,
+    // NotificationSettings->Subject, NotificationSettings->Body, NotificationSettings->Server, NotificationSettings->Port);
     //       success = true;
     //     }
     //     break;
@@ -67,11 +67,14 @@ bool NPlugin_001(NPlugin::Function function, struct EventStruct *event, String& 
     case NPlugin::Function::NPLUGIN_NOTIFY:
     {
       MakeNotificationSettings(NotificationSettings);
-      LoadNotificationSettings(event->NotificationIndex, (uint8_t *)&NotificationSettings, sizeof(NotificationSettingsStruct));
-      NotificationSettings.validate();
+      if (!AllocatedNotificationSettings()) {
+        break;
+      }
+      LoadNotificationSettings(event->NotificationIndex, (uint8_t *)NotificationSettings.get(), sizeof(NotificationSettingsStruct));
+      NotificationSettings->validate();
 
-      String subject = NotificationSettings.Subject;
-      String body    = NotificationSettings.Body;
+      String subject = NotificationSettings->Subject;
+      String body    = NotificationSettings->Body;
 
       if (!event->String1.isEmpty()) {
         body = event->String1;
@@ -80,7 +83,7 @@ bool NPlugin_001(NPlugin::Function function, struct EventStruct *event, String& 
       if (!event->String2.isEmpty()) {
         subject = event->String2;
       }
-      NPlugin_001_send(NotificationSettings, subject, body);
+      NPlugin_001_send(*NotificationSettings, subject, body);
       success = true;
       break;
     }

--- a/src/_N002_Buzzer.cpp
+++ b/src/_N002_Buzzer.cpp
@@ -46,7 +46,7 @@ bool NPlugin_002(NPlugin::Function function, struct EventStruct *event, String& 
     //     if (command == F("buzzer"))
     //     {
     //       MakeNotificationSettings(NotificationSettings);
-    //       LoadNotificationSettings(event->NotificationIndex, (uint8_t*)&NotificationSettings, sizeof(NotificationSettingsStruct));
+    //       LoadNotificationSettings(event->NotificationIndex, (uint8_t *)NotificationSettings.get(), sizeof(NotificationSettingsStruct));
     //       success = true;
     //     }
     //     break;
@@ -55,10 +55,14 @@ bool NPlugin_002(NPlugin::Function function, struct EventStruct *event, String& 
     case NPlugin::Function::NPLUGIN_NOTIFY:
       {
         MakeNotificationSettings(NotificationSettings);
-        LoadNotificationSettings(event->NotificationIndex, (uint8_t*)&NotificationSettings, sizeof(NotificationSettingsStruct));
-        NotificationSettings.validate();
+        if (!AllocatedNotificationSettings()) {
+          break;
+        }
+ 
+        LoadNotificationSettings(event->NotificationIndex, (uint8_t *)NotificationSettings.get(), sizeof(NotificationSettingsStruct));
+        NotificationSettings->validate();
         //this reserves IRAM and uninitialized RAM
-        tone_espEasy(NotificationSettings.Pin1, 440, 500);
+        tone_espEasy(NotificationSettings->Pin1, 440, 500);
         success = true;
       }
 

--- a/src/_P002_ADC.ino
+++ b/src/_P002_ADC.ino
@@ -99,7 +99,7 @@ boolean Plugin_002(uint8_t function, struct EventStruct *event, String& string)
 
     case PLUGIN_INIT:
     {
-      initPluginTaskData(event->TaskIndex, new (std::nothrow) P002_data_struct());
+      special_initPluginTaskData(event->TaskIndex, P002_data_struct);
       P002_data_struct *P002_data =
         static_cast<P002_data_struct *>(getPluginTaskData(event->TaskIndex));
 

--- a/src/_P002_ADC.ino
+++ b/src/_P002_ADC.ino
@@ -57,7 +57,14 @@ boolean Plugin_002(uint8_t function, struct EventStruct *event, String& string)
         P002_data->webformLoad(event);
         success = true;
       } else {
-        P002_data = new (std::nothrow) P002_data_struct();
+        constexpr unsigned size = sizeof(P002_data_struct);
+        void *ptr               = special_calloc(1, size);
+  
+        if (ptr == nullptr) {
+          break;
+        }
+
+        P002_data = new (ptr) P002_data_struct();
 
         if (nullptr != P002_data) {
           P002_data->init(event);

--- a/src/_P023_OLED.ino
+++ b/src/_P023_OLED.ino
@@ -183,7 +183,10 @@ boolean Plugin_023(uint8_t function, struct EventStruct *event, String& string)
         font_spacing = static_cast<P023_data_struct::Spacing>(PCONFIG(4));
       }
 
-      initPluginTaskData(event->TaskIndex, new (std::nothrow) P023_data_struct(PCONFIG(0), type, font_spacing, PCONFIG(2), PCONFIG(5)));
+      void * ptr = special_calloc(1, sizeof(P023_data_struct));
+      if (ptr) {
+        initPluginTaskData(event->TaskIndex, new (ptr) P023_data_struct(PCONFIG(0), type, font_spacing, PCONFIG(2), PCONFIG(5)));
+      }
       P023_data_struct *P023_data = static_cast<P023_data_struct *>(getPluginTaskData(event->TaskIndex));
 
       if (nullptr != P023_data) {

--- a/src/_P036_FrameOLED.ino
+++ b/src/_P036_FrameOLED.ino
@@ -710,14 +710,7 @@ boolean Plugin_036(uint8_t function, struct EventStruct *event, String& string)
 # ifdef P036_CHECK_HEAP
       P036_CheckHeap(F("_INIT: Entering"));
 # endif // P036_CHECK_HEAP
-      {
-        constexpr unsigned size = sizeof(P036_data_struct);
-        void *ptr               = special_calloc(1, size);
-  
-        if (ptr != nullptr) {
-          initPluginTaskData(event->TaskIndex, new (ptr) P036_data_struct());
-        }
-      }
+      special_initPluginTaskData(event->TaskIndex, P036_data_struct);
 # ifdef P036_CHECK_HEAP
       P036_CheckHeap(F("_INIT: Before (*P036_data = static_cast<P036_data_struct *>)"));
 # endif // P036_CHECK_HEAP

--- a/src/_P036_FrameOLED.ino
+++ b/src/_P036_FrameOLED.ino
@@ -711,11 +711,12 @@ boolean Plugin_036(uint8_t function, struct EventStruct *event, String& string)
       P036_CheckHeap(F("_INIT: Entering"));
 # endif // P036_CHECK_HEAP
       {
-        # ifdef USE_SECOND_HEAP
-        HeapSelectIram ephemeral;
-        # endif // ifdef USE_SECOND_HEAP
-
-        initPluginTaskData(event->TaskIndex, new (std::nothrow) P036_data_struct());
+        constexpr unsigned size = sizeof(P036_data_struct);
+        void *ptr               = special_calloc(1, size);
+  
+        if (ptr != nullptr) {
+          initPluginTaskData(event->TaskIndex, new (ptr) P036_data_struct());
+        }
       }
 # ifdef P036_CHECK_HEAP
       P036_CheckHeap(F("_INIT: Before (*P036_data = static_cast<P036_data_struct *>)"));

--- a/src/_P037_MQTTImport.ino
+++ b/src/_P037_MQTTImport.ino
@@ -200,7 +200,12 @@ boolean Plugin_037(uint8_t function, struct EventStruct *event, String& string)
       # endif // if P037_REPLACE_BY_COMMA_SUPPORT
 
       {
-        P037_data_struct *P037_data = new (std::nothrow) P037_data_struct(event->TaskIndex);
+        P037_data_struct *P037_data = nullptr;
+        constexpr size_t size = sizeof(P037_data_struct);
+        void * ptr = special_calloc(1, size);
+        if (ptr) {
+          P037_data = new (ptr) P037_data_struct(event->TaskIndex);
+        }
 
         if (nullptr == P037_data) {
           return success;
@@ -229,7 +234,11 @@ boolean Plugin_037(uint8_t function, struct EventStruct *event, String& string)
 
     case PLUGIN_WEBFORM_SAVE:
     {
-      P037_data_struct *P037_data = new (std::nothrow) P037_data_struct(event->TaskIndex);
+      P037_data_struct *P037_data = nullptr;
+      void * ptr = special_calloc(1, sizeof(P037_data_struct));
+      if (ptr) {
+        P037_data = new (ptr) P037_data_struct(event->TaskIndex);
+      }
 
       if (nullptr == P037_data) {
         return success;
@@ -271,7 +280,10 @@ boolean Plugin_037(uint8_t function, struct EventStruct *event, String& string)
 
     case PLUGIN_INIT:
     {
-      initPluginTaskData(event->TaskIndex, new (std::nothrow) P037_data_struct(event->TaskIndex));
+      void * ptr = special_calloc(1, sizeof(P037_data_struct));
+      if (ptr) {
+        initPluginTaskData(event->TaskIndex, new (ptr) P037_data_struct(event->TaskIndex));
+      }
 
       P037_data_struct *P037_data = static_cast<P037_data_struct *>(getPluginTaskData(event->TaskIndex));
 

--- a/src/_P082_GPS.ino
+++ b/src/_P082_GPS.ino
@@ -314,11 +314,14 @@ boolean Plugin_082(uint8_t function, struct EventStruct *event, String& string) 
       const int16_t serial_tx      = CONFIG_PIN2;
       const int16_t pps_pin        = CONFIG_PIN3;
 
-      # ifdef USE_SECOND_HEAP
-      HeapSelectIram ephemeral;
-      # endif // ifdef USE_SECOND_HEAP
+      // Try to allocate in PSRAM or 2nd heap if possible
+      constexpr unsigned size = sizeof(P082_data_struct);
+      void *ptr               = special_calloc(1, size);
+      if (!ptr) {
+        return success;
+      }
 
-      initPluginTaskData(event->TaskIndex, new (std::nothrow) P082_data_struct());
+      initPluginTaskData(event->TaskIndex, new (ptr) P082_data_struct());
       P082_data_struct *P082_data =
         static_cast<P082_data_struct *>(getPluginTaskData(event->TaskIndex));
 

--- a/src/_P082_GPS.ino
+++ b/src/_P082_GPS.ino
@@ -314,14 +314,7 @@ boolean Plugin_082(uint8_t function, struct EventStruct *event, String& string) 
       const int16_t serial_tx      = CONFIG_PIN2;
       const int16_t pps_pin        = CONFIG_PIN3;
 
-      // Try to allocate in PSRAM or 2nd heap if possible
-      constexpr unsigned size = sizeof(P082_data_struct);
-      void *ptr               = special_calloc(1, size);
-      if (!ptr) {
-        return success;
-      }
-
-      initPluginTaskData(event->TaskIndex, new (ptr) P082_data_struct());
+      special_initPluginTaskData(event->TaskIndex, P082_data_struct);
       P082_data_struct *P082_data =
         static_cast<P082_data_struct *>(getPluginTaskData(event->TaskIndex));
 

--- a/src/_P092_DLbus.ino
+++ b/src/_P092_DLbus.ino
@@ -411,6 +411,8 @@ boolean Plugin_092(uint8_t function, struct EventStruct *event, String& string)
           addLog(LOG_LEVEL_INFO, F("Create P092_data_struct ..."));
 # endif // ifndef P092_LIMIT_BUILD_SIZE
 
+          // FIXME TD-er: This is a really odd and overly complex way to handle this.
+
           P092_data = new (std::nothrow) P092_data_struct();
           initPluginTaskData(event->TaskIndex, P092_data);
 

--- a/src/_Plugin_Helper.h
+++ b/src/_Plugin_Helper.h
@@ -92,6 +92,9 @@
 
 extern PluginTaskData_base *Plugin_task_data[TASKS_MAX];
 
+// Try to allocate in PSRAM or 2nd heap if possible
+#define special_initPluginTaskData(I, T)  void * ptr = special_calloc(1, sizeof(T)); if (ptr) { initPluginTaskData(I, new (ptr) T()); }
+
 String PCONFIG_LABEL(int n);
 
 // ==============================================

--- a/src/src/Commands/InternalCommands.cpp
+++ b/src/src/Commands/InternalCommands.cpp
@@ -64,7 +64,7 @@ bool checkNrArguments(const char *cmd, const String& Line, int nrArguments) {
     if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
       String log;
 
-      if (log.reserve(128)) {
+      if (reserve_special(log, 128)) {
         log += F("Too many arguments: cmd=");
         log += cmd;
 

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -55,7 +55,9 @@ To create/register a plugin, you have to :
         #define WEBSERVER_LOG
     #endif
     #ifndef WEBSERVER_GITHUB_COPY
-        #define WEBSERVER_GITHUB_COPY
+        #ifndef USE_SECOND_HEAP
+          #define WEBSERVER_GITHUB_COPY
+        #endif
     #endif
     #ifndef WEBSERVER_ROOT
         #define WEBSERVER_ROOT

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -3609,10 +3609,15 @@ To create/register a plugin, you have to :
   
   
 #if !defined(CUSTOM_BUILD_CDN_URL) && !defined(FEATURE_ALTERNATIVE_CDN_URL)
+  #ifdef ESP32
+    // Allow to set alternative CDN URL as the default one may not be accessible from all countries
+    #define FEATURE_ALTERNATIVE_CDN_URL 1
+  #else
   #if defined(WEBSERVER_EMBED_CUSTOM_CSS) || defined(EMBED_ESPEASY_DEFAULT_MIN_CSS) || defined(EMBED_ESPEASY_DEFAULT_MIN_CSS_USE_GZ)
     #define FEATURE_ALTERNATIVE_CDN_URL 0 // No need to configure custom CDN url when all content is included in build
   #else
     #define FEATURE_ALTERNATIVE_CDN_URL 1
+  #endif
   #endif
 #endif // if !defined(CUSTOM_BUILD_CDN_URL)
 #if defined(FEATURE_ALTERNATIVE_CDN_URL) && FEATURE_ALTERNATIVE_CDN_URL && defined(PLUGIN_BUILD_MINIMAL_OTA)

--- a/src/src/DataStructs/ESPeasyControllerCache.cpp
+++ b/src/src/DataStructs/ESPeasyControllerCache.cpp
@@ -2,6 +2,8 @@
 
 #if FEATURE_RTC_CACHE_STORAGE
 
+#include "../Helpers/Memory.h"
+
 ControllerCache_struct::~ControllerCache_struct() {
   if (_RTC_cache_handler != nullptr) {
     delete _RTC_cache_handler;
@@ -33,11 +35,12 @@ bool ControllerCache_struct::flush() {
 
 void ControllerCache_struct::init() {
   if (_RTC_cache_handler == nullptr) {
-    # ifdef USE_SECOND_HEAP
-//    HeapSelectIram ephemeral;
-    # endif // ifdef USE_SECOND_HEAP
+    constexpr unsigned size = sizeof(RTC_cache_handler_struct);
+    void *ptr               = special_calloc(1, size);
 
-    _RTC_cache_handler = new (std::nothrow) RTC_cache_handler_struct;
+    if (ptr != nullptr) {
+      _RTC_cache_handler = new (ptr) RTC_cache_handler_struct;
+    }
     if (_RTC_cache_handler != nullptr) {
       _RTC_cache_handler->init();
     }

--- a/src/src/DataStructs/LogEntry.cpp
+++ b/src/src/DataStructs/LogEntry.cpp
@@ -19,13 +19,12 @@ bool LogEntry_t::add(const uint8_t loglevel, const String& line)
   }
 
   {
-    #ifdef USE_SECOND_HEAP
-
-    // Need to make a substring or a copy, which is a new allocation, on the 2nd heap
-    HeapSelectIram ephemeral;
-    #endif // ifdef USE_SECOND_HEAP
-
     if (line.length() > LOG_STRUCT_MESSAGE_SIZE - 1) {
+      #ifdef USE_SECOND_HEAP
+
+      // Need to make a substring or a copy, which is a new allocation, on the 2nd heap
+      HeapSelectIram ephemeral;
+      #endif // ifdef USE_SECOND_HEAP
       move_special(_message, line.substring(0, LOG_STRUCT_MESSAGE_SIZE - 1));
     } else {
       reserve_special(_message, line.length());

--- a/src/src/DataStructs/NodeStruct.cpp
+++ b/src/src/DataStructs/NodeStruct.cpp
@@ -138,10 +138,10 @@ String NodeStruct::getNodeName() const {
   String res;
   size_t length = strnlen(reinterpret_cast<const char *>(nodeName), sizeof(nodeName));
 
-  res.reserve(length);
-
-  for (size_t i = 0; i < length; ++i) {
-    res += static_cast<char>(nodeName[i]);
+  if (reserve_special(res, length)) {
+    for (size_t i = 0; i < length; ++i) {
+      res += static_cast<char>(nodeName[i]);
+    }
   }
   return res;
 }
@@ -212,21 +212,21 @@ float NodeStruct::getLoad() const {
 
 String NodeStruct::getSummary() const {
   String res;
-
-  res.reserve(48);
-  res  = F("Unit: ");
-  res += unit;
-  res += F(" \"");
-  res += getNodeName();
-  res += '"';
-  res += F(" load: ");
-  res += String(getLoad(), 1);
-  res += F(" RSSI: ");
-  res += getRSSI();
-  res += F(" ch: ");
-  res += channel;
-  res += F(" dst: ");
-  res += distance;
+  if (reserve_special(res, 48)) {
+    res  = F("Unit: ");
+    res += unit;
+    res += F(" \"");
+    res += getNodeName();
+    res += '"';
+    res += F(" load: ");
+    res += String(getLoad(), 1);
+    res += F(" RSSI: ");
+    res += getRSSI();
+    res += F(" ch: ");
+    res += channel;
+    res += F(" dst: ");
+    res += distance;
+  }
   return res;
 }
 

--- a/src/src/DataStructs/NodeStruct.cpp
+++ b/src/src/DataStructs/NodeStruct.cpp
@@ -7,6 +7,7 @@
 #include "../Globals/SecuritySettings.h"
 #include "../Globals/Settings.h"
 #include "../Helpers/ESPEasy_time_calc.h"
+#include "../Helpers/StringConverter.h"
 
 
 #define NODE_STRUCT_AGE_TIMEOUT 300000  // 5 minutes

--- a/src/src/DataStructs/NodesHandler.cpp
+++ b/src/src/DataStructs/NodesHandler.cpp
@@ -141,7 +141,7 @@ bool NodesHandler::addNode(const NodeStruct& node, const ESPEasy_now_traceroute_
     if (traceRoute.getDistance() != 255) {
       if (loglevelActiveFor(LOG_LEVEL_INFO)) {
         String log;
-        if (log.reserve(80)) {
+        if (reserve_special(log, 80)) {
           log  = F(ESPEASY_NOW_NAME);
           log += F(": Node: ");
           log += String(node.unit);

--- a/src/src/DataStructs/NotificationSettingsStruct.h
+++ b/src/src/DataStructs/NotificationSettingsStruct.h
@@ -36,8 +36,12 @@ struct NotificationSettingsStruct
 };
 
 typedef std::shared_ptr<NotificationSettingsStruct> NotificationSettingsStruct_ptr_type;
-#define MakeNotificationSettings(T) NotificationSettingsStruct_ptr_type NotificationSettingsStruct_ptr(new (std::nothrow)  NotificationSettingsStruct());\
-                                    NotificationSettingsStruct& T = *NotificationSettingsStruct_ptr;
+
+#define MakeNotificationSettings(T) void * calloc_ptr = special_calloc(1,sizeof(NotificationSettingsStruct)); NotificationSettingsStruct_ptr_type T(new (calloc_ptr)  NotificationSettingsStruct());
+
+// Check to see if MakeNotificationSettings was successful
+#define AllocatedNotificationSettings() (NotificationSettings.get() != nullptr)
+
 
 // Need to make sure every byte between the members is also zero
 // Otherwise the checksum will fail and settings will be saved too often.

--- a/src/src/DataStructs/PluginStats_array.cpp
+++ b/src/src/DataStructs/PluginStats_array.cpp
@@ -40,11 +40,7 @@ void PluginStats_array::initPluginStats(taskIndex_t taskIndex, taskVarIndex_t ta
     }
 
     if (ExtraTaskSettings.enabledPluginStats(taskVarIndex)) {
-      # ifdef USE_SECOND_HEAP
-      HeapSelectIram ephemeral;
-      # endif // ifdef USE_SECOND_HEAP
-
-      // Try to allocate in PSRAM if possible
+      // Try to allocate in PSRAM or 2nd heap if possible
       constexpr unsigned size = sizeof(PluginStats);
       void *ptr               = special_calloc(1, size);
 

--- a/src/src/DataStructs/PluginTaskData_base.cpp
+++ b/src/src/DataStructs/PluginTaskData_base.cpp
@@ -60,7 +60,12 @@ void PluginTaskData_base::initPluginStats(taskIndex_t taskIndex, taskVarIndex_t 
 {
   if (taskVarIndex < VARS_PER_TASK) {
     if (_plugin_stats_array == nullptr) {
-      _plugin_stats_array = new (std::nothrow) PluginStats_array();
+      constexpr unsigned size = sizeof(PluginStats_array);
+      void *ptr               = special_calloc(1, size);
+
+      if (ptr != nullptr) {
+        _plugin_stats_array = new (ptr) PluginStats_array();
+      }
     }
 
     if (_plugin_stats_array != nullptr) {

--- a/src/src/DataStructs/ProvisioningStruct.cpp
+++ b/src/src/DataStructs/ProvisioningStruct.cpp
@@ -6,7 +6,7 @@
 # include "../Helpers/Hardware.h"
 
 ProvisioningStruct::ProvisioningStruct() {
-  memset(this, 0, sizeof(ProvisioningStruct));
+  _allBits = 0u;
 }
 
 void ProvisioningStruct::validate() {

--- a/src/src/DataStructs/ProvisioningStruct.h
+++ b/src/src/DataStructs/ProvisioningStruct.h
@@ -39,20 +39,26 @@ struct ProvisioningStruct
   char pass[64] = { 0 };
   char url[128] = { 0 };
 
-  struct {
-    uint16_t allowFetchFirmware :1;
-    uint16_t allowFetchConfigDat :1;
-    uint16_t allowFetchSecurityDat :1;
-    uint16_t allowFetchNotificationDat :1;
-    uint16_t allowFetchProvisioningDat :1;
-    uint16_t allowFetchRules :4;
+  union {
+    struct {
+      uint16_t allowFetchFirmware :1;
+      uint16_t allowFetchConfigDat :1;
+      uint16_t allowFetchSecurityDat :1;
+      uint16_t allowFetchNotificationDat :1;
+      uint16_t allowFetchProvisioningDat :1;
+      uint16_t allowFetchRules :4;
 
-    uint16_t unused :7;  // Add to use full 16 bit.
-  } allowedFlags;
+      uint16_t unused :7;  // Add to use full 16 bit.
+    } allowedFlags;
+    uint16_t _allBits;
+  };
 };
 
 typedef std::shared_ptr<ProvisioningStruct> ProvisioningStruct_ptr_type;
-# define MakeProvisioningSettings(T) ProvisioningStruct_ptr_type T(new (std::nothrow) ProvisioningStruct());
+//# define MakeProvisioningSettings(T) ProvisioningStruct_ptr_type T(new (std::nothrow) ProvisioningStruct());
+
+#define MakeProvisioningSettings(T) void * calloc_ptr = special_calloc(1,sizeof(ProvisioningStruct)); ProvisioningStruct_ptr_type T(new (calloc_ptr)  ProvisioningStruct());
+
 
 
 #endif // if FEATURE_CUSTOM_PROVISIONING

--- a/src/src/DataStructs/ProvisioningStruct.h
+++ b/src/src/DataStructs/ProvisioningStruct.h
@@ -55,7 +55,6 @@ struct ProvisioningStruct
 };
 
 typedef std::shared_ptr<ProvisioningStruct> ProvisioningStruct_ptr_type;
-//# define MakeProvisioningSettings(T) ProvisioningStruct_ptr_type T(new (std::nothrow) ProvisioningStruct());
 
 #define MakeProvisioningSettings(T) void * calloc_ptr = special_calloc(1,sizeof(ProvisioningStruct)); ProvisioningStruct_ptr_type T(new (calloc_ptr)  ProvisioningStruct());
 

--- a/src/src/DataStructs/WiFi_AP_Candidate.cpp
+++ b/src/src/DataStructs/WiFi_AP_Candidate.cpp
@@ -32,18 +32,24 @@ country({
 #endif
   last_seen(0), rssi(0), channel(0), index(0), enc_type(0)
 {
-  memset(&bits, 0, sizeof(bits));
+  _allBits = 0u;
 }
 
 WiFi_AP_Candidate::WiFi_AP_Candidate(const WiFi_AP_Candidate& other)
+: ssid(other.ssid),
+  last_seen(other.last_seen), 
+  bssid(other.bssid),
+  rssi(other.rssi), 
+  channel(other.channel), 
+  index(other.index), 
+  enc_type(other.enc_type)
 {
-  // All members other than ssid can be mem-copied
-  memcpy(this, &other, sizeof(WiFi_AP_Candidate));
-
-  // Make sure ssid isn't some kind of valid String with heap allocated memory
-  memset(&ssid, 0, sizeof(ssid));
-  // Now copy the ssid String
-  ssid = other.ssid;
+  _allBits = other._allBits;
+  #ifdef ESP32
+  # if ESP_IDF_VERSION_MAJOR >= 5
+  memcpy(&this.country, &other.country, sizeof(wifi_country_t));
+  #endif
+  #endif
 }
 
 WiFi_AP_Candidate::WiFi_AP_Candidate(uint8_t index_c, const String& ssid_c) :
@@ -59,7 +65,7 @@ country({
 #endif
   last_seen(0), rssi(0), channel(0), index(index_c), enc_type(0)
 {
-  memset(&bits, 0, sizeof(bits));
+  _allBits = 0u;
 
   const size_t ssid_length = ssid_c.length();
 
@@ -76,7 +82,7 @@ WiFi_AP_Candidate::WiFi_AP_Candidate(uint8_t networkItem) : index(0) {
   // Need to make sure the phy isn't known as we can't get this information from the AP
   // See: https://github.com/letscontrolit/ESPEasy/issues/4996
   // Not sure why this makes any difference as the flags should already have been set to 0.
-  memset(&bits, 0, sizeof(bits));
+  _allBits = 0u;
 
   ssid     = WiFi.SSID(networkItem);
   rssi     = WiFi.RSSI(networkItem);
@@ -129,8 +135,7 @@ WiFi_AP_Candidate::WiFi_AP_Candidate(const bss_info& ap) :
   phy_11b(ap.phy_11b), phy_11g(ap.phy_11g), phy_11n(ap.phy_11n),
   wps(ap.wps)
 {
-  memset(&bits, 0, sizeof(bits));
-
+  _allBits = 0u;
   last_seen = millis();
 
   switch (ap.authmode) {
@@ -180,13 +185,20 @@ bool WiFi_AP_Candidate::operator<(const WiFi_AP_Candidate& other) const {
 
 WiFi_AP_Candidate& WiFi_AP_Candidate::operator=(const WiFi_AP_Candidate& other)
 {
-  // All members other than ssid can be mem-copied
-  memcpy(this, &other, sizeof(WiFi_AP_Candidate));
-
-  // Make sure ssid isn't some kind of valid String with heap allocated memory
-  memset(&ssid, 0, sizeof(ssid));
-  // Now copy the ssid String
   ssid = other.ssid;
+  last_seen = other.last_seen;
+  bssid = other.bssid;
+  rssi = other.rssi;
+  channel = other.channel;
+  index = other.index;
+  enc_type = other.enc_type;
+  _allBits = other._allBits;
+  #ifdef ESP32
+  # if ESP_IDF_VERSION_MAJOR >= 5
+  memcpy(&this.country, &other.country, sizeof(wifi_country_t));
+  #endif
+  #endif
+
   return *this;
 }
 

--- a/src/src/DataStructs/WiFi_AP_Candidate.cpp
+++ b/src/src/DataStructs/WiFi_AP_Candidate.cpp
@@ -47,7 +47,7 @@ WiFi_AP_Candidate::WiFi_AP_Candidate(const WiFi_AP_Candidate& other)
   _allBits = other._allBits;
   #ifdef ESP32
   # if ESP_IDF_VERSION_MAJOR >= 5
-  memcpy(&this.country, &other.country, sizeof(wifi_country_t));
+  memcpy(&this->country, &other.country, sizeof(wifi_country_t));
   #endif
   #endif
 }
@@ -195,7 +195,7 @@ WiFi_AP_Candidate& WiFi_AP_Candidate::operator=(const WiFi_AP_Candidate& other)
   _allBits = other._allBits;
   #ifdef ESP32
   # if ESP_IDF_VERSION_MAJOR >= 5
-  memcpy(&this.country, &other.country, sizeof(wifi_country_t));
+  memcpy(&this->country, &other.country, sizeof(wifi_country_t));
   #endif
   #endif
 

--- a/src/src/DataStructs/WiFi_AP_Candidate.h
+++ b/src/src/DataStructs/WiFi_AP_Candidate.h
@@ -68,7 +68,7 @@ struct WiFi_AP_Candidate {
     return bits.phy_11b || bits.phy_11g || bits.phy_11n;
   }
 
-  String ssid;
+  String ssid; 
 
   //  String  key;
 
@@ -84,21 +84,24 @@ struct WiFi_AP_Candidate {
   uint8_t       channel{};
   uint8_t       index{};              // Index of the matching credentials
   uint8_t       enc_type{};           // Encryption used (e.g. WPA2)
-  struct {
-    uint16_t isHidden            : 1; // Hidden SSID
-    uint16_t lowPriority         : 1; // Try as last attempt
-    uint16_t isEmergencyFallback : 1;
-    uint16_t phy_11b             : 1;
-    uint16_t phy_11g             : 1;
-    uint16_t phy_11n             : 1;
-    uint16_t phy_lr              : 1;
-    uint16_t phy_11ax            : 1;
-    uint16_t wps                 : 1;
-    uint16_t ftm_responder       : 1;
-    uint16_t ftm_initiator       : 1;
+  union {
+    struct {
+      uint16_t isHidden            : 1; // Hidden SSID
+      uint16_t lowPriority         : 1; // Try as last attempt
+      uint16_t isEmergencyFallback : 1;
+      uint16_t phy_11b             : 1;
+      uint16_t phy_11g             : 1;
+      uint16_t phy_11n             : 1;
+      uint16_t phy_lr              : 1;
+      uint16_t phy_11ax            : 1;
+      uint16_t wps                 : 1;
+      uint16_t ftm_responder       : 1;
+      uint16_t ftm_initiator       : 1;
 
-    uint16_t unused : 5;
-  } bits;
+      uint16_t unused : 5;
+    } bits;
+    uint16_t _allBits;
+  };
 };
 
 #endif // ifndef DATASTRUCTS_WIFI_AP_CANDIDATES_H

--- a/src/src/ESPEasyCore/Controller.cpp
+++ b/src/src/ESPEasyCore/Controller.cpp
@@ -838,12 +838,22 @@ bool MQTTpublish(controllerIndex_t controller_idx,
   }
   topic_str = topic;
   payload_str = payload;
-  const bool success =
-    MQTTDelayHandler->addToQueue(std::unique_ptr<MQTT_queue_element>(new (std::nothrow) MQTT_queue_element(
-      controller_idx, taskIndex, 
-      std::move(topic_str),
-      std::move(payload_str), retained,
-      callbackTask)));
+
+  bool success = false;
+
+  constexpr unsigned size = sizeof(MQTT_queue_element);
+  void *ptr               = special_calloc(1, size);
+
+  if (ptr != nullptr) {
+    success =
+      MQTTDelayHandler->addToQueue(
+        std::unique_ptr<MQTT_queue_element>(
+          new (ptr) MQTT_queue_element(
+            controller_idx, taskIndex, 
+            std::move(topic_str),
+            std::move(payload_str), retained,
+            callbackTask)));
+  }
 
   scheduleNextMQTTdelayQueue();
   return success;
@@ -863,12 +873,21 @@ bool MQTTpublish(controllerIndex_t controller_idx,
     return false;
   }
 
-  const bool success =
-    MQTTDelayHandler->addToQueue(std::unique_ptr<MQTT_queue_element>(new (std::nothrow) MQTT_queue_element(controller_idx, taskIndex,
-                                                                                                           std::move(topic),
-                                                                                                           std::move(payload), retained,
-                                                                                                           callbackTask)));
+  bool success = false;
 
+  constexpr unsigned size = sizeof(MQTT_queue_element);
+  void *ptr               = special_calloc(1, size);
+
+  if (ptr != nullptr) {
+    success = 
+      MQTTDelayHandler->addToQueue(
+        std::unique_ptr<MQTT_queue_element>(
+          new (ptr) MQTT_queue_element(
+            controller_idx, taskIndex,
+            std::move(topic),
+            std::move(payload), retained,
+            callbackTask)));
+  }
   scheduleNextMQTTdelayQueue();
   return success;
 }

--- a/src/src/ESPEasyCore/ESPEasy_Log.cpp
+++ b/src/src/ESPEasyCore/ESPEasy_Log.cpp
@@ -351,15 +351,14 @@ void addToLogMove(uint8_t logLevel, String&& string)
   #endif
 
   if (string.isEmpty()) return;
-  addToSerialLog(logLevel, string);
-  addToSysLog(logLevel, string);
-  addToSDLog(logLevel, string);
+  String tmp;
+  move_special(tmp, std::move(string));
+  addToSerialLog(logLevel, tmp);
+  addToSysLog(logLevel, tmp);
+  addToSDLog(logLevel, tmp);
 
   // May clear the string, so call as last one.
   if (loglevelActiveFor(LOG_TO_WEBLOG, logLevel)) {
-    Logging.add(logLevel, std::move(string));
-  } else {
-    // Make sure the string may no longer keep up memory
-    free_string(string);
+    Logging.add(logLevel, std::move(tmp));
   }
 }

--- a/src/src/ESPEasyCore/ESPEasy_setup.cpp
+++ b/src/src/ESPEasyCore/ESPEasy_setup.cpp
@@ -302,8 +302,7 @@ void ESPEasy_setup()
   readBootCause();
 
   {
-    String log = F("INIT : ");
-    log += getLastBootCauseString();
+    String log;
 
     if (readFromRTC())
     {
@@ -311,9 +310,8 @@ void ESPEasy_setup()
       RTC.bootCounter++;
       lastMixedSchedulerId_beforereboot.mixed_id = RTC.lastMixedSchedulerId;
       readUserVarFromRTC();
-
-      log += F(" #");
-      log += RTC.bootCounter;
+      log = concat(F("INIT : "), getLastBootCauseString()) + 
+            concat(F(" #"), RTC.bootCounter);
 
       #ifndef BUILD_NO_DEBUG
       log += F(" Last Action before Reboot: ");
@@ -335,8 +333,7 @@ void ESPEasy_setup()
       log = F("INIT : Cold Boot");
     }
 
-    log += F(" - Restart Reason: ");
-    log += getResetReasonString();
+    log += concat(F(" - Restart Reason: "), getResetReasonString());
 
     RTC.deepSleepState = 0;
     saveToRTC();
@@ -542,14 +539,15 @@ void ESPEasy_setup()
 
   if (loglevelActiveFor(LOG_LEVEL_INFO)) {
     String log;
-    log.reserve(80);
-    log += concat(F("INFO : Plugins: "), getDeviceCount() + 1);
-    log += ' ';
-    log += getPluginDescriptionString();
-    log += F(" (");
-    log += getSystemLibraryString();
-    log += ')';
-    addLogMove(LOG_LEVEL_INFO, log);
+    if (reserve_special(log, 80)) {
+      log += concat(F("INFO : Plugins: "), getDeviceCount() + 1);
+      log += ' ';
+      log += getPluginDescriptionString();
+      log += F(" (");
+      log += getSystemLibraryString();
+      log += ')';
+      addLogMove(LOG_LEVEL_INFO, log);
+    }
   }
 
   /*

--- a/src/src/Globals/Plugins.cpp
+++ b/src/src/Globals/Plugins.cpp
@@ -419,14 +419,7 @@ bool PluginCallForTask(taskIndex_t taskIndex, uint8_t Function, EventStruct *Tem
                 LoadTaskSettings(taskIndex);
 
                 if (ExtraTaskSettings.anyEnabledPluginStats()) {
-
-                  // Try to allocate in PSRAM or 2nd heap if possible
-                  constexpr unsigned size = sizeof(_StatsOnly_data_struct);
-                  void *ptr               = special_calloc(1, size);
-
-                  if (ptr) {
-                    initPluginTaskData(taskIndex, new (ptr) _StatsOnly_data_struct());
-                  }
+                  special_initPluginTaskData(taskIndex, _StatsOnly_data_struct);
                 }
               }
             }
@@ -452,12 +445,7 @@ bool PluginCallForTask(taskIndex_t taskIndex, uint8_t Function, EventStruct *Tem
 
               if (ExtraTaskSettings.anyEnabledPluginStats()) {
                 // Try to allocate in PSRAM or 2nd heap if possible
-                constexpr unsigned size = sizeof(_StatsOnly_data_struct);
-                void *ptr               = special_calloc(1, size);
-
-                if (ptr) {
-                  initPluginTaskData(taskIndex, new (ptr) _StatsOnly_data_struct());
-                }
+                special_initPluginTaskData(taskIndex, _StatsOnly_data_struct);
               }
             }
           }
@@ -931,7 +919,7 @@ bool PluginCall(uint8_t Function, struct EventStruct *event, String& str)
                 LoadTaskSettings(event->TaskIndex);
 
                 if (ExtraTaskSettings.anyEnabledPluginStats()) {
-                  initPluginTaskData(event->TaskIndex, new (std::nothrow) _StatsOnly_data_struct());
+                  special_initPluginTaskData(event->TaskIndex, _StatsOnly_data_struct);
                 }
               }
             }

--- a/src/src/Globals/Plugins.cpp
+++ b/src/src/Globals/Plugins.cpp
@@ -456,7 +456,7 @@ bool PluginCallForTask(taskIndex_t taskIndex, uint8_t Function, EventStruct *Tem
                 void *ptr               = special_calloc(1, size);
 
                 if (ptr) {
-                  initPluginTaskData(taskIndex, new (std::nothrow) _StatsOnly_data_struct());
+                  initPluginTaskData(taskIndex, new (ptr) _StatsOnly_data_struct());
                 }
               }
             }

--- a/src/src/Helpers/ESPEasy_Storage.cpp
+++ b/src/src/Helpers/ESPEasy_Storage.cpp
@@ -1059,7 +1059,11 @@ String LoadStringArray(SettingsType::Enum settingsType,
               // Specific string length, so we have to set the next string position.
               nextStringPos += maxStringLength;
             }
-            move_special(strings[stringCount], std::move(tmpString));
+            if (!tmpString.isEmpty()) {
+              move_special(strings[stringCount], std::move(tmpString));
+            } else {
+              free_string(strings[stringCount]);
+            }
 
             // Do not allocate tmpString on 2nd heap as byte access on 2nd heap is much slower
             // We're appending per byte, so better prefer speed for short lived objects

--- a/src/src/Helpers/Memory.cpp
+++ b/src/src/Helpers/Memory.cpp
@@ -176,14 +176,14 @@ void* special_calloc(size_t num, size_t size) {
     res = heap_caps_calloc(num, size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
   }
 #else // ifdef ESP32
-  if (size > 64) {
 # ifdef USE_SECOND_HEAP
+  if (size > 64 || FreeMem() < 5000) {
 
     // Try allocating on ESP8266 2nd heap, only when sufficiently large data is needed
     HeapSelectIram ephemeral;
-# endif // ifdef USE_SECOND_HEAP
     res = calloc(num, size);
   }
+# endif // ifdef USE_SECOND_HEAP
 #endif  // ifdef ESP32
 
   if (res == nullptr) {
@@ -212,7 +212,7 @@ bool String_reserve_special(String& str, size_t size) {
     return true;
   }
   #ifdef USE_SECOND_HEAP
-  if (size >= 48) {
+  if (size >= 48 || FreeMem() < 5000) {
     // Only try to store larger strings here as those tend to be kept for a longer period.
     HeapSelectIram ephemeral;
     // String does round up to nearest multiple of 16 bytes, so no need to round up to multiples of 32 bit here

--- a/src/src/Helpers/Memory.cpp
+++ b/src/src/Helpers/Memory.cpp
@@ -233,7 +233,11 @@ bool String_reserve_special(String& str, size_t size) {
 class PSRAM_String : public String {
   public:
   PSRAM_String(size_t size) : String() {
-    init();
+    sso.isSSO = 0;      // setSSO(false);
+    ptr.buff = nullptr; // setBuffer(nullptr);
+    ptr.cap = 0;        // setCapacity(0);
+    ptr.len = 0;        // setLen(0);
+
     if (size != 0 && size > capacity() && UsePSRAM()) {
       size_t newSize = (size + 16) & (~0xf);
       void *ptr = special_calloc(1, newSize);
@@ -249,6 +253,9 @@ class PSRAM_String : public String {
 
 
 bool String_reserve_special(String& str, size_t size) {
+  if (size == 0) {
+    return true;
+  }
   if (!UsePSRAM()) {
     return str.reserve(size);
   }

--- a/src/src/Helpers/RulesHelper.cpp
+++ b/src/src/Helpers/RulesHelper.cpp
@@ -293,7 +293,7 @@ String RulesHelperClass::readLn(const String& filename,
 
       while (f.available()) {
         if (addChar(char(f.read()), tmpStr, firstNonSpaceRead)) {
-          lines.push_back(move_special(std::move(tmpStr)));
+          lines.push_back(std::move(move_special(std::move(tmpStr))));
           ++readPos;
 
           firstNonSpaceRead = false;
@@ -304,7 +304,7 @@ String RulesHelperClass::readLn(const String& filename,
       if (tmpStr.length() > 0) {
         rules_strip_trailing_comments(tmpStr);
         check_rules_line_user_errors(tmpStr);
-        lines.push_back(move_special(std::move(tmpStr)));
+        lines.push_back(std::move(move_special(std::move(tmpStr))));
         tmpStr.clear();
       }
 # ifndef BUILD_NO_DEBUG
@@ -404,7 +404,10 @@ String RulesHelperClass::readLn(const String& filename,
   }
   rules_strip_trailing_comments(line);
   check_rules_line_user_errors(line);
-  return line;
+
+  // Make sure there is no left-over reserved data 
+  // and allocate it to the appropriate memory area.
+  return move_special(std::move(line));
 }
 
 #endif // ifdef CACHE_RULES_IN_MEMORY

--- a/src/src/Helpers/RulesHelper.cpp
+++ b/src/src/Helpers/RulesHelper.cpp
@@ -18,8 +18,7 @@ bool rules_replace_common_mistakes(const String& from, const String& to, String&
 
   if (loglevelActiveFor(LOG_LEVEL_ERROR)) {
     String log;
-
-    if (log.reserve(32 + from.length() + to.length() + line.length())) {
+    if (reserve_special(log, 32 + from.length() + to.length() + line.length())) {
       log  = F("Rules (Syntax Error, auto-corrected): '");
       log += from;
       log += F("' => '");

--- a/src/src/Helpers/SerialWriteBuffer.cpp
+++ b/src/src/Helpers/SerialWriteBuffer.cpp
@@ -10,7 +10,7 @@ void SerialWriteBuffer_t::add(const String& line)
     #ifdef USE_SECOND_HEAP
 
     // Do not store in 2nd heap, std::dequeue cannot handle 2nd heap well
-    HeapSelectDram ephemeral;
+    HeapSelectIram ephemeral;
     #endif // ifdef USE_SECOND_HEAP
     int roomLeft = getRoomLeft();
 
@@ -37,7 +37,7 @@ void SerialWriteBuffer_t::add(char c)
   #ifdef USE_SECOND_HEAP
 
   // Do not store in 2nd heap, std::dequeue cannot handle 2nd heap well
-  HeapSelectDram ephemeral;
+  HeapSelectIram ephemeral;
   #endif // ifdef USE_SECOND_HEAP
 
   if (_buffer.size() > _maxSize) {
@@ -118,7 +118,7 @@ int SerialWriteBuffer_t::getRoomLeft() const {
   #ifdef USE_SECOND_HEAP
 
   // Do not store in 2nd heap, std::dequeue cannot handle 2nd heap well
-  HeapSelectDram ephemeral;
+  HeapSelectIram ephemeral;
   #endif // ifdef USE_SECOND_HEAP
 
   int roomLeft = getMaxFreeBlock();

--- a/src/src/Helpers/StringConverter.cpp
+++ b/src/src/Helpers/StringConverter.cpp
@@ -78,7 +78,7 @@ bool equals(const String& str, const char& c) {
 void move_special(String& dest, String&& source) {
   #ifdef USE_SECOND_HEAP
   // Only try to store larger strings here as those tend to be kept for a longer period.
-  if ((source.length() >= 32) && mmu_is_dram(&(source[0]))) {
+  if ((source.length() >= 64) && mmu_is_dram(&(source[0]))) {
     // The string was not allocated on the 2nd heap, so copy instead of move
     HeapSelectIram ephemeral;
     if (dest.reserve(source.length())) {
@@ -734,11 +734,9 @@ String stripWrappingChar(const String& text, char wrappingChar) {
   const unsigned int length = text.length();
 
   if ((length >= 2) && stringWrappedWithChar(text, wrappingChar)) {
-    # ifdef USE_SECOND_HEAP
-    HeapSelectIram ephemeral;
-    # endif // ifdef USE_SECOND_HEAP
-
-    return text.substring(1, length - 1);
+    String dest;
+    move_special(dest,text.substring(1, length - 1));
+    return dest;
   }
   return text;
 }

--- a/src/src/Helpers/StringConverter.cpp
+++ b/src/src/Helpers/StringConverter.cpp
@@ -110,12 +110,15 @@ bool reserve_special(String& str, size_t size) {
 void free_string(String& str) {
   // This is a call specifically tailored to what is done in:
   //  void String::move(String &rhs)
-  #if defined(ESP32) || defined(CORE_POST_3_0_0)
-  str.clear(); // Prevent any unneeded copying  
-  String tmp(std::move(str));
-  #else
+
+#if defined(ESP32) || defined(CORE_POST_3_0_0)
+  // Use current implementation of String::copy as this
+  // invalidates and thus deallocates current buffer
+  str = (const char*)nullptr;
+  str = String(); // No idea why this is needed, without it, some ESP32's may bootloop
+#else
   str = String();
-  #endif
+#endif
 }
 
 /********************************************************************************************\

--- a/src/src/Helpers/StringConverter.h
+++ b/src/src/Helpers/StringConverter.h
@@ -29,7 +29,7 @@ String concat(const char& str, const String &val);
 template <typename T>
 String concat(const __FlashStringHelper * str, const T &val) {
   # ifdef USE_SECOND_HEAP
-  HeapSelectIram ephemeral;
+  HeapSelectDram ephemeral;
   # endif // ifdef USE_SECOND_HEAP
 
   String res(str);
@@ -40,7 +40,7 @@ String concat(const __FlashStringHelper * str, const T &val) {
 template <typename T>
 String concat(const String& str, const T &val) {
   # ifdef USE_SECOND_HEAP
-  HeapSelectIram ephemeral;
+  HeapSelectDram ephemeral;
   # endif // ifdef USE_SECOND_HEAP
 
   String res(str);

--- a/src/src/Helpers/StringGenerator_GPIO.cpp
+++ b/src/src/Helpers/StringGenerator_GPIO.cpp
@@ -39,14 +39,14 @@ String formatGpioName(const __FlashStringHelper * label, gpio_direction directio
     reserveLength += 11;
   }
   String result;
+  if (reserve_special(result, reserveLength)) {
+    result += F("GPIO ");
+    result += formatGpioDirection(direction);
+    result += label;
 
-  result.reserve(reserveLength);
-  result += F("GPIO ");
-  result += formatGpioDirection(direction);
-  result += label;
-
-  if (optional) {
-    result += F("(optional)");
+    if (optional) {
+      result += F("(optional)");
+    }
   }
   return result;
 }

--- a/src/src/Helpers/_Internal_GPIO_pulseHelper.cpp
+++ b/src/src/Helpers/_Internal_GPIO_pulseHelper.cpp
@@ -461,7 +461,7 @@ void Internal_GPIO_pulseHelper::doTimingLogging(uint8_t logLevel)
     // Timer to logfile. E.g: ... [4|12000|13444|12243|3244]
     String log;
 
-    if (log.reserve(120)) {
+    if (reserve_special(log, 120)) {
       log = strformat(F("Pulse:OverDueStats (GPIO) [dbTim] {step0OdCnt} [maxOdTimeStep0|1|2|3]= (%d) [%d] {%d} ["),
                       config.gpio,
                       config.debounceTime,

--- a/src/src/PluginStructs/P036_data_struct.cpp
+++ b/src/src/PluginStructs/P036_data_struct.cpp
@@ -51,15 +51,12 @@ String P036_LineContent::saveDisplayLines(taskIndex_t taskIndex) {
   if (FreeMem() > 8000) {
     // Write in one single chunk.
     tDisplayLines_storage_full *tmp = nullptr;
-    # ifdef USE_SECOND_HEAP
-    {
-      HeapSelectIram ephemeral;
-      tmp = new (std::nothrow) tDisplayLines_storage_full;
-    }
-    # endif // ifdef USE_SECOND_HEAP
 
-    if (tmp == nullptr) {
-      tmp = new (std::nothrow) tDisplayLines_storage_full;
+    // Try to allocate in PSRAM or 2nd heap if possible
+    constexpr unsigned size = sizeof(tDisplayLines_storage_full);
+    void *ptr               = special_calloc(1, size);
+    if (ptr) {
+      tmp = new (ptr) tDisplayLines_storage_full;
     }
 
     if (tmp != nullptr) {
@@ -231,10 +228,13 @@ bool P036_data_struct::init(taskIndex_t      taskIndex,
   }
 
   {
-    # ifdef USE_SECOND_HEAP
-    HeapSelectIram ephemeral;
-    # endif // ifdef USE_SECOND_HEAP
-    LineContent = new (std::nothrow) P036_LineContent();
+    // Try to allocate in PSRAM or 2nd heap if possible
+    constexpr unsigned size = sizeof(P036_LineContent);
+    void *ptr               = special_calloc(1, size);
+
+    if (ptr) {    
+      LineContent = new (ptr) P036_LineContent();
+    }
   }
 
   if (isInitialized()) {
@@ -723,11 +723,15 @@ void P036_data_struct::setOrientationRotated(bool rotated) {
 void P036_data_struct::RestoreLineContent(taskIndex_t taskIndex,
                                           uint8_t     LoadVersion,
                                           uint8_t     LineNo) {
-  # ifdef USE_SECOND_HEAP
-  HeapSelectIram ephemeral;
-  # endif // ifdef USE_SECOND_HEAP
+  // Try to allocate in PSRAM or 2nd heap if possible
+  constexpr unsigned size = sizeof(P036_LineContent);
+  void *ptr               = special_calloc(1, size);
 
-  P036_LineContent *TempContent = new (std::nothrow) P036_LineContent();
+  if (!ptr) {
+    return;
+  }
+
+  P036_LineContent *TempContent = new (ptr) P036_LineContent();
 
   if (TempContent != nullptr) {
     TempContent->loadDisplayLines(taskIndex, LoadVersion);

--- a/src/src/PluginStructs/P036_data_struct.cpp
+++ b/src/src/PluginStructs/P036_data_struct.cpp
@@ -19,6 +19,9 @@
 # include <OLED_SSD1306_SH1106_images.h>
 
 void P036_LineContent::loadDisplayLines(taskIndex_t taskIndex, uint8_t LoadVersion) {
+  #ifdef USE_SECOND_HEAP
+  HeapSelectIram ephemeral;
+  #endif
   if (LoadVersion == 0) {
     // read data of version 0 (up to 22.11.2019)
     String DisplayLinesV0[P36_Nlines];                                           // used to load the CustomTaskSettings for V0

--- a/src/src/PluginStructs/P037_data_struct.cpp
+++ b/src/src/PluginStructs/P037_data_struct.cpp
@@ -973,11 +973,12 @@ bool P037_data_struct::parseJSONMessage(const String& message) {
   }
 
   if (nullptr == root) {
-    # ifdef USE_SECOND_HEAP
-    HeapSelectIram ephemeral;
-    # endif // ifdef USE_SECOND_HEAP
-
-    root = new (std::nothrow) DynamicJsonDocument(lastJsonMessageLength); // Dynamic allocation
+    // Try to allocate in PSRAM or 2nd heap if possible
+    constexpr unsigned size = sizeof(DynamicJsonDocument);
+    void *ptr               = special_calloc(1, size);
+    if (ptr) {    
+      root = new (ptr) DynamicJsonDocument(lastJsonMessageLength); // Dynamic allocation
+    }
   }
 
   if (nullptr != root) {

--- a/src/src/PluginStructs/P037_data_struct.cpp
+++ b/src/src/PluginStructs/P037_data_struct.cpp
@@ -30,7 +30,11 @@ P037_data_struct::~P037_data_struct() {
  * Load the settings from file
  */
 bool P037_data_struct::loadSettings() {
+
   if (_taskIndex < TASKS_MAX) {
+    # ifdef USE_SECOND_HEAP
+//    HeapSelectIram ephemeral;
+    #endif
     size_t offset = 0;
     LoadCustomTaskSettings(_taskIndex, mqttTopics,
                            VARS_PER_TASK, 41, offset);

--- a/src/src/WebServer/ESPEasy_WebServer.cpp
+++ b/src/src/WebServer/ESPEasy_WebServer.cpp
@@ -165,8 +165,8 @@ void sendHeadandTail_stdtemplate(bool Tail, bool rebooting) {
   // We have sent a lot of data at once.
   // try to flush it to the connected client to free up some RAM
   // from pending transfers
-  TXBuffer.flush();
-  delay(10);
+//  TXBuffer.flush();
+//  delay(10);
 }
 
 bool captivePortal() {
@@ -1092,12 +1092,10 @@ void getStorageTableSVG(SettingsType::Enum settingsType) {
   float textYoffset = yOffset + 0.9f * SVG_BAR_HEIGHT;
 
   if (struct_size != 0) {
-    String text;
-    text.reserve(32);
-    text += formatHumanReadable(struct_size, 1024);
-    text += '/';
-    text += formatHumanReadable(max_size, 1024);
-    text += F(" per item");
+    String text = strformat(
+      F("%s/%s per item"),
+      formatHumanReadable(struct_size, 1024).c_str(),
+      formatHumanReadable(max_size, 1024).c_str());
     createSvgTextElement(text, textXoffset, textYoffset);
   } else {
     createSvgTextElement(F("Variable size"), textXoffset, textYoffset);

--- a/src/src/WebServer/Markup_Buttons.cpp
+++ b/src/src/WebServer/Markup_Buttons.cpp
@@ -3,6 +3,8 @@
 #include "../WebServer/common.h"
 #include "../WebServer/HTML_wrappers.h"
 
+#include "../Helpers/StringConverter.h"
+
 #include "../Static/WebStaticData.h"
 
 
@@ -153,15 +155,7 @@ void addSubmitButton(const String& value, const String& name, const String& clas
 {
   addHtml(F("<input "));
   {
-    String fullClasses;
-    fullClasses.reserve(12 + classes.length());
-    fullClasses = F("button link");
-
-    if (classes.length() > 0) {
-      fullClasses += ' ';
-      fullClasses += classes;
-    }
-    addHtmlAttribute(F("class"), fullClasses);
+    addHtmlAttribute(F("class"), concat(F("button link "), classes));
   }
   addHtmlAttribute(F("type"),  F("submit"));
   addHtmlAttribute(F("value"), value);

--- a/src/src/WebServer/UploadPage.cpp
+++ b/src/src/WebServer/UploadPage.cpp
@@ -174,7 +174,12 @@ void handleFileUploadBase(bool toSDcard) {
         # if FEATURE_TARSTREAM_SUPPORT
 
         if ((upload.filename.length() > 3) && upload.filename.substring(upload.filename.length() - 4).equalsIgnoreCase(F(".tar"))) {
-          tarStream = new (std::nothrow) TarStream(upload.filename, destination);
+          constexpr unsigned size = sizeof(TarStream);
+          void *ptr               = special_calloc(1, size);
+    
+          if (ptr != nullptr) {  
+            tarStream = new (ptr) TarStream(upload.filename, destination);
+          }
           #  ifndef BUILD_NO_DEBUG
 
           if (loglevelActiveFor(LOG_LEVEL_INFO)) {


### PR DESCRIPTION
- Added "normal" ESP8266 2nd heap builds
- Reduce 'overprovisioned' memory of strings to keep (e.g. loaded settings)
- Balance memory allocation between 2nd heap and DRAM on ESP8266 & PSRAM/normal heap on ESP32
- Use `calloc` for more structs to make sure memory is zeroed before calling constructor. (leaves room for reducing constructor later to reduce build size)