### PR TITLE
[Build] Upgrade setuptools package to avoid build issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
           pip3 install --upgrade pip
           pip install wheel
           pip install -r requirements.txt
-          platformio update
+          pio pkg update
       - name: Get current date
         id: date
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
           pip3 install --upgrade pip
           pip install wheel
           pip install -r requirements.txt
-          pio pkg update
+          pio pkg update -e ${{ matrix.env }}
       - name: Get current date
         id: date
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           sudo apt install binutils build-essential libffi-dev libgit2-dev
           pip install -r requirements.txt
-          pio pkg update
+          pio pkg update -e ${{ matrix.env }}
       - name: Build and archive
         id: build-and-archive
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           sudo apt install binutils build-essential libffi-dev libgit2-dev
           pip install -r requirements.txt
-          platformio update
+          pio pkg update
       - name: Build and archive
         id: build-and-archive
         env:

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,15 +19,15 @@ build_cache_dir = .cache
 extra_configs   =
   platformio_core_defs.ini
   platformio_esp82xx_base.ini
-  ; platformio_esp82xx_envs.ini
+  platformio_esp82xx_envs.ini
   platformio_esp32_envs.ini
   platformio_esp32_solo1.ini
-  ; platformio_esp32c3_envs.ini
-  ; platformio_esp32s2_envs.ini
-  ; platformio_esp32s3_envs.ini
-  ; platformio_special_envs.ini
-  ; platformio_esp32c2_envs.ini
-  ; platformio_esp32c6_envs.ini
+  platformio_esp32c3_envs.ini
+  platformio_esp32s2_envs.ini
+  platformio_esp32s3_envs.ini
+  platformio_special_envs.ini
+  platformio_esp32c2_envs.ini
+  platformio_esp32c6_envs.ini
 
 
 ;default_envs = normal_ESP32_4M

--- a/platformio.ini
+++ b/platformio.ini
@@ -82,10 +82,10 @@ build_flags               = -DMQTT_MAX_PACKET_SIZE=1024
 extra_scripts             = pre:tools/pio/install-requirements.py
                             pre:tools/pio/set-ci-defines.py
                             pre:tools/pio/generate-compiletime-defines.py
-                            post:tools/pio/copy_files.py
+                            pre:tools/pio/copy_files.py
 
 [extra_scripts_esp8266]
-extra_scripts             = tools/pio/gzip-firmware.py
+extra_scripts             = pre:tools/pio/gzip-firmware.py
                             pre:tools/pio/remove_concat_cpp_files.py
                             pre:tools/pio/concat_cpp_files.py
                             ${extra_scripts_default.extra_scripts}

--- a/platformio.ini
+++ b/platformio.ini
@@ -82,7 +82,7 @@ build_flags               = -DMQTT_MAX_PACKET_SIZE=1024
 extra_scripts             = pre:tools/pio/install-requirements.py
                             pre:tools/pio/set-ci-defines.py
                             pre:tools/pio/generate-compiletime-defines.py
-                            tools/pio/copy_files.py
+                            post:tools/pio/copy_files.py
 
 [extra_scripts_esp8266]
 extra_scripts             = tools/pio/gzip-firmware.py

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,15 +19,15 @@ build_cache_dir = .cache
 extra_configs   =
   platformio_core_defs.ini
   platformio_esp82xx_base.ini
-  platformio_esp82xx_envs.ini
+  ; platformio_esp82xx_envs.ini
   platformio_esp32_envs.ini
   platformio_esp32_solo1.ini
-  platformio_esp32c3_envs.ini
-  platformio_esp32s2_envs.ini
-  platformio_esp32s3_envs.ini
-  platformio_special_envs.ini
-  platformio_esp32c2_envs.ini
-  platformio_esp32c6_envs.ini
+  ; platformio_esp32c3_envs.ini
+  ; platformio_esp32s2_envs.ini
+  ; platformio_esp32s3_envs.ini
+  ; platformio_special_envs.ini
+  ; platformio_esp32c2_envs.ini
+  ; platformio_esp32c6_envs.ini
 
 
 ;default_envs = normal_ESP32_4M

--- a/platformio_core_defs.ini
+++ b/platformio_core_defs.ini
@@ -198,7 +198,7 @@ lib_extra_dirs            =
 ; ESP_IDF 5.3.1
 [core_esp32_IDF5_3_2__3_1_0_LittleFS]
 platform                    = https://github.com/Jason2866/platform-espressif32.git
-platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/3203/framework-arduinoespressif32-all-release_v5.3-ddc10306.zip
+platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/3427/framework-arduinoespressif32-all-release_v5.3-be550b63.zip
 build_flags                 = -DESP32_STAGE
                               -DESP_IDF_VERSION_MAJOR=5
                               -DLIBRARIES_NO_LOG=1

--- a/platformio_esp32_envs.ini
+++ b/platformio_esp32_envs.ini
@@ -162,6 +162,7 @@ board                     = esp32_16M8M
 board_upload.flash_size   = 16MB
 build_flags               = ${esp32_custom_base_LittleFS.build_flags}
                             -DFEATURE_ETHERNET=1
+extra_scripts             = ${esp32_custom_base_LittleFS.extra_scripts}
 
 ; [env:custom_IR_ESP32_4M316k]
 ; extends                   = esp32_common

--- a/platformio_esp32_envs.ini
+++ b/platformio_esp32_envs.ini
@@ -162,383 +162,382 @@ board                     = esp32_16M8M
 board_upload.flash_size   = 16MB
 build_flags               = ${esp32_custom_base_LittleFS.build_flags}
                             -DFEATURE_ETHERNET=1
-extra_scripts             = ${esp32_custom_base_LittleFS.extra_scripts}
 
-; [env:custom_IR_ESP32_4M316k]
-; extends                   = esp32_common
+[env:custom_IR_ESP32_4M316k]
+extends                   = esp32_common
+board                     = esp32_4M
+build_flags               = ${esp32_common.build_flags}
+                            -DPLUGIN_BUILD_CUSTOM
+                            -DPLUGIN_BUILD_IR
+lib_ignore                = ${esp32_always.lib_ignore}
+                            ESP32_ping
+extra_scripts             = ${esp32_common.extra_scripts}
+                            pre:tools/pio/pre_custom_esp32_IR.py
+                            pre:tools/pio/ir_build_check.py
+
+[env:custom_ESP32_4M2M_NO_OTA_LittleFS_ETH]
+extends                   = esp32_custom_base_LittleFS
+board                     = esp32_4M2M
+build_flags               = ${esp32_custom_base_LittleFS.build_flags}
+                            -DNO_HTTP_UPDATER
+                            -DFEATURE_ETHERNET=1
+
+
+[env:normal_ESP32_4M316k]
+extends                   = esp32_common
+board                     = esp32_4M
+lib_ignore                = ${esp32_common.lib_ignore}
+                            ${no_ir.lib_ignore}
+
+; [env:normal_ESP32_4M316k_LittleFS]
+; extends                   = esp32_common_LittleFS
 ; board                     = esp32_4M
-; build_flags               = ${esp32_common.build_flags}
-;                             -DPLUGIN_BUILD_CUSTOM
-;                             -DPLUGIN_BUILD_IR
-; lib_ignore                = ${esp32_always.lib_ignore}
-;                             ESP32_ping
-; extra_scripts             = ${esp32_common.extra_scripts}
-;                             pre:tools/pio/pre_custom_esp32_IR.py
-;                             pre:tools/pio/ir_build_check.py
-
-; [env:custom_ESP32_4M2M_NO_OTA_LittleFS_ETH]
-; extends                   = esp32_custom_base_LittleFS
-; board                     = esp32_4M2M
-; build_flags               = ${esp32_custom_base_LittleFS.build_flags}
-;                             -DNO_HTTP_UPDATER
-;                             -DFEATURE_ETHERNET=1
-
-
-; [env:normal_ESP32_4M316k]
-; extends                   = esp32_common
-; board                     = esp32_4M
-; lib_ignore                = ${esp32_common.lib_ignore}
+; lib_ignore                = ${esp32_common_LittleFS.lib_ignore}
 ;                             ${no_ir.lib_ignore}
 
-; ; [env:normal_ESP32_4M316k_LittleFS]
-; ; extends                   = esp32_common_LittleFS
-; ; board                     = esp32_4M
-; ; lib_ignore                = ${esp32_common_LittleFS.lib_ignore}
-; ;                             ${no_ir.lib_ignore}
+[env:collection_A_ESP32_4M316k]
+extends                   = esp32_common
+board                     = esp32_4M
+build_flags               = ${esp32_common.build_flags}  
+                            -DFEATURE_ARDUINO_OTA=1
+                            -DPLUGIN_SET_COLLECTION_ESP32
+                            -DCOLLECTION_FEATURE_RTTTL=1
 
-; [env:collection_A_ESP32_4M316k]
-; extends                   = esp32_common
-; board                     = esp32_4M
-; build_flags               = ${esp32_common.build_flags}  
-;                             -DFEATURE_ARDUINO_OTA=1
-;                             -DPLUGIN_SET_COLLECTION_ESP32
-;                             -DCOLLECTION_FEATURE_RTTTL=1
+[env:collection_B_ESP32_4M316k]
+extends                   = esp32_common
+board                     = esp32_4M
+build_flags               = ${esp32_common.build_flags}  
+                            -DFEATURE_ARDUINO_OTA=1
+                            -DPLUGIN_SET_COLLECTION_B_ESP32
+                            -DCOLLECTION_FEATURE_RTTTL=1
 
-; [env:collection_B_ESP32_4M316k]
-; extends                   = esp32_common
-; board                     = esp32_4M
-; build_flags               = ${esp32_common.build_flags}  
-;                             -DFEATURE_ARDUINO_OTA=1
-;                             -DPLUGIN_SET_COLLECTION_B_ESP32
-;                             -DCOLLECTION_FEATURE_RTTTL=1
+[env:collection_C_ESP32_4M316k]
+extends                   = esp32_common
+board                     = esp32_4M
+build_flags               = ${esp32_common.build_flags}  
+                            -DFEATURE_ARDUINO_OTA=1
+                            -DPLUGIN_SET_COLLECTION_C_ESP32
+                            -DCOLLECTION_FEATURE_RTTTL=1
 
-; [env:collection_C_ESP32_4M316k]
-; extends                   = esp32_common
-; board                     = esp32_4M
-; build_flags               = ${esp32_common.build_flags}  
-;                             -DFEATURE_ARDUINO_OTA=1
-;                             -DPLUGIN_SET_COLLECTION_C_ESP32
-;                             -DCOLLECTION_FEATURE_RTTTL=1
+[env:collection_D_ESP32_4M316k]
+extends                   = esp32_common
+board                     = esp32_4M
+build_flags               = ${esp32_common.build_flags}  
+                            -DFEATURE_ARDUINO_OTA=1
+                            -DPLUGIN_SET_COLLECTION_D_ESP32
+                            -DCOLLECTION_FEATURE_RTTTL=1
 
-; [env:collection_D_ESP32_4M316k]
-; extends                   = esp32_common
-; board                     = esp32_4M
-; build_flags               = ${esp32_common.build_flags}  
-;                             -DFEATURE_ARDUINO_OTA=1
-;                             -DPLUGIN_SET_COLLECTION_D_ESP32
-;                             -DCOLLECTION_FEATURE_RTTTL=1
+[env:collection_E_ESP32_4M316k]
+extends                   = esp32_common
+board                     = esp32_4M
+build_flags               = ${esp32_common.build_flags}  
+                            -DFEATURE_ARDUINO_OTA=1
+                            -DPLUGIN_SET_COLLECTION_E_ESP32
+                            -DCOLLECTION_FEATURE_RTTTL=1
 
-; [env:collection_E_ESP32_4M316k]
-; extends                   = esp32_common
-; board                     = esp32_4M
-; build_flags               = ${esp32_common.build_flags}  
-;                             -DFEATURE_ARDUINO_OTA=1
-;                             -DPLUGIN_SET_COLLECTION_E_ESP32
-;                             -DCOLLECTION_FEATURE_RTTTL=1
+[env:collection_F_ESP32_4M316k]
+extends                   = esp32_common
+board                     = esp32_4M
+build_flags               = ${esp32_common.build_flags}  
+                            -DFEATURE_ARDUINO_OTA=1
+                            -DPLUGIN_SET_COLLECTION_F_ESP32
+                            -DCOLLECTION_FEATURE_RTTTL=1
 
-; [env:collection_F_ESP32_4M316k]
-; extends                   = esp32_common
-; board                     = esp32_4M
-; build_flags               = ${esp32_common.build_flags}  
-;                             -DFEATURE_ARDUINO_OTA=1
-;                             -DPLUGIN_SET_COLLECTION_F_ESP32
-;                             -DCOLLECTION_FEATURE_RTTTL=1
-
-; [env:collection_G_ESP32_4M316k]
-; extends                   = esp32_common
-; board                     = esp32_4M
-; build_flags               = ${esp32_common.build_flags}  
-;                             -DFEATURE_ARDUINO_OTA=1
-;                             -DPLUGIN_SET_COLLECTION_G_ESP32
-;                             -DCOLLECTION_FEATURE_RTTTL=1
+[env:collection_G_ESP32_4M316k]
+extends                   = esp32_common
+board                     = esp32_4M
+build_flags               = ${esp32_common.build_flags}  
+                            -DFEATURE_ARDUINO_OTA=1
+                            -DPLUGIN_SET_COLLECTION_G_ESP32
+                            -DCOLLECTION_FEATURE_RTTTL=1
 
 
-; [env:collection_A_ESP32_IRExt_4M316k]
+[env:collection_A_ESP32_IRExt_4M316k]
+extends                   = esp32_IRExt
+board                     = esp32_4M
+build_flags               = ${esp32_IRExt.build_flags}
+                            -DPLUGIN_SET_COLLECTION_ESP32
+
+[env:collection_B_ESP32_IRExt_4M316k]
+extends                   = esp32_IRExt
+board                     = esp32_4M
+build_flags               = ${esp32_IRExt.build_flags}
+                            -DPLUGIN_SET_COLLECTION_B_ESP32
+
+[env:collection_C_ESP32_IRExt_4M316k]
+extends                   = esp32_IRExt
+board                     = esp32_4M
+build_flags               = ${esp32_IRExt.build_flags}
+                            -DPLUGIN_SET_COLLECTION_C_ESP32
+
+[env:collection_D_ESP32_IRExt_4M316k]
+extends                   = esp32_IRExt
+board                     = esp32_4M
+build_flags               = ${esp32_IRExt.build_flags}
+                            -DPLUGIN_SET_COLLECTION_D_ESP32
+
+[env:collection_E_ESP32_IRExt_4M316k]
+extends                   = esp32_IRExt
+board                     = esp32_4M
+build_flags               = ${esp32_IRExt.build_flags}
+                            -DPLUGIN_SET_COLLECTION_E_ESP32
+
+[env:collection_F_ESP32_IRExt_4M316k]
+extends                   = esp32_IRExt
+board                     = esp32_4M
+build_flags               = ${esp32_IRExt.build_flags}
+                            -DPLUGIN_SET_COLLECTION_F_ESP32
+
+[env:collection_G_ESP32_IRExt_4M316k]
+extends                   = esp32_IRExt
+board                     = esp32_4M
+build_flags               = ${esp32_IRExt.build_flags}
+                            -DPLUGIN_SET_COLLECTION_G_ESP32
+
+[env:energy_ESP32_4M316k]
+extends                   = esp32_common
+board                     = esp32_4M
+build_flags               = ${esp32_common.build_flags}  
+                            -DFEATURE_ARDUINO_OTA=1
+                            -DPLUGIN_ENERGY_COLLECTION
+
+[env:display_ESP32_4M316k]
+extends                   = esp32_common
+board                     = esp32_4M
+build_flags               = ${esp32_common.build_flags}  
+                            -DFEATURE_ARDUINO_OTA=1
+                            -DPLUGIN_DISPLAY_COLLECTION
+
+[env:climate_ESP32_4M316k]
+extends                   = esp32_common
+board                     = esp32_4M
+build_flags               = ${esp32_common.build_flags}  
+                            -DFEATURE_ARDUINO_OTA=1
+                            -DPLUGIN_CLIMATE_COLLECTION
+
+[env:neopixel_ESP32_4M316k]
+extends                   = esp32_common
+board                     = esp32_4M
+build_flags               = ${esp32_common.build_flags}  
+                            -DFEATURE_ARDUINO_OTA=1
+                            -DFEATURE_SD=1
+                            -D PLUGIN_NEOPIXEL_COLLECTION
+
+
+[env:custom_ESP32_4M316k_ETH]
+extends                   = env:custom_ESP32_4M316k
+build_flags               = ${env:custom_ESP32_4M316k.build_flags}
+                            -DFEATURE_ETHERNET=1
+
+[env:custom_ESP32_4M316k_LittleFS_ETH]
+extends                   = esp32_custom_base_LittleFS
+board                     = esp32_4M
+build_flags               = ${esp32_custom_base_LittleFS.build_flags}
+                            -DFEATURE_ETHERNET=1
+
+
+[env:custom_IR_ESP32_4M316k_ETH]
+extends                   = env:custom_IR_ESP32_4M316k
+build_flags               = ${env:custom_IR_ESP32_4M316k.build_flags}
+                            -DFEATURE_ETHERNET=1
+extra_scripts             = ${env:custom_IR_ESP32_4M316k.extra_scripts}
+
+[env:custom_IR_ESP32_16M8M_LittleFS_ETH]
+extends                   = esp32_common_LittleFS
+board                     = esp32_16M8M
+board_upload.flash_size   = 16MB
+build_flags               = ${esp32_common_LittleFS.build_flags}
+                            -DPLUGIN_BUILD_CUSTOM
+                            -DPLUGIN_BUILD_IR
+                            -DFEATURE_ETHERNET=1
+lib_ignore                = ${esp32_always.lib_ignore}
+                            ESP32_ping
+                            ${esp32_common_LittleFS.lib_ignore}
+extra_scripts             = ${esp32_common.extra_scripts}
+                            pre:tools/pio/pre_custom_esp32_IR.py
+                            pre:tools/pio/ir_build_check.py
+
+[env:normal_ESP32_4M316k_ETH]
+extends                   = env:normal_ESP32_4M316k
+build_flags               = ${env:normal_ESP32_4M316k.build_flags}
+                            -DFEATURE_ETHERNET=1
+
+
+[env:normal_ESP32_4M316k_LittleFS_ETH]
+extends                   = esp32_common_LittleFS
+board                     = esp32_4M
+lib_ignore                = ${esp32_always.lib_ignore}
+                            ESP32_ping
+                            ${esp32_common_LittleFS.lib_ignore}
+                            ${no_ir.lib_ignore}
+build_flags               = ${esp32_common_LittleFS.build_flags}
+                            -DFEATURE_ETHERNET=1
+
+
+[env:normal_ESP32_IRExt_4M316k_ETH]
+extends                   = esp32_IRExt
+board                     = esp32_4M
+build_flags               = ${esp32_IRExt.build_flags}
+                            -DFEATURE_ETHERNET=1
+
+[env:collection_A_ESP32_4M316k_ETH]
+extends                   = env:collection_A_ESP32_4M316k
+build_flags               = ${env:collection_A_ESP32_4M316k.build_flags}
+                            -DFEATURE_ETHERNET=1
+                            -DCOLLECTION_FEATURE_RTTTL=1
+
+[env:collection_B_ESP32_4M316k_ETH]
+extends                   = env:collection_B_ESP32_4M316k
+build_flags               = ${env:collection_B_ESP32_4M316k.build_flags}
+                            -DFEATURE_ETHERNET=1
+                            -DCOLLECTION_FEATURE_RTTTL=1
+
+[env:collection_C_ESP32_4M316k_ETH]
+extends                   = env:collection_C_ESP32_4M316k
+build_flags               = ${env:collection_C_ESP32_4M316k.build_flags}
+                            -DFEATURE_ETHERNET=1
+                            -DCOLLECTION_FEATURE_RTTTL=1
+
+[env:collection_D_ESP32_4M316k_ETH]
+extends                   = env:collection_D_ESP32_4M316k
+build_flags               = ${env:collection_D_ESP32_4M316k.build_flags}
+                            -DFEATURE_ETHERNET=1
+                            -DCOLLECTION_FEATURE_RTTTL=1
+
+[env:collection_E_ESP32_4M316k_ETH]
+extends                   = env:collection_E_ESP32_4M316k
+build_flags               = ${env:collection_E_ESP32_4M316k.build_flags}
+                            -DFEATURE_ETHERNET=1
+                            -DCOLLECTION_FEATURE_RTTTL=1
+
+[env:collection_F_ESP32_4M316k_ETH]
+extends                   = env:collection_F_ESP32_4M316k
+build_flags               = ${env:collection_F_ESP32_4M316k.build_flags}
+                            -DFEATURE_ETHERNET=1
+                            -DCOLLECTION_FEATURE_RTTTL=1
+
+[env:collection_G_ESP32_4M316k_ETH]
+extends                   = env:collection_G_ESP32_4M316k
+build_flags               = ${env:collection_G_ESP32_4M316k.build_flags}
+                            -DFEATURE_ETHERNET=1
+                            -DCOLLECTION_FEATURE_RTTTL=1
+
+[env:energy_ESP32_4M316k_ETH]
+extends                   = env:energy_ESP32_4M316k
+build_flags               = ${env:energy_ESP32_4M316k.build_flags}
+                            -DFEATURE_ETHERNET=1
+
+[env:display_ESP32_4M316k_ETH]
+extends                   = env:display_ESP32_4M316k
+build_flags               = ${env:display_ESP32_4M316k.build_flags}
+                            -DFEATURE_ETHERNET=1
+
+[env:climate_ESP32_4M316k_ETH]
+extends                   = env:climate_ESP32_4M316k
+build_flags               = ${env:climate_ESP32_4M316k.build_flags}
+                            -DFEATURE_ETHERNET=1
+
+[env:neopixel_ESP32_4M316k_ETH]
+extends                   = env:neopixel_ESP32_4M316k
+build_flags               = ${env:neopixel_ESP32_4M316k.build_flags}
+                            -DFEATURE_ETHERNET=1
+
+; [env:collection_A_ESP32_IRExt_4M316k_ETH]
 ; extends                   = esp32_IRExt
 ; board                     = esp32_4M
 ; build_flags               = ${esp32_IRExt.build_flags}
 ;                             -DPLUGIN_SET_COLLECTION_ESP32
+;                             -DFEATURE_ETHERNET=1
 
-; [env:collection_B_ESP32_IRExt_4M316k]
+; [env:collection_B_ESP32_IRExt_4M316k_ETH]
 ; extends                   = esp32_IRExt
 ; board                     = esp32_4M
 ; build_flags               = ${esp32_IRExt.build_flags}
 ;                             -DPLUGIN_SET_COLLECTION_B_ESP32
+;                             -DFEATURE_ETHERNET=1
 
-; [env:collection_C_ESP32_IRExt_4M316k]
+; [env:collection_C_ESP32_IRExt_4M316k_ETH]
 ; extends                   = esp32_IRExt
 ; board                     = esp32_4M
 ; build_flags               = ${esp32_IRExt.build_flags}
 ;                             -DPLUGIN_SET_COLLECTION_C_ESP32
+;                             -DFEATURE_ETHERNET=1
 
-; [env:collection_D_ESP32_IRExt_4M316k]
+; [env:collection_D_ESP32_IRExt_4M316k_ETH]
 ; extends                   = esp32_IRExt
 ; board                     = esp32_4M
 ; build_flags               = ${esp32_IRExt.build_flags}
 ;                             -DPLUGIN_SET_COLLECTION_D_ESP32
+;                             -DFEATURE_ETHERNET=1
 
-; [env:collection_E_ESP32_IRExt_4M316k]
+; [env:collection_E_ESP32_IRExt_4M316k_ETH]
 ; extends                   = esp32_IRExt
 ; board                     = esp32_4M
 ; build_flags               = ${esp32_IRExt.build_flags}
 ;                             -DPLUGIN_SET_COLLECTION_E_ESP32
+;                             -DFEATURE_ETHERNET=1
 
-; [env:collection_F_ESP32_IRExt_4M316k]
+; [env:collection_F_ESP32_IRExt_4M316k_ETH]
 ; extends                   = esp32_IRExt
 ; board                     = esp32_4M
 ; build_flags               = ${esp32_IRExt.build_flags}
 ;                             -DPLUGIN_SET_COLLECTION_F_ESP32
+;                             -DFEATURE_ETHERNET=1
 
-; [env:collection_G_ESP32_IRExt_4M316k]
+; [env:collection_G_ESP32_IRExt_4M316k_ETH]
 ; extends                   = esp32_IRExt
 ; board                     = esp32_4M
 ; build_flags               = ${esp32_IRExt.build_flags}
 ;                             -DPLUGIN_SET_COLLECTION_G_ESP32
+;                             -DFEATURE_ETHERNET=1
 
-; [env:energy_ESP32_4M316k]
-; extends                   = esp32_common
+; [env:energy_ESP32_IRExt_4M316k_ETH]
+; extends                   = esp32_IRExt
 ; board                     = esp32_4M
-; build_flags               = ${esp32_common.build_flags}  
-;                             -DFEATURE_ARDUINO_OTA=1
+; build_flags               = ${esp32_IRExt.build_flags}
 ;                             -DPLUGIN_ENERGY_COLLECTION
-
-; [env:display_ESP32_4M316k]
-; extends                   = esp32_common
-; board                     = esp32_4M
-; build_flags               = ${esp32_common.build_flags}  
-;                             -DFEATURE_ARDUINO_OTA=1
-;                             -DPLUGIN_DISPLAY_COLLECTION
-
-; [env:climate_ESP32_4M316k]
-; extends                   = esp32_common
-; board                     = esp32_4M
-; build_flags               = ${esp32_common.build_flags}  
-;                             -DFEATURE_ARDUINO_OTA=1
-;                             -DPLUGIN_CLIMATE_COLLECTION
-
-; [env:neopixel_ESP32_4M316k]
-; extends                   = esp32_common
-; board                     = esp32_4M
-; build_flags               = ${esp32_common.build_flags}  
-;                             -DFEATURE_ARDUINO_OTA=1
-;                             -DFEATURE_SD=1
-;                             -D PLUGIN_NEOPIXEL_COLLECTION
-
-
-; [env:custom_ESP32_4M316k_ETH]
-; extends                   = env:custom_ESP32_4M316k
-; build_flags               = ${env:custom_ESP32_4M316k.build_flags}
 ;                             -DFEATURE_ETHERNET=1
 
-; [env:custom_ESP32_4M316k_LittleFS_ETH]
-; extends                   = esp32_custom_base_LittleFS
-; board                     = esp32_4M
-; build_flags               = ${esp32_custom_base_LittleFS.build_flags}
-;                             -DFEATURE_ETHERNET=1
-
-
-; [env:custom_IR_ESP32_4M316k_ETH]
-; extends                   = env:custom_IR_ESP32_4M316k
-; build_flags               = ${env:custom_IR_ESP32_4M316k.build_flags}
-;                             -DFEATURE_ETHERNET=1
-; extra_scripts             = ${env:custom_IR_ESP32_4M316k.extra_scripts}
-
-; [env:custom_IR_ESP32_16M8M_LittleFS_ETH]
-; extends                   = esp32_common_LittleFS
-; board                     = esp32_16M8M
-; board_upload.flash_size   = 16MB
-; build_flags               = ${esp32_common_LittleFS.build_flags}
-;                             -DPLUGIN_BUILD_CUSTOM
-;                             -DPLUGIN_BUILD_IR
-;                             -DFEATURE_ETHERNET=1
-; lib_ignore                = ${esp32_always.lib_ignore}
-;                             ESP32_ping
-;                             ${esp32_common_LittleFS.lib_ignore}
-; extra_scripts             = ${esp32_common.extra_scripts}
-;                             pre:tools/pio/pre_custom_esp32_IR.py
-;                             pre:tools/pio/ir_build_check.py
-
-; [env:normal_ESP32_4M316k_ETH]
-; extends                   = env:normal_ESP32_4M316k
-; build_flags               = ${env:normal_ESP32_4M316k.build_flags}
-;                             -DFEATURE_ETHERNET=1
-
-
-; [env:normal_ESP32_4M316k_LittleFS_ETH]
-; extends                   = esp32_common_LittleFS
-; board                     = esp32_4M
-; lib_ignore                = ${esp32_always.lib_ignore}
-;                             ESP32_ping
-;                             ${esp32_common_LittleFS.lib_ignore}
-;                             ${no_ir.lib_ignore}
-; build_flags               = ${esp32_common_LittleFS.build_flags}
-;                             -DFEATURE_ETHERNET=1
-
-
-; [env:normal_ESP32_IRExt_4M316k_ETH]
+; [env:display_ESP32_IRExt_4M316k_ETH]
 ; extends                   = esp32_IRExt
 ; board                     = esp32_4M
 ; build_flags               = ${esp32_IRExt.build_flags}
+;                             -DPLUGIN_DISPLAY_COLLECTION
 ;                             -DFEATURE_ETHERNET=1
 
-; [env:collection_A_ESP32_4M316k_ETH]
-; extends                   = env:collection_A_ESP32_4M316k
-; build_flags               = ${env:collection_A_ESP32_4M316k.build_flags}
-;                             -DFEATURE_ETHERNET=1
-;                             -DCOLLECTION_FEATURE_RTTTL=1
-
-; [env:collection_B_ESP32_4M316k_ETH]
-; extends                   = env:collection_B_ESP32_4M316k
-; build_flags               = ${env:collection_B_ESP32_4M316k.build_flags}
-;                             -DFEATURE_ETHERNET=1
-;                             -DCOLLECTION_FEATURE_RTTTL=1
-
-; [env:collection_C_ESP32_4M316k_ETH]
-; extends                   = env:collection_C_ESP32_4M316k
-; build_flags               = ${env:collection_C_ESP32_4M316k.build_flags}
-;                             -DFEATURE_ETHERNET=1
-;                             -DCOLLECTION_FEATURE_RTTTL=1
-
-; [env:collection_D_ESP32_4M316k_ETH]
-; extends                   = env:collection_D_ESP32_4M316k
-; build_flags               = ${env:collection_D_ESP32_4M316k.build_flags}
-;                             -DFEATURE_ETHERNET=1
-;                             -DCOLLECTION_FEATURE_RTTTL=1
-
-; [env:collection_E_ESP32_4M316k_ETH]
-; extends                   = env:collection_E_ESP32_4M316k
-; build_flags               = ${env:collection_E_ESP32_4M316k.build_flags}
-;                             -DFEATURE_ETHERNET=1
-;                             -DCOLLECTION_FEATURE_RTTTL=1
-
-; [env:collection_F_ESP32_4M316k_ETH]
-; extends                   = env:collection_F_ESP32_4M316k
-; build_flags               = ${env:collection_F_ESP32_4M316k.build_flags}
-;                             -DFEATURE_ETHERNET=1
-;                             -DCOLLECTION_FEATURE_RTTTL=1
-
-; [env:collection_G_ESP32_4M316k_ETH]
-; extends                   = env:collection_G_ESP32_4M316k
-; build_flags               = ${env:collection_G_ESP32_4M316k.build_flags}
-;                             -DFEATURE_ETHERNET=1
-;                             -DCOLLECTION_FEATURE_RTTTL=1
-
-; [env:energy_ESP32_4M316k_ETH]
-; extends                   = env:energy_ESP32_4M316k
-; build_flags               = ${env:energy_ESP32_4M316k.build_flags}
+; [env:climate_ESP32_IRExt_4M316k_ETH]
+; extends                   = esp32_IRExt
+; board                     = esp32_4M
+; build_flags               = ${esp32_IRExt.build_flags}
+;                             -DPLUGIN_CLIMATE_COLLECTION
 ;                             -DFEATURE_ETHERNET=1
 
-; [env:display_ESP32_4M316k_ETH]
-; extends                   = env:display_ESP32_4M316k
-; build_flags               = ${env:display_ESP32_4M316k.build_flags}
+; [env:neopixel_ESP32_IRExt_4M316k_ETH]
+; extends                   = esp32_IRExt
+; board                     = esp32_4M
+; build_flags               = ${esp32_IRExt.build_flags}
+;                             -D PLUGIN_NEOPIXEL_COLLECTION
 ;                             -DFEATURE_ETHERNET=1
 
-; [env:climate_ESP32_4M316k_ETH]
-; extends                   = env:climate_ESP32_4M316k
-; build_flags               = ${env:climate_ESP32_4M316k.build_flags}
-;                             -DFEATURE_ETHERNET=1
 
-; [env:neopixel_ESP32_4M316k_ETH]
-; extends                   = env:neopixel_ESP32_4M316k
-; build_flags               = ${env:neopixel_ESP32_4M316k.build_flags}
-;                             -DFEATURE_ETHERNET=1
+; ESP32 MAX builds 16M flash ------------------------------
 
-; ; [env:collection_A_ESP32_IRExt_4M316k_ETH]
-; ; extends                   = esp32_IRExt
-; ; board                     = esp32_4M
-; ; build_flags               = ${esp32_IRExt.build_flags}
-; ;                             -DPLUGIN_SET_COLLECTION_ESP32
-; ;                             -DFEATURE_ETHERNET=1
+; A Lolin D32 PRO with 16MB Flash, allowing 4MB sketch size, and file storage using the default (SPIFFS) filesystem
+[env:max_ESP32_16M1M]
+extends                   = esp32_common
+board                     = esp32_16M1M
+board_upload.flash_size   = 16MB
+lib_ignore                = ${esp32_always.lib_ignore}
+                            ESP32_ping
+build_flags               = ${esp32_common.build_flags}
+                            -DFEATURE_ARDUINO_OTA=1
+                            -DPLUGIN_BUILD_MAX_ESP32
+                            -DPLUGIN_BUILD_IR_EXTENDED
 
-; ; [env:collection_B_ESP32_IRExt_4M316k_ETH]
-; ; extends                   = esp32_IRExt
-; ; board                     = esp32_4M
-; ; build_flags               = ${esp32_IRExt.build_flags}
-; ;                             -DPLUGIN_SET_COLLECTION_B_ESP32
-; ;                             -DFEATURE_ETHERNET=1
-
-; ; [env:collection_C_ESP32_IRExt_4M316k_ETH]
-; ; extends                   = esp32_IRExt
-; ; board                     = esp32_4M
-; ; build_flags               = ${esp32_IRExt.build_flags}
-; ;                             -DPLUGIN_SET_COLLECTION_C_ESP32
-; ;                             -DFEATURE_ETHERNET=1
-
-; ; [env:collection_D_ESP32_IRExt_4M316k_ETH]
-; ; extends                   = esp32_IRExt
-; ; board                     = esp32_4M
-; ; build_flags               = ${esp32_IRExt.build_flags}
-; ;                             -DPLUGIN_SET_COLLECTION_D_ESP32
-; ;                             -DFEATURE_ETHERNET=1
-
-; ; [env:collection_E_ESP32_IRExt_4M316k_ETH]
-; ; extends                   = esp32_IRExt
-; ; board                     = esp32_4M
-; ; build_flags               = ${esp32_IRExt.build_flags}
-; ;                             -DPLUGIN_SET_COLLECTION_E_ESP32
-; ;                             -DFEATURE_ETHERNET=1
-
-; ; [env:collection_F_ESP32_IRExt_4M316k_ETH]
-; ; extends                   = esp32_IRExt
-; ; board                     = esp32_4M
-; ; build_flags               = ${esp32_IRExt.build_flags}
-; ;                             -DPLUGIN_SET_COLLECTION_F_ESP32
-; ;                             -DFEATURE_ETHERNET=1
-
-; ; [env:collection_G_ESP32_IRExt_4M316k_ETH]
-; ; extends                   = esp32_IRExt
-; ; board                     = esp32_4M
-; ; build_flags               = ${esp32_IRExt.build_flags}
-; ;                             -DPLUGIN_SET_COLLECTION_G_ESP32
-; ;                             -DFEATURE_ETHERNET=1
-
-; ; [env:energy_ESP32_IRExt_4M316k_ETH]
-; ; extends                   = esp32_IRExt
-; ; board                     = esp32_4M
-; ; build_flags               = ${esp32_IRExt.build_flags}
-; ;                             -DPLUGIN_ENERGY_COLLECTION
-; ;                             -DFEATURE_ETHERNET=1
-
-; ; [env:display_ESP32_IRExt_4M316k_ETH]
-; ; extends                   = esp32_IRExt
-; ; board                     = esp32_4M
-; ; build_flags               = ${esp32_IRExt.build_flags}
-; ;                             -DPLUGIN_DISPLAY_COLLECTION
-; ;                             -DFEATURE_ETHERNET=1
-
-; ; [env:climate_ESP32_IRExt_4M316k_ETH]
-; ; extends                   = esp32_IRExt
-; ; board                     = esp32_4M
-; ; build_flags               = ${esp32_IRExt.build_flags}
-; ;                             -DPLUGIN_CLIMATE_COLLECTION
-; ;                             -DFEATURE_ETHERNET=1
-
-; ; [env:neopixel_ESP32_IRExt_4M316k_ETH]
-; ; extends                   = esp32_IRExt
-; ; board                     = esp32_4M
-; ; build_flags               = ${esp32_IRExt.build_flags}
-; ;                             -D PLUGIN_NEOPIXEL_COLLECTION
-; ;                             -DFEATURE_ETHERNET=1
-
-
-; ; ESP32 MAX builds 16M flash ------------------------------
-
-; ; A Lolin D32 PRO with 16MB Flash, allowing 4MB sketch size, and file storage using the default (SPIFFS) filesystem
-; [env:max_ESP32_16M1M]
-; extends                   = esp32_common
-; board                     = esp32_16M1M
-; board_upload.flash_size   = 16MB
-; lib_ignore                = ${esp32_always.lib_ignore}
-;                             ESP32_ping
-; build_flags               = ${esp32_common.build_flags}
-;                             -DFEATURE_ARDUINO_OTA=1
-;                             -DPLUGIN_BUILD_MAX_ESP32
-;                             -DPLUGIN_BUILD_IR_EXTENDED
-
-; [env:max_ESP32_16M1M_ETH]
-; extends                   = env:max_ESP32_16M1M
-; build_flags               = ${env:max_ESP32_16M1M.build_flags}
-;                             -DFEATURE_ETHERNET=1
+[env:max_ESP32_16M1M_ETH]
+extends                   = env:max_ESP32_16M1M
+build_flags               = ${env:max_ESP32_16M1M.build_flags}
+                            -DFEATURE_ETHERNET=1
 
 
 ; A Lolin D32 PRO with 16MB Flash, allowing 4MB sketch size, and file storage using LittleFS filesystem
@@ -557,12 +556,12 @@ build_flags               = ${esp32_common_LittleFS.build_flags}
 extra_scripts             = ${esp32_common.extra_scripts}
 board_build.filesystem    = littlefs
 
-; ; If you have a board with Ethernet integrated and 16MB Flash, then this configuration could be enabled, it's based on the max_ESP32_16M8M_LittleFS definition
-; ; [env:max_ESP32_16M8M_LittleFS_ETH]
-; ; extends                   = env:max_ESP32_16M8M_LittleFS
-; ; board                     = ${env:max_ESP32_16M8M_LittleFS.board}
-; ; build_flags               = ${env:max_ESP32_16M8M_LittleFS.build_flags}
-; ;                             -DFEATURE_ETHERNET=1
+; If you have a board with Ethernet integrated and 16MB Flash, then this configuration could be enabled, it's based on the max_ESP32_16M8M_LittleFS definition
+; [env:max_ESP32_16M8M_LittleFS_ETH]
+; extends                   = env:max_ESP32_16M8M_LittleFS
+; board                     = ${env:max_ESP32_16M8M_LittleFS.board}
+; build_flags               = ${env:max_ESP32_16M8M_LittleFS.build_flags}
+;                             -DFEATURE_ETHERNET=1
 
 
 

--- a/platformio_esp32_envs.ini
+++ b/platformio_esp32_envs.ini
@@ -163,381 +163,381 @@ board_upload.flash_size   = 16MB
 build_flags               = ${esp32_custom_base_LittleFS.build_flags}
                             -DFEATURE_ETHERNET=1
 
-[env:custom_IR_ESP32_4M316k]
-extends                   = esp32_common
-board                     = esp32_4M
-build_flags               = ${esp32_common.build_flags}
-                            -DPLUGIN_BUILD_CUSTOM
-                            -DPLUGIN_BUILD_IR
-lib_ignore                = ${esp32_always.lib_ignore}
-                            ESP32_ping
-extra_scripts             = ${esp32_common.extra_scripts}
-                            pre:tools/pio/pre_custom_esp32_IR.py
-                            pre:tools/pio/ir_build_check.py
-
-[env:custom_ESP32_4M2M_NO_OTA_LittleFS_ETH]
-extends                   = esp32_custom_base_LittleFS
-board                     = esp32_4M2M
-build_flags               = ${esp32_custom_base_LittleFS.build_flags}
-                            -DNO_HTTP_UPDATER
-                            -DFEATURE_ETHERNET=1
-
-
-[env:normal_ESP32_4M316k]
-extends                   = esp32_common
-board                     = esp32_4M
-lib_ignore                = ${esp32_common.lib_ignore}
-                            ${no_ir.lib_ignore}
-
-; [env:normal_ESP32_4M316k_LittleFS]
-; extends                   = esp32_common_LittleFS
+; [env:custom_IR_ESP32_4M316k]
+; extends                   = esp32_common
 ; board                     = esp32_4M
-; lib_ignore                = ${esp32_common_LittleFS.lib_ignore}
+; build_flags               = ${esp32_common.build_flags}
+;                             -DPLUGIN_BUILD_CUSTOM
+;                             -DPLUGIN_BUILD_IR
+; lib_ignore                = ${esp32_always.lib_ignore}
+;                             ESP32_ping
+; extra_scripts             = ${esp32_common.extra_scripts}
+;                             pre:tools/pio/pre_custom_esp32_IR.py
+;                             pre:tools/pio/ir_build_check.py
+
+; [env:custom_ESP32_4M2M_NO_OTA_LittleFS_ETH]
+; extends                   = esp32_custom_base_LittleFS
+; board                     = esp32_4M2M
+; build_flags               = ${esp32_custom_base_LittleFS.build_flags}
+;                             -DNO_HTTP_UPDATER
+;                             -DFEATURE_ETHERNET=1
+
+
+; [env:normal_ESP32_4M316k]
+; extends                   = esp32_common
+; board                     = esp32_4M
+; lib_ignore                = ${esp32_common.lib_ignore}
 ;                             ${no_ir.lib_ignore}
 
-[env:collection_A_ESP32_4M316k]
-extends                   = esp32_common
-board                     = esp32_4M
-build_flags               = ${esp32_common.build_flags}  
-                            -DFEATURE_ARDUINO_OTA=1
-                            -DPLUGIN_SET_COLLECTION_ESP32
-                            -DCOLLECTION_FEATURE_RTTTL=1
+; ; [env:normal_ESP32_4M316k_LittleFS]
+; ; extends                   = esp32_common_LittleFS
+; ; board                     = esp32_4M
+; ; lib_ignore                = ${esp32_common_LittleFS.lib_ignore}
+; ;                             ${no_ir.lib_ignore}
 
-[env:collection_B_ESP32_4M316k]
-extends                   = esp32_common
-board                     = esp32_4M
-build_flags               = ${esp32_common.build_flags}  
-                            -DFEATURE_ARDUINO_OTA=1
-                            -DPLUGIN_SET_COLLECTION_B_ESP32
-                            -DCOLLECTION_FEATURE_RTTTL=1
+; [env:collection_A_ESP32_4M316k]
+; extends                   = esp32_common
+; board                     = esp32_4M
+; build_flags               = ${esp32_common.build_flags}  
+;                             -DFEATURE_ARDUINO_OTA=1
+;                             -DPLUGIN_SET_COLLECTION_ESP32
+;                             -DCOLLECTION_FEATURE_RTTTL=1
 
-[env:collection_C_ESP32_4M316k]
-extends                   = esp32_common
-board                     = esp32_4M
-build_flags               = ${esp32_common.build_flags}  
-                            -DFEATURE_ARDUINO_OTA=1
-                            -DPLUGIN_SET_COLLECTION_C_ESP32
-                            -DCOLLECTION_FEATURE_RTTTL=1
+; [env:collection_B_ESP32_4M316k]
+; extends                   = esp32_common
+; board                     = esp32_4M
+; build_flags               = ${esp32_common.build_flags}  
+;                             -DFEATURE_ARDUINO_OTA=1
+;                             -DPLUGIN_SET_COLLECTION_B_ESP32
+;                             -DCOLLECTION_FEATURE_RTTTL=1
 
-[env:collection_D_ESP32_4M316k]
-extends                   = esp32_common
-board                     = esp32_4M
-build_flags               = ${esp32_common.build_flags}  
-                            -DFEATURE_ARDUINO_OTA=1
-                            -DPLUGIN_SET_COLLECTION_D_ESP32
-                            -DCOLLECTION_FEATURE_RTTTL=1
+; [env:collection_C_ESP32_4M316k]
+; extends                   = esp32_common
+; board                     = esp32_4M
+; build_flags               = ${esp32_common.build_flags}  
+;                             -DFEATURE_ARDUINO_OTA=1
+;                             -DPLUGIN_SET_COLLECTION_C_ESP32
+;                             -DCOLLECTION_FEATURE_RTTTL=1
 
-[env:collection_E_ESP32_4M316k]
-extends                   = esp32_common
-board                     = esp32_4M
-build_flags               = ${esp32_common.build_flags}  
-                            -DFEATURE_ARDUINO_OTA=1
-                            -DPLUGIN_SET_COLLECTION_E_ESP32
-                            -DCOLLECTION_FEATURE_RTTTL=1
+; [env:collection_D_ESP32_4M316k]
+; extends                   = esp32_common
+; board                     = esp32_4M
+; build_flags               = ${esp32_common.build_flags}  
+;                             -DFEATURE_ARDUINO_OTA=1
+;                             -DPLUGIN_SET_COLLECTION_D_ESP32
+;                             -DCOLLECTION_FEATURE_RTTTL=1
 
-[env:collection_F_ESP32_4M316k]
-extends                   = esp32_common
-board                     = esp32_4M
-build_flags               = ${esp32_common.build_flags}  
-                            -DFEATURE_ARDUINO_OTA=1
-                            -DPLUGIN_SET_COLLECTION_F_ESP32
-                            -DCOLLECTION_FEATURE_RTTTL=1
+; [env:collection_E_ESP32_4M316k]
+; extends                   = esp32_common
+; board                     = esp32_4M
+; build_flags               = ${esp32_common.build_flags}  
+;                             -DFEATURE_ARDUINO_OTA=1
+;                             -DPLUGIN_SET_COLLECTION_E_ESP32
+;                             -DCOLLECTION_FEATURE_RTTTL=1
 
-[env:collection_G_ESP32_4M316k]
-extends                   = esp32_common
-board                     = esp32_4M
-build_flags               = ${esp32_common.build_flags}  
-                            -DFEATURE_ARDUINO_OTA=1
-                            -DPLUGIN_SET_COLLECTION_G_ESP32
-                            -DCOLLECTION_FEATURE_RTTTL=1
+; [env:collection_F_ESP32_4M316k]
+; extends                   = esp32_common
+; board                     = esp32_4M
+; build_flags               = ${esp32_common.build_flags}  
+;                             -DFEATURE_ARDUINO_OTA=1
+;                             -DPLUGIN_SET_COLLECTION_F_ESP32
+;                             -DCOLLECTION_FEATURE_RTTTL=1
 
-
-[env:collection_A_ESP32_IRExt_4M316k]
-extends                   = esp32_IRExt
-board                     = esp32_4M
-build_flags               = ${esp32_IRExt.build_flags}
-                            -DPLUGIN_SET_COLLECTION_ESP32
-
-[env:collection_B_ESP32_IRExt_4M316k]
-extends                   = esp32_IRExt
-board                     = esp32_4M
-build_flags               = ${esp32_IRExt.build_flags}
-                            -DPLUGIN_SET_COLLECTION_B_ESP32
-
-[env:collection_C_ESP32_IRExt_4M316k]
-extends                   = esp32_IRExt
-board                     = esp32_4M
-build_flags               = ${esp32_IRExt.build_flags}
-                            -DPLUGIN_SET_COLLECTION_C_ESP32
-
-[env:collection_D_ESP32_IRExt_4M316k]
-extends                   = esp32_IRExt
-board                     = esp32_4M
-build_flags               = ${esp32_IRExt.build_flags}
-                            -DPLUGIN_SET_COLLECTION_D_ESP32
-
-[env:collection_E_ESP32_IRExt_4M316k]
-extends                   = esp32_IRExt
-board                     = esp32_4M
-build_flags               = ${esp32_IRExt.build_flags}
-                            -DPLUGIN_SET_COLLECTION_E_ESP32
-
-[env:collection_F_ESP32_IRExt_4M316k]
-extends                   = esp32_IRExt
-board                     = esp32_4M
-build_flags               = ${esp32_IRExt.build_flags}
-                            -DPLUGIN_SET_COLLECTION_F_ESP32
-
-[env:collection_G_ESP32_IRExt_4M316k]
-extends                   = esp32_IRExt
-board                     = esp32_4M
-build_flags               = ${esp32_IRExt.build_flags}
-                            -DPLUGIN_SET_COLLECTION_G_ESP32
-
-[env:energy_ESP32_4M316k]
-extends                   = esp32_common
-board                     = esp32_4M
-build_flags               = ${esp32_common.build_flags}  
-                            -DFEATURE_ARDUINO_OTA=1
-                            -DPLUGIN_ENERGY_COLLECTION
-
-[env:display_ESP32_4M316k]
-extends                   = esp32_common
-board                     = esp32_4M
-build_flags               = ${esp32_common.build_flags}  
-                            -DFEATURE_ARDUINO_OTA=1
-                            -DPLUGIN_DISPLAY_COLLECTION
-
-[env:climate_ESP32_4M316k]
-extends                   = esp32_common
-board                     = esp32_4M
-build_flags               = ${esp32_common.build_flags}  
-                            -DFEATURE_ARDUINO_OTA=1
-                            -DPLUGIN_CLIMATE_COLLECTION
-
-[env:neopixel_ESP32_4M316k]
-extends                   = esp32_common
-board                     = esp32_4M
-build_flags               = ${esp32_common.build_flags}  
-                            -DFEATURE_ARDUINO_OTA=1
-                            -DFEATURE_SD=1
-                            -D PLUGIN_NEOPIXEL_COLLECTION
+; [env:collection_G_ESP32_4M316k]
+; extends                   = esp32_common
+; board                     = esp32_4M
+; build_flags               = ${esp32_common.build_flags}  
+;                             -DFEATURE_ARDUINO_OTA=1
+;                             -DPLUGIN_SET_COLLECTION_G_ESP32
+;                             -DCOLLECTION_FEATURE_RTTTL=1
 
 
-[env:custom_ESP32_4M316k_ETH]
-extends                   = env:custom_ESP32_4M316k
-build_flags               = ${env:custom_ESP32_4M316k.build_flags}
-                            -DFEATURE_ETHERNET=1
-
-[env:custom_ESP32_4M316k_LittleFS_ETH]
-extends                   = esp32_custom_base_LittleFS
-board                     = esp32_4M
-build_flags               = ${esp32_custom_base_LittleFS.build_flags}
-                            -DFEATURE_ETHERNET=1
-
-
-[env:custom_IR_ESP32_4M316k_ETH]
-extends                   = env:custom_IR_ESP32_4M316k
-build_flags               = ${env:custom_IR_ESP32_4M316k.build_flags}
-                            -DFEATURE_ETHERNET=1
-extra_scripts             = ${env:custom_IR_ESP32_4M316k.extra_scripts}
-
-[env:custom_IR_ESP32_16M8M_LittleFS_ETH]
-extends                   = esp32_common_LittleFS
-board                     = esp32_16M8M
-board_upload.flash_size   = 16MB
-build_flags               = ${esp32_common_LittleFS.build_flags}
-                            -DPLUGIN_BUILD_CUSTOM
-                            -DPLUGIN_BUILD_IR
-                            -DFEATURE_ETHERNET=1
-lib_ignore                = ${esp32_always.lib_ignore}
-                            ESP32_ping
-                            ${esp32_common_LittleFS.lib_ignore}
-extra_scripts             = ${esp32_common.extra_scripts}
-                            pre:tools/pio/pre_custom_esp32_IR.py
-                            pre:tools/pio/ir_build_check.py
-
-[env:normal_ESP32_4M316k_ETH]
-extends                   = env:normal_ESP32_4M316k
-build_flags               = ${env:normal_ESP32_4M316k.build_flags}
-                            -DFEATURE_ETHERNET=1
-
-
-[env:normal_ESP32_4M316k_LittleFS_ETH]
-extends                   = esp32_common_LittleFS
-board                     = esp32_4M
-lib_ignore                = ${esp32_always.lib_ignore}
-                            ESP32_ping
-                            ${esp32_common_LittleFS.lib_ignore}
-                            ${no_ir.lib_ignore}
-build_flags               = ${esp32_common_LittleFS.build_flags}
-                            -DFEATURE_ETHERNET=1
-
-
-[env:normal_ESP32_IRExt_4M316k_ETH]
-extends                   = esp32_IRExt
-board                     = esp32_4M
-build_flags               = ${esp32_IRExt.build_flags}
-                            -DFEATURE_ETHERNET=1
-
-[env:collection_A_ESP32_4M316k_ETH]
-extends                   = env:collection_A_ESP32_4M316k
-build_flags               = ${env:collection_A_ESP32_4M316k.build_flags}
-                            -DFEATURE_ETHERNET=1
-                            -DCOLLECTION_FEATURE_RTTTL=1
-
-[env:collection_B_ESP32_4M316k_ETH]
-extends                   = env:collection_B_ESP32_4M316k
-build_flags               = ${env:collection_B_ESP32_4M316k.build_flags}
-                            -DFEATURE_ETHERNET=1
-                            -DCOLLECTION_FEATURE_RTTTL=1
-
-[env:collection_C_ESP32_4M316k_ETH]
-extends                   = env:collection_C_ESP32_4M316k
-build_flags               = ${env:collection_C_ESP32_4M316k.build_flags}
-                            -DFEATURE_ETHERNET=1
-                            -DCOLLECTION_FEATURE_RTTTL=1
-
-[env:collection_D_ESP32_4M316k_ETH]
-extends                   = env:collection_D_ESP32_4M316k
-build_flags               = ${env:collection_D_ESP32_4M316k.build_flags}
-                            -DFEATURE_ETHERNET=1
-                            -DCOLLECTION_FEATURE_RTTTL=1
-
-[env:collection_E_ESP32_4M316k_ETH]
-extends                   = env:collection_E_ESP32_4M316k
-build_flags               = ${env:collection_E_ESP32_4M316k.build_flags}
-                            -DFEATURE_ETHERNET=1
-                            -DCOLLECTION_FEATURE_RTTTL=1
-
-[env:collection_F_ESP32_4M316k_ETH]
-extends                   = env:collection_F_ESP32_4M316k
-build_flags               = ${env:collection_F_ESP32_4M316k.build_flags}
-                            -DFEATURE_ETHERNET=1
-                            -DCOLLECTION_FEATURE_RTTTL=1
-
-[env:collection_G_ESP32_4M316k_ETH]
-extends                   = env:collection_G_ESP32_4M316k
-build_flags               = ${env:collection_G_ESP32_4M316k.build_flags}
-                            -DFEATURE_ETHERNET=1
-                            -DCOLLECTION_FEATURE_RTTTL=1
-
-[env:energy_ESP32_4M316k_ETH]
-extends                   = env:energy_ESP32_4M316k
-build_flags               = ${env:energy_ESP32_4M316k.build_flags}
-                            -DFEATURE_ETHERNET=1
-
-[env:display_ESP32_4M316k_ETH]
-extends                   = env:display_ESP32_4M316k
-build_flags               = ${env:display_ESP32_4M316k.build_flags}
-                            -DFEATURE_ETHERNET=1
-
-[env:climate_ESP32_4M316k_ETH]
-extends                   = env:climate_ESP32_4M316k
-build_flags               = ${env:climate_ESP32_4M316k.build_flags}
-                            -DFEATURE_ETHERNET=1
-
-[env:neopixel_ESP32_4M316k_ETH]
-extends                   = env:neopixel_ESP32_4M316k
-build_flags               = ${env:neopixel_ESP32_4M316k.build_flags}
-                            -DFEATURE_ETHERNET=1
-
-; [env:collection_A_ESP32_IRExt_4M316k_ETH]
+; [env:collection_A_ESP32_IRExt_4M316k]
 ; extends                   = esp32_IRExt
 ; board                     = esp32_4M
 ; build_flags               = ${esp32_IRExt.build_flags}
 ;                             -DPLUGIN_SET_COLLECTION_ESP32
-;                             -DFEATURE_ETHERNET=1
 
-; [env:collection_B_ESP32_IRExt_4M316k_ETH]
+; [env:collection_B_ESP32_IRExt_4M316k]
 ; extends                   = esp32_IRExt
 ; board                     = esp32_4M
 ; build_flags               = ${esp32_IRExt.build_flags}
 ;                             -DPLUGIN_SET_COLLECTION_B_ESP32
-;                             -DFEATURE_ETHERNET=1
 
-; [env:collection_C_ESP32_IRExt_4M316k_ETH]
+; [env:collection_C_ESP32_IRExt_4M316k]
 ; extends                   = esp32_IRExt
 ; board                     = esp32_4M
 ; build_flags               = ${esp32_IRExt.build_flags}
 ;                             -DPLUGIN_SET_COLLECTION_C_ESP32
-;                             -DFEATURE_ETHERNET=1
 
-; [env:collection_D_ESP32_IRExt_4M316k_ETH]
+; [env:collection_D_ESP32_IRExt_4M316k]
 ; extends                   = esp32_IRExt
 ; board                     = esp32_4M
 ; build_flags               = ${esp32_IRExt.build_flags}
 ;                             -DPLUGIN_SET_COLLECTION_D_ESP32
-;                             -DFEATURE_ETHERNET=1
 
-; [env:collection_E_ESP32_IRExt_4M316k_ETH]
+; [env:collection_E_ESP32_IRExt_4M316k]
 ; extends                   = esp32_IRExt
 ; board                     = esp32_4M
 ; build_flags               = ${esp32_IRExt.build_flags}
 ;                             -DPLUGIN_SET_COLLECTION_E_ESP32
-;                             -DFEATURE_ETHERNET=1
 
-; [env:collection_F_ESP32_IRExt_4M316k_ETH]
+; [env:collection_F_ESP32_IRExt_4M316k]
 ; extends                   = esp32_IRExt
 ; board                     = esp32_4M
 ; build_flags               = ${esp32_IRExt.build_flags}
 ;                             -DPLUGIN_SET_COLLECTION_F_ESP32
-;                             -DFEATURE_ETHERNET=1
 
-; [env:collection_G_ESP32_IRExt_4M316k_ETH]
+; [env:collection_G_ESP32_IRExt_4M316k]
 ; extends                   = esp32_IRExt
 ; board                     = esp32_4M
 ; build_flags               = ${esp32_IRExt.build_flags}
 ;                             -DPLUGIN_SET_COLLECTION_G_ESP32
-;                             -DFEATURE_ETHERNET=1
 
-; [env:energy_ESP32_IRExt_4M316k_ETH]
-; extends                   = esp32_IRExt
+; [env:energy_ESP32_4M316k]
+; extends                   = esp32_common
 ; board                     = esp32_4M
-; build_flags               = ${esp32_IRExt.build_flags}
+; build_flags               = ${esp32_common.build_flags}  
+;                             -DFEATURE_ARDUINO_OTA=1
 ;                             -DPLUGIN_ENERGY_COLLECTION
-;                             -DFEATURE_ETHERNET=1
 
-; [env:display_ESP32_IRExt_4M316k_ETH]
-; extends                   = esp32_IRExt
+; [env:display_ESP32_4M316k]
+; extends                   = esp32_common
 ; board                     = esp32_4M
-; build_flags               = ${esp32_IRExt.build_flags}
+; build_flags               = ${esp32_common.build_flags}  
+;                             -DFEATURE_ARDUINO_OTA=1
 ;                             -DPLUGIN_DISPLAY_COLLECTION
-;                             -DFEATURE_ETHERNET=1
 
-; [env:climate_ESP32_IRExt_4M316k_ETH]
-; extends                   = esp32_IRExt
+; [env:climate_ESP32_4M316k]
+; extends                   = esp32_common
 ; board                     = esp32_4M
-; build_flags               = ${esp32_IRExt.build_flags}
+; build_flags               = ${esp32_common.build_flags}  
+;                             -DFEATURE_ARDUINO_OTA=1
 ;                             -DPLUGIN_CLIMATE_COLLECTION
+
+; [env:neopixel_ESP32_4M316k]
+; extends                   = esp32_common
+; board                     = esp32_4M
+; build_flags               = ${esp32_common.build_flags}  
+;                             -DFEATURE_ARDUINO_OTA=1
+;                             -DFEATURE_SD=1
+;                             -D PLUGIN_NEOPIXEL_COLLECTION
+
+
+; [env:custom_ESP32_4M316k_ETH]
+; extends                   = env:custom_ESP32_4M316k
+; build_flags               = ${env:custom_ESP32_4M316k.build_flags}
 ;                             -DFEATURE_ETHERNET=1
 
-; [env:neopixel_ESP32_IRExt_4M316k_ETH]
+; [env:custom_ESP32_4M316k_LittleFS_ETH]
+; extends                   = esp32_custom_base_LittleFS
+; board                     = esp32_4M
+; build_flags               = ${esp32_custom_base_LittleFS.build_flags}
+;                             -DFEATURE_ETHERNET=1
+
+
+; [env:custom_IR_ESP32_4M316k_ETH]
+; extends                   = env:custom_IR_ESP32_4M316k
+; build_flags               = ${env:custom_IR_ESP32_4M316k.build_flags}
+;                             -DFEATURE_ETHERNET=1
+; extra_scripts             = ${env:custom_IR_ESP32_4M316k.extra_scripts}
+
+; [env:custom_IR_ESP32_16M8M_LittleFS_ETH]
+; extends                   = esp32_common_LittleFS
+; board                     = esp32_16M8M
+; board_upload.flash_size   = 16MB
+; build_flags               = ${esp32_common_LittleFS.build_flags}
+;                             -DPLUGIN_BUILD_CUSTOM
+;                             -DPLUGIN_BUILD_IR
+;                             -DFEATURE_ETHERNET=1
+; lib_ignore                = ${esp32_always.lib_ignore}
+;                             ESP32_ping
+;                             ${esp32_common_LittleFS.lib_ignore}
+; extra_scripts             = ${esp32_common.extra_scripts}
+;                             pre:tools/pio/pre_custom_esp32_IR.py
+;                             pre:tools/pio/ir_build_check.py
+
+; [env:normal_ESP32_4M316k_ETH]
+; extends                   = env:normal_ESP32_4M316k
+; build_flags               = ${env:normal_ESP32_4M316k.build_flags}
+;                             -DFEATURE_ETHERNET=1
+
+
+; [env:normal_ESP32_4M316k_LittleFS_ETH]
+; extends                   = esp32_common_LittleFS
+; board                     = esp32_4M
+; lib_ignore                = ${esp32_always.lib_ignore}
+;                             ESP32_ping
+;                             ${esp32_common_LittleFS.lib_ignore}
+;                             ${no_ir.lib_ignore}
+; build_flags               = ${esp32_common_LittleFS.build_flags}
+;                             -DFEATURE_ETHERNET=1
+
+
+; [env:normal_ESP32_IRExt_4M316k_ETH]
 ; extends                   = esp32_IRExt
 ; board                     = esp32_4M
 ; build_flags               = ${esp32_IRExt.build_flags}
-;                             -D PLUGIN_NEOPIXEL_COLLECTION
 ;                             -DFEATURE_ETHERNET=1
 
+; [env:collection_A_ESP32_4M316k_ETH]
+; extends                   = env:collection_A_ESP32_4M316k
+; build_flags               = ${env:collection_A_ESP32_4M316k.build_flags}
+;                             -DFEATURE_ETHERNET=1
+;                             -DCOLLECTION_FEATURE_RTTTL=1
 
-; ESP32 MAX builds 16M flash ------------------------------
+; [env:collection_B_ESP32_4M316k_ETH]
+; extends                   = env:collection_B_ESP32_4M316k
+; build_flags               = ${env:collection_B_ESP32_4M316k.build_flags}
+;                             -DFEATURE_ETHERNET=1
+;                             -DCOLLECTION_FEATURE_RTTTL=1
 
-; A Lolin D32 PRO with 16MB Flash, allowing 4MB sketch size, and file storage using the default (SPIFFS) filesystem
-[env:max_ESP32_16M1M]
-extends                   = esp32_common
-board                     = esp32_16M1M
-board_upload.flash_size   = 16MB
-lib_ignore                = ${esp32_always.lib_ignore}
-                            ESP32_ping
-build_flags               = ${esp32_common.build_flags}
-                            -DFEATURE_ARDUINO_OTA=1
-                            -DPLUGIN_BUILD_MAX_ESP32
-                            -DPLUGIN_BUILD_IR_EXTENDED
+; [env:collection_C_ESP32_4M316k_ETH]
+; extends                   = env:collection_C_ESP32_4M316k
+; build_flags               = ${env:collection_C_ESP32_4M316k.build_flags}
+;                             -DFEATURE_ETHERNET=1
+;                             -DCOLLECTION_FEATURE_RTTTL=1
 
-[env:max_ESP32_16M1M_ETH]
-extends                   = env:max_ESP32_16M1M
-build_flags               = ${env:max_ESP32_16M1M.build_flags}
-                            -DFEATURE_ETHERNET=1
+; [env:collection_D_ESP32_4M316k_ETH]
+; extends                   = env:collection_D_ESP32_4M316k
+; build_flags               = ${env:collection_D_ESP32_4M316k.build_flags}
+;                             -DFEATURE_ETHERNET=1
+;                             -DCOLLECTION_FEATURE_RTTTL=1
+
+; [env:collection_E_ESP32_4M316k_ETH]
+; extends                   = env:collection_E_ESP32_4M316k
+; build_flags               = ${env:collection_E_ESP32_4M316k.build_flags}
+;                             -DFEATURE_ETHERNET=1
+;                             -DCOLLECTION_FEATURE_RTTTL=1
+
+; [env:collection_F_ESP32_4M316k_ETH]
+; extends                   = env:collection_F_ESP32_4M316k
+; build_flags               = ${env:collection_F_ESP32_4M316k.build_flags}
+;                             -DFEATURE_ETHERNET=1
+;                             -DCOLLECTION_FEATURE_RTTTL=1
+
+; [env:collection_G_ESP32_4M316k_ETH]
+; extends                   = env:collection_G_ESP32_4M316k
+; build_flags               = ${env:collection_G_ESP32_4M316k.build_flags}
+;                             -DFEATURE_ETHERNET=1
+;                             -DCOLLECTION_FEATURE_RTTTL=1
+
+; [env:energy_ESP32_4M316k_ETH]
+; extends                   = env:energy_ESP32_4M316k
+; build_flags               = ${env:energy_ESP32_4M316k.build_flags}
+;                             -DFEATURE_ETHERNET=1
+
+; [env:display_ESP32_4M316k_ETH]
+; extends                   = env:display_ESP32_4M316k
+; build_flags               = ${env:display_ESP32_4M316k.build_flags}
+;                             -DFEATURE_ETHERNET=1
+
+; [env:climate_ESP32_4M316k_ETH]
+; extends                   = env:climate_ESP32_4M316k
+; build_flags               = ${env:climate_ESP32_4M316k.build_flags}
+;                             -DFEATURE_ETHERNET=1
+
+; [env:neopixel_ESP32_4M316k_ETH]
+; extends                   = env:neopixel_ESP32_4M316k
+; build_flags               = ${env:neopixel_ESP32_4M316k.build_flags}
+;                             -DFEATURE_ETHERNET=1
+
+; ; [env:collection_A_ESP32_IRExt_4M316k_ETH]
+; ; extends                   = esp32_IRExt
+; ; board                     = esp32_4M
+; ; build_flags               = ${esp32_IRExt.build_flags}
+; ;                             -DPLUGIN_SET_COLLECTION_ESP32
+; ;                             -DFEATURE_ETHERNET=1
+
+; ; [env:collection_B_ESP32_IRExt_4M316k_ETH]
+; ; extends                   = esp32_IRExt
+; ; board                     = esp32_4M
+; ; build_flags               = ${esp32_IRExt.build_flags}
+; ;                             -DPLUGIN_SET_COLLECTION_B_ESP32
+; ;                             -DFEATURE_ETHERNET=1
+
+; ; [env:collection_C_ESP32_IRExt_4M316k_ETH]
+; ; extends                   = esp32_IRExt
+; ; board                     = esp32_4M
+; ; build_flags               = ${esp32_IRExt.build_flags}
+; ;                             -DPLUGIN_SET_COLLECTION_C_ESP32
+; ;                             -DFEATURE_ETHERNET=1
+
+; ; [env:collection_D_ESP32_IRExt_4M316k_ETH]
+; ; extends                   = esp32_IRExt
+; ; board                     = esp32_4M
+; ; build_flags               = ${esp32_IRExt.build_flags}
+; ;                             -DPLUGIN_SET_COLLECTION_D_ESP32
+; ;                             -DFEATURE_ETHERNET=1
+
+; ; [env:collection_E_ESP32_IRExt_4M316k_ETH]
+; ; extends                   = esp32_IRExt
+; ; board                     = esp32_4M
+; ; build_flags               = ${esp32_IRExt.build_flags}
+; ;                             -DPLUGIN_SET_COLLECTION_E_ESP32
+; ;                             -DFEATURE_ETHERNET=1
+
+; ; [env:collection_F_ESP32_IRExt_4M316k_ETH]
+; ; extends                   = esp32_IRExt
+; ; board                     = esp32_4M
+; ; build_flags               = ${esp32_IRExt.build_flags}
+; ;                             -DPLUGIN_SET_COLLECTION_F_ESP32
+; ;                             -DFEATURE_ETHERNET=1
+
+; ; [env:collection_G_ESP32_IRExt_4M316k_ETH]
+; ; extends                   = esp32_IRExt
+; ; board                     = esp32_4M
+; ; build_flags               = ${esp32_IRExt.build_flags}
+; ;                             -DPLUGIN_SET_COLLECTION_G_ESP32
+; ;                             -DFEATURE_ETHERNET=1
+
+; ; [env:energy_ESP32_IRExt_4M316k_ETH]
+; ; extends                   = esp32_IRExt
+; ; board                     = esp32_4M
+; ; build_flags               = ${esp32_IRExt.build_flags}
+; ;                             -DPLUGIN_ENERGY_COLLECTION
+; ;                             -DFEATURE_ETHERNET=1
+
+; ; [env:display_ESP32_IRExt_4M316k_ETH]
+; ; extends                   = esp32_IRExt
+; ; board                     = esp32_4M
+; ; build_flags               = ${esp32_IRExt.build_flags}
+; ;                             -DPLUGIN_DISPLAY_COLLECTION
+; ;                             -DFEATURE_ETHERNET=1
+
+; ; [env:climate_ESP32_IRExt_4M316k_ETH]
+; ; extends                   = esp32_IRExt
+; ; board                     = esp32_4M
+; ; build_flags               = ${esp32_IRExt.build_flags}
+; ;                             -DPLUGIN_CLIMATE_COLLECTION
+; ;                             -DFEATURE_ETHERNET=1
+
+; ; [env:neopixel_ESP32_IRExt_4M316k_ETH]
+; ; extends                   = esp32_IRExt
+; ; board                     = esp32_4M
+; ; build_flags               = ${esp32_IRExt.build_flags}
+; ;                             -D PLUGIN_NEOPIXEL_COLLECTION
+; ;                             -DFEATURE_ETHERNET=1
+
+
+; ; ESP32 MAX builds 16M flash ------------------------------
+
+; ; A Lolin D32 PRO with 16MB Flash, allowing 4MB sketch size, and file storage using the default (SPIFFS) filesystem
+; [env:max_ESP32_16M1M]
+; extends                   = esp32_common
+; board                     = esp32_16M1M
+; board_upload.flash_size   = 16MB
+; lib_ignore                = ${esp32_always.lib_ignore}
+;                             ESP32_ping
+; build_flags               = ${esp32_common.build_flags}
+;                             -DFEATURE_ARDUINO_OTA=1
+;                             -DPLUGIN_BUILD_MAX_ESP32
+;                             -DPLUGIN_BUILD_IR_EXTENDED
+
+; [env:max_ESP32_16M1M_ETH]
+; extends                   = env:max_ESP32_16M1M
+; build_flags               = ${env:max_ESP32_16M1M.build_flags}
+;                             -DFEATURE_ETHERNET=1
 
 
 ; A Lolin D32 PRO with 16MB Flash, allowing 4MB sketch size, and file storage using LittleFS filesystem
@@ -556,12 +556,12 @@ build_flags               = ${esp32_common_LittleFS.build_flags}
 extra_scripts             = ${esp32_common.extra_scripts}
 board_build.filesystem    = littlefs
 
-; If you have a board with Ethernet integrated and 16MB Flash, then this configuration could be enabled, it's based on the max_ESP32_16M8M_LittleFS definition
-; [env:max_ESP32_16M8M_LittleFS_ETH]
-; extends                   = env:max_ESP32_16M8M_LittleFS
-; board                     = ${env:max_ESP32_16M8M_LittleFS.board}
-; build_flags               = ${env:max_ESP32_16M8M_LittleFS.build_flags}
-;                             -DFEATURE_ETHERNET=1
+; ; If you have a board with Ethernet integrated and 16MB Flash, then this configuration could be enabled, it's based on the max_ESP32_16M8M_LittleFS definition
+; ; [env:max_ESP32_16M8M_LittleFS_ETH]
+; ; extends                   = env:max_ESP32_16M8M_LittleFS
+; ; board                     = ${env:max_ESP32_16M8M_LittleFS.board}
+; ; build_flags               = ${env:max_ESP32_16M8M_LittleFS.build_flags}
+; ;                             -DFEATURE_ETHERNET=1
 
 
 

--- a/platformio_esp32_solo1.ini
+++ b/platformio_esp32_solo1.ini
@@ -31,6 +31,7 @@ build_flags               = ${esp32_solo1_common_LittleFS.build_flags}
                             -DFEATURE_ETHERNET=1
 lib_ignore                = ${esp32_solo1_common_LittleFS.lib_ignore}
                             ${no_ir.lib_ignore}
+extra_scripts             = ${esp32_solo1_common_LittleFS.extra_scripts}
 
 
 ; [env:energy_ESP32solo1_4M316k_LittleFS_ETH]

--- a/platformio_esp32_solo1.ini
+++ b/platformio_esp32_solo1.ini
@@ -21,8 +21,8 @@ extends                   = esp32_solo1_common_LittleFS
 build_flags               = ${esp32_solo1_common_LittleFS.build_flags} 
                             -DPLUGIN_BUILD_CUSTOM
                             -DFEATURE_ETHERNET=1
-extra_scripts             = pre:tools/pio/pre_custom_esp32.py
-                            ${esp32_solo1_common_LittleFS.extra_scripts}
+extra_scripts             = ${esp32_solo1_common_LittleFS.extra_scripts}
+                            pre:tools/pio/pre_custom_esp32.py
 
 
 [env:normal_ESP32solo1_4M316k_LittleFS_ETH]
@@ -34,14 +34,16 @@ lib_ignore                = ${esp32_solo1_common_LittleFS.lib_ignore}
 extra_scripts             = ${esp32_solo1_common_LittleFS.extra_scripts}
 
 
-; [env:energy_ESP32solo1_4M316k_LittleFS_ETH]
-; extends                   = esp32_solo1_common_LittleFS
-; build_flags               = ${esp32_solo1_common_LittleFS.build_flags}  
-;                             -D PLUGIN_ENERGY_COLLECTION
-;                             -DFEATURE_ETHERNET=1
+[env:energy_ESP32solo1_4M316k_LittleFS_ETH]
+extends                   = esp32_solo1_common_LittleFS
+build_flags               = ${esp32_solo1_common_LittleFS.build_flags}  
+                            -D PLUGIN_ENERGY_COLLECTION
+                            -DFEATURE_ETHERNET=1
+extra_scripts             = ${esp32_solo1_common_LittleFS.extra_scripts}
 
-; [env:climate_ESP32solo1_4M316k_LittleFS_ETH]
-; extends                   = esp32_solo1_common_LittleFS
-; build_flags               = ${esp32_solo1_common_LittleFS.build_flags}  
-;                             -D PLUGIN_CLIMATE_COLLECTION
-;                             -DFEATURE_ETHERNET=1
+[env:climate_ESP32solo1_4M316k_LittleFS_ETH]
+extends                   = esp32_solo1_common_LittleFS
+build_flags               = ${esp32_solo1_common_LittleFS.build_flags}  
+                            -D PLUGIN_CLIMATE_COLLECTION
+                            -DFEATURE_ETHERNET=1
+extra_scripts             = ${esp32_solo1_common_LittleFS.extra_scripts}

--- a/platformio_esp32_solo1.ini
+++ b/platformio_esp32_solo1.ini
@@ -4,7 +4,7 @@
 extends                   = esp32_base_idf5
 board                     = esp32_solo1_4M
 platform                  = https://github.com/Jason2866/platform-espressif32.git#Arduino/IDF53
-platform_packages         = framework-arduino-solo1 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/3204/framework-arduinoespressif32-solo1-release_v5.3-ddc10306.zip
+platform_packages         = framework-arduino-solo1 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/3428/framework-arduinoespressif32-solo1-release_v5.3-be550b63.zip
 build_flags               = ${esp32_base_idf5.build_flags}
                             -DFEATURE_ARDUINO_OTA=1
                             -DUSE_LITTLEFS

--- a/platformio_esp32_solo1.ini
+++ b/platformio_esp32_solo1.ini
@@ -33,14 +33,14 @@ lib_ignore                = ${esp32_solo1_common_LittleFS.lib_ignore}
                             ${no_ir.lib_ignore}
 
 
-[env:energy_ESP32solo1_4M316k_LittleFS_ETH]
-extends                   = esp32_solo1_common_LittleFS
-build_flags               = ${esp32_solo1_common_LittleFS.build_flags}  
-                            -D PLUGIN_ENERGY_COLLECTION
-                            -DFEATURE_ETHERNET=1
+; [env:energy_ESP32solo1_4M316k_LittleFS_ETH]
+; extends                   = esp32_solo1_common_LittleFS
+; build_flags               = ${esp32_solo1_common_LittleFS.build_flags}  
+;                             -D PLUGIN_ENERGY_COLLECTION
+;                             -DFEATURE_ETHERNET=1
 
-[env:climate_ESP32solo1_4M316k_LittleFS_ETH]
-extends                   = esp32_solo1_common_LittleFS
-build_flags               = ${esp32_solo1_common_LittleFS.build_flags}  
-                            -D PLUGIN_CLIMATE_COLLECTION
-                            -DFEATURE_ETHERNET=1
+; [env:climate_ESP32solo1_4M316k_LittleFS_ETH]
+; extends                   = esp32_solo1_common_LittleFS
+; build_flags               = ${esp32_solo1_common_LittleFS.build_flags}  
+;                             -D PLUGIN_CLIMATE_COLLECTION
+;                             -DFEATURE_ETHERNET=1

--- a/platformio_esp32_solo1.ini
+++ b/platformio_esp32_solo1.ini
@@ -21,8 +21,8 @@ extends                   = esp32_solo1_common_LittleFS
 build_flags               = ${esp32_solo1_common_LittleFS.build_flags} 
                             -DPLUGIN_BUILD_CUSTOM
                             -DFEATURE_ETHERNET=1
-extra_scripts             = ${esp32_solo1_common_LittleFS.extra_scripts}
-                            pre:tools/pio/pre_custom_esp32.py
+extra_scripts             = pre:tools/pio/pre_custom_esp32.py
+                            ${esp32_solo1_common_LittleFS.extra_scripts}
 
 
 [env:normal_ESP32solo1_4M316k_LittleFS_ETH]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-platformio>=6.1.9
+platformio==6.1.16
 pygit2>=1.10.1
 cryptography==43.0.1
 setuptools>=75.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 platformio>=6.1.9
 pygit2>=1.10.1
 cryptography==43.0.1
-setuptools
+setuptools>=75.8

--- a/tools/ci/build-and-archive.py
+++ b/tools/ci/build-and-archive.py
@@ -1,7 +1,7 @@
 import os
 import enum
 import subprocess
-from distutils.dir_util import copy_tree
+import shutil
 
 
 class CannotArchive(Exception):
@@ -28,7 +28,7 @@ def cmd(*, env, pio_can_fail):
     # be made into a flashable .bin
 
     for _dir in dirs:
-      copy_tree(_dir, os.path.basename(_dir))
+      shutil.copytree(_dir, os.path.basename(_dir))
 
 
 

--- a/tools/ci/build-and-archive.py
+++ b/tools/ci/build-and-archive.py
@@ -28,6 +28,7 @@ def cmd(*, env, pio_can_fail):
     # be made into a flashable .bin
 
     for _dir in dirs:
+      print(f"dir: {_dir} basename: {os.path.basename(_dir)}")
       shutil.copytree(_dir, os.path.basename(_dir))
 
 

--- a/tools/ci/build-and-archive.py
+++ b/tools/ci/build-and-archive.py
@@ -28,7 +28,6 @@ def cmd(*, env, pio_can_fail):
     # be made into a flashable .bin
 
     for _dir in dirs:
-      print(f"dir: {_dir} basename: {os.path.basename(_dir)}")
       shutil.copytree(_dir, os.path.basename(_dir))
 
 


### PR DESCRIPTION
Features:
- Upgrade Python package `setuptools`
- Fix outdated `treecopy` Python function
- Avoid deprecated `platformio upgrade` command
- Fix registering post-build scripts (in pre-build phase execution)

TODO:
- [x] Restore disabled build environments