### PR TITLE
[Commands] Add command SendToUDPMix

### DIFF
--- a/docs/source/Plugin/P000_commands.repl
+++ b/docs/source/Plugin/P000_commands.repl
@@ -684,6 +684,15 @@
 
     ``SendToUDP,<IP address>,<Portnumber>,<command>``"
     "
+    SendToUDPMix","
+    :green:`Rules`","
+    Send command to other network device using UDP (non-ESP Easy units) and allow for binary data to be sent.
+
+    ``SendToUDPMix,<IP address>,<Portnumber>,'<content to send>'``
+    
+    ``<content to send>``: Text and/or hex byte(s) (having 0x prefix) that will be sent (nearly) unprocessed. Only the regular variable replacements will be applied before sending the content to the remote device. The content has to be quoted if it contains commas or spaces. When using multiple parts, parts that have spaces or commas must *also* be quoted, and use a different quote character!
+    "
+    "
     Settings","
     :red:`Internal`","
     Show settings on serial terminal

--- a/src/src/Commands/InternalCommands.cpp
+++ b/src/src/Commands/InternalCommands.cpp
@@ -420,6 +420,7 @@ bool InternalCommands::executeInternalCommand()
     case ESPEasy_cmd_e::sendtohttp:                 COMMAND_CASE_A(Command_HTTP_SendToHTTP, 3);      // HTTP.h
 #endif // FEATURE_SEND_TO_HTTP
     case ESPEasy_cmd_e::sendtoudp:                  COMMAND_CASE_A(Command_UDP_SendToUPD,   3);      // UDP.h
+    case ESPEasy_cmd_e::sendtoudpmix:               COMMAND_CASE_A(Command_UDP_SendToUPDMix, 3);     // UDP.h
 #ifndef BUILD_NO_DIAGNOSTIC_COMMANDS
     case ESPEasy_cmd_e::serialfloat:                COMMAND_CASE_R(Command_SerialFloat,    0);       // Diagnostic.h
 #endif // ifndef BUILD_NO_DIAGNOSTIC_COMMANDS

--- a/src/src/Commands/InternalCommands_decoder.cpp
+++ b/src/src/Commands/InternalCommands_decoder.cpp
@@ -213,6 +213,7 @@ const char Internal_commands_s[] PROGMEM =
   "sendtohttp|"
 #endif // FEATURE_SEND_TO_HTTP
   "sendtoudp|"
+  "sendtoudpmix|"
 #ifndef BUILD_NO_DIAGNOSTIC_COMMANDS
   "serialfloat|"
 #endif // ifndef BUILD_NO_DIAGNOSTIC_COMMANDS

--- a/src/src/Commands/InternalCommands_decoder.h
+++ b/src/src/Commands/InternalCommands_decoder.h
@@ -177,6 +177,7 @@ enum class ESPEasy_cmd_e : uint8_t {
   sendtohttp,
 #endif // FEATURE_SEND_TO_HTTP
   sendtoudp,
+  sendtoudpmix,
 #ifndef BUILD_NO_DIAGNOSTIC_COMMANDS
   serialfloat,
 #endif // ifndef BUILD_NO_DIAGNOSTIC_COMMANDS

--- a/src/src/Commands/UPD.h
+++ b/src/src/Commands/UPD.h
@@ -3,12 +3,21 @@
 
 #include "../../ESPEasy_common.h"
 
-String Command_UDP_Port(struct EventStruct *event, const char* Line);
+String Command_UDP_Port(struct EventStruct *event,
+                        const char         *Line);
 
 #if FEATURE_ESPEASY_P2P
-const __FlashStringHelper * Command_UDP_Test (struct EventStruct *event, const char* Line);
-const __FlashStringHelper * Command_UPD_SendTo(struct EventStruct *event, const char* Line);
-#endif
-const __FlashStringHelper * Command_UDP_SendToUPD(struct EventStruct *event, const char* Line);
+const __FlashStringHelper* Command_UDP_Test(struct EventStruct *event,
+                                            const char         *Line);
+const __FlashStringHelper* Command_UPD_SendTo(struct EventStruct *event,
+                                              const char         *Line);
+#endif // if FEATURE_ESPEASY_P2P
+const __FlashStringHelper* Command_UDP_SendToUPD(struct EventStruct *event,
+                                                 const char         *Line);
+const __FlashStringHelper* Command_UDP_SendToUPD(struct EventStruct *event,
+                                                 const char         *Line,
+                                                 const bool          handleMix);
+const __FlashStringHelper* Command_UDP_SendToUPDMix(struct EventStruct *event,
+                                                    const char         *Line);
 
 #endif // COMMAND_UDP_H


### PR DESCRIPTION
From a [feature request on the Forum](https://www.letscontrolit.com/forum/viewtopic.php?p=73565#p73561).

Feature:
- Add command `SendToUDPMix` for sending mixed data, that can't be entered in a regular string, to an UDP port on a network device. (Similar to `SerialSendMix` [command](https://espeasy.readthedocs.io/en/latest/Plugin/P020.html#commands) in P020/P044.)
Example:
```
SendToUDPMix,192.168.0.100,666,'0x45535045617379," is"," a lot of ",0x46554E," :-)"' // Sends: ESPEasy is a lot of FUN :-)
```
- Updated documentation

TODO:
- [x] Testing (local testing done for correct command handling) ([confirmed](https://www.letscontrolit.com/forum/viewtopic.php?p=73565#p73569))