### PR TITLE
[P104] Fix increasing character spacing when changing double-height fonts

### DIFF
--- a/src/_P104_max7219_Dotmatrix.ino
+++ b/src/_P104_max7219_Dotmatrix.ino
@@ -73,6 +73,7 @@
 //                                the coordinate set.
 //
 // History:
+// 2025-04-03 tonhuisman: Set character spacing correctly when changing fonts
 // 2023-10-15 tonhuisman: Code improvements, now using NR_ELEMENTS macro instead of multiple #ifdefs and increments
 //                        Re-enable use of settings-version V3 after some more testing
 // 2023-10-08 tonhuisman: Disable use of settings-version V3 for backward compatibility

--- a/src/src/PluginStructs/P104_data_struct.cpp
+++ b/src/src/PluginStructs/P104_data_struct.cpp
@@ -335,18 +335,20 @@ void P104_data_struct::configureZones() {
       # endif // if defined(P104_USE_BAR_GRAPH) || defined(P104_USE_DOT_SET)
       zoneOffset += it->size;
 
+      P->setCharSpacing(currentZone, P104_NORMAL_CHAR_SPACING); // Set default font spacing
+
       switch (it->font) {
         # ifdef P104_USE_NUMERIC_DOUBLEHEIGHT_FONT
         case P104_DOUBLE_HEIGHT_FONT_ID: {
           P->setFont(currentZone, numeric7SegDouble);
-          P->setCharSpacing(currentZone, P->getCharSpacing(currentZone) * 2); // double spacing as well
+          P->setCharSpacing(currentZone, P104_DOUBLE_CHAR_SPACING); // double spacing as well
           break;
         }
         # endif // ifdef P104_USE_NUMERIC_DOUBLEHEIGHT_FONT
         # ifdef P104_USE_FULL_DOUBLEHEIGHT_FONT
         case P104_FULL_DOUBLEHEIGHT_FONT_ID: {
           P->setFont(currentZone, BigFont);
-          P->setCharSpacing(currentZone, P->getCharSpacing(currentZone) * 2); // double spacing as well
+          P->setCharSpacing(currentZone, P104_DOUBLE_CHAR_SPACING); // double spacing as well
           break;
         }
         # endif // ifdef P104_USE_FULL_DOUBLEHEIGHT_FONT

--- a/src/src/PluginStructs/P104_data_struct.h
+++ b/src/src/PluginStructs/P104_data_struct.h
@@ -259,6 +259,9 @@
 // - extend in P104_data_struct::configureZones the switch/case statement to conditionaly support the new font
 // - update documentation
 
+const uint8_t P104_NORMAL_CHAR_SPACING = 1; // Default font-size character spacing
+const uint8_t P104_DOUBLE_CHAR_SPACING = 2; // Character spacing for double-height fonts
+
 // This is the default font id
 # define P104_DEFAULT_FONT_ID     0
 


### PR DESCRIPTION
As [reported in the Forum](https://www.letscontrolit.com/forum/viewtopic.php?t=10671#p73615).

Bugfix:
- When switching between normal and double-height fonts, the character spacing was increased for the double-height font, but not decreased/reset for normal fonts.

TODO:
- [x] Testing by reporter