### PR TITLE
[Bugfix] Build: Adjust processing order for gzip-firmware script

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -84,10 +84,10 @@ extra_scripts             = pre:tools/pio/install-requirements.py
                             pre:tools/pio/generate-compiletime-defines.py
 
 [extra_scripts_esp8266]
-extra_scripts             = pre:tools/pio/gzip-firmware.py
-                            pre:tools/pio/remove_concat_cpp_files.py
+extra_scripts             = pre:tools/pio/remove_concat_cpp_files.py
                             pre:tools/pio/concat_cpp_files.py
                             ${extra_scripts_default.extra_scripts}
+                            post:tools/pio/gzip-firmware.py
                             post:tools/pio/copy_files.py
 
 


### PR DESCRIPTION
Related to: #5300 

Bug-fix:
- GZipping the binary for ESP8266 builds was done _after_ the file was copied, caused by (fairly) recent changes in PlatformIO.