### PR TITLE
[Bugfix] MQTT Controller: Keep Alive Time reset to/use default (60 sec) when 0

### DIFF
--- a/src/src/ESPEasyCore/Controller.cpp
+++ b/src/src/ESPEasyCore/Controller.cpp
@@ -255,7 +255,7 @@ bool MQTTConnect(controllerIndex_t controller_idx)
       mqtt.setTimeout(timeout); // in msec as it should be!
   #  endif // ifdef MUSTFIX_CLIENT_TIMEOUT_IN_SECONDS
       MQTTclient.setClient(mqtt);
-      MQTTclient.setKeepAlive(ControllerSettings->KeepAliveTime);
+      MQTTclient.setKeepAlive(ControllerSettings->KeepAliveTime ? ControllerSettings->KeepAliveTime : CONTROLLER_KEEP_ALIVE_TIME_DFLT);
       MQTTclient.setSocketTimeout(timeout);
       break;
     }
@@ -360,7 +360,7 @@ bool MQTTConnect(controllerIndex_t controller_idx)
     mqtt_tls->setBufferSizes(1024, 1024);
     #  endif // ifdef ESP8266
     MQTTclient.setClient(*mqtt_tls);
-    MQTTclient.setKeepAlive(ControllerSettings->KeepAliveTime);
+    MQTTclient.setKeepAlive(ControllerSettings->KeepAliveTime ? ControllerSettings->KeepAliveTime : CONTROLLER_KEEP_ALIVE_TIME_DFLT);
     MQTTclient.setSocketTimeout(timeout);
 
 
@@ -394,7 +394,7 @@ bool MQTTConnect(controllerIndex_t controller_idx)
 #  endif // ifdef MUSTFIX_CLIENT_TIMEOUT_IN_SECONDS
 
   MQTTclient.setClient(mqtt);
-  MQTTclient.setKeepAlive(ControllerSettings->KeepAliveTime);
+  MQTTclient.setKeepAlive(ControllerSettings->KeepAliveTime ? ControllerSettings->KeepAliveTime : CONTROLLER_KEEP_ALIVE_TIME_DFLT);
   MQTTclient.setSocketTimeout(timeout);
 # endif // if FEATURE_MQTT_TLS
 

--- a/src/src/Helpers/_CPlugin_Helper_webform.cpp
+++ b/src/src/Helpers/_CPlugin_Helper_webform.cpp
@@ -541,6 +541,9 @@ void saveControllerParameterForm(ControllerSettingsStruct        & ControllerSet
       break;
     case ControllerSettingsStruct::CONTROLLER_KEEP_ALIVE_TIME:
       ControllerSettings.KeepAliveTime = getFormItemInt(internalName, ControllerSettings.KeepAliveTime);
+      if (0 == ControllerSettings.KeepAliveTime) {
+        ControllerSettings.KeepAliveTime = CONTROLLER_KEEP_ALIVE_TIME_DFLT;
+      }
       break;
 #endif // if FEATURE_MQTT
     case ControllerSettingsStruct::CONTROLLER_USE_EXTENDED_CREDENTIALS:


### PR DESCRIPTION
From a finding report [here](https://github.com/letscontrolit/ESPEasy/issues/5300#issuecomment-2817281849) (comment)

Bug-fix:
- MQTT Controller Keep Alive Time now uses the default value of 60 sec. when 0/not set.