### PR TITLE
[ESPtool] Prepare use of esptool v5.0.0

### DIFF
--- a/src/src/DataTypes/NodeTypeID.cpp
+++ b/src/src/DataTypes/NodeTypeID.cpp
@@ -4,18 +4,21 @@
 const __FlashStringHelper* toNodeTypeDisplayString(uint8_t nodeType) {
   switch (nodeType)
   {
-    case NODE_TYPE_ID_ESP_EASY_STD:     return F("ESP Easy");
-    case NODE_TYPE_ID_ESP_EASYM_STD:    return F("ESP Easy Mega");
-    case NODE_TYPE_ID_ESP_EASY32_STD:   return F("ESP Easy 32");
-    case NODE_TYPE_ID_ESP_EASY32S2_STD: return F("ESP Easy 32-S2");
-    case NODE_TYPE_ID_ESP_EASY32S3_STD: return F("ESP Easy 32-S3");
-    case NODE_TYPE_ID_ESP_EASY32C2_STD: return F("ESP Easy 32-C2");
-    case NODE_TYPE_ID_ESP_EASY32C3_STD: return F("ESP Easy 32-C3");
-    case NODE_TYPE_ID_ESP_EASY32H2_STD: return F("ESP Easy 32-H2");
-    case NODE_TYPE_ID_ESP_EASY32C6_STD: return F("ESP Easy 32-C6");
-    case NODE_TYPE_ID_RPI_EASY_STD:     return F("RPI Easy");
-    case NODE_TYPE_ID_ARDUINO_EASY_STD: return F("Arduino Easy");
-    case NODE_TYPE_ID_NANO_EASY_STD:    return F("Nano Easy");
+    case NODE_TYPE_ID_ESP_EASY_STD:      return F("ESP Easy");
+    case NODE_TYPE_ID_ESP_EASYM_STD:     return F("ESP Easy Mega");
+    case NODE_TYPE_ID_ESP_EASY32_STD:    return F("ESP Easy 32");
+    case NODE_TYPE_ID_ESP_EASY32S2_STD:  return F("ESP Easy 32-S2");
+    case NODE_TYPE_ID_ESP_EASY32S3_STD:  return F("ESP Easy 32-S3");
+    case NODE_TYPE_ID_ESP_EASY32C2_STD:  return F("ESP Easy 32-C2");
+    case NODE_TYPE_ID_ESP_EASY32C3_STD:  return F("ESP Easy 32-C3");
+    case NODE_TYPE_ID_ESP_EASY32C5_STD:  return F("ESP Easy 32-C5");
+    case NODE_TYPE_ID_ESP_EASY32C6_STD:  return F("ESP Easy 32-C6");
+    case NODE_TYPE_ID_ESP_EASY32C61_STD: return F("ESP Easy 32-C61");
+    case NODE_TYPE_ID_ESP_EASY32H2_STD:  return F("ESP Easy 32-H2");
+    case NODE_TYPE_ID_ESP_EASY32P4_STD:  return F("ESP Easy 32-P4");
+    case NODE_TYPE_ID_RPI_EASY_STD:      return F("RPI Easy");
+    case NODE_TYPE_ID_ARDUINO_EASY_STD:  return F("Arduino Easy");
+    case NODE_TYPE_ID_NANO_EASY_STD:     return F("Nano Easy");
   }
   return F("");
 }

--- a/src/src/DataTypes/NodeTypeID.h
+++ b/src/src/DataTypes/NodeTypeID.h
@@ -3,6 +3,8 @@
 
 #include "../../ESPEasy_common.h"
 
+// These defines are used to identify other ESPEasy build platforms via ESPEasy p2p
+// So don't ever change already assigned values as there might be older builds which rely on these.
 #define NODE_TYPE_ID_ESP_EASY_STD           1
 #define NODE_TYPE_ID_RPI_EASY_STD           5 // https://github.com/enesbcs/rpieasy
 #define NODE_TYPE_ID_ESP_EASYM_STD         17
@@ -13,35 +15,45 @@
 #define NODE_TYPE_ID_ESP_EASY32C2_STD      37
 #define NODE_TYPE_ID_ESP_EASY32H2_STD      38
 #define NODE_TYPE_ID_ESP_EASY32C6_STD      39
+#define NODE_TYPE_ID_ESP_EASY32C61_STD     40
+#define NODE_TYPE_ID_ESP_EASY32C5_STD      41
+#define NODE_TYPE_ID_ESP_EASY32P4_STD      42
 #define NODE_TYPE_ID_ARDUINO_EASY_STD      65
 #define NODE_TYPE_ID_NANO_EASY_STD         81
 
 
 #if defined(ESP8266)
-  #define NODE_TYPE_ID      NODE_TYPE_ID_ESP_EASYM_STD
+  # define NODE_TYPE_ID      NODE_TYPE_ID_ESP_EASYM_STD
 #endif
 
 
 #if defined(ESP32)
-  #ifdef ESP32S2
-    #define NODE_TYPE_ID                        NODE_TYPE_ID_ESP_EASY32S2_STD
-  #elif defined(ESP32S3)
-    #define NODE_TYPE_ID                        NODE_TYPE_ID_ESP_EASY32S3_STD
-  #elif defined(ESP32C6)
-    #define NODE_TYPE_ID                        NODE_TYPE_ID_ESP_EASY32C6_STD
-  #elif defined(ESP32C3)
-    #define NODE_TYPE_ID                        NODE_TYPE_ID_ESP_EASY32C3_STD
-  #elif defined(ESP32C2)
-    #define NODE_TYPE_ID                        NODE_TYPE_ID_ESP_EASY32C2_STD
+  # ifdef ESP32S2
+    #  define NODE_TYPE_ID            NODE_TYPE_ID_ESP_EASY32S2_STD
+  # elif defined(ESP32S3)
+    #  define NODE_TYPE_ID            NODE_TYPE_ID_ESP_EASY32S3_STD
+  # elif defined(ESP32C2)
+    #  define NODE_TYPE_ID            NODE_TYPE_ID_ESP_EASY32C2_STD
+  # elif defined(ESP32C3)
+    #  define NODE_TYPE_ID            NODE_TYPE_ID_ESP_EASY32C3_STD
+  # elif defined(ESP32C5)
+    #  define NODE_TYPE_ID            NODE_TYPE_ID_ESP_EASY32C5_STD
+  # elif defined(ESP32C6)
+    #  define NODE_TYPE_ID            NODE_TYPE_ID_ESP_EASY32C6_STD
+  # elif defined(ESP32C61)
+    #  define NODE_TYPE_ID            NODE_TYPE_ID_ESP_EASY32C61_STD
+  # elif defined(ESP32H2)
+    #  define NODE_TYPE_ID            NODE_TYPE_ID_ESP_EASY32H2_STD
+  # elif defined(ESP32P4)
+    #  define NODE_TYPE_ID            NODE_TYPE_ID_ESP_EASY32P4_STD
   # elif defined(ESP32_CLASSIC)
-    #define NODE_TYPE_ID                        NODE_TYPE_ID_ESP_EASY32_STD
-  # else
+    #  define NODE_TYPE_ID            NODE_TYPE_ID_ESP_EASY32_STD
+  # else 
 
-    static_assert(false, "Implement processor architecture");
+static_assert(false, "Implement processor architecture");
 
-  #endif
+  # endif
 #endif
-
 
 
 const __FlashStringHelper* toNodeTypeDisplayString(uint8_t nodeType);

--- a/tools/pio/post_esp32.py
+++ b/tools/pio/post_esp32.py
@@ -26,6 +26,17 @@ from os.path import join
 sys.path.append(join(platform.get_package_dir("tool-esptoolpy")))
 import esptool
 
+def esptool_call(cmd):
+    try:
+        esptool.main(cmd)
+    except SystemExit as e:
+        # Fetch sys.exit() without leaving the script
+        if e.code == 0:
+            return True
+        else:
+            print(f"❌ esptool failed with exit code: {e.code}")
+            return False
+
 def esp32_create_combined_bin(source, target, env):
     print("Generating combined binary for serial flashing")
 
@@ -66,7 +77,7 @@ def esp32_create_combined_bin(source, target, env):
 
     print('Using esptool.py arguments: %s' % ' '.join(cmd))
 
-    esptool.main(cmd)
+    esptool_call(cmd)
 
 
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", esp32_create_combined_bin)


### PR DESCRIPTION
Needed to support upcoming esptool.py 5.0.0

Also adding a few new ESP chips to the node ID list so ESPEasy can recognize those via p2p when they will eventually be supported.