### PR TITLE
[Rules] Fix processing variables with index > 2^31

### DIFF
--- a/src/src/Globals/RulesCalculate.cpp
+++ b/src/src/Globals/RulesCalculate.cpp
@@ -10,8 +10,8 @@ RulesCalculate_t RulesCalculate{};
 /*******************************************************************************************
 * Helper functions to actually interact with the rules calculation functions.
 * *****************************************************************************************/
-int CalculateParam(const String& TmpStr, int errorValue) {
-  int32_t returnValue = errorValue;
+int64_t CalculateParam(const String& TmpStr, int64_t errorValue) {
+  int64_t returnValue = errorValue;
 
   if (TmpStr.length() == 0) {
     return returnValue;
@@ -20,7 +20,7 @@ int CalculateParam(const String& TmpStr, int errorValue) {
   // Minimize calls to the Calulate function.
   // Only if TmpStr starts with '=' then call Calculate(). Otherwise do not call it
   if (TmpStr[0] != '=') {
-    if (!validIntFromString(TmpStr, returnValue)) {
+    if (!validInt64FromString(TmpStr, returnValue)) {
       return errorValue;
     }
   } else {
@@ -37,10 +37,13 @@ int CalculateParam(const String& TmpStr, int errorValue) {
                    strformat(F("CALCULATE PARAM: %s = %.6g"), TmpStr.c_str(), roundf(param)));
       }
 #endif // ifndef BUILD_NO_DEBUG
-    } else {
-      return errorValue;
+      // return integer only as it's valid only for variable indices and device/task id
+      #if FEATURE_USE_DOUBLE_AS_ESPEASY_RULES_FLOAT_TYPE
+      return round(param);
+      #else
+      return roundf(param);
+      #endif
     }
-    returnValue = roundf(param); // return integer only as it's valid only for device and task id
   }
   return returnValue;
 }

--- a/src/src/Globals/RulesCalculate.h
+++ b/src/src/Globals/RulesCalculate.h
@@ -17,8 +17,8 @@ extern RulesCalculate_t RulesCalculate;
 * Helper functions to actually interact with the rules calculation functions.
 * *****************************************************************************************/
 
-int                 CalculateParam(const String& TmpStr,
-                                   int           errorValue = 0);
+int64_t             CalculateParam(const String& TmpStr,
+                                   int64_t       errorValue = 0ll);
 
 CalculateReturnCode Calculate_preProcessed(const String            & preprocessd_input,
                                            ESPEASY_RULES_FLOAT_TYPE& result);

--- a/src/src/Helpers/SystemVariables.cpp
+++ b/src/src/Helpers/SystemVariables.cpp
@@ -303,10 +303,11 @@ bool parse_pct_v_num_pct(String& s, boolean useURLencode, int start_pos)
       const int pos_closing_pct = s.indexOf('%', v_index + 1);
       const String arg = s.substring(v_index + 2 + (isv_ ? 1 : 0), pos_closing_pct);
       String valArg(arg);
-      const int32_t i = CalculateParam(arg, -1);
+      constexpr int64_t errorvalue = -1;
+      const int64_t i = CalculateParam(arg, errorvalue);
       // addLog(LOG_LEVEL_INFO, strformat(F("s: '%s', calc parse: %s => %d"), s.c_str(), arg.c_str(), i));
-      if (i != -1) { // We're calculating a numeric index like %v=1+%v2%%, so have to use the result for the value
-        valArg = String(i);
+      if (i != errorvalue) { // We're calculating a numeric index like %v=1+%v2%%, so have to use the result for the value
+        valArg = ll2String(i);
       }
 
       // Need to replace the entire arg


### PR DESCRIPTION
Simple use case:
I wanted to count how often a NFC/RFID card was seen using some rules like this:
```
On nfc#tag Do
  Let,%eventvalue1%,1+[int#%eventvalue1%]
Endon
```
However some variables with card IDs like `%v3163460098%` were never incremented.
So now the range (at least on builds using `double` type in rules) of variable indices is now 1 ... (2^32-1).