### PR TITLE
[PWM motor] Speedup acting on limit switch interrupt

### DIFF
--- a/src/src/PluginStructs/P098_data_struct.cpp
+++ b/src/src/PluginStructs/P098_data_struct.cpp
@@ -4,6 +4,8 @@
 
 # include "../ESPEasyCore/ESPEasyGPIO.h"
 
+# include <GPIO_Direct_Access.h>
+
 # include "../Commands/GPIO.h" // FIXME TD-er: Only needed till we can call GPIO commands from the ESPEasy core.
 
 
@@ -440,7 +442,8 @@ void ICACHE_RAM_ATTR P098_data_struct::process_limit_switch(
   ISR_noInterrupts();
   {
     // Don't call gpio_config.readState() here
-    const bool pinState        = gpio_config.inverted ? digitalRead(gpio_config.gpio) == 0 : digitalRead(gpio_config.gpio) != 0;
+    const bool pinState        = 
+      (DIRECT_pinRead_ISR(gpio_config.gpio) == 0) ^ gpio_config.inverted;
     const uint64_t currentTime = getMicros64();
 
 


### PR DESCRIPTION
ESP-IDF 5.x is much slower in handling Arduino-style `digitalRead` GPIO access.
So when handling GPIO interrupts, we should use direct GPIO access.