### PR TITLE
[WebServer] Properly close chunked transfer

### DIFF
--- a/src/src/DataStructs/Web_StreamingBuffer.cpp
+++ b/src/src/DataStructs/Web_StreamingBuffer.cpp
@@ -270,7 +270,7 @@ void Web_StreamingBuffer::endStream() {
   if (!lowMemorySkip) {
     if (buf.length() > 0) { sendContentBlocking(buf); }
     buf.clear();
-    sendContentBlocking(buf);
+//    sendContentBlocking(buf);
 
     web_server.client().PR_9453_FLUSH_TO_CLEAR();
 
@@ -293,9 +293,12 @@ void Web_StreamingBuffer::endStream() {
       addLog(LOG_LEVEL_ERROR, concat("Webpage skipped: low memory: ", finalRam));
     lowMemorySkip = false;
   }
+  const char *footer_empty = "0\r\n\r\n";
+  web_server.client().write(footer_empty, 5);
+
   delay(5);
-  #ifdef ESP8266
   web_server.client().stop();
+  #ifdef ESP8266
   tcpCleanup();
   #endif
 }


### PR DESCRIPTION
Does speed up ending serving chunked transfer, like serving a web page or JSON