### PR TITLE
[Backup] Add backup without credentials included (security.dat)

### DIFF
--- a/docs/source/Tools/Tools.rst
+++ b/docs/source/Tools/Tools.rst
@@ -1011,6 +1011,13 @@ Backup files
 
 The :cyan:`Backup files` button is only available if .tar file support is included in the build, and offers to download a .tar archive containing all files on the flash file system. These can be stored as a backup and restored in case of some configuration or system failure, or used to create 1 or multiple clones of the unit for multi-deployment. Uploading can also be started from an automation system or script, POST-ing the .tar archive from an external source.
 
+Backup w/o credentials
+======================
+
+The :cyan:`Backup w/o credentials` button acts like the :cyan:`Backup files` button, with the exception that the ``security.dat`` file is excluded from the backup, so you can share a complete system configuration, without sharing any usernames, passwords and similar secrets that should often not be shared.
+
+The backup filename includes ``no_creds`` to show this fact.
+
 Firmware
 ********
 

--- a/src/src/WebServer/DownloadPage.cpp
+++ b/src/src/WebServer/DownloadPage.cpp
@@ -18,14 +18,19 @@
 // ********************************************************************************
 void handle_download() {
 # if FEATURE_TARSTREAM_SUPPORT
-  handle_config_download(false);
+  handle_config_download(false, false);
 }
 
 void handle_full_backup() {
-  handle_config_download(true);
+  handle_config_download(true, false);
 }
 
-void handle_config_download(bool fullBackup) {
+void handle_full_backup_no_usr_pwd() {
+  handle_config_download(true, true);
+}
+
+void handle_config_download(bool fullBackup,
+                            bool noUsrPwd) {
 # endif // if FEATURE_TARSTREAM_SUPPORT
   # ifndef BUILD_NO_RAM_TRACKER
   checkRAM(F("handle_download"));
@@ -54,6 +59,10 @@ void handle_config_download(bool fullBackup) {
   {
     str += F("config_");
   }
+
+  if (noUsrPwd) {
+    str += F("no_usrpwd_");
+  }
   str += strformat(F("%s_U%d_Build%s_"),
                    Settings.getName().c_str(),
                    Settings.Unit,
@@ -72,6 +81,7 @@ void handle_config_download(bool fullBackup) {
     : nullptr;
 
   if (fullBackup && (nullptr != tarStream)) {
+    const String security_dat = getFileName(FileType::SECURITY_DAT);
     #  if defined(ESP8266)
 
     fs::Dir dir = ESPEASY_FS.openDir("");
@@ -80,7 +90,9 @@ void handle_config_download(bool fullBackup) {
       fs::File f = dir.openFile("r");
 
       if (f) {
-        tarStream->addFile(f.name(), f.size());
+        if (!noUsrPwd || (noUsrPwd && (0 != strncasecmp(file.name(), security_dat.c_str(), security_dat.length())))) {
+          tarStream->addFile(f.name(), f.size());
+        }
         f.close();
       }
     }
@@ -91,7 +103,9 @@ void handle_config_download(bool fullBackup) {
 
     while (file) {
       if (!file.isDirectory()) {
-        tarStream->addFile(file.name(), file.size());
+        if (!noUsrPwd || (noUsrPwd && (0 != strncasecmp(file.name(), security_dat.c_str(), security_dat.length())))) {
+          tarStream->addFile(file.name(), file.size());
+        }
       }
       file = root.openNextFile();
     }
@@ -111,7 +125,10 @@ void handle_config_download(bool fullBackup) {
       // other config files
       tarStream->addFileIfExists(getFileName(FileType::NOTIFICATION_DAT));
       tarStream->addFileIfExists(getFileName(FileType::PROVISIONING_DAT));
-      tarStream->addFileIfExists(getFileName(FileType::SECURITY_DAT));
+
+      if (!noUsrPwd) {
+        tarStream->addFileIfExists(getFileName(FileType::SECURITY_DAT));
+      }
 
       // rules<n>.txt files
       for (unsigned int rf = 0; rf < RULESETS_MAX; ++rf) {

--- a/src/src/WebServer/DownloadPage.cpp
+++ b/src/src/WebServer/DownloadPage.cpp
@@ -30,7 +30,7 @@ void handle_full_backup_no_usr_pwd() {
 }
 
 void handle_config_download(bool fullBackup,
-                            bool noUsrPwd) {
+                            bool noCreds) {
 # endif // if FEATURE_TARSTREAM_SUPPORT
   # ifndef BUILD_NO_RAM_TRACKER
   checkRAM(F("handle_download"));
@@ -60,8 +60,8 @@ void handle_config_download(bool fullBackup,
     str += F("config_");
   }
 
-  if (noUsrPwd) {
-    str += F("no_usrpwd_");
+  if (noCreds) {
+    str += F("no_creds_");
   }
   str += strformat(F("%s_U%d_Build%s_"),
                    Settings.getName().c_str(),
@@ -90,7 +90,7 @@ void handle_config_download(bool fullBackup,
       fs::File f = dir.openFile("r");
 
       if (f) {
-        if (!noUsrPwd || (noUsrPwd && (0 != strncasecmp(file.name(), security_dat.c_str(), security_dat.length())))) {
+        if (!noCreds || (noCreds && (0 != strncasecmp(file.name(), security_dat.c_str(), security_dat.length())))) {
           tarStream->addFile(f.name(), f.size());
         }
         f.close();
@@ -103,7 +103,7 @@ void handle_config_download(bool fullBackup,
 
     while (file) {
       if (!file.isDirectory()) {
-        if (!noUsrPwd || (noUsrPwd && (0 != strncasecmp(file.name(), security_dat.c_str(), security_dat.length())))) {
+        if (!noCreds || (noCreds && (0 != strncasecmp(file.name(), security_dat.c_str(), security_dat.length())))) {
           tarStream->addFile(file.name(), file.size());
         }
       }
@@ -126,7 +126,7 @@ void handle_config_download(bool fullBackup,
       tarStream->addFileIfExists(getFileName(FileType::NOTIFICATION_DAT));
       tarStream->addFileIfExists(getFileName(FileType::PROVISIONING_DAT));
 
-      if (!noUsrPwd) {
+      if (!noCreds) {
         tarStream->addFileIfExists(getFileName(FileType::SECURITY_DAT));
       }
 

--- a/src/src/WebServer/DownloadPage.h
+++ b/src/src/WebServer/DownloadPage.h
@@ -13,7 +13,7 @@ void handle_download();
 void handle_full_backup();
 void handle_full_backup_no_usr_pwd();
 void handle_config_download(bool fullBackup,
-                            bool noUsrPwd);
+                            bool noCreds);
 # endif // if FEATURE_TARSTREAM_SUPPORT
 
 #endif // ifdef WEBSERVER_DOWNLOAD

--- a/src/src/WebServer/DownloadPage.h
+++ b/src/src/WebServer/DownloadPage.h
@@ -11,7 +11,9 @@
 void handle_download();
 # if FEATURE_TARSTREAM_SUPPORT
 void handle_full_backup();
-void handle_config_download(bool fullBackup);
+void handle_full_backup_no_usr_pwd();
+void handle_config_download(bool fullBackup,
+                            bool noUsrPwd);
 # endif // if FEATURE_TARSTREAM_SUPPORT
 
 #endif // ifdef WEBSERVER_DOWNLOAD

--- a/src/src/WebServer/ESPEasy_WebServer.cpp
+++ b/src/src/WebServer/ESPEasy_WebServer.cpp
@@ -219,6 +219,7 @@ void WebServerInit()
   web_server.on(F("/advanced"),            handle_advanced);
   # if defined(WEBSERVER_DOWNLOAD) && FEATURE_TARSTREAM_SUPPORT
   web_server.on(F("/backup"),              handle_full_backup);
+  web_server.on(F("/backupnup"),           handle_full_backup_no_usr_pwd);
   # endif // if defined(WEBSERVER_DOWNLOAD) && FEATURE_TARSTREAM_SUPPORT
   #endif // ifdef WEBSERVER_ADVANCED
   #ifdef WEBSERVER_CONFIG

--- a/src/src/WebServer/ToolsPage.cpp
+++ b/src/src/WebServer/ToolsPage.cpp
@@ -129,7 +129,7 @@ void handle_tools() {
                                );
   #if FEATURE_TARSTREAM_SUPPORT
   addWideButtonPlusDescription(F("backup"), F("Backup files"), F("Save all files as a .tar archive"));
-  addWideButtonPlusDescription(F("backupnup"), F("Backup w/o user/pwd"), F("Save all files as a .tar archive but exclude usernames/passwords"));
+  addWideButtonPlusDescription(F("backupnup"), F("Backup w/o credentials"), F("Save all files as a .tar archive but exclude usernames & passwords"));
   #endif // if FEATURE_TARSTREAM_SUPPORT
 
 # ifdef WEBSERVER_NEW_UI

--- a/src/src/WebServer/ToolsPage.cpp
+++ b/src/src/WebServer/ToolsPage.cpp
@@ -129,6 +129,7 @@ void handle_tools() {
                                );
   #if FEATURE_TARSTREAM_SUPPORT
   addWideButtonPlusDescription(F("backup"), F("Backup files"), F("Save all files as a .tar archive"));
+  addWideButtonPlusDescription(F("backupnup"), F("Backup w/o user/pwd"), F("Save all files as a .tar archive but exclude usernames/passwords"));
   #endif // if FEATURE_TARSTREAM_SUPPORT
 
 # ifdef WEBSERVER_NEW_UI


### PR DESCRIPTION
From an internal feature request

Features:
- Add `Backup w/o credentials` button on Tools page, like `Backup files` but without `security.dat`, holding all credentials (usernames and passwords).

TODO:
- [ ] Testing
- [x] Update documentation