### PR TITLE
[Metrics] Add internal CPU temperature

### DIFF
--- a/docs/source/Tools/Tools.rst
+++ b/docs/source/Tools/Tools.rst
@@ -852,6 +852,7 @@ System metrics exposed are:
 * Wifi Strength
 * Wifi connection time
 * Wifi reconnection count (since boot)
+* CPU temperature (when available in the build) (Added: 2025/07/22)
 
 In Addition, device values are exposed.  
 

--- a/src/src/WebServer/Metrics.cpp
+++ b/src/src/WebServer/Metrics.cpp
@@ -82,6 +82,18 @@ void handle_metrics() {
   addHtml(getValue(LabelType::NUMBER_RECONNECTS));
   addHtml('\n');
 
+  # if FEATURE_INTERNAL_TEMPERATURE
+
+  // CPU Temperature
+  addHtml(prefixHELP);
+  addHtml(F("cpu_temperature Level of CPU temperature in Celcius\n"));
+  addHtml(prefixTYPE);
+  addHtml(F("cpu_temperature gauge\n"));
+  addHtml(F("espeasy_cpu_temperature "));
+  addHtml(getValue(LabelType::INTERNAL_TEMPERATURE));
+  addHtml('\n');
+  # endif // if FEATURE_INTERNAL_TEMPERATURE
+
   // devices
   handle_metrics_devices();
 


### PR DESCRIPTION
Resolves #5358 

Features:
- Add internal CPU temperature (when available) in Open Prometheus metrics
- Update documentation

TODO:
- [x] Testing by requester ([confirmed](https://github.com/letscontrolit/ESPEasy/issues/5358#issuecomment-3104700275))