### PR TITLE
[Bugfix] Backup argument missing and some warnings

### DIFF
--- a/lib/MFRC522/MFRC522.cpp
+++ b/lib/MFRC522/MFRC522.cpp
@@ -191,7 +191,6 @@ MFRC522::StatusCode MFRC522::PCD_CalculateCRC(	uint8_t *data,		///< In: Pointer 
  * Initializes the MFRC522 chip.
  */
 void MFRC522::PCD_Init() {
-	bool hardReset = false;
 
 	// Set the chipSelectPin as digital output, do not select the slave yet
 	pinMode(_chipSelectPin, OUTPUT);

--- a/lib/pubsubclient3/src/PubSubClient.h
+++ b/lib/pubsubclient3/src/PubSubClient.h
@@ -165,7 +165,7 @@ class PubSubClient : public Print {
     uint16_t port{};
     Stream* stream{};
     int _state{MQTT_DISCONNECTED};
-    int _bufferWritePos = 0;
+    size_t _bufferWritePos{};
 
     size_t readPacket(uint8_t* hdrLen);
     bool handlePacket(uint8_t hdrLen, size_t len);

--- a/src/src/WebServer/DownloadPage.cpp
+++ b/src/src/WebServer/DownloadPage.cpp
@@ -31,6 +31,8 @@ void handle_full_backup_no_usr_pwd() {
 
 void handle_config_download(bool fullBackup,
                             bool noCreds) {
+# else // if FEATURE_TARSTREAM_SUPPORT
+  const bool noCreds = false;
 # endif // if FEATURE_TARSTREAM_SUPPORT
   # ifndef BUILD_NO_RAM_TRACKER
   checkRAM(F("handle_download"));


### PR DESCRIPTION
Fixes:
- Backup: When TAR is not in the build, the arguments are not available
- [Lib] MFRC522 Unused variable removed
- [Lib] PubSubClient3 Signed vs Unsigned comparison warning