### PR TITLE
[TaskValueSetDerived] Improved parsing of Unit of Measure value

### DIFF
--- a/docs/source/Plugin/P000_commands.repl
+++ b/docs/source/Plugin/P000_commands.repl
@@ -805,7 +805,7 @@
 
     ``<formula>``: The formula to calculate and return as the value for the derived value. The content of the formula should be escaped, else the rules processor will fill the current values, instead of during retrieval of the derived value. Formulas often contain spaces or commas, if so they have to be quoted. See examples.
 
-    ``<UnitOfMeasure>``: An optional Unit of Measure to be appended after the value. Must be quoted if it contains spaces or commas. (Added:2025/06/08)
+    ``<UnitOfMeasure>``: An optional Unit of Measure to be appended after the value. Must be quoted if it contains spaces or commas. Not case-sensitive, 'official' value will be used if the Unit of Measure selector is included in the build. (Added:2025/06/08)
 
     ``<VType>``: The ValueType to be used for MQTT AutoDiscovery. The same values as available in the Value Type combobox on the Device configuration page can be used (not case-sensitive, 'official' value will be used) (Added: 2025/06/19)
 
@@ -817,9 +817,9 @@
 
     ``TaskValueSetDerived,BME,Fahrenheit,'\%c_c2f\%(\[BME#temperature\])'``
     
-    In other places, like rules, and in Display tasks, you can now use ``[BME#DewPoint]`` and ``[BME#Fahrenheit]`` to retrieve the freshly calculated result of the formulas. NB: If the value doesn't get updated, most likely the formula wasn't escaped properly, and the *calculate result* stored in memory, instead of the formula.
+    In other places, like rules, and in Display tasks, you can now use ``[BME#DewPoint]`` and ``[BME#Fahrenheit]`` to retrieve the freshly calculated result of the formulas. NB: If the value doesn't get updated, most likely the formula wasn't escaped properly, and the *calculated result* is stored in memory, instead of the formula.
 
-    Derived values can be shown on the Devices overview page, and included in the ``/json`` output, by enabling the **Show derived values** checkbox in the device configuration.
+    Derived values can be shown on the Devices overview page, and included in the ``/json`` output, by enabling the **Show derived values** checkbox in the device configuration. The value will be included in event generation if the per-task **Event & Log derived values** checkbox is enabled.
     "
     "
     TaskValueSetPresentation","

--- a/src/src/Commands/Tasks.cpp
+++ b/src/src/Commands/Tasks.cpp
@@ -293,7 +293,24 @@ const __FlashStringHelper * taskValueSetString(struct EventStruct *event, const 
       if (GetArgv(Line, argument, 5)) { // check for extra argument holding UoM
         key = strformat(uomTemplate, taskName.c_str(), valueName.c_str());
         if (!argument.isEmpty()) {
-          setCustomStringVar(key, argument);
+          #if FEATURE_TASKVALUE_UNIT_OF_MEASURE
+
+          uint8_t i = 1; // Index 0 is empty/None
+          String uom = toUnitOfMeasureName(i);
+          while (i < 255 && !uom.isEmpty()) {
+            if (argument.equalsIgnoreCase(uom)) {
+              setCustomStringVar(key, uom);
+              argument.clear();
+              break;
+            }
+            ++i;
+            uom = toUnitOfMeasureName(i);
+          }
+          if (!argument.isEmpty()) 
+          #endif // if FEATURE_TASKVALUE_UNIT_OF_MEASURE
+          {
+            setCustomStringVar(key, argument);
+          }
         } else {
           clearCustomStringVar(key);
         }

--- a/src/src/Helpers/_CPlugin_Helper_mqtt.cpp
+++ b/src/src/Helpers/_CPlugin_Helper_mqtt.cpp
@@ -616,7 +616,11 @@ bool MQTT_HomeAssistant_SendAutoDiscovery(controllerIndex_t         ControllerIn
                   String valueDeviceClass = parseStringKeepCase(pluginDeviceClass, v + 1); // Device classes per value
 
                   if (valueDeviceClass.isEmpty()) { valueDeviceClass = F("power"); } // default
+                  #  if FEATURE_MQTT_DEVICECLASS
                   const bool twoWay = MQTT_binary_deviceClassTwoWay(MQTT_binary_deviceClassIndex(valueDeviceClass));
+                  #  else // if FEATURE_MQTT_DEVICECLASS
+                  const bool twoWay = true;
+                  #  endif // if FEATURE_MQTT_DEVICECLASS
 
                   // Discover 2-way as Light
                   const __FlashStringHelper*componentClass = twoWay && discoveryItems[s].canSet ? F("light") : F("binary_sensor");


### PR DESCRIPTION
Features:
- [TaskValueSetDerived] Improved parsing of Unit of Measure value by comparing to the list of known UoM values (if that feature is included in the build), to use correct character casing (f.e. `dbm` -> `dBm`).
- Updated documentation
- [AutoDiscover] Fix conditional compilation issue