### PR TITLE
[Rules] Enable rules by default on a clean install

### DIFF
--- a/src/Custom-sample.h
+++ b/src/Custom-sample.h
@@ -137,7 +137,7 @@
 #define DEFAULT_PIN_RESET_BUTTON                (-1)
 
 
-#define DEFAULT_USE_RULES                       false             // (true|false) Enable Rules?
+#define DEFAULT_USE_RULES                       true              // (true|false) Enable Rules?
 #define DEFAULT_RULES_OLDENGINE                 true
 
 #define DEFAULT_MQTT_RETAIN                     false             // (true|false) Retain MQTT messages?

--- a/src/src/CustomBuild/ESPEasyDefaults.h
+++ b/src/src/CustomBuild/ESPEasyDefaults.h
@@ -299,7 +299,7 @@
 #endif
 
 #ifndef DEFAULT_USE_RULES
-#define DEFAULT_USE_RULES                       false   // (true|false) Enable Rules?
+#define DEFAULT_USE_RULES                       true   // (true|false) Enable Rules?
 #endif
 #ifndef DEFAULT_RULES_OLDENGINE
 #define DEFAULT_RULES_OLDENGINE                true


### PR DESCRIPTION
Enable Rules by default on the Tools/Advanced page, as it is used in many installs and examples.

Only automatically enabled on a clean install, disabling is still possible, if desired 🤔 