### PR TITLE
[Build] Add [P105] AHT2x to Collection G so it can be used with [P164] ENS160

### DIFF
--- a/docs/source/Plugin/_plugin_substitutions_p10x.repl
+++ b/docs/source/Plugin/_plugin_substitutions_p10x.repl
@@ -79,7 +79,7 @@
 .. |P105_type| replace:: :cyan:`Environment`
 .. |P105_typename| replace:: :cyan:`Environment - AHT1x/AHT2x/DHT20/AM2301B`
 .. |P105_porttype| replace:: `.`
-.. |P105_status| replace:: :yellow:`COLLECTION A` :yellow:`CLIMATE`
+.. |P105_status| replace:: :yellow:`COLLECTION A` :yellow:`COLLECTION G` :yellow:`CLIMATE`
 .. |P105_github| replace:: P105_AHT.ino
 .. _P105_github: https://github.com/letscontrolit/ESPEasy/blob/mega/src/_P105_AHT.ino
 .. |P105_usedby| replace:: `.`

--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -1691,6 +1691,11 @@ To create/register a plugin, you have to :
       #define USES_P163   // Environment - RadSens I2C radiation counter
     #endif
   #endif
+  #ifdef ESP32
+    #ifndef USES_P105
+      #define USES_P105
+    #endif
+  #endif
   #ifndef USES_P164
     #define USES_P164   // Gases - ENS16x TVOC\eCO2
   #endif


### PR DESCRIPTION
Resolves #5372 

Features:
- Add [P105] AHT2x to Collection G builds (ESP32 only) so it can be combined with [P164] ENS160 in an IRExt ESP32 build.
- Update documentation

TODO:
- [x] Testing by requester ([confirmed](https://github.com/letscontrolit/ESPEasy/issues/5372#issuecomment-3176704426))