### PR TITLE
[P089] Bugfix: Put include in scope

### DIFF
--- a/src/src/PluginStructs/P089_data_struct.h
+++ b/src/src/PluginStructs/P089_data_struct.h
@@ -4,6 +4,8 @@
 #include "../../_Plugin_Helper.h"
 #ifdef USES_P089
 
+# include "src/ESPEasyCore/ESPEasyNetwork.h"
+
 
 # define PLUGIN_ID_089             89
 
@@ -51,8 +53,6 @@ extern "C"
 #  include <lwip/sys.h>         // needed for sys_now()
 #  include <lwip/netif.h>
 }
-
-#  include "src/ESPEasyCore/ESPEasyNetwork.h"
 
 
 struct P089_icmp_pcb {


### PR DESCRIPTION
Features:
- Fix build error for ESP32 `LIMIT_BUILD_SIZE` builds by getting include file in scope.