### PR TITLE
[C011] HTTP Advanced - Don't URL-encode header

### DIFF
--- a/src/_C011.cpp
+++ b/src/_C011.cpp
@@ -305,7 +305,7 @@ boolean Create_schedule_HTTP_C011(struct EventStruct *event)
     }
 
     ReplaceTokenByValue(element.uri,    event, false);
-    ReplaceTokenByValue(element.header, event, false);
+    ReplaceTokenByValue(element.header, event, true); // Header shouldn't be URL-encoded https://github.com/letscontrolit/ESPEasy/issues/4819
 
     if (element.postStr.length() > 0)
     {


### PR DESCRIPTION
Resolves #4819 

Bugfix:
- Any non-printable ASCII characters in the Header, like `%CR%` and `%LF%` or new-lines in the input, where always URL-encoded before sending, making it nearly impossible to send multiple header values

TODO:
- [ ] Testing by requester