### PR TITLE
[EasyFetch] config file endpoint

### DIFF
--- a/src/src/WebServer/DownloadPage.cpp
+++ b/src/src/WebServer/DownloadPage.cpp
@@ -176,4 +176,18 @@ void handle_config_download(bool fullBackup,
   dataFile.close();
 }
 
+void handle_efc_download() {
+  fs::File dataFile = tryOpenFile("efc.json.gz", "r", FileDestination_e::ANY);
+
+  if (!dataFile) {
+    web_server.send(404, "text/plain", "File not found");
+    return;
+  }
+
+  web_server.enableCORS(true);
+  web_server.streamFile(dataFile, F("application/gzip"));
+  dataFile.close();
+  web_server.enableCORS(false);
+}
+
 #endif // ifdef WEBSERVER_DOWNLOAD

--- a/src/src/WebServer/DownloadPage.h
+++ b/src/src/WebServer/DownloadPage.h
@@ -9,6 +9,7 @@
 // Web Interface download page
 // ********************************************************************************
 void handle_download();
+void handle_efc_download();
 # if FEATURE_TARSTREAM_SUPPORT
 void handle_full_backup();
 void handle_full_backup_no_usr_pwd();

--- a/src/src/WebServer/ESPEasy_WebServer.cpp
+++ b/src/src/WebServer/ESPEasy_WebServer.cpp
@@ -378,6 +378,8 @@ void WebServerInit()
   }
   # endif // if FEATURE_SSDP
   #endif  // if defined(ESP8266)
+  
+web_server.on(F("/efc.json.gz"), HTTP_GET, handle_efc_download);
 }
 
 void setWebserverRunning(bool state) {


### PR DESCRIPTION
I think this could make my life easier in the future. :)
This PR adds  a download endpoint with per-request CORS for the config file of EasyFetch (efc.json.gz).
Right now, I am storing all config data of ESPEasy nodes in a global JSON file on the main unit, but it is not optimal regarding keeping track of changes. I already store the individual config on the nodes as a backup, which until now couldn’t be read by other nodes.