### PR TITLE
[SysVars] Fix showing variables with hex number as index

### DIFF
--- a/src/src/Helpers/SystemVariables.cpp
+++ b/src/src/Helpers/SystemVariables.cpp
@@ -303,11 +303,13 @@ bool parse_pct_v_num_pct(String& s, boolean useURLencode, int start_pos)
       const int pos_closing_pct = s.indexOf('%', v_index + 1);
       const String arg = s.substring(v_index + 2 + (isv_ ? 1 : 0), pos_closing_pct);
       String valArg(arg);
-      constexpr int64_t errorvalue = -1;
-      const int64_t i = CalculateParam(arg, errorvalue);
-      // addLog(LOG_LEVEL_INFO, strformat(F("s: '%s', calc parse: %s => %d"), s.c_str(), arg.c_str(), i));
-      if (i != errorvalue) { // We're calculating a numeric index like %v=1+%v2%%, so have to use the result for the value
-        valArg = ll2String(i);
+      if (!isv_) {
+        constexpr int64_t errorvalue = -1;
+        const int64_t i = CalculateParam(arg, errorvalue);
+        // addLog(LOG_LEVEL_INFO, strformat(F("s: '%s', calc parse: %s => %d"), s.c_str(), arg.c_str(), i));
+        if (i != errorvalue) { // We're calculating a numeric index like %v=1+%v2%%, so have to use the result for the value
+          valArg = ll2String(i);
+        }
       }
 
       // Need to replace the entire arg

--- a/src/src/WebServer/SysVarPage.cpp
+++ b/src/src/WebServer/SysVarPage.cpp
@@ -60,10 +60,12 @@ void handle_sysvars() {
     html_TD();
     html_TD();
   } else {
-    uint32_t tmpVar{};
-
     for (auto it = customFloatVar.begin(); it != customFloatVar.end(); ++it) {
-      const bool isv_ = !validUIntFromString(it->first, tmpVar);
+      NumericalType detectedType;
+      bool isv_ = true;
+      if (getNumerical(it->first, NumericalType::HexadecimalUInt, detectedType).length() > 0) {
+        isv_ = detectedType != NumericalType::Integer;
+      }
       addSysVar_html(strformat(F("%%%s%s%%"), FsP(isv_ ? F("v_") : F("v")), it->first.c_str()), false);
     }
   }


### PR DESCRIPTION
Bugfix:
- Parsing of variable names improved to handle hex value names in an expected way (authored by TD-er)