### PR TITLE
[MQTT AutoDiscovery] Add support for Switch Device Class

### DIFF
--- a/docs/source/Plugin/DeviceClass_binary.repl
+++ b/docs/source/Plugin/DeviceClass_binary.repl
@@ -3,10 +3,10 @@ MQTT Device class
 
 (Only available if both MQTT Auto Discovery and Device Class features are included in the build.)
 
-* **MQTT Device class**: Select the Binary Device class that's to be used for this task device. Device classes marked with ``²`` are 'two-way' devices, meaning that the state will be updated when changed, either on the ESPEasy side, or on the MQTT (Home Assistant) side.
+* **MQTT Device class**: Select the Binary Device class that's to be used for this task device. Device classes marked with ``²`` are 'two-way' devices, meaning that the state will be updated when changed, either on the ESPEasy side, or on the MQTT (Home Assistant) side. For the MQTT Device classes ``switch`` and ``outlet``, both also marked with ``÷``, the discovery is marked as ``switch`` instead of ``light``.
 
-The default value used is ``power``, also when not set (empty), and can be updated in Home Assistant by resending the MQTT Discovery.
+The default value used is ``switch``, also when not set (empty), and can be updated in Home Assistant by resending the MQTT Discovery.
 
-The available options are based on the Summer 2025 version of this `Home Assistant MQTT Binary sensor documentation page <https://www.home-assistant.io/integrations/binary_sensor/#device-class>`_
+The available options are based on the Summer 2025 version of this `Home Assistant MQTT Binary sensor documentation page <https://www.home-assistant.io/integrations/binary_sensor/#device-class>`_ and also related to this `Home Assistant MQTT Switch device page <https://www.home-assistant.io/integrations/switch.mqtt/>`_ (though that doesn't document *any* Auto Discovery information)
 
-The On/Off icon shown in Home Assistant (HA) can be changed for an alternative in the HA configuration, after Auto Discovery has created the device there.
+The ``switch`` device class shows an On/Off icon, the default icon shown for other ``light`` or ``binary_sensor`` devices in Home Assistant (HA) can be changed for an alternative in the HA configuration, if desired, after Auto Discovery has created the device there.

--- a/src/src/Helpers/_CPlugin_Helper_mqtt.h
+++ b/src/src/Helpers/_CPlugin_Helper_mqtt.h
@@ -38,6 +38,7 @@ String                     makeHomeAssistantCompliantName(const String& name);
 #  if FEATURE_MQTT_DEVICECLASS
 String                     MQTT_binary_deviceClassName(int devClassIndex);
 bool                       MQTT_binary_deviceClassTwoWay(int devClassIndex);
+bool                       MQTT_binary_deviceClassSwitch(int devClassIndex);
 int                        MQTT_binary_deviceClassIndex(const String& deviceClassName);
 #  endif // if FEATURE_MQTT_DEVICECLASS
 #  if FEATURE_MQTT_STATE_CLASS

--- a/src/src/PluginStructs/P026_data_struct.cpp
+++ b/src/src/PluginStructs/P026_data_struct.cpp
@@ -172,7 +172,7 @@ Sensor_VType P026_get_valueVType(uint8_t type) {
     case P026_VALUETYPE_ip4:       return Sensor_VType::SENSOR_TYPE_NONE;
     case P026_VALUETYPE_web:       return Sensor_VType::SENSOR_TYPE_DURATION;
     case P026_VALUETYPE_freestack: return Sensor_VType::SENSOR_TYPE_DATA_SIZE;
-    case P026_VALUETYPE_txpwr:     return Sensor_VType::SENSOR_TYPE_POWER_FACT_ONLY;
+    case P026_VALUETYPE_txpwr:     return Sensor_VType::SENSOR_TYPE_SOUND_PRESSURE;
 #  ifdef USE_SECOND_HEAP
     case P026_VALUETYPE_free2ndheap:  return Sensor_VType::SENSOR_TYPE_DATA_SIZE;
 #  endif // ifdef USE_SECOND_HEAP

--- a/src/src/WebServer/Markup_Forms.cpp
+++ b/src/src/WebServer/Markup_Forms.cpp
@@ -764,6 +764,9 @@ void addFormSelector_binarySensorDeviceClass(const __FlashStringHelper*label,
   if (MQTT_binary_deviceClassTwoWay(devClassIndex)) {
     devClassName += F("²");
   }
+  if (MQTT_binary_deviceClassSwitch(devClassIndex)) {
+    devClassName += F("÷"); // These are multi-byte chars, so we have to use the F() macro
+  }
 
   while (!devClassName.isEmpty() || (0 == devClassIndex)) {
     binaryDeviceClasses.push_back(devClassName);
@@ -771,6 +774,9 @@ void addFormSelector_binarySensorDeviceClass(const __FlashStringHelper*label,
     devClassName = MQTT_binary_deviceClassName(devClassIndex);
     if (MQTT_binary_deviceClassTwoWay(devClassIndex)) {
       devClassName += F("²");
+    }
+    if (MQTT_binary_deviceClassSwitch(devClassIndex)) {
+      devClassName += F("÷");
     }
   }
   const FormSelectorOptions deviceClass(


### PR DESCRIPTION
Resolves #5409 (partly)

Features:
- [MQTT AutoDiscovery] Add support for Switch Device Class adding `switch` and `outlet` options
- Update documentation
- [P026] Fix Value Type for TX power so the UoM is `dBm` by default
