### PR TITLE
[Build] Remove _LittleFS and _ETH from build names due to linker issues (cherry-pick)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.x'
+          python-version: '3.13'
       - name: Dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.x'
+          python-version: '3.13'
       - name: Build documentation
         run: |
           cd docs
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.x'
+          python-version: '3.13'
       - id: set-matrix
         run: |
           pip install uv
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.x'
+          python-version: '3.13'
       - name: Get current date
         id: date
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
       - name: Dependencies
         run: |
           sudo apt install binutils build-essential libffi-dev libgit2-dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.x'
+          python-version: '3.13'
       - id: set-matrix
         run: |
           pip install uv
@@ -123,7 +123,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.x'
+          python-version: '3.13'
       - name: Get current date
         id: date
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -77,7 +77,7 @@ managed_components/
 
 CMakeLists.txt
 
-sdkconfig.max_ESP32s3_16M8M_LittleFS_OPI_PSRAM_ETH
+sdkconfig.max_ESP32s3_16M8M_OPI_PSRAM
 
 sdkconfig.defaults
 
@@ -88,3 +88,5 @@ dependencies.lock
 .cache/
 
 src/src/CustomBuild/CompiletimeDefines_generated.h
+
+bhutan_16m.bin

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Flash size | Description                 |
 
 N.B. Starting with release 2023/12/25, All ESP32 LittleFS builds use IDF 5.3, to support newer ESP32 chips like ESP32-C2 and ESP32-C6, and SPI Ethernet. Other SPIFFS based ESP32 builds will be migrated to LittleFS as SPIFFS is no longer officially available in IDF 5 and later. As a temporary solution, a specially crafted IDF 5.1 build that still includes SPIFFS, is used for the SPIFFS builds. A migration plan will be made available in 2025.
 
+N.B.2 Starting with builds made after 2025/11/04, ESP32 builds will no longer have ``_LittleFS`` in the name as all ESP32 builds use LittleFS. Also the suffix ``_ETH`` has been removed since all builds will have Ethernet support, except for ESP32C2 builds.
+
 *[opt-build-features]* can be any of:
 Build features  | Description                                                                                               |
 ----------------|-----------------------------------------------------------------------------------------------------------|
@@ -129,18 +131,18 @@ noOTA/NO_OTA    | Does not support OTA (Over The Air-updating of the firmware) U
 N.B. Starting ca. 2025/02/27, many ESP32 builds are *only* available with _ETH suffix, indicating that Ethernet support is enabled, to reduce the (rather high) number of builds.
 
 Some example firmware names:
-Firmware name                                                         | Hardware                                        | Included plugins                 |
-----------------------------------------------------------------------|-------------------------------------------------|----------------------------------|
-ESPEasy_mega-20230822_normal_ESP8266_1M.bin                           | ESP8266/ESP8285 with 1MB flash                  | Stable                           |
-ESPEasy_mega-20230822_normal_ESP8266_4M1M.bin                         | ESP8266 with 4MB flash                          | Stable                           |
-ESPEasy_mega-20230822_collection_A_ESP8266_4M1M.bin                   | ESP8266 with 4MB flash                          | Stable + Collection base + set A |
-ESPEasy_mega-20230822_normal_ESP32_4M316k_ETH.bin                     | ESP32 with 4MB flash                            | Stable                           |
-ESPEasy_mega-20230822_collection_A_ESP32_4M316k_ETH.bin               | ESP32 with 4MB flash                            | Stable + Collection base + set A |
-ESPEasy_mega-20230822_collection_B_ESP32_4M316k_ETH.bin               | ESP32 with 4MB flash                            | Stable + Collection base + set B |
-ESPEasy_mega-20230822_max_ESP32s3_8M1M_LittleFS_ETH.bin           | ESP32-S3 with 8MB flash, CDC-serial, Ethernet   | All available plugins            |
-ESPEasy_mega-20230822_max_ESP32s3_8M1M_LittleFS_OPI_PSRAM_ETH.bin | ESP32-S3 8MB flash, PSRAM, CDC-serial, Ethernet | All available plugins            |
-ESPEasy_mega-20230822_max_ESP32_16M1M_ETH.bin                         | ESP32 with 16MB flash, SPIFFS, Ethernet         | All available plugins            |
-ESPEasy_mega-20230822_max_ESP32_16M8M_LittleFS_ETH.bin                | ESP32 with 16MB flash, LittleFS, Ethernet       | All available plugins            |
+Firmware name                                           | Hardware                                        | Included plugins                 |
+--------------------------------------------------------|-------------------------------------------------|----------------------------------|
+ESPEasy_mega-20230822_normal_ESP8266_1M.bin             | ESP8266/ESP8285 with 1MB flash                  | Stable                           |
+ESPEasy_mega-20230822_normal_ESP8266_4M1M.bin           | ESP8266 with 4MB flash                          | Stable                           |
+ESPEasy_mega-20230822_collection_A_ESP8266_4M1M.bin     | ESP8266 with 4MB flash                          | Stable + Collection base + set A |
+ESPEasy_mega-20230822_normal_ESP32_4M316k_ETH.bin       | ESP32 with 4MB flash                            | Stable                           |
+ESPEasy_mega-20230822_collection_A_ESP32_4M316k_ETH.bin | ESP32 with 4MB flash                            | Stable + Collection base + set A |
+ESPEasy_mega-20230822_collection_B_ESP32_4M316k_ETH.bin | ESP32 with 4MB flash                            | Stable + Collection base + set B |
+ESPEasy_mega-20230822_max_ESP32s3_8M1M.bin              | ESP32-S3 with 8MB flash, CDC-serial, Ethernet   | All available plugins            |
+ESPEasy_mega-20230822_max_ESP32s3_8M1M_OPI_PSRAM.bin    | ESP32-S3 8MB flash, PSRAM, CDC-serial, Ethernet | All available plugins            |
+ESPEasy_mega-20230822_max_ESP32_16M1M_ETH.bin           | ESP32 with 16MB flash, SPIFFS, Ethernet         | All available plugins            |
+ESPEasy_mega-20230822_max_ESP32_16M8M.bin               | ESP32 with 16MB flash, LittleFS, Ethernet       | All available plugins            |
 
 The binary files for the different ESP32 variants (S2, C3, S3, C2, C6, Solo1, 'Classic') are available in separate archives.
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -31,8 +31,8 @@ extra_configs   =
 
 
 ;default_envs = normal_ESP32_4M
-default_envs = max_ESP32_16M8M_LittleFS_ETH
-;default_envs = max_ESP32c5_8M1M_LittleFS_ETH
+default_envs = max_ESP32_16M8M
+;default_envs = max_ESP32c5_8M1M
 
 ;default_envs = normal_ESP32c6_4M316k_LittleFS_CDC
 ; default_envs = custom_ESP8266_4M1M

--- a/platformio_core_defs.ini
+++ b/platformio_core_defs.ini
@@ -168,6 +168,7 @@ extra_scripts             = ${esp82xx_common.extra_scripts}
 platform                    = https://github.com/Jason2866/platform-espressif32.git#Arduino/IDF54
 platform_packages           =
 ;platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/3743/framework-arduinoespressif32-all-release_v5.4-a4437683.zip
+custom_remove_include = true
 build_flags                 = -DESP32_STAGE
                               -DESP_IDF_VERSION_MAJOR=5
                               -DLIBRARIES_NO_LOG=1
@@ -187,7 +188,7 @@ build_flags                 = -DESP32_STAGE
                               -include "ESPEasy_config.h"
                               -include "esp32x_fixes.h"
 ;                              -Wnull-dereference
-lib_ignore                = 
+lib_ignore                = BLE
 lib_extra_dirs            =
                             lib/lib_ssl
 

--- a/platformio_esp32_envs.ini
+++ b/platformio_esp32_envs.ini
@@ -66,7 +66,7 @@ lib_ignore                = ${esp32_always.lib_ignore}
                             ${esp32_base_idf5.lib_ignore}
 
 
-[esp32_IRExt_LittleFS_ETH]
+[esp32_IRExt]
 extends                   = esp32_common_LittleFS_ETH
 lib_ignore                = ${esp32_always.lib_ignore}
                             ESP32_ping
@@ -88,21 +88,21 @@ extra_scripts             = ${esp32_common_LittleFS_ETH.extra_scripts}
                             pre:tools/pio/pre_custom_esp32.py
 
 
-[env:custom_ESP32_4M316k_LittleFS_ETH]
+[env:custom_ESP32_4M316k]
 extends                   = esp32_custom_base_LittleFS
 board                     = esp32_4M
 build_flags               = ${esp32_custom_base_LittleFS.build_flags}
                             -DFEATURE_ETHERNET=1
 
                             
-[env:custom_ESP32_16M8M_LittleFS_ETH]
-extends                   = env:custom_ESP32_4M316k_LittleFS_ETH
+[env:custom_ESP32_16M8M]
+extends                   = env:custom_ESP32_4M316k
 board                     = esp32_16M8M
 board_upload.flash_size   = 16MB
-build_flags               = ${env:custom_ESP32_4M316k_LittleFS_ETH.build_flags}
+build_flags               = ${env:custom_ESP32_4M316k.build_flags}
                             
 
-[env:custom_IR_ESP32_4M316k_LittleFS_ETH]
+[env:custom_IR_ESP32_4M316k]
 extends                   = esp32_common_LittleFS_ETH
 board                     = esp32_4M
 build_flags               = ${esp32_common_LittleFS_ETH.build_flags}
@@ -115,15 +115,15 @@ extra_scripts             = ${esp32_common_LittleFS_ETH.extra_scripts}
                             pre:tools/pio/pre_custom_esp32_IR.py
                             pre:tools/pio/ir_build_check.py
 
-[env:custom_ESP32_4M2M_NO_OTA_LittleFS_ETH]
-extends                   = env:custom_ESP32_4M316k_LittleFS_ETH
+[env:custom_ESP32_4M2M_NO_OTA]
+extends                   = env:custom_ESP32_4M316k
 board                     = esp32_4M2M
-build_flags               = ${env:custom_ESP32_4M316k_LittleFS_ETH.build_flags}
+build_flags               = ${env:custom_ESP32_4M316k.build_flags}
                             -DNO_HTTP_UPDATER
                             
 
 
-[env:collection_A_ESP32_4M316k_LittleFS_ETH]
+[env:collection_A_ESP32_4M316k]
 extends                   = esp32_common_LittleFS_ETH
 board                     = esp32_4M
 build_flags               = ${esp32_common_LittleFS_ETH.build_flags}  
@@ -132,7 +132,7 @@ build_flags               = ${esp32_common_LittleFS_ETH.build_flags}
                             -DCOLLECTION_FEATURE_RTTTL=1
                             
 
-[env:collection_B_ESP32_4M316k_LittleFS_ETH]
+[env:collection_B_ESP32_4M316k]
 extends                   = esp32_common_LittleFS_ETH
 board                     = esp32_4M
 build_flags               = ${esp32_common_LittleFS_ETH.build_flags}  
@@ -141,7 +141,7 @@ build_flags               = ${esp32_common_LittleFS_ETH.build_flags}
                             -DCOLLECTION_FEATURE_RTTTL=1
                             
 
-[env:collection_C_ESP32_4M316k_LittleFS_ETH]
+[env:collection_C_ESP32_4M316k]
 extends                   = esp32_common_LittleFS_ETH
 board                     = esp32_4M
 build_flags               = ${esp32_common_LittleFS_ETH.build_flags}  
@@ -150,7 +150,7 @@ build_flags               = ${esp32_common_LittleFS_ETH.build_flags}
                             -DCOLLECTION_FEATURE_RTTTL=1
                             
 
-[env:collection_D_ESP32_4M316k_LittleFS_ETH]
+[env:collection_D_ESP32_4M316k]
 extends                   = esp32_common_LittleFS_ETH
 board                     = esp32_4M
 build_flags               = ${esp32_common_LittleFS_ETH.build_flags}  
@@ -159,7 +159,7 @@ build_flags               = ${esp32_common_LittleFS_ETH.build_flags}
                             -DCOLLECTION_FEATURE_RTTTL=1
                             
 
-[env:collection_E_ESP32_4M316k_LittleFS_ETH]
+[env:collection_E_ESP32_4M316k]
 extends                   = esp32_common_LittleFS_ETH
 board                     = esp32_4M
 build_flags               = ${esp32_common_LittleFS_ETH.build_flags}  
@@ -168,7 +168,7 @@ build_flags               = ${esp32_common_LittleFS_ETH.build_flags}
                             -DCOLLECTION_FEATURE_RTTTL=1
                             
 
-[env:collection_F_ESP32_4M316k_LittleFS_ETH]
+[env:collection_F_ESP32_4M316k]
 extends                   = esp32_common_LittleFS_ETH
 board                     = esp32_4M
 build_flags               = ${esp32_common_LittleFS_ETH.build_flags}  
@@ -177,7 +177,7 @@ build_flags               = ${esp32_common_LittleFS_ETH.build_flags}
                             -DCOLLECTION_FEATURE_RTTTL=1
                             
 
-[env:collection_G_ESP32_4M316k_LittleFS_ETH]
+[env:collection_G_ESP32_4M316k]
 extends                   = esp32_common_LittleFS_ETH
 board                     = esp32_4M
 build_flags               = ${esp32_common_LittleFS_ETH.build_flags}  
@@ -187,49 +187,49 @@ build_flags               = ${esp32_common_LittleFS_ETH.build_flags}
                             
 
 
-[env:collection_A_ESP32_IRExt_4M316k_LittleFS_ETH]
-extends                   = esp32_IRExt_LittleFS_ETH
+[env:collection_A_ESP32_IRExt_4M316k]
+extends                   = esp32_IRExt
 board                     = esp32_4M
-build_flags               = ${esp32_IRExt_LittleFS_ETH.build_flags}
+build_flags               = ${esp32_IRExt.build_flags}
                             -DPLUGIN_SET_COLLECTION_ESP32
 
-[env:collection_B_ESP32_IRExt_4M316k_LittleFS_ETH]
-extends                   = esp32_IRExt_LittleFS_ETH
+[env:collection_B_ESP32_IRExt_4M316k]
+extends                   = esp32_IRExt
 board                     = esp32_4M
-build_flags               = ${esp32_IRExt_LittleFS_ETH.build_flags}
+build_flags               = ${esp32_IRExt.build_flags}
                             -DPLUGIN_SET_COLLECTION_B_ESP32
 
-[env:collection_C_ESP32_IRExt_4M316k_LittleFS_ETH]
-extends                   = esp32_IRExt_LittleFS_ETH
+[env:collection_C_ESP32_IRExt_4M316k]
+extends                   = esp32_IRExt
 board                     = esp32_4M
-build_flags               = ${esp32_IRExt_LittleFS_ETH.build_flags}
+build_flags               = ${esp32_IRExt.build_flags}
                             -DPLUGIN_SET_COLLECTION_C_ESP32
 
-[env:collection_D_ESP32_IRExt_4M316k_LittleFS_ETH]
-extends                   = esp32_IRExt_LittleFS_ETH
+[env:collection_D_ESP32_IRExt_4M316k]
+extends                   = esp32_IRExt
 board                     = esp32_4M
-build_flags               = ${esp32_IRExt_LittleFS_ETH.build_flags}
+build_flags               = ${esp32_IRExt.build_flags}
                             -DPLUGIN_SET_COLLECTION_D_ESP32
 
-[env:collection_E_ESP32_IRExt_4M316k_LittleFS_ETH]
-extends                   = esp32_IRExt_LittleFS_ETH
+[env:collection_E_ESP32_IRExt_4M316k]
+extends                   = esp32_IRExt
 board                     = esp32_4M
-build_flags               = ${esp32_IRExt_LittleFS_ETH.build_flags}
+build_flags               = ${esp32_IRExt.build_flags}
                             -DPLUGIN_SET_COLLECTION_E_ESP32
 
-[env:collection_F_ESP32_IRExt_4M316k_LittleFS_ETH]
-extends                   = esp32_IRExt_LittleFS_ETH
+[env:collection_F_ESP32_IRExt_4M316k]
+extends                   = esp32_IRExt
 board                     = esp32_4M
-build_flags               = ${esp32_IRExt_LittleFS_ETH.build_flags}
+build_flags               = ${esp32_IRExt.build_flags}
                             -DPLUGIN_SET_COLLECTION_F_ESP32
 
-[env:collection_G_ESP32_IRExt_4M316k_LittleFS_ETH]
-extends                   = esp32_IRExt_LittleFS_ETH
+[env:collection_G_ESP32_IRExt_4M316k]
+extends                   = esp32_IRExt
 board                     = esp32_4M
-build_flags               = ${esp32_IRExt_LittleFS_ETH.build_flags}
+build_flags               = ${esp32_IRExt.build_flags}
                             -DPLUGIN_SET_COLLECTION_G_ESP32
 
-[env:energy_ESP32_4M316k_LittleFS_ETH]
+[env:energy_ESP32_4M316k]
 extends                   = esp32_common_LittleFS_ETH
 board                     = esp32_4M
 build_flags               = ${esp32_common_LittleFS_ETH.build_flags}  
@@ -237,7 +237,7 @@ build_flags               = ${esp32_common_LittleFS_ETH.build_flags}
                             -DPLUGIN_ENERGY_COLLECTION
                             
 
-[env:display_A_ESP32_4M316k_LittleFS_ETH]
+[env:display_A_ESP32_4M316k]
 extends                   = esp32_common_LittleFS_ETH
 board                     = esp32_4M
 build_flags               = ${esp32_common_LittleFS_ETH.build_flags}  
@@ -246,7 +246,7 @@ build_flags               = ${esp32_common_LittleFS_ETH.build_flags}
                             -D ST7789_EXTRA_INIT=1
                             -D P116_EXTRA_ST7789=1
 
-[env:display_B_ESP32_4M316k_LittleFS_ETH]
+[env:display_B_ESP32_4M316k]
 extends                   = esp32_common_LittleFS_ETH
 board                     = esp32_4M
 build_flags               = ${esp32_common_LittleFS_ETH.build_flags}  
@@ -257,7 +257,7 @@ build_flags               = ${esp32_common_LittleFS_ETH.build_flags}
 
 
 
-[env:climate_ESP32_4M316k_LittleFS_ETH]
+[env:climate_ESP32_4M316k]
 extends                   = esp32_common_LittleFS_ETH
 board                     = esp32_4M
 lib_ignore                = ${esp32_always.lib_ignore}
@@ -268,7 +268,7 @@ build_flags               = ${esp32_common_LittleFS_ETH.build_flags}
                             -DPLUGIN_CLIMATE_COLLECTION
                             
 
-[env:neopixel_ESP32_4M316k_LittleFS_ETH]
+[env:neopixel_ESP32_4M316k]
 extends                   = esp32_common_LittleFS_ETH
 board                     = esp32_4M
 build_flags               = ${esp32_common_LittleFS_ETH.build_flags}  
@@ -279,7 +279,7 @@ build_flags               = ${esp32_common_LittleFS_ETH.build_flags}
 
 
 
-[env:custom_IR_ESP32_16M8M_LittleFS_ETH]
+[env:custom_IR_ESP32_16M8M]
 extends                   = esp32_common_LittleFS_ETH
 board                     = esp32_16M8M
 board_upload.flash_size   = 16MB
@@ -295,7 +295,7 @@ extra_scripts             = ${esp32_common_LittleFS_ETH.extra_scripts}
 
 
 
-[env:normal_ESP32_4M316k_LittleFS_ETH]
+[env:normal_ESP32_4M316k]
 extends                   = esp32_common_LittleFS_ETH
 board                     = esp32_4M
 lib_ignore                = ${esp32_always.lib_ignore}
@@ -306,10 +306,10 @@ build_flags               = ${esp32_common_LittleFS_ETH.build_flags}
                             
 
 
-[env:normal_ESP32_IRExt_4M316k_LittleFS_ETH]
-extends                   = esp32_IRExt_LittleFS_ETH
+[env:normal_ESP32_IRExt_4M316k]
+extends                   = esp32_IRExt
 board                     = esp32_4M
-build_flags               = ${esp32_IRExt_LittleFS_ETH.build_flags}
+build_flags               = ${esp32_IRExt.build_flags}
                             
 
 
@@ -317,7 +317,7 @@ build_flags               = ${esp32_IRExt_LittleFS_ETH.build_flags}
 ; ESP32 MAX builds 16M flash ------------------------------
 
 ; A Lolin D32 PRO with 16MB Flash, allowing 4MB sketch size, and file storage using LittleFS filesystem
-[env:max_ESP32_16M8M_LittleFS_ETH]
+[env:max_ESP32_16M8M]
 extends                   = esp32_common_LittleFS_ETH
 board                     = esp32_16M8M
 board_upload.flash_size   = 16MB
@@ -334,7 +334,7 @@ extra_scripts             = ${esp32_common_LittleFS_ETH.extra_scripts}
 board_build.filesystem    = littlefs
 
 ; If you have a board with Ethernet integrated and 16MB Flash, then this configuration could be enabled, it's based on the max_ESP32_16M8M_LittleFS definition
-; [env:max_ESP32_16M8M_LittleFS_ETH]
+; [env:max_ESP32_16M8M]
 ; extends                   = env:max_ESP32_16M8M_LittleFS
 ; board                     = ${env:max_ESP32_16M8M_LittleFS.board}
 ; build_flags               = ${env:max_ESP32_16M8M_LittleFS.build_flags}

--- a/platformio_esp32_solo1.ini
+++ b/platformio_esp32_solo1.ini
@@ -16,7 +16,7 @@ build_unflags             = ${esp32_base_idf5.build_unflags}
 board_build.filesystem    = littlefs
 
 
-[env:custom_ESP32solo1_4M316k_LittleFS_ETH]
+[env:custom_ESP32solo1_4M316k]
 extends                   = esp32_solo1_common_LittleFS
 build_flags               = ${esp32_solo1_common_LittleFS.build_flags} 
                             -DPLUGIN_BUILD_CUSTOM
@@ -25,7 +25,7 @@ extra_scripts             = ${esp32_solo1_common_LittleFS.extra_scripts}
                             pre:tools/pio/pre_custom_esp32.py
 
 
-[env:normal_ESP32solo1_4M316k_LittleFS_ETH]
+[env:normal_ESP32solo1_4M316k]
 extends                   = esp32_solo1_common_LittleFS
 build_flags               = ${esp32_solo1_common_LittleFS.build_flags} 
                             -DFEATURE_ETHERNET=1
@@ -34,14 +34,14 @@ lib_ignore                = ${esp32_solo1_common_LittleFS.lib_ignore}
 extra_scripts             = ${esp32_solo1_common_LittleFS.extra_scripts}
 
 
-[env:energy_ESP32solo1_4M316k_LittleFS_ETH]
+[env:energy_ESP32solo1_4M316k]
 extends                   = esp32_solo1_common_LittleFS
 build_flags               = ${esp32_solo1_common_LittleFS.build_flags}  
                             -D PLUGIN_ENERGY_COLLECTION
                             -DFEATURE_ETHERNET=1
 extra_scripts             = ${esp32_solo1_common_LittleFS.extra_scripts}
 
-[env:climate_ESP32solo1_4M316k_LittleFS_ETH]
+[env:climate_ESP32solo1_4M316k]
 extends                   = esp32_solo1_common_LittleFS
 build_flags               = ${esp32_solo1_common_LittleFS.build_flags}  
                             -D PLUGIN_CLIMATE_COLLECTION

--- a/platformio_esp32c3_envs.ini
+++ b/platformio_esp32c3_envs.ini
@@ -13,7 +13,7 @@ lib_ignore                = ${esp32_base_idf5.lib_ignore}
 board                     = esp32c3cdc
 
 
-[env:custom_ESP32c3_4M316k_LittleFS_ETH]
+[env:custom_ESP32c3_4M316k]
 extends                   = esp32c3_common_LittleFS
 build_flags               = ${esp32c3_common_LittleFS.build_flags} 
                             -DPLUGIN_BUILD_CUSTOM
@@ -22,88 +22,88 @@ extra_scripts             = ${esp32c3_common_LittleFS.extra_scripts}
 
 
 
-[env:normal_ESP32c3_4M316k_LittleFS_ETH]
+[env:normal_ESP32c3_4M316k]
 extends                   = esp32c3_common_LittleFS
 build_flags               = ${esp32c3_common_LittleFS.build_flags} 
 lib_ignore                = ${esp32c3_common_LittleFS.lib_ignore}
                             ${no_ir.lib_ignore}
 
-[env:collection_A_ESP32c3_4M316k_LittleFS_ETH]
+[env:collection_A_ESP32c3_4M316k]
 extends                   = esp32c3_common_LittleFS
 build_flags               = ${esp32c3_common_LittleFS.build_flags}  
                             -DPLUGIN_SET_COLLECTION_ESP32
                             -DCOLLECTION_FEATURE_RTTTL=1
 
-[env:collection_B_ESP32c3_4M316k_LittleFS_ETH]
+[env:collection_B_ESP32c3_4M316k]
 extends                   = esp32c3_common_LittleFS
 build_flags               = ${esp32c3_common_LittleFS.build_flags}  
                             -DPLUGIN_SET_COLLECTION_B_ESP32
                             -DCOLLECTION_FEATURE_RTTTL=1
 
-[env:collection_C_ESP32c3_4M316k_LittleFS_ETH]
+[env:collection_C_ESP32c3_4M316k]
 extends                   = esp32c3_common_LittleFS
 build_flags               = ${esp32c3_common_LittleFS.build_flags}  
                             -DPLUGIN_SET_COLLECTION_C_ESP32
                             -DCOLLECTION_FEATURE_RTTTL=1
 
-[env:collection_D_ESP32c3_4M316k_LittleFS_ETH]
+[env:collection_D_ESP32c3_4M316k]
 extends                   = esp32c3_common_LittleFS
 build_flags               = ${esp32c3_common_LittleFS.build_flags}  
                             -DPLUGIN_SET_COLLECTION_D_ESP32
                             -DCOLLECTION_FEATURE_RTTTL=1
 
-[env:collection_E_ESP32c3_4M316k_LittleFS_ETH]
+[env:collection_E_ESP32c3_4M316k]
 extends                   = esp32c3_common_LittleFS
 build_flags               = ${esp32c3_common_LittleFS.build_flags}  
                             -DPLUGIN_SET_COLLECTION_E_ESP32
                             -DCOLLECTION_FEATURE_RTTTL=1
 
-[env:collection_F_ESP32c3_4M316k_LittleFS_ETH]
+[env:collection_F_ESP32c3_4M316k]
 extends                   = esp32c3_common_LittleFS
 build_flags               = ${esp32c3_common_LittleFS.build_flags}  
                             -DPLUGIN_SET_COLLECTION_F_ESP32
                             -DCOLLECTION_FEATURE_RTTTL=1
 
-[env:collection_G_ESP32c3_4M316k_LittleFS_ETH]
+[env:collection_G_ESP32c3_4M316k]
 extends                   = esp32c3_common_LittleFS
 build_flags               = ${esp32c3_common_LittleFS.build_flags}  
                             -DPLUGIN_SET_COLLECTION_G_ESP32
                             -DCOLLECTION_FEATURE_RTTTL=1
 
 
-[env:energy_ESP32c3_4M316k_LittleFS_ETH]
+[env:energy_ESP32c3_4M316k]
 extends                   = esp32c3_common_LittleFS
 build_flags               = ${esp32c3_common_LittleFS.build_flags}  
                             -D PLUGIN_ENERGY_COLLECTION
                             
 
-[env:display_A_ESP32c3_4M316k_LittleFS_ETH]
+[env:display_A_ESP32c3_4M316k]
 extends                   = esp32c3_common_LittleFS
 build_flags               = ${esp32c3_common_LittleFS.build_flags}  
                             -D PLUGIN_DISPLAY_A_COLLECTION
                             -D ST7789_EXTRA_INIT=1
                             -D P116_EXTRA_ST7789=1
 
-[env:display_B_ESP32c3_4M316k_LittleFS_ETH]
+[env:display_B_ESP32c3_4M316k]
 extends                   = esp32c3_common_LittleFS
 build_flags               = ${esp32c3_common_LittleFS.build_flags}  
                             -D PLUGIN_DISPLAY_B_COLLECTION
                             -D ST7789_EXTRA_INIT=1
                             -D P116_EXTRA_ST7789=1
 
-[env:climate_ESP32c3_4M316k_LittleFS_ETH]
+[env:climate_ESP32c3_4M316k]
 extends                   = esp32c3_common_LittleFS
 build_flags               = ${esp32c3_common_LittleFS.build_flags}  
                             -D PLUGIN_CLIMATE_COLLECTION
 
-[env:neopixel_ESP32c3_4M316k_LittleFS_ETH]
+[env:neopixel_ESP32c3_4M316k]
 extends                   = esp32c3_common_LittleFS
 build_flags               = ${esp32c3_common_LittleFS.build_flags} 
                             -DFEATURE_ARDUINO_OTA=1
                             -DFEATURE_SD=1
                             -DPLUGIN_NEOPIXEL_COLLECTION
 
-[env:max_ESP32c3_16M8M_LittleFS_ETH]
+[env:max_ESP32c3_16M8M]
 extends                   = esp32c3_common_LittleFS
 board                     = esp32c3cdc-16M
 build_flags               = ${esp32c3_common_LittleFS.build_flags} 

--- a/platformio_esp32c6_envs.ini
+++ b/platformio_esp32c6_envs.ini
@@ -12,7 +12,7 @@ lib_ignore                = ${esp32_base_idf5.lib_ignore}
 board                     = esp32c6cdc
 
 
-[env:custom_ESP32c6_4M316k_LittleFS_ETH]
+[env:custom_ESP32c6_4M316k]
 extends                   = esp32c6_common_LittleFS
 build_flags               = ${esp32c6_common_LittleFS.build_flags} 
                             -DPLUGIN_BUILD_CUSTOM
@@ -21,39 +21,39 @@ extra_scripts             = ${esp32c6_common_LittleFS.extra_scripts}
                             pre:tools/pio/pre_custom_esp32c6.py
 
 
-[env:normal_ESP32c6_4M316k_LittleFS_ETH]
+[env:normal_ESP32c6_4M316k]
 extends                   = esp32c6_common_LittleFS
 build_flags               = ${esp32c6_common_LittleFS.build_flags} 
                             -DFEATURE_ETHERNET=1
 lib_ignore                = ${esp32c6_common_LittleFS.lib_ignore}
                             ${no_ir.lib_ignore}
 
-[env:energy_ESP32c6_4M316k_LittleFS_ETH]
+[env:energy_ESP32c6_4M316k]
 extends                   = esp32c6_common_LittleFS
 build_flags               = ${esp32c6_common_LittleFS.build_flags}  
                             -D PLUGIN_ENERGY_COLLECTION
                             
 
-[env:display_A_ESP32c6_4M316k_LittleFS_ETH]
+[env:display_A_ESP32c6_4M316k]
 extends                   = esp32c6_common_LittleFS
 build_flags               = ${esp32c6_common_LittleFS.build_flags}  
                             -D PLUGIN_DISPLAY_A_COLLECTION
                             -D ST7789_EXTRA_INIT=1
                             -D P116_EXTRA_ST7789=1
 
-[env:display_B_ESP32c6_4M316k_LittleFS_ETH]
+[env:display_B_ESP32c6_4M316k]
 extends                   = esp32c6_common_LittleFS
 build_flags               = ${esp32c6_common_LittleFS.build_flags}  
                             -D PLUGIN_DISPLAY_B_COLLECTION
                             -D ST7789_EXTRA_INIT=1
                             -D P116_EXTRA_ST7789=1
 
-[env:climate_ESP32c6_4M316k_LittleFS_ETH]
+[env:climate_ESP32c6_4M316k]
 extends                   = esp32c6_common_LittleFS
 build_flags               = ${esp32c6_common_LittleFS.build_flags}  
                             -D PLUGIN_CLIMATE_COLLECTION
 
-[env:neopixel_ESP32c6_4M316k_LittleFS_ETH]
+[env:neopixel_ESP32c6_4M316k]
 extends                   = esp32c6_common_LittleFS
 build_flags               = ${esp32c6_common_LittleFS.build_flags} 
                             -DFEATURE_ARDUINO_OTA=1
@@ -61,7 +61,7 @@ build_flags               = ${esp32c6_common_LittleFS.build_flags}
                             -DPLUGIN_NEOPIXEL_COLLECTION
 
 
-[env:max_ESP32c6_8M1M_LittleFS_ETH]
+[env:max_ESP32c6_8M1M]
 extends                   = esp32c6_common_LittleFS
 board                     = esp32c6cdc-8M
 build_flags               = ${esp32c6_common_LittleFS.build_flags}  
@@ -74,7 +74,7 @@ build_flags               = ${esp32c6_common_LittleFS.build_flags}
 extra_scripts             = ${esp32c6_common_LittleFS.extra_scripts}
 
 
-[env:max_ESP32c6_16M8M_LittleFS_ETH]
+[env:max_ESP32c6_16M8M]
 extends                   = esp32c6_common_LittleFS
 board                     = esp32c6cdc-16M
 build_flags               = ${esp32c6_common_LittleFS.build_flags}  

--- a/platformio_esp32s2_envs.ini
+++ b/platformio_esp32s2_envs.ini
@@ -12,7 +12,7 @@ board_build.filesystem    = littlefs
 lib_ignore                = ${esp32_base_idf5.lib_ignore}
 
 
-[env:neopixel_ESP32s2_4M316k_LittleFS_ETH]
+[env:neopixel_ESP32s2_4M316k]
 extends                   = esp32s2_common_LittleFS
 board                     = esp32s2cdc
 build_flags               = ${esp32s2_common_LittleFS.build_flags} 
@@ -22,7 +22,7 @@ build_flags               = ${esp32s2_common_LittleFS.build_flags}
                             
 
 
-[env:custom_IR_ESP32s2_4M316k_LittleFS_ETH]
+[env:custom_IR_ESP32s2_4M316k]
 extends                   = esp32s2_common_LittleFS
 board                     = esp32s2cdc
 build_flags               = ${esp32s2_common_LittleFS.build_flags}
@@ -35,7 +35,7 @@ extra_scripts             = ${esp32s2_common_LittleFS.extra_scripts}
                             pre:tools/pio/ir_build_check.py
 
 
-[env:custom_ESP32s2_4M316k_LittleFS_ETH]
+[env:custom_ESP32s2_4M316k]
 extends                   = esp32s2_common_LittleFS
 board                     = esp32s2cdc
 lib_ignore                = ${esp32s2_common_LittleFS.lib_ignore}
@@ -48,7 +48,7 @@ extra_scripts             = ${esp32s2_common_LittleFS.extra_scripts}
 
 
 
-[env:normal_ESP32s2_4M316k_LittleFS_ETH]
+[env:normal_ESP32s2_4M316k]
 extends                   = esp32s2_common_LittleFS
 board                     = esp32s2cdc
 build_flags               = ${esp32s2_common_LittleFS.build_flags}
@@ -56,49 +56,49 @@ build_flags               = ${esp32s2_common_LittleFS.build_flags}
 lib_ignore                = ${esp32s2_common_LittleFS.lib_ignore}
                             ${no_ir.lib_ignore}
 
-[env:collection_A_ESP32s2_4M316k_LittleFS_ETH]
+[env:collection_A_ESP32s2_4M316k]
 extends                   = esp32s2_common_LittleFS
 board                     = esp32s2cdc
 build_flags               = ${esp32s2_common_LittleFS.build_flags}  
                             -DPLUGIN_SET_COLLECTION_ESP32
                             -DCOLLECTION_FEATURE_RTTTL=1
 
-[env:collection_B_ESP32s2_4M316k_LittleFS_ETH]
+[env:collection_B_ESP32s2_4M316k]
 extends                   = esp32s2_common_LittleFS
 board                     = esp32s2cdc
 build_flags               = ${esp32s2_common_LittleFS.build_flags}  
                             -DPLUGIN_SET_COLLECTION_B_ESP32
                             -DCOLLECTION_FEATURE_RTTTL=1
 
-[env:collection_C_ESP32s2_4M316k_LittleFS_ETH]
+[env:collection_C_ESP32s2_4M316k]
 extends                   = esp32s2_common_LittleFS
 board                     = esp32s2cdc
 build_flags               = ${esp32s2_common_LittleFS.build_flags}  
                             -DPLUGIN_SET_COLLECTION_C_ESP32
                             -DCOLLECTION_FEATURE_RTTTL=1
 
-[env:collection_D_ESP32s2_4M316k_LittleFS_ETH]
+[env:collection_D_ESP32s2_4M316k]
 extends                   = esp32s2_common_LittleFS
 board                     = esp32s2cdc
 build_flags               = ${esp32s2_common_LittleFS.build_flags}  
                             -DPLUGIN_SET_COLLECTION_D_ESP32
                             -DCOLLECTION_FEATURE_RTTTL=1
 
-[env:collection_E_ESP32s2_4M316k_LittleFS_ETH]
+[env:collection_E_ESP32s2_4M316k]
 extends                   = esp32s2_common_LittleFS
 board                     = esp32s2cdc
 build_flags               = ${esp32s2_common_LittleFS.build_flags}  
                             -DPLUGIN_SET_COLLECTION_E_ESP32
                             -DCOLLECTION_FEATURE_RTTTL=1
 
-[env:collection_F_ESP32s2_4M316k_LittleFS_ETH]
+[env:collection_F_ESP32s2_4M316k]
 extends                   = esp32s2_common_LittleFS
 board                     = esp32s2cdc
 build_flags               = ${esp32s2_common_LittleFS.build_flags}  
                             -DPLUGIN_SET_COLLECTION_F_ESP32
                             -DCOLLECTION_FEATURE_RTTTL=1
 
-[env:collection_G_ESP32s2_4M316k_LittleFS_ETH]
+[env:collection_G_ESP32s2_4M316k]
 extends                   = esp32s2_common_LittleFS
 board                     = esp32s2cdc
 build_flags               = ${esp32s2_common_LittleFS.build_flags}  
@@ -106,13 +106,13 @@ build_flags               = ${esp32s2_common_LittleFS.build_flags}
                             -DCOLLECTION_FEATURE_RTTTL=1
 
 
-[env:energy_ESP32s2_4M316k_LittleFS_ETH]
+[env:energy_ESP32s2_4M316k]
 extends                   = esp32s2_common_LittleFS
 board                     = esp32s2cdc
 build_flags               = ${esp32s2_common_LittleFS.build_flags}  
                             -D PLUGIN_ENERGY_COLLECTION
 
-[env:display_A_ESP32s2_4M316k_LittleFS_ETH]
+[env:display_A_ESP32s2_4M316k]
 extends                   = esp32s2_common_LittleFS
 board                     = esp32s2cdc
 build_flags               = ${esp32s2_common_LittleFS.build_flags}  
@@ -120,7 +120,7 @@ build_flags               = ${esp32s2_common_LittleFS.build_flags}
                             -D ST7789_EXTRA_INIT=1
                             -D P116_EXTRA_ST7789=1
 
-[env:display_B_ESP32s2_4M316k_LittleFS_ETH]
+[env:display_B_ESP32s2_4M316k]
 extends                   = esp32s2_common_LittleFS
 board                     = esp32s2cdc
 build_flags               = ${esp32s2_common_LittleFS.build_flags}  
@@ -128,7 +128,7 @@ build_flags               = ${esp32s2_common_LittleFS.build_flags}
                             -D ST7789_EXTRA_INIT=1
                             -D P116_EXTRA_ST7789=1
 
-[env:climate_ESP32s2_4M316k_LittleFS_ETH]
+[env:climate_ESP32s2_4M316k]
 extends                   = esp32s2_common_LittleFS
 board                     = esp32s2cdc
 build_flags               = ${esp32s2_common_LittleFS.build_flags}  

--- a/platformio_esp32s3_envs.ini
+++ b/platformio_esp32s3_envs.ini
@@ -15,7 +15,7 @@ build_unflags             = ${esp32_base_idf5.build_unflags}
 board_build.filesystem    = littlefs
 
 
-[env:custom_ESP32s3_4M316k_LittleFS_ETH]
+[env:custom_ESP32s3_4M316k]
 extends                   = esp32s3_common_LittleFS
 board                     = esp32s3cdc-qio_qspi
 build_flags               = ${esp32s3_common_LittleFS.build_flags} 
@@ -24,7 +24,7 @@ extra_scripts             = ${esp32s3_common_LittleFS.extra_scripts}
                             pre:tools/pio/pre_custom_esp32.py
 
 
-[env:custom_IR_ESP32s3_4M316k_LittleFS_ETH]
+[env:custom_IR_ESP32s3_4M316k]
 extends                   = esp32s3_common_LittleFS
 board                     = esp32s3cdc-qio_qspi
 build_flags               = ${esp32s3_common_LittleFS.build_flags}
@@ -37,7 +37,7 @@ extra_scripts             = ${esp32s3_common_LittleFS.extra_scripts}
                             pre:tools/pio/ir_build_check.py
 
 
-[env:normal_ESP32s3_4M316k_LittleFS_ETH]
+[env:normal_ESP32s3_4M316k]
 extends                   = esp32s3_common_LittleFS
 board                     = esp32s3cdc-qio_qspi
 lib_ignore                = ${esp32s3_common_LittleFS.lib_ignore}
@@ -47,49 +47,49 @@ build_flags               = ${esp32s3_common_LittleFS.build_flags}
                             -DFEATURE_SD=1
                             
 
-[env:collection_A_ESP32s3_4M316k_LittleFS_ETH]
+[env:collection_A_ESP32s3_4M316k]
 extends                   = esp32s3_common_LittleFS
 board                     = esp32s3cdc-qio_qspi
 build_flags               = ${esp32s3_common_LittleFS.build_flags}  
                             -DPLUGIN_SET_COLLECTION_ESP32
                             -DCOLLECTION_FEATURE_RTTTL=1
 
-[env:collection_B_ESP32s3_4M316k_LittleFS_ETH]
+[env:collection_B_ESP32s3_4M316k]
 extends                   = esp32s3_common_LittleFS
 board                     = esp32s3cdc-qio_qspi
 build_flags               = ${esp32s3_common_LittleFS.build_flags}  
                             -DPLUGIN_SET_COLLECTION_B_ESP32
                             -DCOLLECTION_FEATURE_RTTTL=1
 
-[env:collection_C_ESP32s3_4M316k_LittleFS_ETH]
+[env:collection_C_ESP32s3_4M316k]
 extends                   = esp32s3_common_LittleFS
 board                     = esp32s3cdc-qio_qspi
 build_flags               = ${esp32s3_common_LittleFS.build_flags}  
                             -DPLUGIN_SET_COLLECTION_C_ESP32
                             -DCOLLECTION_FEATURE_RTTTL=1
 
-[env:collection_D_ESP32s3_4M316k_LittleFS_ETH]
+[env:collection_D_ESP32s3_4M316k]
 extends                   = esp32s3_common_LittleFS
 board                     = esp32s3cdc-qio_qspi
 build_flags               = ${esp32s3_common_LittleFS.build_flags}  
                             -DPLUGIN_SET_COLLECTION_D_ESP32
                             -DCOLLECTION_FEATURE_RTTTL=1
 
-[env:collection_E_ESP32s3_4M316k_LittleFS_ETH]
+[env:collection_E_ESP32s3_4M316k]
 extends                   = esp32s3_common_LittleFS
 board                     = esp32s3cdc-qio_qspi
 build_flags               = ${esp32s3_common_LittleFS.build_flags}  
                             -DPLUGIN_SET_COLLECTION_E_ESP32
                             -DCOLLECTION_FEATURE_RTTTL=1
 
-[env:collection_F_ESP32s3_4M316k_LittleFS_ETH]
+[env:collection_F_ESP32s3_4M316k]
 extends                   = esp32s3_common_LittleFS
 board                     = esp32s3cdc-qio_qspi
 build_flags               = ${esp32s3_common_LittleFS.build_flags}  
                             -DPLUGIN_SET_COLLECTION_F_ESP32
                             -DCOLLECTION_FEATURE_RTTTL=1
 
-[env:collection_G_ESP32s3_4M316k_LittleFS_ETH]
+[env:collection_G_ESP32s3_4M316k]
 extends                   = esp32s3_common_LittleFS
 board                     = esp32s3cdc-qio_qspi
 build_flags               = ${esp32s3_common_LittleFS.build_flags}  
@@ -97,13 +97,13 @@ build_flags               = ${esp32s3_common_LittleFS.build_flags}
                             -DCOLLECTION_FEATURE_RTTTL=1
 
 
-[env:energy_ESP32s3_4M316k_LittleFS_ETH]
+[env:energy_ESP32s3_4M316k]
 extends                   = esp32s3_common_LittleFS
 board                     = esp32s3cdc-qio_qspi
 build_flags               = ${esp32s3_common_LittleFS.build_flags}  
                             -D PLUGIN_ENERGY_COLLECTION
 
-[env:display_A_ESP32s3_4M316k_LittleFS_ETH]
+[env:display_A_ESP32s3_4M316k]
 extends                   = esp32s3_common_LittleFS
 board                     = esp32s3cdc-qio_qspi
 build_flags               = ${esp32s3_common_LittleFS.build_flags}  
@@ -111,7 +111,7 @@ build_flags               = ${esp32s3_common_LittleFS.build_flags}
                             -D ST7789_EXTRA_INIT=1
                             -D P116_EXTRA_ST7789=1
 
-[env:display_B_ESP32s3_4M316k_LittleFS_ETH]
+[env:display_B_ESP32s3_4M316k]
 extends                   = esp32s3_common_LittleFS
 board                     = esp32s3cdc-qio_qspi
 build_flags               = ${esp32s3_common_LittleFS.build_flags}  
@@ -119,14 +119,14 @@ build_flags               = ${esp32s3_common_LittleFS.build_flags}
                             -D ST7789_EXTRA_INIT=1
                             -D P116_EXTRA_ST7789=1
 
-[env:climate_ESP32s3_4M316k_LittleFS_ETH]
+[env:climate_ESP32s3_4M316k]
 extends                   = esp32s3_common_LittleFS
 board                     = esp32s3cdc-qio_qspi
 build_flags               = ${esp32s3_common_LittleFS.build_flags}  
                             -D PLUGIN_CLIMATE_COLLECTION
 
 
-[env:neopixel_ESP32s3_4M316k_LittleFS_ETH]
+[env:neopixel_ESP32s3_4M316k]
 extends                   = esp32s3_common_LittleFS
 board                     = esp32s3cdc-qio_qspi
 build_flags               = ${esp32s3_common_LittleFS.build_flags} 
@@ -136,7 +136,7 @@ build_flags               = ${esp32s3_common_LittleFS.build_flags}
                             
 
 
-[env:custom_ESP32s3_8M1M_LittleFS_ETH]
+[env:custom_ESP32s3_8M1M]
 extends                   = esp32s3_common_LittleFS
 board                     = esp32s3cdc-qio_qspi-8M
 build_flags               = ${esp32s3_common_LittleFS.build_flags} 
@@ -146,12 +146,12 @@ build_flags               = ${esp32s3_common_LittleFS.build_flags}
 extra_scripts             = ${esp32s3_common_LittleFS.extra_scripts}
                             pre:tools/pio/pre_custom_esp32.py
 
-[env:custom_ESP32s3_8M1M_LittleFS_OPI_PSRAM_ETH]
-extends                   = env:custom_ESP32s3_8M1M_LittleFS_ETH
+[env:custom_ESP32s3_8M1M_OPI_PSRAM]
+extends                   = env:custom_ESP32s3_8M1M
 board                     = esp32s3cdc-qio_opi-8M
 
 
-[env:max_ESP32s3_8M1M_LittleFS_ETH]
+[env:max_ESP32s3_8M1M]
 extends                   = esp32s3_common_LittleFS
 board                     = esp32s3cdc-qio_qspi-8M
 build_flags               = ${esp32s3_common_LittleFS.build_flags}  
@@ -163,12 +163,12 @@ build_flags               = ${esp32s3_common_LittleFS.build_flags}
 extra_scripts             = ${esp32s3_common_LittleFS.extra_scripts}
 
 
-[env:max_ESP32s3_8M1M_LittleFS_OPI_PSRAM_ETH]
-extends                   = env:max_ESP32s3_8M1M_LittleFS_ETH
+[env:max_ESP32s3_8M1M_OPI_PSRAM]
+extends                   = env:max_ESP32s3_8M1M
 board                     = esp32s3cdc-qio_opi-8M
 
 
-[env:custom_ESP32s3_16M8M_LittleFS_ETH]
+[env:custom_ESP32s3_16M8M]
 extends                   = esp32s3_common_LittleFS
 board                     = esp32s3cdc-qio_qspi-16M
 build_flags               = ${esp32s3_common_LittleFS.build_flags} 
@@ -179,12 +179,12 @@ build_flags               = ${esp32s3_common_LittleFS.build_flags}
 extra_scripts             = ${esp32s3_common_LittleFS.extra_scripts}
                             pre:tools/pio/pre_custom_esp32.py
 
-[env:custom_ESP32s3_16M8M_LittleFS_OPI_PSRAM_ETH]
-extends                   = env:custom_ESP32s3_16M8M_LittleFS_ETH
+[env:custom_ESP32s3_16M8M_OPI_PSRAM]
+extends                   = env:custom_ESP32s3_16M8M
 board                     = esp32s3cdc-qio_opi-16M
 
 
-[env:max_ESP32s3_16M8M_LittleFS_ETH]
+[env:max_ESP32s3_16M8M]
 extends                   = esp32s3_common_LittleFS
 board                     = esp32s3cdc-qio_qspi-16M
 build_flags               = ${esp32s3_common_LittleFS.build_flags}  
@@ -196,7 +196,7 @@ build_flags               = ${esp32s3_common_LittleFS.build_flags}
 extra_scripts             = ${esp32s3_common_LittleFS.extra_scripts}
 
 
-[env:max_ESP32s3_16M8M_LittleFS_OPI_PSRAM_ETH]
+[env:max_ESP32s3_16M8M_OPI_PSRAM]
 extends                   = esp32s3_common_LittleFS
 board                     = esp32s3cdc-qio_opi-16M
 build_flags               = ${esp32s3_common_LittleFS.build_flags}  


### PR DESCRIPTION
Features:
- [Build] Remove _LittleFS and _ETH from build names due to linker issues
- [Build] Enable `custom_remove_include` to not build ignored libs
- [Build] Limit max Python version for running binary compilation to 3.13

Cherry picked from #5149 