### PR TITLE
[UI] Update addTaskSelector() to use FormSelectorOptions

### DIFF
--- a/src/src/WebServer/ESPEasy_WebServer.cpp
+++ b/src/src/WebServer/ESPEasy_WebServer.cpp
@@ -678,54 +678,34 @@ void json_prop(LabelType::Enum label) {
 // Add a task select dropdown list
 // This allows to select a task index based on the existing tasks.
 // ********************************************************************************
-void addTaskSelect(const String& name,  taskIndex_t choice, const String& cssclass)
+void addTaskSelect(const String& name,  taskIndex_t choice, const __FlashStringHelper* cssclass)
 {
   String deviceName;
-
-  addHtml(F("<select "));
-  addHtmlAttribute(F("id"),   F("selectwidth"));
-  addHtmlAttribute(F("name"), name);
-
-  if (!cssclass.isEmpty()) {
-    addHtmlAttribute(F("class"), cssclass);
-  }
-  addHtmlAttribute(F("onchange"), F("return task_select_onchange(frmselect)"));
-  addHtml('>');
+  String deviceNr;
+  String options[TASKS_MAX + 1];
+  String attrs[TASKS_MAX + 1];
 
   for (taskIndex_t x = 0; x <= TASKS_MAX; x++)
   {
+    deviceNr.clear();
     if (validTaskIndex(x)) {
       const deviceIndex_t DeviceIndex = getDeviceIndex_from_TaskIndex(x);
       deviceName = getPluginNameFromDeviceIndex(DeviceIndex);
+      deviceNr += (x + 1);
     } else {
       deviceName = F("Not Set");
     }
-    {
-      addHtml(F("<option value='"));
-      addHtmlInt(x);
-      addHtml('\'');
-
-      if (choice == x) {
-        addHtml(F(" selected"));
-      }
-    }
 
     if (validTaskIndex(x) && !validPluginID_fullcheck(Settings.getPluginID_for_task(x))) {
-      addDisabled();
+      attrs[x] = F("disabled");
     }
-    {
-      addHtml('>');
-
-      if (validTaskIndex(x)) {
-        addHtmlInt(x + 1);
-      }
-      addHtml(F(" - "));
-      addHtml(deviceName);
-      addHtml(F(" - "));
-      addHtml(getTaskDeviceName(x));
-      addHtml(F("</option>"));
-    }
+    options[x] = strformat(F("%s - %s - %s"), deviceNr.c_str(), deviceName.c_str(), getTaskDeviceName(x).c_str());
   }
+
+  FormSelectorOptions selector(TASKS_MAX + 1, options, nullptr, attrs);
+  selector.reloadonchange = true;
+  selector.classname = cssclass;
+  selector.addSelector(name, choice);
 }
 
 // ********************************************************************************

--- a/src/src/WebServer/ESPEasy_WebServer.h
+++ b/src/src/WebServer/ESPEasy_WebServer.h
@@ -110,7 +110,7 @@ void json_prop(LabelType::Enum label);
 // ********************************************************************************
 void addTaskSelect(const String& name,
                    taskIndex_t   choice,
-                   const String& cssclass = "wide");
+                   const __FlashStringHelper* cssclass = F("wide"));
 
 // ********************************************************************************
 // Add a Value select dropdown list, based on TaskIndex


### PR DESCRIPTION
Features:
- [UI] Update the code for `addTaskSelector()` to use latest `FormSelectorOptions` class, so it shows the reload icon as it should, and reduces code