### PR TITLE
[Bugfix] Derived values avoid parsing invalid values causing crashes

### DIFF
--- a/src/src/Helpers/StringParser.cpp
+++ b/src/src/Helpers/StringParser.cpp
@@ -320,7 +320,7 @@ String parseTemplate_padded(String& tmpString, uint8_t minimal_lineSize, bool us
             }
           }
           #if FEATURE_STRING_VARIABLES
-          if (!isHandled) {
+          if (!isHandled && Settings.TaskDeviceEnabled[taskIndex]) {
             String value;
             const String valName = parseString(valueName, 1);
             String derived = getCustomStringVar(strformat(F(TASK_VALUE_DERIVED_PREFIX_TEMPLATE), deviceName.c_str(), valName.c_str()));
@@ -334,6 +334,7 @@ String parseTemplate_padded(String& tmpString, uint8_t minimal_lineSize, bool us
               }
             }
           }
+          #endif // if FEATURE_STRING_VARIABLES
 
           #if FEATURE_TASKVALUE_ATTRIBUTES
           if (!isHandled && valueName.indexOf('.') > -1) { // TaskValue specific attributes
@@ -377,6 +378,7 @@ String parseTemplate_padded(String& tmpString, uint8_t minimal_lineSize, bool us
           }
           #endif // if FEATURE_TASKVALUE_ATTRIBUTES
 
+          #if FEATURE_STRING_VARIABLES
           if (!isHandled && valueName.indexOf('.') > -1) {
             String value;
             const String fullValueName = parseString(valueName, 1);

--- a/src/src/WebServer/DevicesPage.cpp
+++ b/src/src/WebServer/DevicesPage.cpp
@@ -896,8 +896,13 @@ void handle_devicess_ShowAllTasksTable(uint8_t page)
                   }
                   if (!it->second.isEmpty()) {
                     String value(it->second);
-                    value = parseTemplateAndCalculate(value);
-                    String presentation = getCustomStringVar(strformat(F(TASK_VALUE_PRESENTATION_PREFIX_TEMPLATE), taskName.c_str(), valueName.c_str()));
+                    String presentation;
+                    if (Settings.TaskDeviceEnabled[x]) {
+                      value = parseTemplateAndCalculate(value);
+                      presentation = getCustomStringVar(strformat(F(TASK_VALUE_PRESENTATION_PREFIX_TEMPLATE), taskName.c_str(), valueName.c_str()));
+                    } else {
+                      value = F("0");
+                    }
                     if (!uom.isEmpty()) {
                       value = strformat(F("%s %s"), value.c_str(), uom.c_str());
                     }

--- a/src/src/WebServer/DevicesPage.cpp
+++ b/src/src/WebServer/DevicesPage.cpp
@@ -896,13 +896,8 @@ void handle_devicess_ShowAllTasksTable(uint8_t page)
                   }
                   if (!it->second.isEmpty()) {
                     String value(it->second);
-                    String presentation;
-                    if (Settings.TaskDeviceEnabled[x]) {
-                      value = parseTemplateAndCalculate(value);
-                      presentation = getCustomStringVar(strformat(F(TASK_VALUE_PRESENTATION_PREFIX_TEMPLATE), taskName.c_str(), valueName.c_str()));
-                    } else {
-                      value = F("0");
-                    }
+                    value = parseTemplateAndCalculate(value);
+                    String presentation = getCustomStringVar(strformat(F(TASK_VALUE_PRESENTATION_PREFIX_TEMPLATE), taskName.c_str(), valueName.c_str()));
                     if (!uom.isEmpty()) {
                       value = strformat(F("%s %s"), value.c_str(), uom.c_str());
                     }

--- a/src/src/WebServer/DevicesPage.cpp
+++ b/src/src/WebServer/DevicesPage.cpp
@@ -1592,20 +1592,6 @@ void devicePage_show_controller_config(taskIndex_t taskIndex, deviceIndex_t Devi
         if (!separatorAdded) {
           addFormSeparator(2);
         }
-        separatorAdded = true;
-        html_TR_TD();
-        addHtml(F("Send to Controller "));
-        addHtml(getControllerSymbol(controllerNr));
-        addHtmlDiv(F("note"), wrap_braces(getCPluginNameFromCPluginID(Settings.Protocol[controllerNr]) + F(", ") + // Most compact code...
-                                          (Settings.ControllerEnabled[controllerNr] ? F("enabled") : F("disabled"))));
-        html_TD();
-
-        addHtml(F("<table style='padding-left:0;'>"));     // remove left padding 2x to align vertically with other inputs
-        html_TD(F("width:50px;padding-left:0"));
-        addCheckBox(
-          getPluginCustomArgName(F("TDSD"), controllerNr), // ="taskdevicesenddata"
-          Settings.TaskDeviceSendData[controllerNr][taskIndex]);
-
         protocolIndex_t ProtocolIndex = getProtocolIndex_from_ControllerIndex(controllerNr);
         const bool showControllerIDX  = validProtocolIndex(ProtocolIndex) &&
                                         getProtocolStruct(ProtocolIndex).usesID &&
@@ -1614,6 +1600,24 @@ void devicePage_show_controller_config(taskIndex_t taskIndex, deviceIndex_t Devi
         const bool showMqttGroup = (validProtocolIndex(ProtocolIndex) &&
                                     getProtocolStruct(ProtocolIndex).mqttAutoDiscover);
         # endif // if FEATURE_MQTT_DISCOVER
+        separatorAdded = true;
+        html_TR_TD();
+        addHtml(F("Send to Controller "));
+        addHtml(getControllerSymbol(controllerNr));
+        addHtmlDiv(F("note"), wrap_braces(getCPluginNameFromCPluginID(Settings.Protocol[controllerNr]) + F(", ") + // Most compact code...
+                                          (Settings.ControllerEnabled[controllerNr] ? F("enabled") : F("disabled"))
+                                          #if FEATURE_MQTT_DISCOVER
+                                          + (showMqttGroup ? F(", Auto Discovery") : F(""))
+                                          #endif // if FEATURE_MQTT_DISCOVER
+                                         ));
+        html_TD();
+
+        addHtml(F("<table style='padding-left:0;'>"));     // remove left padding 2x to align vertically with other inputs
+        html_TD(F("width:50px;padding-left:0"));
+        addCheckBox(
+          getPluginCustomArgName(F("TDSD"), controllerNr), // ="taskdevicesenddata"
+          Settings.TaskDeviceSendData[controllerNr][taskIndex]);
+
         # if FEATURE_STRING_VARIABLES
         const bool allowSendDerived = !device.HideDerivedValues &&
                                       (validProtocolIndex(ProtocolIndex) &&

--- a/src/src/WebServer/JSON.cpp
+++ b/src/src/WebServer/JSON.cpp
@@ -506,17 +506,11 @@ void handle_json()
               }
               if (!it->second.isEmpty()) {
                 String value(it->second);
+                stripEscapeCharacters(value);
+                value = parseTemplate(value);
                 uint8_t nrDecimals = 255; // FIXME Use the minimal number of decimals needed
-                String presentation;
-                if (Settings.TaskDeviceEnabled[TaskIndex]) {
-                  stripEscapeCharacters(value);
-                  value = parseTemplate(value);
-                  bool hasPresentation;
-                  presentation = formatUserVarForPresentation(&TempEvent, INVALID_TASKVAR_INDEX, hasPresentation, value, DeviceIndex, valueName);
-                } else {
-                  value = F("0");
-                  nrDecimals = 0;
-                }
+                bool hasPresentation;
+                const String presentation = formatUserVarForPresentation(&TempEvent, INVALID_TASKVAR_INDEX, hasPresentation, value, DeviceIndex, valueName);
 
                 stream_comma_newline(); // Push out a comma and newline
                 handle_json_stream_task_value_data(varNr + 1,

--- a/src/src/WebServer/JSON.cpp
+++ b/src/src/WebServer/JSON.cpp
@@ -506,11 +506,17 @@ void handle_json()
               }
               if (!it->second.isEmpty()) {
                 String value(it->second);
-                stripEscapeCharacters(value);
-                value = parseTemplate(value);
                 uint8_t nrDecimals = 255; // FIXME Use the minimal number of decimals needed
-                bool hasPresentation;
-                const String presentation = formatUserVarForPresentation(&TempEvent, INVALID_TASKVAR_INDEX, hasPresentation, value, DeviceIndex, valueName);
+                String presentation;
+                if (Settings.TaskDeviceEnabled[TaskIndex]) {
+                  stripEscapeCharacters(value);
+                  value = parseTemplate(value);
+                  bool hasPresentation;
+                  presentation = formatUserVarForPresentation(&TempEvent, INVALID_TASKVAR_INDEX, hasPresentation, value, DeviceIndex, valueName);
+                } else {
+                  value = F("0");
+                  nrDecimals = 0;
+                }
 
                 stream_comma_newline(); // Push out a comma and newline
                 handle_json_stream_task_value_data(varNr + 1,


### PR DESCRIPTION
Bugfix:
- Parsing derived values caused unwanted recursion when using task values

Feature:
- Show `Auto Discovery` on Task configuration page for MQTT Controllers that have this enabled
  - Example:
    <img width="254" height="74" alt="image" src="https://github.com/user-attachments/assets/39859215-aaf8-4f53-854d-05ffedcca7ad" />
