### PR TITLE
[Bugfix] Calculation missed value when returning from multiple brackets

### DIFF
--- a/src/src/Helpers/Rules_calculate.cpp
+++ b/src/src/Helpers/Rules_calculate.cpp
@@ -568,7 +568,7 @@ CalculateReturnCode RulesCalculate_t::doCalculate(const char *input, ESPEASY_RUL
             if (sl > 1) {
               sc = stack[sl - 2];
               if (!(is_operator(sc) || is_unary_operator(sc) || is_quinary_operator(sc))) {
-                sc = '(';
+                sc = '\0';
               }
             }
           }


### PR DESCRIPTION
Resolves #5438 

Bugfix:
- Calculations sometimes missed the result or last calculation-part when resolving multiple round brackets

