### PR TITLE
[Bugfix] MQTT StateClass selector stored wrong index

### DIFF
--- a/src/_P003_Pulse.ino
+++ b/src/_P003_Pulse.ino
@@ -68,6 +68,7 @@ boolean Plugin_003(uint8_t function, struct EventStruct *event, String& string)
       dev.PluginStats      = true;
       dev.TaskLogsOwnPeaks = true;
       dev.CustomVTypeVar   = true;
+      dev.MqttStateClass   = true;
       break;
     }
 

--- a/src/src/Helpers/_CPlugin_Helper_mqtt.cpp
+++ b/src/src/Helpers/_CPlugin_Helper_mqtt.cpp
@@ -471,9 +471,9 @@ const __FlashStringHelper* MQTT_sensor_StateClass(uint8_t index,
   switch (index) {
     case 0: return F("");
     case 1: return display ? F("Measurement") : F("measurement");
-    case 2: return display ? F("Total") : F("total");
-    case 3: return display ? F("Total-increasing") : F("total_increasing");
-    case 4: return display ? F("Measurement-angle") : F("measurement_angle");
+    case 2: return display ? F("Measurement-angle") : F("measurement_angle");
+    case 3: return display ? F("Total") : F("total");
+    case 4: return display ? F("Total-increasing") : F("total_increasing");
   }
   return F("");
 }

--- a/src/src/WebServer/DevicesPage.cpp
+++ b/src/src/WebServer/DevicesPage.cpp
@@ -1838,9 +1838,9 @@ void devicePage_show_task_values(taskIndex_t taskIndex, deviceIndex_t DeviceInde
     const __FlashStringHelper *stateClasses[] = {
       MQTT_sensor_StateClass(0),
       MQTT_sensor_StateClass(1),
-      MQTT_sensor_StateClass(4),
       MQTT_sensor_StateClass(2),
       MQTT_sensor_StateClass(3),
+      MQTT_sensor_StateClass(4),
     };
     constexpr size_t stateCount = NR_ELEMENTS(stateClasses);
     #endif // if FEATURE_MQTT_STATE_CLASS


### PR DESCRIPTION
Bugfix:
- MQTT State Class was stored with wrong index, causing the wrong value to be used in the Auto Discovery message sent to Home Assistant

Feature:
- [P003] Enable MQTT State Class option so pulse-counter can be used for energy measurement (in HA) (solved [this request](https://github.com/letscontrolit/ESPEasy/issues/5431#issuecomment-3598931657))

TODO:
- [ ] Testing by reporter