### PR TITLE
[Bugfix] Metrics: Export 0 for empty values

### DIFF
--- a/src/src/WebServer/Metrics.cpp
+++ b/src/src/WebServer/Metrics.cpp
@@ -137,7 +137,8 @@ void handle_metrics_devices() {
                 addHtml(F("{valueName=\""));
                 addHtml(Cache.getTaskDeviceValueName(x, varNr));
                 addHtml(F("\"} "));
-                addHtml(formatUserVarNoCheck(&TempEvent, varNr));
+                const String value(formatUserVarNoCheck(&TempEvent, varNr));
+                addHtml(value.isEmpty() ? F("0") : value); // Return 0 for not-set values
                 addHtml('\n');
               }
             }

--- a/src/src/WebServer/Metrics.cpp
+++ b/src/src/WebServer/Metrics.cpp
@@ -138,7 +138,12 @@ void handle_metrics_devices() {
                 addHtml(Cache.getTaskDeviceValueName(x, varNr));
                 addHtml(F("\"} "));
                 const String value(formatUserVarNoCheck(&TempEvent, varNr));
-                addHtml(value.isEmpty() ? F("0") : value); // Return 0 for not-set values
+
+                if (value.isEmpty()) {
+                  addHtml('0'); // Return 0 for not-set values
+                } else {
+                  addHtml(value);
+                }
                 addHtml('\n');
               }
             }


### PR DESCRIPTION
Resolves #5457 

Bugfix:
- Metrics: Export 0 for empty task device values

TODO:
- [x] Testing by reporter ([confirmed](https://github.com/letscontrolit/ESPEasy/issues/5457#issuecomment-3676442150))