### PR TITLE
[OLED] Fix: 128×64 shows only left half in display_A builds (#5469)

### DIFF
--- a/src/src/PluginStructs/P023_data_struct.cpp
+++ b/src/src/PluginStructs/P023_data_struct.cpp
@@ -435,7 +435,6 @@ void P023_data_struct::sendStrXY(const char *string, int X, int Y) {
     for (i = 0; i < char_width && currentPixels < maxPixels; ++i,++currentPixels) { // Prevent display overflow on the pixel-level
       sendChar((i == 0 || i > 5) ? 0x00 : pgm_read_byte(baddr + i - 1)); 
     }
-    currentPixels += char_width;
     string++;
   }
 }


### PR DESCRIPTION
Fixes: #5469