### PR TITLE
[P135] Bugfix: Correct Discovery VTypes

### DIFF
--- a/src/_P135_SCD4x.ino
+++ b/src/_P135_SCD4x.ino
@@ -77,7 +77,8 @@ boolean Plugin_135(uint8_t function, struct EventStruct *event, String& string)
     case PLUGIN_GET_DISCOVERY_VTYPES:
     {
       event->Par1 = static_cast<int>(Sensor_VType::SENSOR_TYPE_CO2_ONLY);
-      event->Par2 = static_cast<int>(Sensor_VType::SENSOR_TYPE_TEMP_HUM);
+      event->Par2 = static_cast<int>(Sensor_VType::SENSOR_TYPE_HUM_ONLY);
+      event->Par3 = static_cast<int>(Sensor_VType::SENSOR_TYPE_TEMP_ONLY);
       success     = true;
       break;
     }


### PR DESCRIPTION
As [reported in the forum](https://www.letscontrolit.com/forum/viewtopic.php?t=10880)

Bugfix:
- [P135] Temperature value Unit of Measure was not configurable