### PR TITLE
[MQTT] Bugfix: Import wasn't initiated and handled correctly

### DIFF
--- a/src/src/Globals/Plugins.cpp
+++ b/src/src/Globals/Plugins.cpp
@@ -1013,9 +1013,10 @@ bool PluginCall(uint8_t Function, struct EventStruct *event, String& str)
     case PLUGIN_GET_UOM_GROUPS:
     #endif // if FEATURE_TASKVALUE_UNIT_OF_MEASURE
 
-      // PLUGIN_MQTT_xxx functions are directly called from the scheduler.
-      // case PLUGIN_MQTT_CONNECTION_STATE:
-      // case PLUGIN_MQTT_IMPORT:
+    #if FEATURE_MQTT
+    case PLUGIN_MQTT_CONNECTION_STATE:
+    case PLUGIN_MQTT_IMPORT:
+    #endif // if FEATURE_MQTT
     {
       START_TIMER;
       const deviceIndex_t DeviceIndex = getDeviceIndex_from_TaskIndex(event->TaskIndex);

--- a/src/src/Helpers/PeriodicalActions.cpp
+++ b/src/src/Helpers/PeriodicalActions.cpp
@@ -322,10 +322,6 @@ void scheduleNextMQTTdelayQueue() {
 }
 
 void schedule_all_MQTTimport_tasks() {
-  controllerIndex_t ControllerIndex = firstEnabledMQTT_ControllerIndex();
-
-  if (!validControllerIndex(ControllerIndex)) { return; }
-
   constexpr pluginID_t PLUGIN_MQTT_IMPORT(PLUGIN_ID_MQTT_IMPORT);
 
   deviceIndex_t DeviceIndex = getDeviceIndex(PLUGIN_MQTT_IMPORT); // Check if P037_MQTTimport is present in the build
@@ -420,9 +416,6 @@ void updateMQTTclient_connected() {
         addLogMove(LOG_LEVEL_ERROR, connectionError);
       }
       MQTTclient_must_send_LWT_connected = false;
-    } else {
-      // Now schedule all tasks using the MQTT controller.
-      schedule_all_MQTTimport_tasks();
     }
     if (Settings.UseRules) {
       if (MQTTclient_connected) {
@@ -431,6 +424,8 @@ void updateMQTTclient_connected() {
         eventQueue.add(F("MQTT#Disconnected"));
       }
     }
+    // Now schedule all tasks using the MQTT Import plugin.
+    schedule_all_MQTTimport_tasks();
   }
   if (!MQTTclient_connected) {
     // As suggested here: https://github.com/letscontrolit/ESPEasy/issues/1356


### PR DESCRIPTION
Resolves #5471

Bugfix:
- [MQTT] The MQTT Import plugin wasn't initialized correctly, and import messages weren't processed.

TODO:
- [ ] Testing