### PR TITLE
[Build] Fix compilation with Custom.h and TLS on ESP32

### DIFF
--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -3541,15 +3541,6 @@ To create/register a plugin, you have to :
   #endif
 #endif
 
-#if FEATURE_MQTT_TLS || FEATURE_EMAIL_TLS || FEATURE_HTTP_TLS
-  #if defined(FEATURE_TLS) && !FEATURE_TLS
-    #undef FEATURE_TLS
-  #endif
-  #ifndef FEATURE_TLS
-    #define FEATURE_TLS 1
-  #endif
-#endif
-
 
 #if !defined(FEATURE_MQTT_DISCOVER) && FEATURE_MQTT
   #if defined(LIMIT_BUILD_SIZE) || defined(ESP8266) // Must enable this explicitly for ESP8266 Custom build
@@ -3933,6 +3924,16 @@ To create/register a plugin, you have to :
     #define FEATURE_HTTP_TLS 0
   #endif
 #endif // ifndef FEATURE_HTTP_TLS
+
+#if FEATURE_MQTT_TLS || FEATURE_EMAIL_TLS || FEATURE_HTTP_TLS
+  #if defined(FEATURE_TLS) && !FEATURE_TLS
+    #undef FEATURE_TLS
+  #endif
+  #ifndef FEATURE_TLS
+    #define FEATURE_TLS 1
+  #endif
+#endif
+
 
 #ifndef FEATURE_AUTO_DARK_MODE
   #ifdef LIMIT_BUILD_SIZE

--- a/src/src/ESPEasyCore/Controller.cpp
+++ b/src/src/ESPEasyCore/Controller.cpp
@@ -34,6 +34,11 @@
 #include "../Helpers/PeriodicalActions.h"
 #include "../Helpers/PortStatus.h"
 
+# if FEATURE_MQTT_TLS
+  #  include <WiFiClientSecureLightBearSSL.h>
+  #  include "../CustomBuild/Certificate_CA.h"
+# endif // if FEATURE_MQTT_TLS
+
 
 constexpr pluginID_t PLUGIN_ID_MQTT_IMPORT(37);
 

--- a/src/src/Globals/MQTT.h
+++ b/src/src/Globals/MQTT.h
@@ -16,6 +16,7 @@
 
 # if FEATURE_MQTT_TLS
   #  include <WiFiClientSecureLightBearSSL.h>
+  #  include "../CustomBuild/Certificate_CA.h"
 # endif // if FEATURE_MQTT_TLS
 
 # if FEATURE_MQTT_CONNECT_BACKGROUND


### PR DESCRIPTION
Resolves #5485 (part 2)

Bugfix:
- Compilation failed for a Custom ESP32 build that implicitly includes TLS features