### PR TITLE
[Email] Add encryption selector

### DIFF
--- a/src/src/DataStructs/NotificationSettingsStruct.cpp
+++ b/src/src/DataStructs/NotificationSettingsStruct.cpp
@@ -2,21 +2,46 @@
 
 #if FEATURE_NOTIFIER
 
+# if FEATURE_EMAIL_TLS
+
+const __FlashStringHelper * NotificationSettingsStruct::toString(EncryptionType encType)
+{
+  switch (encType)
+  {
+    case EncryptionType::Auto:         return F("Auto");
+    case EncryptionType::NoEncryption: return F("No Encryption");
+//    case EncryptionType::SSL:          return F("SSL");
+//    case EncryptionType::TLS:          return F("TLS");
+
+    case EncryptionType::MAX_ENCRYPTION_TYPE: break;
+  }
+  return F("");
+}
+
+# endif // if FEATURE_EMAIL_TLS
+
 NotificationSettingsStruct::NotificationSettingsStruct() {
   memset(this, 0, sizeof(NotificationSettingsStruct));
   Pin1 = -1;
   Pin2 = -1;
 }
 
-  void NotificationSettingsStruct::validate() {
-    ZERO_TERMINATE(Server);
-    ZERO_TERMINATE(Domain);
-    ZERO_TERMINATE(Sender);
-    ZERO_TERMINATE(Receiver);
-    ZERO_TERMINATE(Subject);
-    ZERO_TERMINATE(Body);
-    ZERO_TERMINATE(User);
-    ZERO_TERMINATE(Pass);
-  }
+void NotificationSettingsStruct::validate() {
+  ZERO_TERMINATE(Server);
+  ZERO_TERMINATE(Domain);
+  ZERO_TERMINATE(Sender);
+  ZERO_TERMINATE(Receiver);
+  ZERO_TERMINATE(Subject);
+  ZERO_TERMINATE(Body);
+  ZERO_TERMINATE(User);
+  ZERO_TERMINATE(Pass);
 
-#endif
+# if FEATURE_EMAIL_TLS
+
+  if (EncryptionSelector >= static_cast<uint8_t>(EncryptionType::MAX_ENCRYPTION_TYPE)) {
+    EncryptionSelector = 0;
+  }
+# endif // if FEATURE_EMAIL_TLS
+}
+
+#endif // if FEATURE_NOTIFIER

--- a/src/src/DataStructs/NotificationSettingsStruct.h
+++ b/src/src/DataStructs/NotificationSettingsStruct.h
@@ -16,11 +16,29 @@
 \*********************************************************************************************/
 struct NotificationSettingsStruct
 {
+# if FEATURE_EMAIL_TLS
+  // Will be stored
+  enum class EncryptionType {
+    Auto = 0,
+    NoEncryption = 1,
+//    SSL = 2,
+//    TLS = 3,
+
+    MAX_ENCRYPTION_TYPE // Keep as last
+  };
+
+  static const __FlashStringHelper* toString(EncryptionType encType);
+#endif
+
+
+
   NotificationSettingsStruct();
 
   void validate();
 
   char          Server[65];
+  uint8_t       EncryptionSelector;
+  uint8_t       unused1[2];
   unsigned int  Port;
   char          Domain[65];
   char          Sender[65];
@@ -31,6 +49,7 @@ struct NotificationSettingsStruct
   int8_t        Pin2;
   char          User[49];
   char          Pass[33];
+  uint8_t       unused2[3];
   unsigned int  Timeout_ms;
   //its safe to extend this struct, up to 4096 bytes, default values in config are 0
 };

--- a/src/src/Helpers/ESPEasy_checks.cpp
+++ b/src/src/Helpers/ESPEasy_checks.cpp
@@ -98,6 +98,11 @@ void run_compiletime_checks() {
   #if FEATURE_NOTIFIER
   check_size<NotificationSettingsStruct,            1000u>();
   check_max_size<NotificationSettingsStruct,        DAT_NOTIFICATION_SIZE>();
+  constexpr size_t NSS_Port_offset = offsetof(NotificationSettingsStruct, Port);
+  constexpr size_t NSS_Timeout_offset = offsetof(NotificationSettingsStruct, Timeout_ms);
+  static_assert(NSS_Port_offset == 68u, "NotificationSettingsStruct Port offset changed");
+  static_assert(NSS_Timeout_offset == 996u, "NotificationSettingsStruct Timeout offset changed");
+
   #endif // if FEATURE_NOTIFIER
   check_size<ExtraTaskSettingsStruct,               536u>();
   check_max_size<ExtraTaskSettingsStruct,           DAT_TASKS_SIZE>();

--- a/src/src/NotifierStructs/N001_data_struct.cpp
+++ b/src/src/NotifierStructs/N001_data_struct.cpp
@@ -34,8 +34,13 @@ bool NPlugin_001_send(const NotificationSettingsStruct& notificationsettings, St
 
   BearSSL::WiFiClientSecure_light secureClient(4096, 4096);
 
+  const NotificationSettingsStruct::EncryptionType encType = 
+    static_cast<NotificationSettingsStruct::EncryptionType>(
+      notificationsettings.EncryptionSelector);
+
   // Port 25 or 2525 is a standard WiFiClient, all else is a secure client...
-  if ((notificationsettings.Port != 25) && (notificationsettings.Port != 2525)) {
+  if (NotificationSettingsStruct::EncryptionType::NoEncryption != encType &&
+    (notificationsettings.Port != 25) && (notificationsettings.Port != 2525)) {
     secureClient.setUtcTime_fcn(getUnixTime);
     secureClient.setCfgTime_fcn(get_build_unixtime);
     secureClient.setTrustAnchor(Tasmota_TA, Tasmota_TA_size);

--- a/src/src/WebServer/NotificationPage.cpp
+++ b/src/src/WebServer/NotificationPage.cpp
@@ -90,6 +90,9 @@ void handle_notifications() {
                                      sizeof(NotificationSettingsStruct));
             NotificationSettings->validate();
             NotificationSettings->Port = getFormItemInt(F("port"), 0);
+# if FEATURE_EMAIL_TLS
+            NotificationSettings->EncryptionSelector = getFormItemInt(F("enctype"), 0);
+#endif
 
             NotificationSettings->Timeout_ms                = getFormItemInt(F("timeout"), NPLUGIN_001_DEF_TM);
             NotificationSettings->Pin1                      = getFormItemInt(F("pin1"), -1);
@@ -257,9 +260,20 @@ void handle_notifications() {
               65535);
 # if FEATURE_EMAIL_TLS
             addFormNote(F("default port SSL: 465"));
+            {
+              const __FlashStringHelper *options[] = { 
+                F("Auto"), 
+                F("No Encryption") };
+              const int optionValues[] = { 
+                static_cast<int>(NotificationSettingsStruct::EncryptionType::Auto),
+                static_cast<int>(NotificationSettingsStruct::EncryptionType::NoEncryption) };
+              FormSelectorOptions selector(NR_ELEMENTS(options), options, optionValues);
+              selector.addFormSelector(F("Encryption"), F("enctype"), NotificationSettings->EncryptionSelector);
+            }
 # else // if FEATURE_EMAIL_TLS
             addFormNote(F("default port: 25, SSL/TLS servers NOT supported!"));
 # endif // if FEATURE_EMAIL_TLS
+
 
             if ((NotificationSettings->Timeout_ms < NPLUGIN_001_MIN_TM) ||
                 (NotificationSettings->Timeout_ms > NPLUGIN_001_MAX_TM))


### PR DESCRIPTION
Apparently there are email providers hat accept non-encrypted connections on port 587. However ESP32-builds now try to setup a secure connection, which then fails.