### PR TITLE
[Build] Fix failing build for minimal_core_274_ESP8266_1M_OTA_FHEM_HA

### DIFF
--- a/platformio_esp82xx_base.ini
+++ b/platformio_esp82xx_base.ini
@@ -366,6 +366,7 @@ lib_ignore                = ESP32_ping
                             HeatpumpIR										
                             I2Cdevlib-Core
                             ILI9488											
+                            INA2xx
                             IRremoteESP8266									
                             ITG3205											
                             Improv WiFi Library								


### PR DESCRIPTION
Fix build for minimal OTA, where `FEATURE_I2C` isn't set and all I2C code is excluded.