### PR TITLE
feat(P070): Enhance NeoPixel Clock functionality

### DIFF
--- a/docs/source/Plugin/_plugin_sets_overview.repl
+++ b/docs/source/Plugin/_plugin_sets_overview.repl
@@ -73,6 +73,11 @@ Build set:  :green:`NORMAL`
       ":ref:`C013_page`","C013"
       ":ref:`N001_page`","N001"
       ":ref:`N002_page`","N002"
+      ":ref:`NW001_page`","NW001"
+      ":ref:`NW002_page`","NW002"
+      ":ref:`NW003_page`","NW003"
+      ":ref:`NW004_page`","NW004"
+      ":ref:`NW005_page`","NW005"
 
 Build set:  :yellow:`COLLECTION A`
 ---------------------------------------------
@@ -118,6 +123,7 @@ Build set:  :yellow:`COLLECTION A`
       ":ref:`P034_page`","P034"
       ":ref:`P036_page`","P036"
       ":ref:`P037_page`","P037"
+      ":ref:`P038_page`","P038"
       ":ref:`P039_page`","P039"
       ":ref:`P040_page`","P040"
       ":ref:`P043_page`","P043"
@@ -190,6 +196,11 @@ Build set:  :yellow:`COLLECTION A`
       ":ref:`C018_page`","C018"
       ":ref:`N001_page`","N001"
       ":ref:`N002_page`","N002"
+      ":ref:`NW001_page`","NW001"
+      ":ref:`NW002_page`","NW002"
+      ":ref:`NW003_page`","NW003"
+      ":ref:`NW004_page`","NW004"
+      ":ref:`NW005_page`","NW005"
 
 Build set:  :yellow:`COLLECTION B`
 ---------------------------------------------
@@ -302,6 +313,11 @@ Build set:  :yellow:`COLLECTION B`
       ":ref:`C018_page`","C018"
       ":ref:`N001_page`","N001"
       ":ref:`N002_page`","N002"
+      ":ref:`NW001_page`","NW001"
+      ":ref:`NW002_page`","NW002"
+      ":ref:`NW003_page`","NW003"
+      ":ref:`NW004_page`","NW004"
+      ":ref:`NW005_page`","NW005"
 
 Build set:  :yellow:`COLLECTION C`
 ---------------------------------------------
@@ -347,6 +363,7 @@ Build set:  :yellow:`COLLECTION C`
       ":ref:`P034_page`","P034"
       ":ref:`P036_page`","P036"
       ":ref:`P037_page`","P037"
+      ":ref:`P038_page`","P038"
       ":ref:`P039_page`","P039"
       ":ref:`P040_page`","P040"
       ":ref:`P043_page`","P043"
@@ -410,6 +427,11 @@ Build set:  :yellow:`COLLECTION C`
       ":ref:`C018_page`","C018"
       ":ref:`N001_page`","N001"
       ":ref:`N002_page`","N002"
+      ":ref:`NW001_page`","NW001"
+      ":ref:`NW002_page`","NW002"
+      ":ref:`NW003_page`","NW003"
+      ":ref:`NW004_page`","NW004"
+      ":ref:`NW005_page`","NW005"
 
 Build set:  :yellow:`COLLECTION D`
 ---------------------------------------------
@@ -455,6 +477,7 @@ Build set:  :yellow:`COLLECTION D`
       ":ref:`P034_page`","P034"
       ":ref:`P036_page`","P036"
       ":ref:`P037_page`","P037"
+      ":ref:`P038_page`","P038"
       ":ref:`P039_page`","P039"
       ":ref:`P040_page`","P040"
       ":ref:`P043_page`","P043"
@@ -518,6 +541,11 @@ Build set:  :yellow:`COLLECTION D`
       ":ref:`C018_page`","C018"
       ":ref:`N001_page`","N001"
       ":ref:`N002_page`","N002"
+      ":ref:`NW001_page`","NW001"
+      ":ref:`NW002_page`","NW002"
+      ":ref:`NW003_page`","NW003"
+      ":ref:`NW004_page`","NW004"
+      ":ref:`NW005_page`","NW005"
 
 Build set:  :yellow:`COLLECTION E`
 ---------------------------------------------
@@ -630,6 +658,11 @@ Build set:  :yellow:`COLLECTION E`
       ":ref:`C018_page`","C018"
       ":ref:`N001_page`","N001"
       ":ref:`N002_page`","N002"
+      ":ref:`NW001_page`","NW001"
+      ":ref:`NW002_page`","NW002"
+      ":ref:`NW003_page`","NW003"
+      ":ref:`NW004_page`","NW004"
+      ":ref:`NW005_page`","NW005"
 
 Build set:  :yellow:`COLLECTION F`
 ---------------------------------------------
@@ -675,6 +708,7 @@ Build set:  :yellow:`COLLECTION F`
       ":ref:`P034_page`","P034"
       ":ref:`P036_page`","P036"
       ":ref:`P037_page`","P037"
+      ":ref:`P038_page`","P038"
       ":ref:`P039_page`","P039"
       ":ref:`P040_page`","P040"
       ":ref:`P043_page`","P043"
@@ -740,6 +774,11 @@ Build set:  :yellow:`COLLECTION F`
       ":ref:`C018_page`","C018"
       ":ref:`N001_page`","N001"
       ":ref:`N002_page`","N002"
+      ":ref:`NW001_page`","NW001"
+      ":ref:`NW002_page`","NW002"
+      ":ref:`NW003_page`","NW003"
+      ":ref:`NW004_page`","NW004"
+      ":ref:`NW005_page`","NW005"
 
 Build set:  :yellow:`COLLECTION G`
 ---------------------------------------------
@@ -785,6 +824,7 @@ Build set:  :yellow:`COLLECTION G`
       ":ref:`P034_page`","P034"
       ":ref:`P036_page`","P036"
       ":ref:`P037_page`","P037"
+      ":ref:`P038_page`","P038"
       ":ref:`P039_page`","P039"
       ":ref:`P040_page`","P040"
       ":ref:`P043_page`","P043"
@@ -834,9 +874,6 @@ Build set:  :yellow:`COLLECTION G`
       ":ref:`P168_page`","P168"
       ":ref:`P170_page`","P170"
       ":ref:`P172_page`","P172"
-      ":ref:`P173_page`","P173"
-      ":ref:`P177_page`","P177"
-      ":ref:`P178_page`","P178"
       ":ref:`P180_page`","P180"
       ":ref:`C001_page`","C001"
       ":ref:`C002_page`","C002"
@@ -856,6 +893,11 @@ Build set:  :yellow:`COLLECTION G`
       ":ref:`C018_page`","C018"
       ":ref:`N001_page`","N001"
       ":ref:`N002_page`","N002"
+      ":ref:`NW001_page`","NW001"
+      ":ref:`NW002_page`","NW002"
+      ":ref:`NW003_page`","NW003"
+      ":ref:`NW004_page`","NW004"
+      ":ref:`NW005_page`","NW005"
 
 Build set:  :yellow:`COLLECTION H`
 ---------------------------------------------
@@ -901,6 +943,7 @@ Build set:  :yellow:`COLLECTION H`
       ":ref:`P034_page`","P034"
       ":ref:`P036_page`","P036"
       ":ref:`P037_page`","P037"
+      ":ref:`P038_page`","P038"
       ":ref:`P039_page`","P039"
       ":ref:`P040_page`","P040"
       ":ref:`P043_page`","P043"
@@ -939,6 +982,9 @@ Build set:  :yellow:`COLLECTION H`
       ":ref:`P139_page`","P139"
       ":ref:`P146_page`","P146"
       ":ref:`P152_page`","P152"
+      ":ref:`P173_page`","P173"
+      ":ref:`P177_page`","P177"
+      ":ref:`P178_page`","P178"
       ":ref:`P180_page`","P180"
       ":ref:`C001_page`","C001"
       ":ref:`C002_page`","C002"
@@ -958,6 +1004,11 @@ Build set:  :yellow:`COLLECTION H`
       ":ref:`C018_page`","C018"
       ":ref:`N001_page`","N001"
       ":ref:`N002_page`","N002"
+      ":ref:`NW001_page`","NW001"
+      ":ref:`NW002_page`","NW002"
+      ":ref:`NW003_page`","NW003"
+      ":ref:`NW004_page`","NW004"
+      ":ref:`NW005_page`","NW005"
 
 Build set:  :yellow:`CLIMATE A`
 ---------------------------------------------
@@ -1030,6 +1081,7 @@ Build set:  :yellow:`CLIMATE A`
       ":ref:`P153_page`","P153"
       ":ref:`P154_page`","P154"
       ":ref:`P164_page`","P164"
+      ":ref:`P167_page`","P167"
       ":ref:`P180_page`","P180"
       ":ref:`C011_page`","C011"
       ":ref:`N001_page`","N001"
@@ -1106,7 +1158,6 @@ Build set:  :yellow:`CLIMATE B`
       ":ref:`P153_page`","P153"
       ":ref:`P154_page`","P154"
       ":ref:`P164_page`","P164"
-      ":ref:`P167_page`","P167"
       ":ref:`P168_page`","P168"
       ":ref:`P169_page`","P169"
       ":ref:`P172_page`","P172"
@@ -1199,6 +1250,11 @@ Build set:  :yellow:`DISPLAY A`
       ":ref:`C013_page`","C013"
       ":ref:`N001_page`","N001"
       ":ref:`N002_page`","N002"
+      ":ref:`NW001_page`","NW001"
+      ":ref:`NW002_page`","NW002"
+      ":ref:`NW003_page`","NW003"
+      ":ref:`NW004_page`","NW004"
+      ":ref:`NW005_page`","NW005"
 
 Build set:  :yellow:`DISPLAY B`
 ---------------------------------------------
@@ -1283,6 +1339,11 @@ Build set:  :yellow:`DISPLAY B`
       ":ref:`C013_page`","C013"
       ":ref:`N001_page`","N001"
       ":ref:`N002_page`","N002"
+      ":ref:`NW001_page`","NW001"
+      ":ref:`NW002_page`","NW002"
+      ":ref:`NW003_page`","NW003"
+      ":ref:`NW004_page`","NW004"
+      ":ref:`NW005_page`","NW005"
 
 Build set:  :yellow:`ENERGY`
 ---------------------------------------------
@@ -1344,6 +1405,7 @@ Build set:  :yellow:`ENERGY`
       ":ref:`P078_page`","P078"
       ":ref:`P079_page`","P079"
       ":ref:`P085_page`","P085"
+      ":ref:`P087_page`","P087"
       ":ref:`P089_page`","P089"
       ":ref:`P093_page`","P093"
       ":ref:`P102_page`","P102"
@@ -1371,6 +1433,11 @@ Build set:  :yellow:`ENERGY`
       ":ref:`C013_page`","C013"
       ":ref:`N001_page`","N001"
       ":ref:`N002_page`","N002"
+      ":ref:`NW001_page`","NW001"
+      ":ref:`NW002_page`","NW002"
+      ":ref:`NW003_page`","NW003"
+      ":ref:`NW004_page`","NW004"
+      ":ref:`NW005_page`","NW005"
 
 Build set:  :yellow:`IR`
 ---------------------------------------------
@@ -1418,6 +1485,7 @@ Build set:  :yellow:`IR`
       ":ref:`P035_page`","P035"
       ":ref:`P036_page`","P036"
       ":ref:`P037_page`","P037"
+      ":ref:`P038_page`","P038"
       ":ref:`P039_page`","P039"
       ":ref:`P040_page`","P040"
       ":ref:`P043_page`","P043"
@@ -1445,6 +1513,11 @@ Build set:  :yellow:`IR`
       ":ref:`C013_page`","C013"
       ":ref:`N001_page`","N001"
       ":ref:`N002_page`","N002"
+      ":ref:`NW001_page`","NW001"
+      ":ref:`NW002_page`","NW002"
+      ":ref:`NW003_page`","NW003"
+      ":ref:`NW004_page`","NW004"
+      ":ref:`NW005_page`","NW005"
 
 Build set:  :yellow:`IRext`
 ---------------------------------------------
@@ -1490,7 +1563,6 @@ Build set:  :yellow:`IRext`
       ":ref:`P034_page`","P034"
       ":ref:`P036_page`","P036"
       ":ref:`P037_page`","P037"
-      ":ref:`P038_page`","P038"
       ":ref:`P039_page`","P039"
       ":ref:`P040_page`","P040"
       ":ref:`P043_page`","P043"
@@ -1519,6 +1591,11 @@ Build set:  :yellow:`IRext`
       ":ref:`C013_page`","C013"
       ":ref:`N001_page`","N001"
       ":ref:`N002_page`","N002"
+      ":ref:`NW001_page`","NW001"
+      ":ref:`NW002_page`","NW002"
+      ":ref:`NW003_page`","NW003"
+      ":ref:`NW004_page`","NW004"
+      ":ref:`NW005_page`","NW005"
 
 Build set:  :yellow:`NEOPIXEL`
 ---------------------------------------------
@@ -1602,6 +1679,11 @@ Build set:  :yellow:`NEOPIXEL`
       ":ref:`C013_page`","C013"
       ":ref:`N001_page`","N001"
       ":ref:`N002_page`","N002"
+      ":ref:`NW001_page`","NW001"
+      ":ref:`NW002_page`","NW002"
+      ":ref:`NW003_page`","NW003"
+      ":ref:`NW004_page`","NW004"
+      ":ref:`NW005_page`","NW005"
 
 Build set:  :yellow:`MAX`
 ---------------------------------------------
@@ -1799,4 +1881,9 @@ Build set:  :yellow:`MAX`
       ":ref:`C018_page`","C018"
       ":ref:`N001_page`","N001"
       ":ref:`N002_page`","N002"
+      ":ref:`NW001_page`","NW001"
+      ":ref:`NW002_page`","NW002"
+      ":ref:`NW003_page`","NW003"
+      ":ref:`NW004_page`","NW004"
+      ":ref:`NW005_page`","NW005"
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -38,7 +38,7 @@ default_envs = max_ESP32_16M8M
 ;default_envs = max_ESP32c5_8M1M
 
 ;default_envs = normal_ESP32c6_4M316k_LittleFS_CDC
-; default_envs = custom_ESP8266_4M1M
+; default_envs = custom_274_ESP8266_4M1M
 
 ;default_envs = normal_ESP8266_4M1M
 ;default_envs = test_beta_ESP8266_4M1M

--- a/src/_P070_NeoPixel_Clock.ino
+++ b/src/_P070_NeoPixel_Clock.ino
@@ -4,22 +4,21 @@
 # include "src/PluginStructs/P070_data_struct.h"
 
 // #######################################################################################################
-// #################################### Plugin 070: NeoPixel ring clock #######################################
+// #################################### Plugin 070: NeoPixel ring clock #################################
 // #######################################################################################################
 
 /** Changelog:
- * 2025-01-12 tonhuisman: Add support for MQTT AutoDiscovery (not supported for Neopixel)
+ * 2024-xx-xx: Add predefined color selection for hands/marks and hourly lightshow (PCONFIG(7/8), PCONFIG_LONG(0-3))
+ * 2024-xx-xx: Add automatic brightness control via BH1750 lux sensor (PCONFIG(6))
+ * 2024-xx-xx: Add selectable LED ring mode: 60-LED (standard) or 24-LED via web interface (PCONFIG(5))
  * 2023-10-26 tonhuisman: Apply NeoPixelBus_wrapper as replacement for Adafruit_NeoPixel library
- * 2023-10 tonhuisman: Add changelog.
+ * 2023-10    tonhuisman: Add changelog.
  */
 
-
-// A clock that uses a strip/ring of 60 WS2812 NeoPixel LEDs as display for a classic clock.
-// The hours are RED, the minutes are GREEN, the seconds are BLUE and the hour marks are WHITE.
-// The brightness of the clock hands and the hour marks can be set in the device page,
-// or can be set by commands. The format is as follows:
-//	Clock,<Enabled 1/0>,<Hand brightness 0-255>,<Mark brightness 0-255>
-
+// A clock that uses a strip/ring of 60 or 24 WS2812 NeoPixel LEDs as display for a classic clock.
+// Hand/mark colors are configurable. An optional hourly colour-chase lightshow is available.
+// Brightness can be set manually or automatically via a BH1750 lux sensor (Task name: "BH1750").
+// Commands: Clock,<Enabled 1/0>,<Hand brightness 0-255>,<Mark brightness 0-255>
 
 # define PLUGIN_070
 # define PLUGIN_ID_070         70
@@ -27,6 +26,42 @@
 # define PLUGIN_VALUENAME1_070 "Enabled"
 # define PLUGIN_VALUENAME2_070 "Brightness"
 # define PLUGIN_VALUENAME3_070 "Marks"
+
+// Helper: emit a row of color radio buttons for one hand/element
+static void addColorRadioRow(const __FlashStringHelper *label,
+                             const char               *fieldName,
+                             uint8_t                   currentValue)
+{
+  const char *colorNames[] = { "Red", "Green", "Blue", "Yellow", "Cyan", "Magenta", "White" };
+  const char *colorStyles[] = {
+    "background:#e00;color:#fff",
+    "background:#0c0;color:#fff",
+    "background:#00e;color:#fff",
+    "background:#cc0;color:#000",
+    "background:#0cc;color:#000",
+    "background:#c0c;color:#fff",
+    "background:#ddd;color:#000"
+  };
+
+  addRowLabel(label);
+  String html;
+  html.reserve(512);
+
+  for (uint8_t i = 0; i < P070_COLOR_COUNT; i++) {
+    html += F("<label style='margin-right:6px;padding:2px 7px;border-radius:4px;cursor:pointer;");
+    html += colorStyles[i];
+    html += F("'><input type='radio' name='");
+    html += fieldName;
+    html += F("' value='");
+    html += String(i);
+    html += F("'");
+    if (currentValue == i) { html += F(" checked"); }
+    html += F("> ");
+    html += colorNames[i];
+    html += F("</label>");
+  }
+  addHtml(html);
+}
 
 
 boolean Plugin_070(uint8_t function, struct EventStruct *event, String& string)
@@ -37,15 +72,18 @@ boolean Plugin_070(uint8_t function, struct EventStruct *event, String& string)
   {
     case PLUGIN_DEVICE_ADD:
     {
-      auto& dev = Device[++deviceCount];
-      dev.Number     = PLUGIN_ID_070;
-      dev.Type       = DEVICE_TYPE_SINGLE;
-      dev.VType      = Sensor_VType::SENSOR_TYPE_TRIPLE;
-      dev.ValueCount = 3;
-      dev.setPin1Direction(gpio_direction::gpio_output);
-
-      // FIXME TD-er: Not sure if access to any existing task data is needed when saving
-      dev.ExitTaskBeforeSave = false;
+      Device[++deviceCount].Number           = PLUGIN_ID_070;
+      Device[deviceCount].Type               = DEVICE_TYPE_SINGLE;
+      Device[deviceCount].VType              = Sensor_VType::SENSOR_TYPE_TRIPLE;
+      Device[deviceCount].Ports              = 0;
+      Device[deviceCount].PullUpOption       = false;
+      Device[deviceCount].InverseLogicOption = false;
+      Device[deviceCount].FormulaOption      = false;
+      Device[deviceCount].ValueCount         = 3;
+      Device[deviceCount].SendDataOption     = false;
+      Device[deviceCount].TimerOption        = false;
+      Device[deviceCount].GlobalSyncOption   = false;
+      Device[deviceCount].ExitTaskBeforeSave = false;
       break;
     }
 
@@ -63,15 +101,6 @@ boolean Plugin_070(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
-    # if FEATURE_MQTT_DISCOVER
-    case PLUGIN_GET_DISCOVERY_VTYPES:
-    {
-      event->Par1 = static_cast<int>(Sensor_VType::SENSOR_TYPE_NONE); // Not yet supported
-      success     = true;
-      break;
-    }
-    # endif // if FEATURE_MQTT_DISCOVER
-
     case PLUGIN_GET_DEVICEGPIONAMES:
     {
       event->String1 = formatGpioName_output(F("LED"));
@@ -80,17 +109,89 @@ boolean Plugin_070(uint8_t function, struct EventStruct *event, String& string)
 
     case PLUGIN_WEBFORM_LOAD:
     {
-      addFormSubHeader(F("Clock configuration"));
+      // ---------------------------------------------------------------
+      // Section: Ring & display
+      // ---------------------------------------------------------------
+      addFormSubHeader(F("Ring &amp; Display"));
+
+      {
+        String radioHtml = F("<input type='radio' name='led_mode' value='0'");
+        if (PCONFIG(5) == P070_LED_MODE_60) { radioHtml += F(" checked"); }
+        radioHtml += F("> 60 LEDs&nbsp;&nbsp;&nbsp;");
+        radioHtml += F("<input type='radio' name='led_mode' value='1'");
+        if (PCONFIG(5) == P070_LED_MODE_24) { radioHtml += F(" checked"); }
+        radioHtml += F("> 24 LEDs&nbsp;&nbsp;&nbsp;");
+        radioHtml += F("<input type='radio' name='led_mode' value='2'");
+        if (PCONFIG(5) == P070_LED_MODE_16) { radioHtml += F(" checked"); }
+        radioHtml += F("> 16 LEDs&nbsp;&nbsp;&nbsp;");
+        radioHtml += F("<input type='radio' name='led_mode' value='3'");
+        if (PCONFIG(5) == P070_LED_MODE_12) { radioHtml += F(" checked"); }
+        radioHtml += F("> 12 LEDs");
+        addRowLabel(F("LED Ring size"));
+        addHtml(radioHtml);
+      }
+      addFormNote(F("Default: 60 LEDs. Changing LED ring size or type requires a reboot."));
+
+      {
+        String typeHtml = F("<input type='radio' name='led_type' value='0'");
+        if (PCONFIG(9) == P070_LED_TYPE_RGB)  { typeHtml += F(" checked"); }
+        typeHtml += F("> RGB (3-channel)&nbsp;&nbsp;&nbsp;");
+        typeHtml += F("<input type='radio' name='led_type' value='1'");
+        if (PCONFIG(9) == P070_LED_TYPE_RGBW) { typeHtml += F(" checked"); }
+        typeHtml += F("> RGBW (4-channel, dedicated white LED)");
+        addRowLabel(F("LED Strip type"));
+        addHtml(typeHtml);
+      }
+
       addFormNumericBox(F("12 o'clock LED position"), F("offset"), PCONFIG(3), 0, 59);
-      addFormNote(F("Position of the 12 o'clock LED in the strip"));
+      addFormNote(F("Position of the 12 o'clock LED (0-59 for 60-LED, 0-23 for 24-LED)"));
       addFormCheckBox(F("Thick 12 o'clock mark"), F("thick_12_mark"), PCONFIG(4));
-      addFormNote(F("Check to have 3 LEDs marking the 12 o'clock position"));
+      addFormNote(F("3 LEDs mark the 12 o'clock position"));
       addFormCheckBox(F("Clock display enabled"), F("enabled"), PCONFIG(0));
-      addFormNote(F("LED activation"));
+
+      // ---------------------------------------------------------------
+      // Section: Brightness
+      // ---------------------------------------------------------------
+      addFormSubHeader(F("Brightness"));
+
+      addFormCheckBox(F("Auto brightness (BH1750)"), F("auto_brightness"), PCONFIG(6));
+      addFormNote(F("Automatically adjust brightness via BH1750 sensor (Task name must be 'BH1750')"));
       addFormNumericBox(F("LED brightness"), F("brightness"), PCONFIG(1), 0, 255);
-      addFormNote(F("Brightness level of the H/M/S hands (0-255)"));
+      addFormNote(F("Brightness of clock hands (0-255) — used when auto brightness is off"));
       addFormNumericBox(F("Hour mark brightness"), F("marks"), PCONFIG(2), 0, 255);
-      addFormNote(F("Brightness level of the hour marks (0-255)"));
+      addFormNote(F("Brightness of hour marks (0-255) — used when auto brightness is off"));
+
+      // ---------------------------------------------------------------
+      // Section: Colors
+      // ---------------------------------------------------------------
+      addFormSubHeader(F("Hand &amp; Mark Colors"));
+
+      addColorRadioRow(F("Hours hand color"),   "color_hours",   PCONFIG_LONG(0));
+      addColorRadioRow(F("Minutes hand color"), "color_minutes", PCONFIG_LONG(1));
+      addColorRadioRow(F("Seconds hand color"), "color_seconds", PCONFIG_LONG(2));
+      addColorRadioRow(F("Hour marks color"),   "color_marks",   PCONFIG_LONG(3));
+
+      // ---------------------------------------------------------------
+      // Section: Hourly lightshow
+      // ---------------------------------------------------------------
+      addFormSubHeader(F("Hourly Lightshow"));
+
+      {
+        String lsHtml = F("<input type='radio' name='lightshow_mode' value='0'");
+        if (PCONFIG(7) == P070_LIGHTSHOW_OFF)   { lsHtml += F(" checked"); }
+        lsHtml += F("> Aus &nbsp;&nbsp;&nbsp;");
+        lsHtml += F("<input type='radio' name='lightshow_mode' value='1'");
+        if (PCONFIG(7) == P070_LIGHTSHOW_CHASE) { lsHtml += F(" checked"); }
+        lsHtml += F("> Lauflicht (Farbe zuf&auml;llig) &nbsp;&nbsp;&nbsp;");
+        lsHtml += F("<input type='radio' name='lightshow_mode' value='2'");
+        if (PCONFIG(7) == P070_LIGHTSHOW_FLASH) { lsHtml += F(" checked"); }
+        lsHtml += F("> Flash (alle LEDs + Zeiger-Blink)");
+        addRowLabel(F("Lightshow Modus"));
+        addHtml(lsHtml);
+      }
+      addFormNote(F("Lightshow startet jede volle Stunde (hh:00:00)"));
+      addFormNumericBox(F("Lightshow duration (seconds)"), F("lightshow_duration"), PCONFIG(8), 1, 30);
+      addFormNote(F("How many seconds the lightshow runs (1-30)"));
 
       success = true;
       break;
@@ -98,19 +199,35 @@ boolean Plugin_070(uint8_t function, struct EventStruct *event, String& string)
 
     case PLUGIN_WEBFORM_SAVE:
     {
+      const uint8_t new_led_mode = getFormItemInt(F("led_mode"));
+      const uint8_t new_led_type = getFormItemInt(F("led_type"));
+      const bool    mode_changed = (new_led_mode != PCONFIG(5)) || (new_led_type != PCONFIG(9));
+
       PCONFIG(0) = isFormItemChecked(F("enabled"));
       PCONFIG(1) = getFormItemInt(F("brightness"));
       PCONFIG(2) = getFormItemInt(F("marks"));
       PCONFIG(3) = getFormItemInt(F("offset"));
       PCONFIG(4) = isFormItemChecked(F("thick_12_mark"));
+      PCONFIG(5) = new_led_mode;
+      PCONFIG(6) = isFormItemChecked(F("auto_brightness"));
+      PCONFIG(7) = getFormItemInt(F("lightshow_mode"));
+      PCONFIG(8) = getFormItemInt(F("lightshow_duration"));
+      PCONFIG(9) = new_led_type;
+
+      PCONFIG_LONG(0) = getFormItemInt(F("color_hours"));
+      PCONFIG_LONG(1) = getFormItemInt(F("color_minutes"));
+      PCONFIG_LONG(2) = getFormItemInt(F("color_seconds"));
+      PCONFIG_LONG(3) = getFormItemInt(F("color_marks"));
+
       P070_data_struct *P070_data = static_cast<P070_data_struct *>(getPluginTaskData(event->TaskIndex));
 
       if (nullptr != P070_data) {
-        P070_data->display_enabled       = PCONFIG(0);
-        P070_data->brightness            = PCONFIG(1);
-        P070_data->brightness_hour_marks = PCONFIG(2);
-        P070_data->offset_12h_mark       = PCONFIG(3);
-        P070_data->thick_12_mark         = PCONFIG(4);
+        if (mode_changed) {
+          P070_data->reset();
+          P070_data->init(event);
+        } else {
+          P070_data->set(event);
+        }
         P070_data->calculateMarks();
       }
 

--- a/src/src/PluginStructs/P070_data_struct.cpp
+++ b/src/src/PluginStructs/P070_data_struct.cpp
@@ -4,26 +4,39 @@
 
 
 P070_data_struct::~P070_data_struct() {
-  delete Plugin_070_pixels;
-  Plugin_070_pixels = nullptr;
+  if (Plugin_070_pixels != nullptr) {
+    delete Plugin_070_pixels;
+    Plugin_070_pixels = nullptr;
+  }
 }
 
 void P070_data_struct::reset() {
-  delete Plugin_070_pixels;
-  Plugin_070_pixels = nullptr;
+  if (Plugin_070_pixels != nullptr) {
+    delete Plugin_070_pixels;
+    Plugin_070_pixels = nullptr;
+  }
 }
 
 void P070_data_struct::init(struct EventStruct *event) {
   if (nullptr == Plugin_070_pixels)
   {
-    Plugin_070_pixels = new (std::nothrow) NeoPixelBus_wrapper(NUMBER_LEDS, CONFIG_PIN1, NEO_GRB + NEO_KHZ800);
+    set(event);
+
+    const uint8_t neoFlags = (led_type == P070_LED_TYPE_RGBW)
+                             ? (NEO_GRBW + NEO_KHZ800)
+                             : (NEO_GRB  + NEO_KHZ800);
+
+    Plugin_070_pixels = new (std::nothrow) NeoPixelBus_wrapper(number_leds, CONFIG_PIN1, neoFlags);
 
     if (Plugin_070_pixels == nullptr) {
       return;
     }
-    Plugin_070_pixels->begin(); // This initializes the NeoPixel library.
+    Plugin_070_pixels->begin();
   }
-  set(event);
+  else
+  {
+    set(event);
+  }
 }
 
 void P070_data_struct::set(struct EventStruct *event) {
@@ -32,91 +45,329 @@ void P070_data_struct::set(struct EventStruct *event) {
   brightness_hour_marks = PCONFIG(2);
   offset_12h_mark       = PCONFIG(3);
   thick_12_mark         = PCONFIG(4);
+  led_mode              = PCONFIG(5);
+  auto_brightness       = PCONFIG(6);
+  lightshow_mode        = PCONFIG(7);
+  lightshow_duration    = PCONFIG(8);
+  led_type              = PCONFIG(9);
+
+  // Color settings stored in PCONFIG_LONG
+  color_hours   = PCONFIG_LONG(0);
+  color_minutes = PCONFIG_LONG(1);
+  color_seconds = PCONFIG_LONG(2);
+  color_marks   = PCONFIG_LONG(3);
+
+  // Clamp colors to valid range
+  if (color_hours   >= P070_COLOR_COUNT) { color_hours   = P070_COLOR_RED;   }
+  if (color_minutes >= P070_COLOR_COUNT) { color_minutes = P070_COLOR_GREEN; }
+  if (color_seconds >= P070_COLOR_COUNT) { color_seconds = P070_COLOR_BLUE;  }
+  if (color_marks   >= P070_COLOR_COUNT) { color_marks   = P070_COLOR_WHITE; }
+
+  // Clamp lightshow duration
+  if (lightshow_duration < 1)  { lightshow_duration = 1;  }
+  if (lightshow_duration > 30) { lightshow_duration = 30; }
+
+  // Set actual LED count based on selected mode
+  switch (led_mode) {
+    case P070_LED_MODE_24: number_leds = NUMBER_LEDS_24; break;
+    case P070_LED_MODE_16: number_leds = NUMBER_LEDS_16; break;
+    case P070_LED_MODE_12: number_leds = NUMBER_LEDS_12; break;
+    default:               number_leds = NUMBER_LEDS_60; break; // P070_LED_MODE_60
+  }
 }
+
+// ---------------------------------------------------------------------------
+// Color helpers
+// ---------------------------------------------------------------------------
+
+void P070_data_struct::colorFromIndex(uint8_t colorIndex, uint8_t bright, uint8_t &r, uint8_t &g, uint8_t &b) {
+  r = 0; g = 0; b = 0;
+  switch (colorIndex) {
+    case P070_COLOR_RED:     r = bright;                         break;
+    case P070_COLOR_GREEN:   g = bright;                         break;
+    case P070_COLOR_BLUE:    b = bright;                         break;
+    case P070_COLOR_YELLOW:  r = bright; g = bright;             break;
+    case P070_COLOR_CYAN:    g = bright; b = bright;             break;
+    case P070_COLOR_MAGENTA: r = bright; b = bright;             break;
+    case P070_COLOR_WHITE:   r = bright; g = bright; b = bright; break;
+    default:                 r = bright;                         break;
+  }
+}
+
+// Sets a pixel respecting RGB vs RGBW mode.
+// For RGBW: WHITE color uses the dedicated W channel for a pure white.
+// All other colors use RGB channels with W=0.
+void P070_data_struct::setPixel(uint16_t pos, uint8_t r, uint8_t g, uint8_t b) {
+  if (led_type == P070_LED_TYPE_RGBW) {
+    // If all channels equal → pure white via W channel
+    if (r == g && g == b) {
+      Plugin_070_pixels->setPixelColor(pos, Plugin_070_pixels->Color(0, 0, 0, r));
+    } else {
+      Plugin_070_pixels->setPixelColor(pos, Plugin_070_pixels->Color(r, g, b, 0));
+    }
+  } else {
+    Plugin_070_pixels->setPixelColor(pos, Plugin_070_pixels->Color(r, g, b));
+  }
+}
+
+
+
+uint8_t P070_data_struct::luxToBrightness(float lux) {
+  if (lux >= 1000.0f) { return 255; } // Sehr hell
+  if (lux >= 500.0f)  { return 128; } // Hell
+  if (lux >= 100.0f)  { return 100; } // Flurbeleuchtung
+  if (lux >= 50.0f)   { return  64; } // Dunkel
+  return 32;                           // Sehr dunkel (0..49 lux)
+}
+
+void P070_data_struct::applyAutoBrightness() {
+  if (!auto_brightness) { return; }
+
+  for (taskIndex_t i = 0; i < TASKS_MAX; i++) {
+    if (Settings.TaskDeviceEnabled[i]) {
+      LoadTaskSettings(i);
+      if (String(ExtraTaskSettings.TaskDeviceName).equalsIgnoreCase(F(P070_LUX_TASK_NAME))) {
+        const float   lux            = UserVar.getFloat(i, 0);
+        const uint8_t new_brightness = luxToBrightness(lux);
+        brightness            = new_brightness;
+        brightness_hour_marks = new_brightness;
+        return;
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hourly lightshow
+// ---------------------------------------------------------------------------
+
+void P070_data_struct::runLightshow() {
+  if (lightshow_mode == P070_LIGHTSHOW_OFF) { return; }
+
+  const int sec = node_time.second();
+  const int min = node_time.minute();
+
+  // --- Start condition: exactly at hh:00:00 ---
+  if (min == 0 && sec == 0) {
+    lightshow_running     = true;
+    lightshow_step        = 0;
+    lightshow_flash_phase = 0;
+    // Pick a random color (avoid repeating the same one)
+    uint8_t newColor;
+    do {
+      newColor = (uint8_t)(random(P070_COLOR_COUNT));
+    } while (newColor == lightshow_color && P070_COLOR_COUNT > 1);
+    lightshow_color = newColor;
+  }
+
+  // --- Stop condition ---
+  if (lightshow_running && sec >= lightshow_duration) {
+    lightshow_running = false;
+    lightshow_step    = 0;
+    lightshow_flash_phase = 0;
+  }
+
+  if (!lightshow_running) { return; }
+
+  const uint8_t bright = brightness > 0 ? brightness : 128;
+
+  // -----------------------------------------------------------------------
+  // Mode 1: Colour-chase (Lauflicht)
+  // -----------------------------------------------------------------------
+  if (lightshow_mode == P070_LIGHTSHOW_CHASE) {
+    clearClock();
+
+    const uint8_t trail = 3;
+    for (uint8_t t = 0; t <= trail; t++) {
+      int pos = (int)lightshow_step - (int)t;
+      if (pos < 0) { pos += number_leds; }
+      pos = pos % number_leds;
+
+      uint8_t fade = bright >> t; // each trail LED half as bright
+      uint8_t r, g, b;
+      colorFromIndex(lightshow_color, fade, r, g, b);
+      setPixel(pos, r, g, b);
+    }
+
+    Plugin_070_pixels->show();
+    lightshow_step = (lightshow_step + (number_leds / lightshow_duration) + 1) % number_leds;
+    return;
+  }
+
+  // -----------------------------------------------------------------------
+  // Mode 2: Flash — all LEDs white, then hand blink, repeating
+  // Each "flash cycle" = 2 seconds: sec 0 flash-on, sec 1 flash-off+hands
+  // -----------------------------------------------------------------------
+  if (lightshow_mode == P070_LIGHTSHOW_FLASH) {
+    const uint8_t cycle = sec % 2; // 0 = flash all, 1 = show hands briefly
+
+    if (cycle == 0) {
+      // All LEDs on in the chosen random color
+      uint8_t r, g, b;
+      colorFromIndex(lightshow_color, bright, r, g, b);
+      for (int i = 0; i < number_leds; i++) {
+        setPixel(i, r, g, b);
+      }
+      Plugin_070_pixels->show();
+    }
+    else {
+      // Show clock hands briefly then clear (hand blink)
+      clearClock();
+
+      int hours   = node_time.hour();
+      int minutes = node_time.minute();
+      int seconds = node_time.second();
+      if (hours > 11) { hours -= 12; }
+
+      const float scale = (float)number_leds / 60.0f;
+      int hpos = (int)((hours * 5 + minutes / 12) * scale + 0.5f) + offset_12h_mark;
+      hpos = ((hpos % number_leds) + number_leds) % number_leds;
+      int mpos = (int)(minutes * scale + 0.5f) + offset_12h_mark;
+      mpos = ((mpos % number_leds) + number_leds) % number_leds;
+      int spos = (int)(seconds * scale + 0.5f) + offset_12h_mark;
+      spos = ((spos % number_leds) + number_leds) % number_leds;
+
+      // Hour hand: 3 LEDs wide (cyan)
+      uint8_t r, g, b;
+      colorFromIndex(P070_COLOR_CYAN, bright, r, g, b);
+      setPixel(hpos % number_leds,                     r, g, b);
+      setPixel((hpos + 1) % number_leds,               r, g, b);
+      setPixel((hpos - 1 + number_leds) % number_leds, r, g, b);
+
+      // Minute hand: magenta
+      colorFromIndex(P070_COLOR_MAGENTA, bright, r, g, b);
+      setPixel(mpos % number_leds, r, g, b);
+
+      // Second hand: yellow
+      colorFromIndex(P070_COLOR_YELLOW, bright, r, g, b);
+      setPixel(spos % number_leds, r, g, b);
+
+      Plugin_070_pixels->show();
+    }
+    return;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main clock update
+// ---------------------------------------------------------------------------
 
 void P070_data_struct::Clock_update()
 {
-  clearClock();              // turn off the LEDs
+  applyAutoBrightness();
 
-  if (display_enabled > 0) { // if the display is enabled, calculate the LEDs to turn on
-    const int Hours   = node_time.hour();
-    const int Minutes = node_time.minute();
-    const int Seconds = node_time.second();
+  // If lightshow is active, runLightshow() handles drawing and show()
+  if (lightshow_mode != P070_LIGHTSHOW_OFF) {
+    runLightshow();
+    if (lightshow_running) { return; }
+  }
+
+  clearClock();
+
+  if (display_enabled > 0) {
+    int Hours   = node_time.hour();
+    int Minutes = node_time.minute();
+    int Seconds = node_time.second();
     timeToStrip(Hours, Minutes, Seconds);
   }
-  Plugin_070_pixels->show(); // This sends the updated pixel color to the hardware.
+  Plugin_070_pixels->show();
 }
 
+// ---------------------------------------------------------------------------
+// Hour marks
+// ---------------------------------------------------------------------------
+
 void P070_data_struct::calculateMarks()
-{ // generate a list of the LEDs that have hour marks
-  for (int i = 0; i < 12; ++i) {
-    marks[i] = 5 * i + (offset_12h_mark % 5);
+{
+  // For each mode: 12 hour marks evenly distributed, plus optional thick 12h mark
+  // number of LEDs per hour-mark interval: total / 12
+  const uint8_t step = number_leds / 12; // 60→5, 24→2, 16→1 (rounded), 12→1
+
+  for (int i = 0; i < 12; i++) {
+    marks[i] = (step * i + offset_12h_mark) % number_leds;
   }
 
-  if (thick_12_mark) {
-    if (offset_12h_mark == 0) {
-      marks[12] = 1;
-      marks[13] = 59;
-    }
-    else if (offset_12h_mark == 59) {
-      marks[12] = 0;
-      marks[13] = 58;
-    }
-    else {
-      marks[12] = offset_12h_mark + 1;
-      marks[13] = offset_12h_mark - 1;
-    }
-  }
-  else {
+  if (thick_12_mark && step >= 2) {
+    // Only add neighbours when there is room (step >= 2)
+    marks[12] = (offset_12h_mark + 1) % number_leds;
+    marks[13] = (offset_12h_mark + number_leds - 1) % number_leds;
+  } else {
     marks[12] = 255;
     marks[13] = 255;
   }
 }
 
+// ---------------------------------------------------------------------------
+// Clear
+// ---------------------------------------------------------------------------
+
 void P070_data_struct::clearClock() {
-  for (int i = 0; i < NUMBER_LEDS; ++i) {
-    Plugin_070_pixels->setPixelColor(i, Plugin_070_pixels->Color(0, 0, 0));
+  for (int i = 0; i < number_leds; i++) {
+    if (led_type == P070_LED_TYPE_RGBW) {
+      Plugin_070_pixels->setPixelColor(i, Plugin_070_pixels->Color(0, 0, 0, 0));
+    } else {
+      Plugin_070_pixels->setPixelColor(i, Plugin_070_pixels->Color(0, 0, 0));
+    }
   }
 }
 
+// ---------------------------------------------------------------------------
+// Draw clock hands
+// ---------------------------------------------------------------------------
+
 void P070_data_struct::timeToStrip(int hours, int minutes, int seconds) {
   if (hours > 11) { hours = hours - 12; }
-  hours = (hours * 5) + (minutes / 12) + offset_12h_mark; // make the hour hand move each 12 minutes and apply the offset
 
-  if (hours > 59) { hours = hours - 60; }
-  minutes = minutes + offset_12h_mark;                    // apply offset to minutes
+  // Scale factor: how many LEDs per full rotation
+  const float scale = (float)number_leds / 60.0f; // 60→1.0, 24→0.4, 16→0.267, 12→0.2
 
-  if (minutes > 59) { minutes = minutes - 60; }
-  seconds = seconds + offset_12h_mark;                    // apply offset to seconds
+  // Hours: 12h * 5 positions = 60 base units, moves 1 unit per 12 min
+  int hpos = (int)((hours * 5 + minutes / 12) * scale + 0.5f) + offset_12h_mark;
+  hpos = ((hpos % number_leds) + number_leds) % number_leds;
 
-  if (seconds > 59) { seconds = seconds - 60; }
+  // Minutes: 60 base units
+  int mpos = (int)(minutes * scale + 0.5f) + offset_12h_mark;
+  mpos = ((mpos % number_leds) + number_leds) % number_leds;
 
-  for (int i = 0; i < 14; ++i) {                                                                      // set the hour marks as white;
-    if ((marks[i] != hours) && (marks[i] != minutes) && (marks[i] != seconds) && (marks[i] != 255)) { // do not draw a mark there is a clock
-                                                                                                      // hand in that position
-      Plugin_070_pixels->setPixelColor(marks[i],
-                                       Plugin_070_pixels->Color(brightness_hour_marks, brightness_hour_marks, brightness_hour_marks));
+  // Seconds: 60 base units
+  int spos = (int)(seconds * scale + 0.5f) + offset_12h_mark;
+  spos = ((spos % number_leds) + number_leds) % number_leds;
+
+  // Draw hour marks
+  uint8_t mr, mg, mb;
+  colorFromIndex(color_marks, brightness_hour_marks, mr, mg, mb);
+
+  for (int i = 0; i < 14; i++) {
+    if ((marks[i] != (uint8_t)hpos) && (marks[i] != (uint8_t)mpos) &&
+        (marks[i] != (uint8_t)spos) && (marks[i] != 255)) {
+      setPixel(marks[i], mr, mg, mb);
     }
   }
+
+  // Draw clock hands — blend colors when hands overlap
+  uint8_t r, g, b;
   uint32_t currentColor;
-  uint8_t  r_val, g_val;                  // , b_val;
 
-  for (int i = 0; i < NUMBER_LEDS; ++i) { // draw the clock hands, adding the colors together
-    if (i == hours) {                     // hours hand is RED
-      Plugin_070_pixels->setPixelColor(i, Plugin_070_pixels->Color(brightness, 0, 0));
+  for (int i = 0; i < number_leds; i++) {
+    if (i == hpos) {
+      colorFromIndex(color_hours, brightness, r, g, b);
+      setPixel(i, r, g, b);
     }
-
-    if (i == minutes) { // minutes hand is GREEN
+    if (i == mpos) {
       currentColor = Plugin_070_pixels->getPixelColor(i);
-      r_val        = (uint8_t)(currentColor >> 16);
-      Plugin_070_pixels->setPixelColor(i, Plugin_070_pixels->Color(r_val, brightness, 0));
+      uint8_t er = (uint8_t)(currentColor >> 16);
+      uint8_t eg = (uint8_t)(currentColor >>  8);
+      uint8_t eb = (uint8_t)(currentColor);
+      colorFromIndex(color_minutes, brightness, r, g, b);
+      setPixel(i, er | r, eg | g, eb | b);
     }
-
-    if (i == seconds) { // seconds hand is BLUE
+    if (i == spos) {
       currentColor = Plugin_070_pixels->getPixelColor(i);
-      r_val        = (uint8_t)(currentColor >> 16);
-      g_val        = (uint8_t)(currentColor >>  8);
-      Plugin_070_pixels->setPixelColor(i, Plugin_070_pixels->Color(r_val, g_val, brightness));
+      uint8_t er = (uint8_t)(currentColor >> 16);
+      uint8_t eg = (uint8_t)(currentColor >>  8);
+      uint8_t eb = (uint8_t)(currentColor);
+      colorFromIndex(color_seconds, brightness, r, g, b);
+      setPixel(i, er | r, eg | g, eb | b);
     }
   }
 }

--- a/src/src/PluginStructs/P070_data_struct.h
+++ b/src/src/PluginStructs/P070_data_struct.h
@@ -5,10 +5,40 @@
 #ifdef USES_P070
 
 
-# include <NeoPixelBus_wrapper.h>
+#include <NeoPixelBus_wrapper.h>
 
 
-# define NUMBER_LEDS      60 // number of LED in the strip
+# define NUMBER_LEDS_60   60  // number of LEDs for 60-LED ring
+# define NUMBER_LEDS_24   24  // number of LEDs for 24-LED ring
+# define NUMBER_LEDS_16   16  // number of LEDs for 16-LED ring
+# define NUMBER_LEDS_12   12  // number of LEDs for 12-LED ring
+
+# define P070_LED_MODE_60  0  // Selector value for 60-LED mode
+# define P070_LED_MODE_24  1  // Selector value for 24-LED mode
+# define P070_LED_MODE_16  2  // Selector value for 16-LED mode
+# define P070_LED_MODE_12  3  // Selector value for 12-LED mode
+
+// Task name of the BH1750 lux sensor (P010), used for auto brightness
+# define P070_LUX_TASK_NAME  "BH1750"
+
+// LED strip type
+# define P070_LED_TYPE_RGB   0  // RGB  LEDs (3 channel)
+# define P070_LED_TYPE_RGBW  1  // RGBW LEDs (4 channel, dedicated white)
+
+// Lightshow modes
+# define P070_LIGHTSHOW_OFF    0  // no lightshow
+# define P070_LIGHTSHOW_CHASE  1  // colour-chase / Lauflicht
+# define P070_LIGHTSHOW_FLASH  2  // all-LED flash + hand blink
+
+// Predefined color indices
+# define P070_COLOR_RED      0
+# define P070_COLOR_GREEN    1
+# define P070_COLOR_BLUE     2
+# define P070_COLOR_YELLOW   3
+# define P070_COLOR_CYAN     4
+# define P070_COLOR_MAGENTA  5
+# define P070_COLOR_WHITE    6
+# define P070_COLOR_COUNT    7
 
 struct P070_data_struct : public PluginTaskData_base {
   P070_data_struct() = default;
@@ -21,7 +51,6 @@ struct P070_data_struct : public PluginTaskData_base {
 
   void set(struct EventStruct *event);
 
-
   void Clock_update();
 
   void calculateMarks();
@@ -32,12 +61,46 @@ struct P070_data_struct : public PluginTaskData_base {
                    int minutes,
                    int seconds);
 
-  bool    display_enabled       = false; // used to enable/disable the display.
-  uint8_t brightness            = 0;     // brightness of the clock "hands"
-  uint8_t brightness_hour_marks = 0;     // brightness of the hour marks
-  uint8_t offset_12h_mark       = 0;     // position of the 12 o'clock LED on the strip
-  bool    thick_12_mark         = false; // thicker marking of the 12h position
-  uint8_t marks[14]             = { 0 }; // Positions of the hour marks and dials
+  // Returns a brightness value (32..255) based on lux level
+  uint8_t luxToBrightness(float lux);
+
+  // Reads lux from BH1750 task and updates brightness when auto_brightness is active
+  void applyAutoBrightness();
+
+  // Fills r,g,b with the color for colorIndex scaled by bright
+  void colorFromIndex(uint8_t colorIndex, uint8_t bright, uint8_t &r, uint8_t &g, uint8_t &b);
+
+  // Sets a pixel color, using W channel for white if RGBW mode
+  void setPixel(uint16_t pos, uint8_t r, uint8_t g, uint8_t b);
+
+  // Runs one step of the hourly lightshow; called once per second
+  void runLightshow();
+
+  bool    display_enabled       = false;            // used to enable/disable the display
+  uint8_t brightness            = 0;                // brightness of the clock "hands"
+  uint8_t brightness_hour_marks = 0;                // brightness of the hour marks
+  uint8_t offset_12h_mark       = 0;                // position of the 12 o'clock LED on the strip
+  bool    thick_12_mark         = false;            // thicker marking of the 12h position
+  uint8_t led_mode              = P070_LED_MODE_60; // 0 = 60 LEDs, 1 = 24 LEDs
+  uint8_t led_type              = P070_LED_TYPE_RGB; // 0 = RGB, 1 = RGBW
+  uint8_t number_leds           = NUMBER_LEDS_60;   // actual LED count based on mode
+  bool    auto_brightness       = false;            // automatic brightness control via BH1750
+
+  // Hand / mark colors (use P070_COLOR_* indices)
+  uint8_t color_hours           = P070_COLOR_RED;
+  uint8_t color_minutes         = P070_COLOR_GREEN;
+  uint8_t color_seconds         = P070_COLOR_BLUE;
+  uint8_t color_marks           = P070_COLOR_WHITE;
+
+  // Hourly lightshow
+  uint8_t lightshow_mode        = P070_LIGHTSHOW_OFF; // 0=off, 1=chase, 2=flash
+  uint8_t lightshow_duration    = 5;                  // duration in seconds (1-30)
+  uint8_t lightshow_color       = P070_COLOR_RED;     // random color chosen at start of show
+  bool    lightshow_running     = false;              // true while show is active
+  uint8_t lightshow_step        = 0;                  // current LED position in chase
+  uint8_t lightshow_flash_phase = 0;                  // sub-phase counter for flash show
+
+  uint8_t marks[14]             = { 0 };          // positions of the hour marks
 
   NeoPixelBus_wrapper *Plugin_070_pixels = nullptr;
 };

--- a/tools/pio/pre_custom_esp32.py
+++ b/tools/pio/pre_custom_esp32.py
@@ -28,6 +28,7 @@ else:
     "-DUSES_P002",  # ADC
     "-DUSES_P003",  # Generic pulse counter
     "-DUSES_P004",  # Dallas DS18b20
+    "-DUSES_P010",  # Light/Lux - BH1750
     "-DUSES_P026",  # System info
     "-DUSES_P027",  # INA219
     "-DUSES_P028",  # BME280
@@ -40,6 +41,7 @@ else:
     "-DUSES_P052",  # SenseAir
     "-DUSES_P056",  # SDS011-Dust
     "-DUSES_P059",  # Encoder
+    "-DUSES_P070",  # Neopixel Clock
     "-DUSES_P080",  # Dallas iButton
     "-DUSES_P081",  # Cron
     "-DUSES_P082",  # GPS

--- a/tools/pio/pre_custom_esp82xx.py
+++ b/tools/pio/pre_custom_esp82xx.py
@@ -29,17 +29,20 @@ else:
     "-DUSES_P002",  # ADC
     "-DUSES_P003",  # Generic Pulse Counter
     "-DUSES_P004",  # Dallas DS18b20
+    "-DUSES_P010",  # Light/Lux - BH1750
     "-DUSES_P026",  # System info
     "-DUSES_P027",  # INA219
     "-DUSES_P028",  # BME280
     "-DUSES_P033",  # Dummy
     "-DUSES_P036",  # FrameOLED
     "-DUSES_P037",  # MQTT Import
+    "-DUSES_P038",  # Neopixel
     "-DUSES_P045",  # MPU6050
     "-DUSES_P049",  # MHZ19
     "-DUSES_P052",  # SenseAir
     "-DUSES_P056",  # SDS011-Dust
 #    "-DUSES_P059",  # Encoder
+    "-DUSES_P070",  # Neopixel Clock
 #    "-DUSES_P080",  # Dallas iButton
     "-DUSES_P081",  # Cron
     "-DUSES_P082",  # GPS
@@ -51,7 +54,7 @@ else:
 #   "-DUSES_P095",  # TFT ILI9341
 #    "-DUSES_P106",  # BME680
 #    "-DUSES_P107",  # SI1145 UV index
-
+#    "-DUSES_P131",  # NeoPixel Matrix
     "-DUSES_P146",  # Cache Reader
 #    "-DUSES_P169",  # AS3935 Lightning Detector 
 


### PR DESCRIPTION
- Improved NeoPixel Clock plugin with new features:
  - Added predefined color selection for hands/marks and hourly lightshow.
  - Implemented automatic brightness control via BH1750 lux sensor.
  - Introduced selectable LED ring mode: 60-LED (standard) and 16/12/24-LED.
- Refactored P070_data_struct to manage new configurations and features:
  - Added support for RGBW LEDs and various lightshow modes.
  - Implemented auto brightness adjustment based on lux readings.
  - Enhanced clock update logic to include lightshow functionality.
- Updated web interface for configuration options related to LED modes, brightness, colors, and lightshow settings.
