### PR TITLE
[Bugfix] [I2C] Connection-check failure didn't correctly disable the plugin

### DIFF
--- a/src/src/Helpers/I2C_access.cpp
+++ b/src/src/Helpers/I2C_access.cpp
@@ -484,10 +484,14 @@ bool I2C_deviceCheck(uint8_t     i2caddr,
       if (maxRetries > 0) {
         deviceCheckI2C[taskIndex]++;
 
+        // If the number of retries is reached, disable the device
         if (deviceCheckI2C[taskIndex] >= maxRetries) {
           // Disable temporarily as device check failed
           // FIXME TD-er: Should reschedule call to PLUGIN_INIT????
-          Settings.TaskDeviceEnabled[taskIndex] = false; // If the number of retries is reached, disable the device
+          struct EventStruct TempEvent(taskIndex);
+          String dummy;
+
+          PluginCall(PLUGIN_EXIT, &TempEvent, dummy);
           # ifndef BUILD_NO_DEBUG
           addLog(LOG_LEVEL_ERROR, concat(F("I2C  : Device doesn't respond for task: "), static_cast<int>(taskIndex + 1)));
           # endif // ifndef BUILD_NO_DEBUG


### PR DESCRIPTION
Bugfix:

- I2C Connection check on failure didn't correctly disable the plugin, so it couldn't be re-enabled again after a failure