### PR TITLE
[Build] Add C5 4MB Custom, 16MB MAX and 32 MB MAX32 and P4 32MB MAX32 builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ collection_F | Normal + plugin collection F              | Stable + Collection b
 collection_G | Normal + plugin collection G              | Stable + Collection base + set G |
 collection_H | Normal + plugin collection H              | Stable + Collection base + set H |
 max          | All available plugins                     | All available                    |
+max32        | All available plugins, 32MB Flash         | All available, large file system |
 energy       | All plugins related to energy measurement | Stable + Energy measurement      |
 display A    | All plugins related to displays A         | Stable + Displays A              |
 display B    | All plugins related to displays B         | Stable + Displays B              |
@@ -101,6 +102,10 @@ ESP32c3          | Espressif ESP32-C3 generic boards           |
 ESP32s3          | Espressif ESP32-S3 generic boards           |
 ESP32c2          | Espressif ESP32-C2 generic boards           |
 ESP32c6          | Espressif ESP32-C6 generic boards           |
+ESP32c61         | Espressif ESP32-C61 generic boards (experimental) |
+ESP32c5          | Espressif ESP32-C5 generic boards (experimental) |
+ESP32p4          | Espressif ESP32-P4 (Rev.1) generic boards   |
+ESP32p4r3        | Espressif ESP32-P4 (Rev.3/P4X) generic boards |
 ESP32-wrover-kit | Espressif ESP32 wrover-kit boards           |
 SONOFF           | Sonoff hardware specific                    |
 other_POW        | Switch with power measurement               |
@@ -124,10 +129,10 @@ Flash size | Description                 |
 16M        | 16 MB with 14 MB filesystem |
 4M316k     | 4 MB with 316 kB filesystem |
 8M1M       | 8 MB with 1 MB filesystem   |
-16M1M      | 16 MB with 1 MB filesystem  |
 16M8M      | 16 MB with 8 MB filesystem  |
+32M20M     | 32 MB with 20 MB filesystem |
 
-N.B. Starting with release 2023/12/25, All ESP32 LittleFS builds use IDF 5.3, to support newer ESP32 chips like ESP32-C2 and ESP32-C6, and SPI Ethernet. Other SPIFFS based ESP32 builds will be migrated to LittleFS as SPIFFS is no longer officially available in IDF 5 and later. As a temporary solution, a specially crafted IDF 5.1 build that still includes SPIFFS, is used for the SPIFFS builds. A migration plan will be made available in 2025.
+N.B. Starting with release 2023/12/25, All ESP32 LittleFS builds use IDF 5.3, to support newer ESP32 chips like ESP32-C2 and ESP32-C6, and SPI Ethernet. Other SPIFFS based ESP32 builds will be migrated to LittleFS as SPIFFS is no longer officially available in IDF 5 and later. As a temporary solution, a specially crafted IDF 5.1 build that still includes SPIFFS, is used for the SPIFFS builds. A migration plan is available, [here](https://espeasy.readthedocs.io/en/latest/Reference/Migrate_SPIFFS_to_LittleFS.html).
 
 N.B.2 Starting with builds made after 2025/11/04, ESP32 builds will no longer have ``_LittleFS`` in the name as all ESP32 builds use LittleFS. Also the suffix ``_ETH`` has been removed since all builds will have Ethernet support, except for ESP32C2 builds.
 
@@ -142,7 +147,7 @@ Domoticz_MQTT   | Only Domoticz controllers (MQTT) and plugins included         
 FHEM_HA         | Only FHEM/OpenHAB/Home Assistant (MQTT) controllers and plugins included                                  |
 ETH             | Ethernet support enabled (ESP32 and IDF 5.x based builds)                                                 |
 OPI_PSRAM       | Specific configuration to enable PSRAM detection, ESP32-S3 only                                           |
-CDC             | Support USBCDC/HWCDC-serial console on ESP32-C3, ESP32-S2, ESP32-S3 and ESP32-C6                          |
+CDC             | Support USBCDC/HWCDC-serial console on ESP32-C3, ESP32-S2, ESP32-S3, ESP32-C6, ESP32-C61 and ESP32-C5     |
 noOTA/NO_OTA    | Does not support OTA (Over The Air-updating of the firmware) Use [the flash page](https://td-er.nl/ESPEasy/) or ESPTool via USB Serial |
 
 N.B. Starting ca. 2025/02/27, many ESP32 builds are *only* available with _ETH suffix, indicating that Ethernet support is enabled, to reduce the (rather high) number of builds.
@@ -150,18 +155,17 @@ N.B. Starting ca. 2025/02/27, many ESP32 builds are *only* available with _ETH s
 Some example firmware names:
 Firmware name                                           | Hardware                                        | Included plugins                 |
 --------------------------------------------------------|-------------------------------------------------|----------------------------------|
-ESPEasy_mega-20230822_normal_ESP8266_1M.bin             | ESP8266/ESP8285 with 1MB flash                  | Stable                           |
-ESPEasy_mega-20230822_normal_ESP8266_4M1M.bin           | ESP8266 with 4MB flash                          | Stable                           |
-ESPEasy_mega-20230822_collection_A_ESP8266_4M1M.bin     | ESP8266 with 4MB flash                          | Stable + Collection base + set A |
-ESPEasy_mega-20230822_normal_ESP32_4M316k_ETH.bin       | ESP32 with 4MB flash                            | Stable                           |
-ESPEasy_mega-20230822_collection_A_ESP32_4M316k_ETH.bin | ESP32 with 4MB flash                            | Stable + Collection base + set A |
-ESPEasy_mega-20230822_collection_B_ESP32_4M316k_ETH.bin | ESP32 with 4MB flash                            | Stable + Collection base + set B |
-ESPEasy_mega-20230822_max_ESP32s3_8M1M.bin              | ESP32-S3 with 8MB flash, CDC-serial, Ethernet   | All available plugins            |
-ESPEasy_mega-20230822_max_ESP32s3_8M1M_OPI_PSRAM.bin    | ESP32-S3 8MB flash, PSRAM, CDC-serial, Ethernet | All available plugins            |
-ESPEasy_mega-20230822_max_ESP32_16M1M_ETH.bin           | ESP32 with 16MB flash, SPIFFS, Ethernet         | All available plugins            |
-ESPEasy_mega-20230822_max_ESP32_16M8M.bin               | ESP32 with 16MB flash, LittleFS, Ethernet       | All available plugins            |
+ESPEasy_mega-20260121_normal_ESP8266_1M.bin             | ESP8266/ESP8285 with 1MB flash                  | Stable                           |
+ESPEasy_mega-20260121_normal_ESP8266_4M1M.bin           | ESP8266 with 4MB flash                          | Stable                           |
+ESPEasy_mega-20260121_collection_A_ESP8266_4M1M.bin     | ESP8266 with 4MB flash                          | Stable + Collection base + set A |
+ESPEasy_mega-20260121_normal_ESP32_4M316k.bin           | ESP32 with 4MB flash                            | Stable                           |
+ESPEasy_mega-20260121_collection_A_ESP32_4M316k.bin     | ESP32 with 4MB flash                            | Stable + Collection base + set A |
+ESPEasy_mega-20260121_collection_B_ESP32_4M316k.bin     | ESP32 with 4MB flash                            | Stable + Collection base + set B |
+ESPEasy_mega-20260121_max_ESP32s3_8M1M.bin              | ESP32-S3 with 8MB flash, CDC-serial, Ethernet   | All available plugins            |
+ESPEasy_mega-20260121_max_ESP32s3_8M1M_OPI_PSRAM.bin    | ESP32-S3 8MB flash, PSRAM, CDC-serial, Ethernet | All available plugins            |
+ESPEasy_mega-20260121_max_ESP32_16M8M.bin               | ESP32 with 16MB flash, LittleFS, Ethernet       | All available plugins            |
 
-The binary files for the different ESP32 variants (S2, C3, S3, C2, C6, Solo1, 'Classic') are available in separate archives.
+The binary files for the different ESP32 variants (S2, C3, S3, C2, C6/C61, C5, P4, Solo1, 'Classic') are available in separate archives.
 
 To see what plugins are included in which collection set, you can find that on the [ESPEasy Plugin overview page](https://espeasy.readthedocs.io/en/latest/Plugin/_Plugin.html)
 

--- a/boards/esp32c5cdc-16M.json
+++ b/boards/esp32c5cdc-16M.json
@@ -1,0 +1,40 @@
+{
+    "build": {
+      "arduino":{
+        "ldscript": "esp32c5_out.ld"
+      },
+      "core": "esp32",
+      "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=1 -DUSE_USB_CDC_CONSOLE -DESP32_16M -DESP32C5 -DARDUINO_USB_CDC_ON_BOOT=0",
+      "f_cpu": "160000000L",
+      "f_flash": "80000000L",
+      "flash_mode": "qio",
+      "mcu": "esp32c5",
+      "variant": "esp32c5",
+      "partitions": "boards/partitions/esp32_partition_app4096k_spiffs8124k.csv"
+    },
+    "connectivity": [
+      "wifi",
+      "bluetooth"
+    ],
+    "debug": {
+      "default_tool": "esp-builtin",
+      "onboard_tools": [
+        "esp-builtin"
+      ],
+      "openocd_target": "esp32c5.cfg"
+    },
+    "frameworks": [
+      "arduino",
+      "espidf"
+    ],
+    "name": "Espressif Generic ESP32-C5 16M Flash, ESPEasy 4096k Code/OTA 8M FS",
+    "upload": {
+      "flash_size": "16MB",
+      "maximum_ram_size": 327680,
+      "maximum_size": 16777216,
+      "require_upload_port": true,
+      "speed": 460800
+    },
+    "url": "https://docs.espressif.com/projects/espressif-esp-dev-kits/en/latest/esp32c5/esp32-c5-devkitc-1/index.html",
+    "vendor": "Espressif"
+  }

--- a/boards/esp32c5cdc-32M.json
+++ b/boards/esp32c5cdc-32M.json
@@ -27,9 +27,9 @@
       "arduino",
       "espidf"
     ],
-    "name": "Espressif Generic ESP32-C5 16M Flash, ESPEasy 6144k Code/OTA 20M FS",
+    "name": "Espressif Generic ESP32-C5 32M Flash, ESPEasy 6144k Code/OTA 20M FS",
     "upload": {
-      "flash_size": "16MB",
+      "flash_size": "32MB",
       "maximum_ram_size": 327680,
       "maximum_size": 33554432,
       "require_upload_port": true,

--- a/boards/esp32c5cdc-32M.json
+++ b/boards/esp32c5cdc-32M.json
@@ -1,0 +1,40 @@
+{
+    "build": {
+      "arduino":{
+        "ldscript": "esp32c5_out.ld"
+      },
+      "core": "esp32",
+      "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=1 -DUSE_USB_CDC_CONSOLE -DESP32_32M -DESP32C5 -DARDUINO_USB_CDC_ON_BOOT=0",
+      "f_cpu": "160000000L",
+      "f_flash": "80000000L",
+      "flash_mode": "qio",
+      "mcu": "esp32c5",
+      "variant": "esp32c5",
+      "partitions": "boards/partitions/esp32_partition_app6144k_spiffs20412k.csv"
+    },
+    "connectivity": [
+      "wifi",
+      "bluetooth"
+    ],
+    "debug": {
+      "default_tool": "esp-builtin",
+      "onboard_tools": [
+        "esp-builtin"
+      ],
+      "openocd_target": "esp32c5.cfg"
+    },
+    "frameworks": [
+      "arduino",
+      "espidf"
+    ],
+    "name": "Espressif Generic ESP32-C5 16M Flash, ESPEasy 6144k Code/OTA 20M FS",
+    "upload": {
+      "flash_size": "16MB",
+      "maximum_ram_size": 327680,
+      "maximum_size": 33554432,
+      "require_upload_port": true,
+      "speed": 460800
+    },
+    "url": "https://docs.espressif.com/projects/espressif-esp-dev-kits/en/latest/esp32c5/esp32-c5-devkitc-1/index.html",
+    "vendor": "Espressif"
+  }

--- a/boards/esp32p4_ev-32M.json
+++ b/boards/esp32p4_ev-32M.json
@@ -1,0 +1,39 @@
+{
+  "build": {
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_TASMOTA -DESP32P4 -DESP32_32M -DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=1 -DUSE_USB_CDC_CONSOLE"
+    ],
+    "f_cpu": "360000000L",
+    "f_flash": "80000000L",
+    "f_psram": "200000000L",
+    "flash_mode": "qio",
+    "mcu": "esp32p4",
+    "chip_variant": "esp32p4_es",
+    "variant": "esp32p4",
+    "partitions": "boards/partitions/esp32_partition_app6144k_spiffs20412k.csv"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "openthread",
+    "ethernet"
+  ],
+  "debug": {
+    "openocd_target": "esp32p4.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Espressif ESP32-P4 Function EV Board 32M Flash, ESPEasy 6144k Code/OTA 20M FS",
+  "upload": {
+    "flash_size": "32MB",
+    "maximum_ram_size": 768000,
+    "maximum_size": 33554432,
+    "require_upload_port": true,
+    "speed": 1500000
+  },
+  "url": "https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32p4/esp32-p4-function-ev-board/index.html",
+  "vendor": "Espressif"
+}

--- a/boards/esp32p4r3-32M.json
+++ b/boards/esp32p4r3-32M.json
@@ -1,0 +1,39 @@
+{
+  "build": {
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_TASMOTA -DESP32P4R3 -DESP32_32M -DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=1 -DUSE_USB_CDC_CONSOLE"
+    ],
+    "f_cpu": "400000000L",
+    "f_flash": "80000000L",
+    "f_psram": "200000000L",
+    "flash_mode": "qio",
+    "mcu": "esp32p4",
+    "chip_variant": "esp32p4",
+    "variant": "esp32p4",
+    "partitions": "boards/partitions/esp32_partition_app6144k_spiffs20412k.csv"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "openthread",
+    "ethernet"
+  ],
+  "debug": {
+    "openocd_target": "esp32p4.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Espressif Generic ESP32-P4 rev.3 16M Flash, ESPEasy 4096k Code/OTA 8M FS",
+  "upload": {
+    "flash_size": "32MB",
+    "maximum_ram_size": 768000,
+    "maximum_size": 33554432,
+    "require_upload_port": true,
+    "speed": 1500000
+  },
+  "url": "https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32p4/esp32-p4-function-ev-board/index.html",
+  "vendor": "Espressif"
+}

--- a/boards/esp32p4r3-32M.json
+++ b/boards/esp32p4r3-32M.json
@@ -26,7 +26,7 @@
     "arduino",
     "espidf"
   ],
-  "name": "Espressif Generic ESP32-P4 rev.3 16M Flash, ESPEasy 4096k Code/OTA 8M FS",
+  "name": "Espressif Generic ESP32-P4 rev.3 32M Flash, ESPEasy 6144k Code/OTA 20M FS",
   "upload": {
     "flash_size": "32MB",
     "maximum_ram_size": 768000,
@@ -34,6 +34,6 @@
     "require_upload_port": true,
     "speed": 1500000
   },
-  "url": "https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32p4/esp32-p4-function-ev-board/index.html",
+  "url": "https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32p4/esp32-p4x-function-ev-board/index.html",
   "vendor": "Espressif"
 }

--- a/boards/esp32p4r3.json
+++ b/boards/esp32p4r3.json
@@ -34,6 +34,6 @@
     "require_upload_port": true,
     "speed": 1500000
   },
-  "url": "https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32p4/esp32-p4-function-ev-board/index.html",
+  "url": "https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32p4/esp32-p4x-function-ev-board/index.html",
   "vendor": "Espressif"
 }

--- a/boards/partitions/esp32_partition_app6144k_spiffs20412k.csv
+++ b/boards/partitions/esp32_partition_app6144k_spiffs20412k.csv
@@ -1,0 +1,7 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x600000,
+app1,     app,  ota_1,   0x610000,0x600000,
+eeprom,   data, 0x99,    0xC10000,0x1000,
+spiffs,   data, spiffs,  0xC11000,0x13EF000,

--- a/dist/README.txt
+++ b/dist/README.txt
@@ -66,10 +66,10 @@ ESP32 now has a number of builds:
 - custom_ESP32_4M316k  Build template using either the plugin set defined in ``Custom.h`` or ``tools/pio/pre_custom_esp32.py``
 - test_ESP32_4M316k  Build using the "testing" set of plugins for ESP32
 - test_ESP32-wrover-kit_4M316k  A build for ESP32 including build flags for the official WRover test kit.
-- max_ESP32_16M1M  A build for ESP32 with larger flash size including all plugins.
+- max_ESP32_16M8M  A build for ESP32 with larger flash size including all plugins.
 
 ESP32 also supports Ethernet.
-Ethernet support is included in similar builds as mentioned before, only ending with "_ETH" in the file name.
+Ethernet support is included in nearly all ESP32 builds, only ESP32-C2 doesn't have support for Ethernet.
 
 
 

--- a/docs/source/Participate/ProjectStructure.rst
+++ b/docs/source/Participate/ProjectStructure.rst
@@ -10,9 +10,14 @@ ESPEasy Project Directories
 
 Below a list of the most important directories and files used in this project.
 
-* ``.pio/`` Working dir for PlatformIO (Ignored by Git)
-* ``build_output/`` The output directory where all built files are collected.
-* ``dist/`` Files also includd in the nightly builds (e.g. blank flash files and ESPEasy flasher)
+* ``.github/`` Buildscripts used by the Github Actions build and release CI jobs.
+* ``.pio/`` Working dir for pioarduino (Ignored by Git)
+* ``.platformio/`` Working dir for pioarduino (Ignored by Git)
+* ``.platformio/penv/`` Directory to store the used Python Virtual Environment.
+* ``boards/`` Used board definitions.
+* ``boards/partitions/`` Used partition layout in ESP32 builds.
+* ``build_output/`` The output directory where all built files are collected. (Ignored by Git)
+* ``dist/`` Files also includd in the nightly builds (e.g. blank flash files and Espressif flash download tool)
 * ``docs/`` Documentation tree using Sphinx to build the documents.
 * ``hooks/`` Used for the continous integration process, used by Travis CI.
 * ``include/`` PlatformIO's suggested folder for .h files (not yet used)
@@ -20,16 +25,14 @@ Below a list of the most important directories and files used in this project.
 * ``misc/`` Additional files needed for some use cases, like specialized a firmware for some boards or decoder files for the TTN project.
 * ``patches/`` Patches we apply during build for core libraries.
 * ``src/`` The source code of ESPeasy
+* ``src/ESPEasy/`` Parts of ESPeasy use C++ namespaces, and are placed in this directory, matching the namespace structure.
 * ``static/`` Static files we use in ESPEasy, like CSS/JS/ICO files.
 * ``test/`` Test scripts to be used in the continous integration process.
 * ``tools/`` Tools to help build ESPeasy.
-* ``tools/pio/pre_custom_esp32.py`` Python helper script for building custom ESP32 binary.
-* ``tools/pio/pre_custom_esp8266.py`` Python helper script for building custom ESP8266 binary.
-* ``venv/`` Directory to store the used Python Virtual Environment. (Ignored by Git)
-* ``platformio.ini``  Configuration file for PlatformIO to define various build setups.
-* ``uncrustify.cfg``  Configuration file for Uncrustify, to format source code using some uniform formatting rules.
+* ``tools/pio/pre_custom_esp*.py`` Python helper scripts for building custom ESP binaries.
+* ``platformio.ini``  Configuration file for pioarduino to define various build setups.
 * ``requirements.txt``  List of used Python libraries and their version (result of ``pip freeze`` with Virtual env active)
-* ``boards/partitions/esp32_partition_app1810k_spiffs316k.csv`` Used partition layout in ESP32 4M builds.
+* ``uncrustify.cfg``  Configuration file for Uncrustify, to format source code using some uniform formatting rules.
 
 
 ESPEasy src dir
@@ -107,14 +110,17 @@ There is also a number of special builds:
 ESP Chip Type
 -------------
 
-* ``ESP8266`` Most likely option.
+* ``ESP8266`` Deprecated for new projects, as support from Espressif has been stopped, even though new chips are still being produced.
 * ``ESP8285`` Supported in ``ESP8266`` builds. Used in some Sonoff modules. This chip has embedded flash, so no extra flash chip.
 * ``ESP32``   Allows for more memory and more GPIO pins.
 * ``ESP32-S2`` Newer version of ESP32. Has even more GPIO pins, but some specific features of ESP32 were removed.
 * ``ESP32-S3`` Newer version of ESP32 and ESP32-S2. Has even more GPIO pins, some specific features of ESP32 were removed, and some design choices of ESP32-S2 are reverted and implemented differently.
-* ``ESP32-C2`` Preliminary supported. Cheaper variant of ESP32-C3, and also an ESP8266 replacement. Available as pin-compatible module for ESP8266. Single core, and max 120 MHz clock speed.
+* ``ESP32-C2`` Cheaper variant of ESP32-C3, and also an ESP8266 replacement. Available as pin-compatible module for ESP8266. Single core, and max 120 MHz clock speed.
 * ``ESP32-C3`` Intended as a replacement for ESP8266, using ESP32 technology, though single-core and with limited clock speed (160 MHz, some models 120 MHz).
-* ``ESP32-C6`` Preliminary supported. Will allow connectivity with IEEE 802.15.4 (Thread/Zigbee) wireless protocol.
+* ``ESP32-C6`` Will allow connectivity with IEEE 802.15.4 (Thread/Zigbee) wireless protocol.
+* ``ESP32-C61`` Preliminary supported. Will allow connectivity with IEEE 802.15.4 (Thread/Zigbee) wireless protocol.
+* ``ESP32-C5`` Will allow connectivity with WiFi 2.4GHz and 5GHz support.
+* ``ESP32-P4`` High-end dual-core MCU, with many GPIO pins and support for camera, display, RMII Ethernet and many other protocols. No on-chip WiFi support. Often has an additional ESP32-C6 with ESP-HostedMCU to provide wireless support via an SDIO connection.
 
 Memory Size and Partitioning
 ----------------------------
@@ -123,12 +129,12 @@ Memory Size and Partitioning
 * ``2M`` 2 MB flash modules (e.g. Shelly1/WROOM02)
 * ``4M`` 4 MB flash modules (e.g. NodeMCU/ESP32)
 * ``16M`` 16 MB flash modules (e.g. Wemos D1 mini pro) (has 14 MB LittleFS filesystem, as SPIFFS is unstable > 2 MB)
-* ``4M1M`` 4 MB flash modules with 1 MB filesystem (usually SPIFFS)
-* ``4M2M`` 4 MB flash modules with 2 MB filesystem (usually SPIFFS)
-* ``4M316k`` 4 MB flash modules using 1.8 MB sketch size, with 316 kB filesystem (usually SPIFFS) (for ESP32)
-* ``8M1M`` 8 MB flash modules using 3.5MB sketch size, with 1 MB filesystem (LittleFS) (ESP32 only a.t.m.)
-* ``16M1M`` 16 MB flash modules using 4MB sketch size, with 1 MB filesystem (usually SPIFFS) (ESP32 only a.t.m.)
-* ``16M8M`` 16 MB flash modules using 4MB sketch size, with 8 MB filesystem (LittleFS) (ESP32 only a.t.m.)
+* ``4M1M`` 4 MB flash modules with 1 MB filesystem (SPIFFS)
+* ``4M2M`` 4 MB flash modules with 2 MB filesystem (SPIFFS)
+* ``4M316k`` 4 MB flash modules using 1.8 MB sketch size, with 316 kB filesystem (LittleFS) (for ESP32)
+* ``8M1M`` 8 MB flash modules using 3.5MB sketch size, with 1 MB filesystem (LittleFS) (ESP32 only)
+* ``16M8M`` 16 MB flash modules using 4MB sketch size, with 8 MB filesystem (LittleFS) (ESP32 only)
+* ``32M20M`` 32 MB flash modules using 6MB sketch size, with 20 MB filesystem (LittleFS) (ESP32 only)
 
 Optional build options
 ----------------------
@@ -143,7 +149,7 @@ Optional build options
 * ``OPI`` Flash via OPI protocol support (ESP32 only)
 * ``QIO`` Flash via QIO protocol support (ESP32 only)
 * ``CDC`` CDC Serial (built-in USB) support (ESP32 only)
-* ``ETH`` Ethernet interface enabled (ESP32 only)
+* ``ETH`` Ethernet interface enabled (ESP32 only, no longer used, as all ESP32, except for ESP32-C2, have support for Ethernet included)
 
 
 Please note that the performance of 14MB SPIFFS (16M flash ESP8266 modules) is really slow.
@@ -183,17 +189,15 @@ This also means we still need to update the 2-step updater to support .bin.gz fi
 ESP32 builds
 ------------
 
-There are several builds for ESP32:
+There are several builds for ESP32, this is just a selection:
 
-* ``normal_ESP32_4M316k``  Build using the "stable" set of plugins for ESP32
-* ``normal_ESP32_4M316k_ETH``  Build using the "stable" set of plugins for ESP32, with support for an on-board Ethernet controller
+* ``normal_ESP32_4M316k``  Build using the "stable" set of plugins for ESP32, with support for an on-board Ethernet controller
 * ``custom_ESP32_4M316k``  Build template using either the plugin set defined in ``Custom.h`` or ``tools/pio/pre_custom_esp32.py``
 * ``collection_A_ESP32_4M316k``  Build using the "Collection" set "A" of plugins for ESP32
 * ``collection_B_ESP32_4M316k``  Build using the "Collection" set "B" of plugins for ESP32
 * ``collection_C_ESP32_4M316k``  Build using the "Collection" set "C" of plugins for ESP32
 * ``collection_D_ESP32_4M316k``  Build using the "Collection" set "D" of plugins for ESP32
-* ``collection_A_ESP32-wrover-kit_4M316k``  A build for ESP32 including build flags for the official WRover test kit.
-* ``max_ESP32_16M8M_LittleFS``  Build using all available plugins and controllers for ESP32 with 16 MB flash (some lolin_d32_pro boards)
+* ``max_ESP32_16M8M``  Build using all available plugins and controllers for ESP32 with 16 MB flash (like lolin_d32_pro boards)
 
 Since ESP32 does have its flash partitioned in several blocks, we have 2 bin files of each ESP32 build, f.e.:
 

--- a/platformio_esp32c5_envs.ini
+++ b/platformio_esp32c5_envs.ini
@@ -14,9 +14,42 @@ lib_ignore                = ${esp32_base_idf5_5.lib_ignore}
 board                     = esp32c5cdc
 
 
+[env:custom_ESP32c5_4M316k]
+extends                   = esp32c5_common_LittleFS
+build_flags               = ${esp32c5_common_LittleFS.build_flags} 
+                            -DPLUGIN_BUILD_CUSTOM
+extra_scripts             = ${esp32c5_common_LittleFS.extra_scripts}
+                            pre:tools/pio/pre_custom_esp32.py
+
+
+
 [env:max_ESP32c5_8M1M]
 extends                   = esp32c5_common_LittleFS
 board                     = esp32c5cdc-8M
+build_flags               = ${esp32c5_common_LittleFS.build_flags}  
+                            -DFEATURE_ETHERNET=1
+                            -DFEATURE_ARDUINO_OTA=1
+                            -DPLUGIN_BUILD_MAX_ESP32
+                            -DPLUGIN_BUILD_IR_EXTENDED
+                            -D ST7789_EXTRA_INIT=1
+                            -D P116_EXTRA_ST7789=1
+extra_scripts             = ${esp32c5_common_LittleFS.extra_scripts}
+
+[env:max_ESP32c5_16M8M]
+extends                   = esp32c5_common_LittleFS
+board                     = esp32c5cdc-16M
+build_flags               = ${esp32c5_common_LittleFS.build_flags}  
+                            -DFEATURE_ETHERNET=1
+                            -DFEATURE_ARDUINO_OTA=1
+                            -DPLUGIN_BUILD_MAX_ESP32
+                            -DPLUGIN_BUILD_IR_EXTENDED
+                            -D ST7789_EXTRA_INIT=1
+                            -D P116_EXTRA_ST7789=1
+extra_scripts             = ${esp32c5_common_LittleFS.extra_scripts}
+
+[env:max32_ESP32c5_32M20M]
+extends                   = esp32c5_common_LittleFS
+board                     = esp32c5cdc-32M
 build_flags               = ${esp32c5_common_LittleFS.build_flags}  
                             -DFEATURE_ETHERNET=1
                             -DFEATURE_ARDUINO_OTA=1

--- a/platformio_esp32p4_envs.ini
+++ b/platformio_esp32p4_envs.ini
@@ -27,4 +27,10 @@ build_flags               = ${esp32p4_common_LittleFS.build_flags}
                             -D P116_EXTRA_ST7789=1
 extra_scripts             = ${esp32p4_common_LittleFS.extra_scripts}
 
+[env:max32_ESP32p4_32M20M]
+extends                   = env:max_ESP32p4_16M8M
+board                     = esp32p4_ev-32M
+build_flags               = ${esp32p4_common_LittleFS.build_flags}  
+                            -DPLUGIN_BUILD_MAX32_ESP32
+
 

--- a/platformio_esp32p4r3_envs.ini
+++ b/platformio_esp32p4r3_envs.ini
@@ -11,4 +11,10 @@ board                     = esp32p4r3
 extends                   = env:max_ESP32p4_16M8M
 board                     = esp32p4r3
 
+[env:max32_ESP32p4r3_32M20M]
+extends                   = env:max_ESP32p4_16M8M
+board                     = esp32p4r3-32M
+build_flags               = ${esp32p4_common_LittleFS.build_flags}  
+                            -DPLUGIN_BUILD_MAX32_ESP32
+
 

--- a/tools/pio/copy_files.py
+++ b/tools/pio/copy_files.py
@@ -25,10 +25,13 @@ def get_max_bin_size(env_name, file_suffix):
         if "_8M1M" in env_name:
             # ESP32 with 3520k of sketch space.
             max_bin_size = 3604480
-    if "_ESP32_" in env_name or "_ESP32c3_" in env_name or "_ESP32c5_" in env_name or "_ESP32c6_" in env_name or "_ESP32p4_" in env_name or "_ESP32p4r3_" in env_name or "_ESP32s2_" in env_name or "_ESP32s3_" in env_name:
+    if "_ESP32_" in env_name or "_ESP32c3_" in env_name or "_ESP32c5_" in env_name or "_ESP32c6_" in env_name or "_ESP32c61_" in env_name or "_ESP32p4_" in env_name or "_ESP32p4r3_" in env_name or "_ESP32s2_" in env_name or "_ESP32s3_" in env_name:
         if "_16M8M" in env_name or "_16M2M" in env_name or "_16M1M" in env_name:
             # ESP32 with 4096k of sketch space.
             max_bin_size = 4194304
+        if "_32M20M" in env_name:
+            # ESP32 with 6144k of sketch space.
+            max_bin_size = 6291456
     if "factory" in file_suffix:
         # Factory bin files include a part which is not overwritten via OTA
         max_bin_size = max_bin_size + 65536

--- a/tools/pio/generate_web_flasher_manifest.py
+++ b/tools/pio/generate_web_flasher_manifest.py
@@ -160,7 +160,7 @@ def parse_filename(file, version, variant, file_suffix):
                 group = 'NeoPixel'
             elif 'normal_' in variant:
                 group = 'Normal'
-            elif 'max_' in variant:
+            elif 'max_' in variant or 'max32_' in variant or 'max8_' in variant:
                 group = 'MAX'
             elif 'custom_' in variant:
                 group = 'Custom'


### PR DESCRIPTION
Features:
Add builds for:
- ESP32-C5 `Custom` (4MB Flash)
- ESP32-C5 `MAX` (16MB Flash)
- ESP32-C5 `MAX32` (32MB Flash)
- ESP32-P4 `MAX32` (32MB Flash)
- ESP32-P4r3 `MAX32` (32MB Flash)

`MAX32` builds have 6MB Code partition and ~20MB LittleFS File system.

TODO:
- [ ] Add all available features, like fonts etc., to MAX32 builds
- [ ] Testing
- [x] Update documentation
