### PR TITLE
[Docs] Fix link to I2C Bus settings

### DIFF
--- a/docs/source/Plugin/P007.rst
+++ b/docs/source/Plugin/P007.rst
@@ -54,7 +54,7 @@ Configuration
 I2C Options 
 ^^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus`
 
 As the chip is specified to only work correctly up to 100 kHz, the **Force Slow I2C speed** checkbox should normally be *enabled*.
 

--- a/docs/source/Plugin/P009.rst
+++ b/docs/source/Plugin/P009.rst
@@ -60,7 +60,7 @@ Sensor
 I2C Options 
 ^^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 * **I2C Address**: The address the device is using. As there are 8 possible I2C addresses, when the jumpers are configured, the selected value should match with that.
 

--- a/docs/source/Plugin/P011.rst
+++ b/docs/source/Plugin/P011.rst
@@ -55,7 +55,7 @@ Sensor
 I2C Options 
 ^^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 Device Settings
 ^^^^^^^^^^^^^^^

--- a/docs/source/Plugin/P012.rst
+++ b/docs/source/Plugin/P012.rst
@@ -42,7 +42,7 @@ After adding the plugin to a Task in the Devices list, it should be configured f
 I2C Options 
 ^^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 **I2C Address**: The address the device is using. Most devices allow a configurable address, usually the information on how to set/change that address is available on the printed circuit board, or on the manufacturers website.
 

--- a/docs/source/Plugin/P019.rst
+++ b/docs/source/Plugin/P019.rst
@@ -60,7 +60,7 @@ Sensor
 I2C Options 
 ^^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 * **I2C Address**: The address the device is using. As there are 16 possible I2C addresses, when the jumpers are configured, the selected value should match with that.
 

--- a/docs/source/Plugin/P023.rst
+++ b/docs/source/Plugin/P023.rst
@@ -40,7 +40,7 @@ Configuration
 I2C Options 
 ^^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 Device Settings
 ^^^^^^^^^^^^^^^

--- a/docs/source/Plugin/P027.rst
+++ b/docs/source/Plugin/P027.rst
@@ -44,7 +44,7 @@ Configuration
 I2C options
 ^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 
 Selectable I2C addresses:

--- a/docs/source/Plugin/P028.rst
+++ b/docs/source/Plugin/P028.rst
@@ -69,7 +69,7 @@ Configuration
 I2C Options 
 ^^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 * **I2C Address**: The address the device is using. Depending on the board used, when available a SDO pin, or soldering a 0 ohm resistor on a different location, can be used to select the used address. If that address selection is not available, then an I2C multiplexer (in a matching ESPEasy build) can be used to use multiple sensors on a single ESPEasy unit. Below are instructions for selecting the alternate address.
 

--- a/docs/source/Plugin/P034.rst
+++ b/docs/source/Plugin/P034.rst
@@ -48,7 +48,7 @@ Settings
 I2C options
 ^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 Device Settings
 ^^^^^^^^^^^^^^^

--- a/docs/source/Plugin/P036.rst
+++ b/docs/source/Plugin/P036.rst
@@ -44,7 +44,7 @@ Configuration
 I2C Options 
 ^^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 Device Settings
 ^^^^^^^^^^^^^^^

--- a/docs/source/Plugin/P045.rst
+++ b/docs/source/Plugin/P045.rst
@@ -42,7 +42,7 @@ Configuration
 I2C Options 
 ^^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 **I2C Address**: The address the device is using. Depending on the board used, when available an ADDR pin can be used to select the used address. If that address selection is not available, then an I2C multiplexer (in a matching ESPEasy build) can be used to use multiple sensors on a single ESPEasy unit.
 

--- a/docs/source/Plugin/P047.rst
+++ b/docs/source/Plugin/P047.rst
@@ -65,7 +65,7 @@ Configuration
 I2C Options 
 ^^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 * **I2C Address (Hex)**: The address the device is using. The default I2C address is prefilled, and can be configured to use a different address, see below. As this can be any valid I2C address in range: 0x01..0x7F, it has to be typed here, using a hexadecimal value.
 

--- a/docs/source/Plugin/P057.rst
+++ b/docs/source/Plugin/P057.rst
@@ -55,7 +55,7 @@ I2C options
 
 .. image:: P057_I2CAddressOptions.png
 
-The available settings here depend on the build and hardware configuration used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build and hardware configuration used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 
 

--- a/docs/source/Plugin/P061.rst
+++ b/docs/source/Plugin/P061.rst
@@ -108,7 +108,7 @@ Configuration
 I2C Options 
 ^^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 **I2C Address**: The address the device is using. Usually, for this type of I/O boards, the I2C address can be configured by connecting ``A0``/``A1``/``A2`` to either GND or VCC.
 

--- a/docs/source/Plugin/P062.rst
+++ b/docs/source/Plugin/P062.rst
@@ -60,7 +60,7 @@ Configuration
 I2C Options 
 ^^^^^^^^^^^^
 
-* The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+* The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 * **I2C Address**: The address the device is using. Depending on the board used, when available a SDO or ADD(R) pin, can be used to select the used address. If that address selection is not available, then an I2C multiplexer (in a matching ESPEasy build) can be used to use multiple sensors on a single ESPEasy unit.
 

--- a/docs/source/Plugin/P064.rst
+++ b/docs/source/Plugin/P064.rst
@@ -40,7 +40,7 @@ Device Configuration
 I2C options
 ^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 There is only 1 I2C address available for this sensor, ``0x39`` (not shown).
 

--- a/docs/source/Plugin/P103.rst
+++ b/docs/source/Plugin/P103.rst
@@ -55,7 +55,7 @@ Device configuration
 I2C options
 ^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 When loading the Device configuration page, the plugin will try to detect the type of sensor connected based on the selected I2C addresses. If no sensor is found, the message in red will be shown.
 

--- a/docs/source/Plugin/P105.rst
+++ b/docs/source/Plugin/P105.rst
@@ -52,7 +52,7 @@ Settings
 I2C Options 
 ^^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 * **I2C Address**: The address the device is using. The AHT10 sensor allows to select a secondary address by pulling the AO (sometimes marked as A0) pin to high (3.3V) to select the secondary address. That address should then be selected here too. The AHT20/AHT21 based sensors only support a single I2C address, so it will be forced to the default address.
 

--- a/docs/source/Plugin/P106.rst
+++ b/docs/source/Plugin/P106.rst
@@ -51,7 +51,7 @@ I2C options
 
 * **I2C Address**: The device supports 2 addresses, that can be configured using the ``SDO`` pin: (not all boards have that pin available, but could use soldering-pads to configure the address)
 
-The available I2C settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available I2C settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 Device Settings
 ^^^^^^^^^^^^^^^

--- a/docs/source/Plugin/P109.rst
+++ b/docs/source/Plugin/P109.rst
@@ -50,7 +50,7 @@ Task settings
 I2C Options 
 ^^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 **I2C Address**: The address the device is using. Some boards offer a solderable address selector that is to be used to select the address. The available addresses are ``0x3C`` and ``0x3D``.
 

--- a/docs/source/Plugin/P110.rst
+++ b/docs/source/Plugin/P110.rst
@@ -40,7 +40,7 @@ Configuration
 I2C Options 
 ^^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 * **I2C Address**: The address the device is using. Some boards holding this chip offer an extra connection SDO that can be used to select the address, other boards just allow to select the secondary address and keep that active until the next power-cycle of the sensor.
 

--- a/docs/source/Plugin/P113.rst
+++ b/docs/source/Plugin/P113.rst
@@ -44,7 +44,7 @@ Configuration
 I2C Options 
 ^^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 * **I2C Address**: The address the device is using. Because of an issue with changing the I2C address of the sensor, this list is limited to 1 item, and the address isn't changed/set.
 

--- a/docs/source/Plugin/P114.rst
+++ b/docs/source/Plugin/P114.rst
@@ -44,7 +44,7 @@ Configuration
 I2C Options 
 ^^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 **I2C Address**: The address the device is using. Depending on the board used, when available a SDO pin, or soldering a 0 ohm resistor on a different location, can be used to select the used address. If that address selection is not available, then an I2C multiplexer (in a matching ESPEasy build) can be used to use multiple sensors on a single ESPEasy unit.
 

--- a/docs/source/Plugin/P117.rst
+++ b/docs/source/Plugin/P117.rst
@@ -44,7 +44,7 @@ I2C options
 
 .. note:: According to manufacturer specification, the I2C ClockStretchLimit setting should be configured at a minimum value of 20 milliseconds, and can take up to 150 msec once a day. For ESP8266 and ESP32 there are somewhat different values to fill, ESP8266 expects microseconds (usec) there, 20000 to 150000, and ESP32 needs 1/80 usec, 1600000 to 12000000, so a factor 80 difference.
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 .. note:: The SCD30 sensor supports a max. I2C Clock Speed of 100 kHz, so **Force Slow I2C speed** should be checked! (ESPEasy has a default setting of 100 kHz for I2C Slow device Clock Speed).
 

--- a/docs/source/Plugin/P119.rst
+++ b/docs/source/Plugin/P119.rst
@@ -39,7 +39,7 @@ Task settings
 I2C Options 
 ^^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 **I2C Address**: The address the device is using. The ITG3205 chip allows to select a secondary address by pulling the AD0 pin to high (3.3V) to select the secondary address. That address should then be selected here too. Not all available modules allow configuring the secondary address.
 

--- a/docs/source/Plugin/P120.rst
+++ b/docs/source/Plugin/P120.rst
@@ -43,7 +43,7 @@ Configuration
 I2C Options 
 ^^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 **I2C Address**: The address the device is using. Some boards holding this chip offer an extra connection SD0 that can be used to select the address. The available addresses are ``0x53`` and ``0x1D`` (secondary).
 

--- a/docs/source/Plugin/P121.rst
+++ b/docs/source/Plugin/P121.rst
@@ -50,7 +50,7 @@ Configuration
 I2C Options 
 ^^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 Device Settings
 ^^^^^^^^^^^^^^^

--- a/docs/source/Plugin/P123.rst
+++ b/docs/source/Plugin/P123.rst
@@ -42,7 +42,7 @@ Device configuration
 I2C options
 ^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 Device Settings
 ^^^^^^^^^^^^^^^
@@ -93,7 +93,7 @@ The configured display will be used to draw the objects, if any, that can be con
 
 .. warning:: Some devices that have the reset pin connected, initially set that GPIO to low/0, causing the touch controller not to start, and it won't even show up on the I2C Scan. This can be solved by setting the involved GPIO pin to **Output High** on the :ref:`Hardware_page`.
 
-.. warning:: During testing we found that specifically the CST816 touchscreen controller, whiel working as expected, **doesn't** show up in an I2C Scan. This also implies they can't be auto-detected, and have to be set explicitly.
+.. warning:: During testing we found that specifically the CST816 touchscreen controller, while working as expected, **doesn't** show up in an I2C Scan. This also implies this device can't be auto-detected, and has to be set explicitly.
 
 .. include:: Touch_Configuration.repl
 

--- a/docs/source/Plugin/P124.rst
+++ b/docs/source/Plugin/P124.rst
@@ -56,7 +56,7 @@ Configuration
 I2C Options 
 ^^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 * **I2C Address**: The address the device is using.
 

--- a/docs/source/Plugin/P127.rst
+++ b/docs/source/Plugin/P127.rst
@@ -52,7 +52,7 @@ Configuration
 I2C Options 
 ^^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 * **I2C Address**: The address the device is using. Depending on the state of the ``CAD0`` pin, the address can be changed, open or high state selects the default address 0x69, when connected to GND, the configured address is 0x68. If more than 2 sensors have to be connected, an I2C multiplexer (in a custom ESPEasy build) can be used to use more than 2 sensors on a single ESPEasy unit.
 

--- a/docs/source/Plugin/P132.rst
+++ b/docs/source/Plugin/P132.rst
@@ -45,7 +45,7 @@ Configuration
 I2C Options 
 ^^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 * **I2C Address**: The address the sensor is using. The different addresses can be selected by connecting the appropriate signal to ``A0`` and ``A1`` when available. Often also documented on the board.
 
@@ -196,7 +196,7 @@ Configuration
 I2C Options 
 ^^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 **I2C Address**: The address the sensor is using. The different addresses can be selected by connecting the appropriate signal to ``A0``. Often also documented on the board.
 

--- a/docs/source/Plugin/P133.rst
+++ b/docs/source/Plugin/P133.rst
@@ -41,7 +41,7 @@ Configuration
 I2C Options 
 ^^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 Device Settings
 ^^^^^^^^^^^^^^^^

--- a/docs/source/Plugin/P135.rst
+++ b/docs/source/Plugin/P135.rst
@@ -44,7 +44,7 @@ Configuration
 I2C options
 ^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 .. note:: According to the documentation, the SCD4x sensors support a max. I2C Clock Speed of 100 kHz, but during testing it worked fine at the regular 400 kHz speed, so your milage may vary. If the readings are out of range, or other issues arise, **Force Slow I2C speed** should be checked! (ESPEasy has a default setting of 100 kHz for I2C Slow device Clock Speed).
 

--- a/docs/source/Plugin/P137.rst
+++ b/docs/source/Plugin/P137.rst
@@ -45,7 +45,7 @@ Configuration
 I2C Options 
 ^^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 Device Settings
 ^^^^^^^^^^^^^^^^

--- a/docs/source/Plugin/P138.rst
+++ b/docs/source/Plugin/P138.rst
@@ -43,7 +43,7 @@ Configuration
 I2C Options 
 ^^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 Device Settings
 ^^^^^^^^^^^^^^^^

--- a/docs/source/Plugin/P139.rst
+++ b/docs/source/Plugin/P139.rst
@@ -45,7 +45,7 @@ Configuration
 I2C Options 
 ^^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 Device Settings
 ^^^^^^^^^^^^^^^^

--- a/docs/source/Plugin/P140.rst
+++ b/docs/source/Plugin/P140.rst
@@ -45,7 +45,7 @@ Configuration
 I2C Options 
 ^^^^^^^^^^^^
 
-The available settings here depend on the build used, and configuration options set. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used, and configuration options set. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 Device Settings
 ^^^^^^^^^^^^^^^^

--- a/docs/source/Plugin/P142.rst
+++ b/docs/source/Plugin/P142.rst
@@ -46,7 +46,7 @@ Configuration
 I2C options
 ^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 * **I2C Address**: The address the sensor is using. The AS5600 uses I2C address 0x36 and the AS5600L has address 0x40, allowing 2 of these sensor on an I2C bus without using an I2C multiplexer.
 

--- a/docs/source/Plugin/P143.rst
+++ b/docs/source/Plugin/P143.rst
@@ -56,7 +56,7 @@ I2C options
 
 * **I2C Address**: Depending on the selected **Encoder type**, different I2C Addresses are available. Adafruit supports 8 addresses, M5Stack only supports 1 address and DFRobot can be configured for 4 different addresses.
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 Device Settings
 ^^^^^^^^^^^^^^^

--- a/docs/source/Plugin/P147.rst
+++ b/docs/source/Plugin/P147.rst
@@ -42,7 +42,7 @@ Configuration
 I2C options
 ^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 The sensor has a fixed I2C address of 0x59, so to connect multiple sensors to a single ESP, an I2C multiplexer should be used.
 

--- a/docs/source/Plugin/P150.rst
+++ b/docs/source/Plugin/P150.rst
@@ -68,7 +68,7 @@ I2C options
     "0x4A", "SDA", ""
     "0x4B", "SCL", ""
 
-The available I2C settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available I2C settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 Device Settings
 ^^^^^^^^^^^^^^^

--- a/docs/source/Plugin/P153.rst
+++ b/docs/source/Plugin/P153.rst
@@ -50,7 +50,7 @@ I2C options
     "0x45", "SHT4x-Bxxx", ""
     "0x46", "SHT4x-Cxxx", ""
 
-The available I2C settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available I2C settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 Device Settings
 ^^^^^^^^^^^^^^^

--- a/docs/source/Plugin/P154.rst
+++ b/docs/source/Plugin/P154.rst
@@ -58,7 +58,7 @@ I2C options
     "0x76",  "Connect SDO to GND"
     "0x77",  "Connect SDO to V_DDIO (default on most boards)"
 
-The available I2C settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available I2C settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 Since this chip supports both SPI and I2C, the pin naming may be slightly confusing:
 

--- a/docs/source/Plugin/P163.rst
+++ b/docs/source/Plugin/P163.rst
@@ -53,7 +53,7 @@ Dats Source
 I2C options
 ^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 Currently, only the default I2C address of ``0x66`` is supported. Multiple sensors can be connected using an I2C multiplexer.
 

--- a/docs/source/Plugin/P164.rst
+++ b/docs/source/Plugin/P164.rst
@@ -57,7 +57,7 @@ I2C options
     "0x52",  "Connect ADDR GND"
     "0x53",  "Connect ADDR to VDD (default on most boards)"
 
-The available I2C settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available I2C settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 The chip supports both SPI and I2C. The plugin only support I2C using the following pins:
 

--- a/docs/source/Plugin/P166.rst
+++ b/docs/source/Plugin/P166.rst
@@ -50,7 +50,7 @@ I2C options
 
 Available addresses are in the range ``0x58`` to ``0x5F``.
 
-The available I2C settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available I2C settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 Device Settings
 ^^^^^^^^^^^^^^^

--- a/docs/source/Plugin/P167.rst
+++ b/docs/source/Plugin/P167.rst
@@ -53,7 +53,7 @@ Configuration
 I2C options
 ^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 .. note:: According to the documentation, the SEN5x sensors support a max. I2C Clock Speed of 100 kHz, **Force Slow I2C speed** should be checked. (ESPEasy has a default setting of 100 kHz for I2C Slow device Clock Speed).
 

--- a/docs/source/Plugin/P168.rst
+++ b/docs/source/Plugin/P168.rst
@@ -43,7 +43,7 @@ Configuration
 I2C options
 ^^^^^^^^^^^
 
-The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 The VEML6030 has the option of selecting an alternative I2C address of ``0x48`` by pulling up the ADDR pin to VCC, when that pin is available on the board used. The VEML6030 also supports interrupt-driven operation, but that's not implemented in this plugin.
 

--- a/docs/source/Plugin/P169.rst
+++ b/docs/source/Plugin/P169.rst
@@ -311,7 +311,7 @@ I2C options
 
 Available addresses are in the range ``0x01`` to ``0x03``.
 
-The available I2C settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available I2C settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 Device Settings
 ^^^^^^^^^^^^^^^

--- a/docs/source/Plugin/P170.rst
+++ b/docs/source/Plugin/P170.rst
@@ -47,7 +47,7 @@ I2C options
 
 * **I2C Address**: Is not available in the configuration, but the device has a fixed address, or actually 2 fixed adjacent addresses, ``0x77`` and ``0x78``, as there are to separate but similar microcontrollers on the board, each delivering a part of the measurement range.
 
-The available I2C settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`Hardware_page`
+The available I2C settings here depend on the build used. At least the **Force Slow I2C speed** option is available, but selections for the I2C Multiplexer can also be shown. For details see the :ref:`i2c-bus` page
 
 Device Settings
 ^^^^^^^^^^^^^^^

--- a/docs/source/Plugin/P173.rst
+++ b/docs/source/Plugin/P173.rst
@@ -40,7 +40,7 @@ Configuration
 I2C options
 ^^^^^^^^^^^
 
-The available I2C settings here depend on the build used. At least the **Force Slow I2C speed** option is available. This sensor can also be used with an I2C Multiplexer, but as the (fixed) device address is ``0x70`` the I2C multiplexer has to be configured to use a different from the default I2C address. For details see the :ref:`Hardware_page`.
+The available I2C settings here depend on the build used. At least the **Force Slow I2C speed** option is available. This sensor can also be used with an I2C Multiplexer, but as the (fixed) device address is ``0x70`` the I2C multiplexer has to be configured to use a different from the default I2C address. For details see the :ref:`i2c-bus` page.
 
 Device Settings
 ^^^^^^^^^^^^^^^

--- a/docs/source/Plugin/P175.rst
+++ b/docs/source/Plugin/P175.rst
@@ -71,7 +71,7 @@ Configuration
 I2C options
 ^^^^^^^^^^^
 
-The available I2C settings here depend on the build used. At least the **Force Slow I2C speed** option is available. This sensor can also be used with an I2C Multiplexer. For details see the :ref:`Hardware_page`.
+The available I2C settings here depend on the build used. At least the **Force Slow I2C speed** option is available. This sensor can also be used with an I2C Multiplexer. For details see the :ref:`i2c-bus` page.
 
 According to the documentation, the max. communication speed for this sensor is 100 kHz, the default Slow I2C speed setting, so this option is enabled by default.
 

--- a/docs/source/Plugin/P177.rst
+++ b/docs/source/Plugin/P177.rst
@@ -42,7 +42,7 @@ Configuration
 I2C options
 ^^^^^^^^^^^
 
-The available I2C settings here depend on the build used. At least the **Force Slow I2C speed** option is available. This sensor can also be used with an I2C Multiplexer, as the (fixed) device address is ``0x7F`` to allow for multiple sensors on a single ESP. For details see the :ref:`Hardware_page`.
+The available I2C settings here depend on the build used. At least the **Force Slow I2C speed** option is available. This sensor can also be used with an I2C Multiplexer, as the (fixed) device address is ``0x7F`` to allow for multiple sensors on a single ESP. For details see the :ref:`i2c-bus` page.
 
 Device Settings
 ^^^^^^^^^^^^^^^

--- a/docs/source/Plugin/P180.rst
+++ b/docs/source/Plugin/P180.rst
@@ -58,7 +58,7 @@ I2C options
 
 * **I2C Address (Hex)**: Because of the flexible nature of the plugin, setting the I2C address requires typing the hexadecimal I2C address of the device. This should be in the range 0x01 .. 0x7F.
 
-The available I2C settings here depend on the build used. At least the **Force Slow I2C speed** option is available. This plugin can also be used with an I2C Multiplexer, or use a separate I2C Bus when configured, to allow for multiple sensors on a single ESP. For details see the :ref:`Hardware_page`.
+The available I2C settings here depend on the build used. At least the **Force Slow I2C speed** option is available. This plugin can also be used with an I2C Multiplexer, or use a separate I2C Bus when configured, to allow for multiple sensors on a single ESP. For details see the :ref:`i2c-bus` page.
 
 Device Settings
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
Improvements:
- [Docs] For devices using I2C bus, the link still pointed to the Hardware page
- [Docs] Small typo and improved description (P123)
- 