### PR TITLE
[Console] Accept all valid ASCII characters for input

### DIFF
--- a/src/src/ESPEasyCore/ESPEasy_Console_Port.cpp
+++ b/src/src/ESPEasyCore/ESPEasy_Console_Port.cpp
@@ -152,7 +152,7 @@ bool EspEasy_Console_Port::process_consoleInput(uint8_t SerialInByte)
     return false;
   }
 
-  if (isprint(SerialInByte))
+  if (SerialInByte >= 32)                                  // Any character from space and up
   {
     if (SerialInByteCounter < CONSOLE_INPUT_BUFFER_SIZE) { // add char to string if it still fits
       InputBuffer_Serial[SerialInByteCounter++] = SerialInByte;


### PR DESCRIPTION
Feature:
- [Console] Accept any character from space and up, so we can type in complex SSID-names and passwords via the console