### PR TITLE
[Build] Fix install-requirements script on Windows

### DIFF
--- a/tools/pio/install-requirements.py
+++ b/tools/pio/install-requirements.py
@@ -11,6 +11,7 @@ except ImportError:
     # Activate the Python environment penv and install the requirements there when not yet available
     # Windows is different from other OS-es, assuming Powershell as default shell, not CMD (where separator: & instead of ;)
     if os.name == "nt":
-        env.Execute(".\.platformio\penv\Scripts\activate ; uv pip install -r requirements.txt")
+        env.Execute(".\\.platformio\\penv\\Scripts\\activate")
+        env.Execute("uv pip install -r requirements.txt")
     else:
         env.Execute(". .platformio/penv/bin/activate ; uv pip install -r requirements.txt")


### PR DESCRIPTION
Feature:

- [Bugfix] The fall-back script to install missing requirements didn't work as intended on Windows. Now it does.