### PR TITLE
[WiFi] Fix using all set WiFi credentials

### DIFF
--- a/src/ESPEasy/net/Helpers/WiFi_AP_CandidatesList.cpp
+++ b/src/ESPEasy/net/Helpers/WiFi_AP_CandidatesList.cpp
@@ -9,6 +9,7 @@
 #include "../../../src/Globals/SecuritySettings.h"
 #include "../../../src/Globals/Settings.h"
 #include "../../../src/Helpers/StringConverter.h"
+#include "../wifi/ESPEasyWifi.h"
 
 #if defined(ESP8266)
   # include <ESP8266WiFi.h>
@@ -85,7 +86,6 @@ void WiFi_AP_CandidatesList::load_knownCredentials() {
           }
         }
         known.push_back(tmp_known);
-        ++index;
       }
     }
   }
@@ -591,7 +591,7 @@ bool WiFi_AP_CandidatesList::get_SSID_key(uint8_t index, String& ssid, String& k
 # endif // if FEATURE_STORE_CREDENTIALS_SEPARATE_FILE
 
   // Spaces are allowed in both SSID and pass phrase, so make sure to not trim the ssid and key.
-  return !ssid.isEmpty() && key.length() >= 8;
+  return ESPEasy::net::wifi::validWiFiCredentials(ssid, key);
 }
 
 bool WiFi_AP_CandidatesList::hasWiFiCredentials()

--- a/src/src/DataStructs/SecurityStruct.cpp
+++ b/src/src/DataStructs/SecurityStruct.cpp
@@ -104,12 +104,13 @@ bool SecurityStruct::hasWiFiCredentials(SecurityStruct::WiFiCredentialsSlot slot
 
 String SecurityStruct::getSSID(WiFiCredentialsSlot slot) const
 {
-  if (hasWiFiCredentials(slot)) {
+  String res;
   if (slot == SecurityStruct::WiFiCredentialsSlot::first)
-      return WifiSSID;
+      res = WifiSSID;
   if (slot == SecurityStruct::WiFiCredentialsSlot::second)
-      return WifiSSID2;
-  }
+      res = WifiSSID2;
+  if (ESPEasy::net::wifi::validWiFiSSID(res))
+    return res;
   return EMPTY_STRING;
 }
 

--- a/src/src/DataStructs/SecurityStruct_deviceSpecific.cpp
+++ b/src/src/DataStructs/SecurityStruct_deviceSpecific.cpp
@@ -84,23 +84,18 @@ bool SecurityStruct_deviceSpecific::hasWiFiCredentials() const
 
 bool SecurityStruct_deviceSpecific::hasWiFiCredentials(uint8_t index) const
 {
-  if (index >= MAX_EXTRA_WIFI_CREDENTIALS_SEPARATE_FILE) { return false; }
-  String ssid, pass;
-
-  if (!_kvs.getValue(createKey(KeyType::WiFi_SSID, index), ssid, KVS_StorageType::Enum::string_type) ||
-      !_kvs.getValue(createKey(KeyType::WiFi_Password, index), pass, KVS_StorageType::Enum::string_type)) {
-    return false;
-  }
-  return ESPEasy::net::wifi::validWiFiCredentials(ssid, pass);
+  String ssid, passwd;
+  return getWiFiCredentials(index, ssid, passwd);
 }
 
 bool SecurityStruct_deviceSpecific::getWiFiCredentials(uint8_t index,
                                                        String& ssid,
                                                        String& passwd) const
 {
-  return
-    index < MAX_EXTRA_WIFI_CREDENTIALS_SEPARATE_FILE &&
-    getCredentials(KeyType::WiFi_SSID, KeyType::WiFi_Password, index, ssid, passwd);
+  if (index >= MAX_EXTRA_WIFI_CREDENTIALS_SEPARATE_FILE) { return false; }
+
+  if (!getCredentials(KeyType::WiFi_SSID, KeyType::WiFi_Password, index, ssid, passwd)) { return false; }
+  return ESPEasy::net::wifi::validWiFiCredentials(ssid, passwd);
 }
 
 void SecurityStruct_deviceSpecific::setWiFiCredentials(


### PR DESCRIPTION
Problem was, the index was incremented extra when a valid value was found, thus skipping every odd one when multiple credentials were set.

reported here: https://github.com/letscontrolit/ESPEasy/issues/5534#issuecomment-4497513862
