### PR TITLE
[UI] Update icon for Tools tab

### DIFF
--- a/src/src/WebServer/WebTemplateParser.cpp
+++ b/src/src/WebServer/WebTemplateParser.cpp
@@ -135,7 +135,7 @@ const __FlashStringHelper* getGpMenuIcon(uint8_t index) {
     case MENU_INDEX_DEVICES:       return ICON("&#10070;");
     case MENU_INDEX_RULES:         return ICON("&#10740;");
     case MENU_INDEX_NOTIFICATIONS: return ICON("&#9993;");
-    case MENU_INDEX_TOOLS:         return ICON("&#9888;");
+    case MENU_INDEX_TOOLS:         return ICON("&#128295;");
   }
   return F("");
 }


### PR DESCRIPTION
Feature:

- [UI] Use a better fitting icon for the Tools tab, as requested [here](https://github.com/letscontrolit/ESPEasy/issues/5534#issuecomment-4289366942)

<img width="513" height="69" alt="image" src="https://github.com/user-attachments/assets/87e33537-a5ba-4ae8-aea4-63667fd59fd9" />

<img width="513" height="69" alt="image" src="https://github.com/user-attachments/assets/f03d7636-7520-4579-b352-697c086b75c9" />
