### PR TITLE
docs: fix occurrence spelling in docs

### DIFF
--- a/docs/source/Rules/Rules.rst
+++ b/docs/source/Rules/Rules.rst
@@ -436,7 +436,7 @@ For example, there is a task named "bme280" which has a value named "temperature
 
 Its value can be referenced like this: ``[bme280#temperature]``.
 This can be used in some plugins like the "OLED Framed" plugin to populate some lines on the display.
-It can also be used in rules. Every occurance of this text will then be replaced by its value.
+It can also be used in rules. Every occurrence of this text will then be replaced by its value.
 
 When having a rule to handle the value of a task, like this:
 


### PR DESCRIPTION
Changes:
- `occurance` -> `occurrence` in `docs/source/Rules/Rules.rst` (1 occurrence(s), preserving capitalization where applicable)

Verification:
- Applied an exact spelling-only replacement against the current upstream base branch.
- Checked the repository is not archived or a fork.
- Checked open PR titles and my open PRs before opening this PR.
