### PR TITLE
[SysVars] List variables numerically sorted

### DIFF
--- a/docs/source/Participate/PlatformIO.rst
+++ b/docs/source/Participate/PlatformIO.rst
@@ -83,7 +83,7 @@ Optional, but highly recommended:
 * C/C++ DevTools (by Microsoft)
 * Bookmarks (by Alessandro Fragnani)
 * GitLens - Git supercharged (by Gitkraken)
-* Todo Tree (by Gruntfuggly)
+* TODO Highlight (by Wayou Liu)
 * All Autocomplete (by Atishay Jain)
 * Excel Viewer (by GrapeCity)
 * Esbonio - An extension for editing sphinx projects (by Swyddfa)

--- a/src/src/WebServer/SysVarPage.cpp
+++ b/src/src/WebServer/SysVarPage.cpp
@@ -52,6 +52,16 @@ void handle_sysvars() {
   html_table_header(F("URL encoded"), F("RTDReference/SystemVariable.html"), 0);
 
   addTableSeparator(F("Custom Variables"), 3, 3);
+  # if !defined(LIMIT_BUILD_SIZE) || FEATURE_STRING_VARIABLES
+  auto numAlphaSort = [](const String& a, const String& b) {
+                        const int32_t ai = a.toInt();
+
+                        if (!ai) { return false; } // Alphanum after num
+                        return ai < b.toInt();     // Numerical order
+                      };
+  std::vector<String> customStringSort;
+
+  # endif // if !defined(LIMIT_BUILD_SIZE) || FEATURE_STRING_VARIABLES
 
   if (customFloatVar.empty()) {
     html_TR_TD();
@@ -59,14 +69,33 @@ void handle_sysvars() {
     html_TD();
     html_TD();
   } else {
+    # if !defined(LIMIT_BUILD_SIZE) || FEATURE_STRING_VARIABLES
+
+    for (auto it = customFloatVar.begin(); it != customFloatVar.end(); ++it) {
+      customStringSort.push_back(it->first);
+    }
+    std::sort(customStringSort.begin(), customStringSort.end(), numAlphaSort);
+
+    for (auto& it : customStringSort) {
+      NumericalType detectedType;
+      bool isv_ = true;
+
+      if (getNumerical(it, NumericalType::HexadecimalUInt, detectedType).length() > 0) {
+        isv_ = detectedType != NumericalType::Integer;
+      }
+      addSysVar_html(strformat(F("%%%s%s%%"), FsP(isv_ ? F("v_") : F("v")), it.c_str()), false);
+    }
+    # else // if !defined(LIMIT_BUILD_SIZE) || FEATURE_STRING_VARIABLES
     for (auto it = customFloatVar.begin(); it != customFloatVar.end(); ++it) {
       NumericalType detectedType;
       bool isv_ = true;
+
       if (getNumerical(it->first, NumericalType::HexadecimalUInt, detectedType).length() > 0) {
         isv_ = detectedType != NumericalType::Integer;
       }
       addSysVar_html(strformat(F("%%%s%s%%"), FsP(isv_ ? F("v_") : F("v")), it->first.c_str()), false);
     }
+    # endif // if !defined(LIMIT_BUILD_SIZE) || FEATURE_STRING_VARIABLES
   }
 
   # if FEATURE_STRING_VARIABLES
@@ -78,8 +107,15 @@ void handle_sysvars() {
     html_TD();
     html_TD();
   } else {
+    customStringSort.clear();
+
     for (auto it = customStringVar.begin(); it != customStringVar.end(); ++it) {
-      addSysVar_html(strformat(F("[str#%s]"), it->first.c_str()), false);
+      customStringSort.push_back(it->first);
+    }
+    std::sort(customStringSort.begin(), customStringSort.end(), numAlphaSort);
+
+    for (auto& it : customStringSort) {
+      addSysVar_html(strformat(F("[str#%s]"), it.c_str()), false);
     }
   }
   # endif // if FEATURE_STRING_VARIABLES

--- a/src/src/WebServer/SysVarPage.cpp
+++ b/src/src/WebServer/SysVarPage.cpp
@@ -55,9 +55,12 @@ void handle_sysvars() {
   # if !defined(LIMIT_BUILD_SIZE) || FEATURE_STRING_VARIABLES
   auto numAlphaSort = [](const String& a, const String& b) {
                         const int32_t ai = a.toInt();
+                        const int32_t bi = b.toInt();
+
+                        if (!ai && !bi) { return a < b; } // a..z
 
                         if (!ai) { return false; } // Alphanum after num
-                        return ai < b.toInt();     // Numerical order
+                        return ai < bi;     // Numerical order
                       };
   std::vector<String> customStringSort;
 


### PR DESCRIPTION
Features:
- Sort System variables numerically correct, as they are stored alphanumerically sorted. (Not available in `LIMIT_BUILD_SIZE` builds because of size.)
- [Docs] Suggest VSCode plugin TODO Highlight instead of Todo Tree as that doesn't work anymore without an external tool

Example:
<img width="268" height="630" alt="Image" src="https://github.com/user-attachments/assets/e4f3cb4c-f752-4f36-956b-f14e07f28702" />