### PR TITLE
[Bugfix] Limit humidity to 100% after applying temperature compensation

### DIFF
--- a/src/_P028_BME280.ino
+++ b/src/_P028_BME280.ino
@@ -6,6 +6,7 @@
 // #######################################################################################################
 
 /** Changelog:
+ * 2026-07-03 tonhuisman: Cap humidity at 100% when applying temperature compensation value
  * 2023-07-27 tonhuisman: Revert most below changes and implement PLUGIN_GET_DEVICEVTYPE so the P2P controller validates against the correct
  *                        setting. Setting is only available if a remote data-feed is active, and offers BME280 and BMP280 options only.
  * 2023-07-26 tonhuisman: Ignore all humidity data (and log messages) if BMP280 Sensor model is selected

--- a/src/_P068_SHT3x.ino
+++ b/src/_P068_SHT3x.ino
@@ -17,11 +17,14 @@
 // ########################## Adapted to ESPEasy 2.0 by Jochen Krapf #####################################
 // #######################################################################################################
 
-// Changelog:
-// 2023-04-28 @iz8mbw: Rename sensor to SHT3x from SHT30/31/35
-// 2021-06-12 @tonhuisman: Add temperature offset setting, with humidity compensation method 'borrowed' from BME280 sensor
-// 2020-??    @TD-er: Maitenance updates
-// 2017-07-18 @JK-de: Plugin adaption for ESPEasy 2.0
+/** Changelog:
+ * 2026-07-03 tonhuisman: Cap humidity at 100% when applying temperature compensation value
+ *                        Reformat Changelog
+ * 2023-04-28 @iz8mbw: Rename sensor to SHT3x from SHT30/31/35
+ * 2021-06-12 @tonhuisman: Add temperature offset setting, with humidity compensation method 'borrowed' from BME280 sensor
+ * 2020-??    @TD-er: Maitenance updates
+ * 2017-07-18 @JK-de: Plugin adaption for ESPEasy 2.0
+ */
 
 # define PLUGIN_068
 # define PLUGIN_ID_068         68

--- a/src/_P105_AHT.ino
+++ b/src/_P105_AHT.ino
@@ -27,6 +27,7 @@
  */
 
 /** History:
+ * 2026-07-03 tonhuisman: Cap humidity at 100% when applying temperature compensation value
  * 2024-12-21 chromoxdor: Add temperature offset + simple humidity compensation
  * 2024-12-03 tonhuisman: Add alternative initialization for AHT10 (clone), see https://github.com/letscontrolit/ESPEasy/issues/5172
  *                        Small code optimization.
@@ -155,6 +156,7 @@ boolean Plugin_105(uint8_t function, struct EventStruct *event, String& string)
         FormSelectorOptions selector(optionCount, options, indices);
         selector.reloadonchange = true;
         selector.addFormSelector(F("Sensor model"), F("ahttype"), P105_AHT_TYPE);
+
         // addFormNote(F("Changing Sensor model will reload the page."));
 
         if (static_cast<int>(AHTx_device_type::AHT10_DEVICE) == P105_AHT_TYPE) {
@@ -220,7 +222,7 @@ boolean Plugin_105(uint8_t function, struct EventStruct *event, String& string)
         P105_data->state = AHTx_state::AHTx_Values_read;
 
         UserVar.setFloat(event->TaskIndex, 0, P105_data->getTemperature() + (P105_TEMPERATURE_OFFSET / 10.0f));
-        UserVar.setFloat(event->TaskIndex, 1, P105_data->getHumidity() * (1 - 0.005f * P105_TEMPERATURE_OFFSET));
+        UserVar.setFloat(event->TaskIndex, 1, min(P105_data->getHumidity() * (1 - 0.005f * P105_TEMPERATURE_OFFSET), 100.0f));
 
         if (loglevelActiveFor(LOG_LEVEL_INFO)) {
           addLogMove(LOG_LEVEL_INFO, strformat(F("%s : Addr: 0x%02x"), P105_data->getDeviceName().c_str(), P105_I2C_ADRESS));

--- a/src/src/PluginStructs/P028_data_struct.cpp
+++ b/src/src/PluginStructs/P028_data_struct.cpp
@@ -137,7 +137,7 @@ bool P028_data_struct::updateMeasurements(taskIndex_t task_index) {
         log += concat(F(" humidity: "), last_hum_val);
       }
       # endif // ifndef LIMIT_BUILD_SIZE
-      last_hum_val = compute_humidity_from_dewpoint(last_temp_val + temp_offset, last_dew_temp_val);
+      last_hum_val = min(compute_humidity_from_dewpoint(last_temp_val + temp_offset, last_dew_temp_val), 100.0f);
 
       # ifndef LIMIT_BUILD_SIZE
 

--- a/src/src/PluginStructs/P068_data_struct.cpp
+++ b/src/src/PluginStructs/P068_data_struct.cpp
@@ -47,7 +47,7 @@ void P068_SHT3X::readFromSensor()
       if (!essentiallyZero(tmpOff)) {
         const float last_dew_temp_val = compute_dew_point_temp(tmp + (tmpOff / 2.0f), hum);
         tmp += tmpOff;
-        hum  = compute_humidity_from_dewpoint(tmp, last_dew_temp_val);
+        hum  = min(compute_humidity_from_dewpoint(tmp, last_dew_temp_val), 100.0f);
       }
     }
   }


### PR DESCRIPTION
Resolves #5572 

Bugfixes:
- [P028] Limit humidity to 100% after applying temperature compensation
- [P068] Limit humidity to 100% after applying temperature compensation
- [P105] Limit humidity to 100% after applying temperature compensation

TODO:
- [ ] Investigate updated `compute_humidity_from_dewpoint()` function
- [ ] Investigate updated `compute_dew_point_temp()` function
- [ ] Testing