### PR TITLE
[UI] DevicesPage: Hide Controllers if no values to send

### DIFF
--- a/src/src/ESPEasyCore/ESPEasyRules.cpp
+++ b/src/src/ESPEasyCore/ESPEasyRules.cpp
@@ -1462,30 +1462,31 @@ void createRuleEvents(struct EventStruct *event) {
     for (uint8_t varNr = 0; varNr < valueCount; varNr++) {
       eventQueue.add(event->TaskIndex, Cache.getTaskDeviceValueName(event->TaskIndex, varNr), formatUserVarNoCheck(event, varNr));
     }
-    #if FEATURE_STRING_VARIABLES
-    if (Settings.EventAndLogDerivedTaskValues(event->TaskIndex)) {
-      taskName.toLowerCase();
-
-      auto it = customStringVar.begin();
-      while (it != customStringVar.end()) {
-        if (it->first.startsWith(search) && it->first.endsWith(postfix)) {
-          String valueName = it->first.substring(search.length(), it->first.indexOf('-'));
-          const String vname2 = getDerivedValueName(taskName, valueName);
-          if (!vname2.isEmpty()) {
-            valueName = vname2;
-          }
-          if (!it->second.isEmpty()) {
-            String value(it->second);
-            value = parseTemplateAndCalculate(value);
-            eventQueue.add(event->TaskIndex, valueName, value);
-          }
-        }
-        else if (it->first.substring(0, search.length()).compareTo(search) > 0) {
-          break;
-        }
-        ++it;
-      }
-    }
-    #endif // if FEATURE_STRING_VARIABLES
   }
+  #if FEATURE_STRING_VARIABLES
+  if (!Settings.CombineTaskValues_SingleEvent(event->TaskIndex) // Send events of derived values for all sensorTypes when enabled
+      && Settings.EventAndLogDerivedTaskValues(event->TaskIndex)) {
+    taskName.toLowerCase();
+
+    auto it = customStringVar.begin();
+    while (it != customStringVar.end()) {
+      if (it->first.startsWith(search) && it->first.endsWith(postfix)) {
+        String valueName = it->first.substring(search.length(), it->first.indexOf('-'));
+        const String vname2 = getDerivedValueName(taskName, valueName);
+        if (!vname2.isEmpty()) {
+          valueName = vname2;
+        }
+        if (!it->second.isEmpty()) {
+          String value(it->second);
+          value = parseTemplateAndCalculate(value);
+          eventQueue.add(event->TaskIndex, valueName, value);
+        }
+      }
+      else if (it->first.substring(0, search.length()).compareTo(search) > 0) {
+        break;
+      }
+      ++it;
+    }
+  }
+  #endif // if FEATURE_STRING_VARIABLES
 }

--- a/src/src/WebServer/DevicesPage.cpp
+++ b/src/src/WebServer/DevicesPage.cpp
@@ -1664,17 +1664,20 @@ void devicePage_show_controller_config(taskIndex_t taskIndex, deviceIndex_t Devi
                   F("Unchecked: Send event per value. Checked: Send single event (%s#All) containing all values"),
                   getTaskDeviceName(taskIndex).c_str()));
 
+    bool sendDerived{};
     # if FEATURE_STRING_VARIABLES
 
     if (!device.HideDerivedValues) {
+      sendDerived = Settings.EventAndLogDerivedTaskValues(taskIndex);
       addFormCheckBox(F("Show derived values"),            F("TSDV"), Settings.ShowDerivedTaskValues(taskIndex));
-      addFormCheckBox(F("Event &amp; Log derived values"), F("TELD"), Settings.EventAndLogDerivedTaskValues(taskIndex));
+      addFormCheckBox(F("Event &amp; Log derived values"), F("TELD"), sendDerived);
     }
     # endif // if FEATURE_STRING_VARIABLES
 
-    bool separatorAdded = false;
+    const uint8_t valueCount = getValueCountForTask(taskIndex);
+    bool separatorAdded      = false;
 
-    for (controllerIndex_t controllerNr = 0; controllerNr < CONTROLLER_MAX; controllerNr++)
+    for (controllerIndex_t controllerNr = 0; controllerNr < CONTROLLER_MAX && (valueCount > 0 || sendDerived); controllerNr++)
     {
       if (Settings.Protocol[controllerNr] != 0)
       {


### PR DESCRIPTION
From a RFLink [forum question](https://www.letscontrolit.com/forum/viewtopic.php?t=10974#p76742)

Features:
- Hide Controllers on the Device configuration page if no values can be sent. Will enable if `Event & Log derived values` is enabled, as then there can be values to send.
- Send Derived values as events for all Device Sensor `VType` values (`SENSOR_TYPE_STRING` was not handled)