### PR TITLE
[ESPEasy p2p] Only update remote task with changes on the sender #5496

### DIFF
--- a/src/_C013.cpp
+++ b/src/_C013.cpp
@@ -259,7 +259,7 @@ void C013_Receive(struct EventStruct *event) {
         // Allocate this is a separate scope since C013_SensorInfoStruct is a HUGE object
         // Should not be left allocated on the stack when calling PLUGIN_INIT and save, etc.
 
-        auto infoReply = C013_SensorInfoStruct::create(event->Data, event->Par2);
+        auto infoReply = C013_SensorInfoStruct::createFromReceived(event->Data, event->Par2);
         if (!infoReply) return;
 
         {
@@ -280,13 +280,13 @@ void C013_Receive(struct EventStruct *event) {
           if ((mustUpdateCurrentTask || !validPluginID_fullcheck(currentPluginID)) &&
               supportedPluginID(infoReply->deviceNumber))
           {
-            taskClear(infoReply->destTaskIndex, false);
+            if (mustUpdateCurrentTask) {
+              setTaskEnableStatus(infoReply->destTaskIndex, false);
+            } else {
+              taskClear(infoReply->destTaskIndex, false);
+            }
             Settings.TaskDeviceNumber[infoReply->destTaskIndex]   = infoReply->deviceNumber.value;
             Settings.TaskDeviceDataFeed[infoReply->destTaskIndex] = infoReply->sourceUnit; // remote feed store unit nr sending the data
-
-            if (mustUpdateCurrentTask) {
-              Settings.TaskDeviceEnabled[infoReply->destTaskIndex] = true;
-            }
 
             constexpr pluginID_t DUMMY_PLUGIN_ID{ 33 };
 
@@ -336,8 +336,7 @@ void C013_Receive(struct EventStruct *event) {
           struct EventStruct TempEvent(taskIndex);
           TempEvent.Source = EventValueSource::Enum::VALUE_SOURCE_UDP;
 
-          String dummy;
-          PluginCall(PLUGIN_INIT, &TempEvent, dummy);
+          setTaskEnableStatus(&TempEvent, true);
         }
       }
       break;

--- a/src/_P102_PZEM004Tv3.ino
+++ b/src/_P102_PZEM004Tv3.ino
@@ -368,6 +368,7 @@ boolean                    Plugin_102(uint8_t function, struct EventStruct *even
 # if FEATURE_PACKED_RAW_DATA
     case PLUGIN_GET_PACKED_RAW_DATA:
     {
+      if (P102_PZEM_sensor == nullptr) break;
       // Matching JS code for PZEM-004T:
       // return decode(bytes, [header, int16_1e1, int32_1e3, int32_1e1, int32_1e1, uint16_1e2, uint8_1e1],
       //   ['header', 'voltage', 'current', 'power', 'energy', 'powerfactor', 'frequency']);

--- a/src/src/DataStructs/C013_p2p_SensorInfoStruct.cpp
+++ b/src/src/DataStructs/C013_p2p_SensorInfoStruct.cpp
@@ -94,7 +94,7 @@ bool C013_SensorInfoStruct::prepareForSend(size_t& sizeToSend)
   return true;
 }
 
-UP_C013_SensorInfoStruct C013_SensorInfoStruct::create(const uint8_t *data, size_t size)
+UP_C013_SensorInfoStruct C013_SensorInfoStruct::createFromReceived(const uint8_t *data, size_t size)
 {
   {
     UP_C013_SensorInfoStruct invalid_res{};

--- a/src/src/DataStructs/C013_p2p_SensorInfoStruct.h
+++ b/src/src/DataStructs/C013_p2p_SensorInfoStruct.h
@@ -25,7 +25,7 @@ struct __attribute__((__packed__)) C013_SensorInfoStruct
   C013_SensorInfoStruct() = default;
 
 
-  static UP_C013_SensorInfoStruct create(const uint8_t *data, size_t size);
+  static UP_C013_SensorInfoStruct createFromReceived(const uint8_t *data, size_t size);
 
   bool prepareForSend(size_t& sizeToSend);
 

--- a/src/src/Globals/Plugins.cpp
+++ b/src/src/Globals/Plugins.cpp
@@ -807,15 +807,20 @@ bool PluginCall(uint8_t Function, struct EventStruct *event, String& str)
         return false;
       }
 
-      if ((Function == PLUGIN_READ) || (Function == PLUGIN_INIT) || (Function == PLUGIN_PROCESS_CONTROLLER_DATA)) {
+      if ((Function == PLUGIN_READ) 
+       || (Function == PLUGIN_INIT) 
+       || (Function == PLUGIN_GET_PACKED_RAW_DATA)
+       || (Function == PLUGIN_TASKTIMER_IN) 
+       || (Function == PLUGIN_PROCESS_CONTROLLER_DATA)) {
         if (!Settings.TaskDeviceEnabled[event->TaskIndex]) {
           return false;
         }
+      }
 
-        if (Function == PLUGIN_INIT) {
-          clearTaskCache(event->TaskIndex);
-          UserVar.clear_computed(event->TaskIndex);
-        }
+      if ((Function == PLUGIN_INIT) 
+        || (Function == PLUGIN_EXIT)) {
+        clearTaskCache(event->TaskIndex);
+        UserVar.clear_computed(event->TaskIndex);
       }
       const deviceIndex_t DeviceIndex = getDeviceIndex_from_TaskIndex(event->TaskIndex);
 
@@ -826,7 +831,9 @@ bool PluginCall(uint8_t Function, struct EventStruct *event, String& str)
             // Only exception is when ErrorStateValues is needed.
             // Therefore only need to call LoadTaskSettings for those tasks with ErrorStateValues
             LoadTaskSettings(event->TaskIndex);
-          } else if ((Function == PLUGIN_INIT) || (Function == PLUGIN_WEBFORM_LOAD) || (Function == PLUGIN_WEBFORM_LOAD_ALWAYS)) {
+          } else if ((Function == PLUGIN_INIT) 
+                  || (Function == PLUGIN_WEBFORM_LOAD) 
+                  || (Function == PLUGIN_WEBFORM_LOAD_ALWAYS)) {
             // LoadTaskSettings may call PLUGIN_GET_DEVICEVALUENAMES.
             LoadTaskSettings(event->TaskIndex);
           }

--- a/src/src/Helpers/Hardware_PWM.cpp
+++ b/src/src/Helpers/Hardware_PWM.cpp
@@ -237,7 +237,7 @@ bool set_Gpio_PWM(int gpio, uint32_t dutyCycle, uint32_t fadeDuration_ms, uint32
 #if ESP_IDF_VERSION_MAJOR >= 5
 
 // FIXME TD-er: For now fade is disabled. See: https://github.com/espressif/arduino-esp32/issues/12709
-fadeDuration_ms = 0;
+//fadeDuration_ms = 0;
 
   if (fadeDuration_ms == 0)
   {

--- a/src/src/Helpers/Misc.cpp
+++ b/src/src/Helpers/Misc.cpp
@@ -145,6 +145,17 @@ bool setControllerEnableStatus(controllerIndex_t controllerIndex, bool enabled)
 /********************************************************************************************\
    Toggle task enabled state
  \*********************************************************************************************/
+bool setTaskEnableStatus(taskIndex_t taskIndex,
+                         bool        enabled)
+{
+  if (Settings.TaskDeviceEnabled[taskIndex] != enabled) {
+    struct EventStruct TempEvent(taskIndex);
+    return setTaskEnableStatus(&TempEvent, enabled);
+  }
+  return true;
+}
+
+
 bool setTaskEnableStatus(struct EventStruct *event, bool enabled)
 {
   if (!validTaskIndex(event->TaskIndex)) { return false; }
@@ -192,11 +203,8 @@ void taskClear(taskIndex_t taskIndex, bool save)
   checkRAM(F("taskClear"));
   #endif // ifndef BUILD_NO_RAM_TRACKER
 
-  if (Settings.TaskDeviceEnabled[taskIndex]) {
-    struct EventStruct TempEvent(taskIndex);
-    String dummy;
-    PluginCall(PLUGIN_EXIT, &TempEvent, dummy);
-  }
+  setTaskEnableStatus(taskIndex, false);
+
   Settings.clearTask(taskIndex);
   clearTaskCache(taskIndex); // Invalidate any cached values.
   ExtraTaskSettings.clear();

--- a/src/src/Helpers/Misc.h
+++ b/src/src/Helpers/Misc.h
@@ -60,9 +60,11 @@ bool setControllerEnableStatus(controllerIndex_t controllerIndex,
 /********************************************************************************************\
    Toggle task enabled state
  \*********************************************************************************************/
-bool setTaskEnableStatus(struct EventStruct *event,
+bool setTaskEnableStatus(taskIndex_t taskIndex,
                          bool        enabled);
 
+bool setTaskEnableStatus(struct EventStruct *event,
+                         bool        enabled);
 
 /********************************************************************************************\
    Clear task settings for given task


### PR DESCRIPTION
When an existing remote task already existed, it was cleared and initialized only with settings in the p2p packet when the sender task was saved.

Fixes: #5496
Fixes: #5344