### PR TITLE
[Bugfix] Taskname wasn't saved because cache was cleared unexpectedly

### DIFF
--- a/src/src/Globals/Plugins.cpp
+++ b/src/src/Globals/Plugins.cpp
@@ -817,8 +817,7 @@ bool PluginCall(uint8_t Function, struct EventStruct *event, String& str)
         }
       }
 
-      if ((Function == PLUGIN_INIT) 
-        || (Function == PLUGIN_EXIT)) {
+      if (Function == PLUGIN_INIT) {
         clearTaskCache(event->TaskIndex);
         UserVar.clear_computed(event->TaskIndex);
       }


### PR DESCRIPTION
Bugfix:
- The task settings-cache was cleared too early on `PLUGIN_EXIT`