### PR TITLE
Change in P037_MQTTImport to enable processing of JSON messages in rules

### DIFF
--- a/src/_P037_MQTTImport.ino
+++ b/src/_P037_MQTTImport.ino
@@ -632,8 +632,6 @@ boolean Plugin_037(uint8_t function, struct EventStruct *event, String& string)
                 }
                 UserVar.setFloat(event->TaskIndex, x, doublePayload);      // Save the new value
 
-
-
                 // Generate event for rules processing - proposed by TridentTD
 
                 if (Settings.UseRules && P037_SEND_EVENTS) {
@@ -661,11 +659,10 @@ boolean Plugin_037(uint8_t function, struct EventStruct *event, String& string)
                     }
                     P037_addEventToQueue(event, RuleEvent);
                   }
-                  else
-                  { // Generate event of all non-json topic/payloads
+                  else // Generate event of all non-json topic/payloads
+                  {
                     String tmp = unparsedPayload;
-                    tmp.replace('}', '>'); // Replace curly braces by angle brackets to avoid problems with string processing in rules
-                    tmp.replace('{', '<');
+                    addEscapeCharacters(tmp); // Add escape characters to avoid problems with rules processing if a JSON message is received
 
                     String RuleEvent = strformat(F("%s#%s=%s"),
                                                 getTaskDeviceName(event->TaskIndex).c_str(),
@@ -697,9 +694,8 @@ boolean Plugin_037(uint8_t function, struct EventStruct *event, String& string)
                     RuleEvent += toString(doublePayload, ExtraTaskSettings.TaskDeviceValueDecimals[x]);
                   } else {
                     String tmp = Payload;
-                    tmp.replace('}', '>');  // Replace curly braces by angle brackets to avoid problems with 
-                    tmp.replace('{', '<');  // string processing in rules if a JSON message is received
-
+                    addEscapeCharacters(tmp); // Add escape characters to avoid problems with rules processing if a JSON message is received
+					
                     RuleEvent += wrapWithQuotesIfContainsParameterSeparatorChar(tmp);
                   }
                   P037_addEventToQueue(event, RuleEvent);

--- a/src/_P037_MQTTImport.ino
+++ b/src/_P037_MQTTImport.ino
@@ -632,24 +632,7 @@ boolean Plugin_037(uint8_t function, struct EventStruct *event, String& string)
                 }
                 UserVar.setFloat(event->TaskIndex, x, doublePayload);      // Save the new value
 
-                if (!checkJson && P037_SEND_EVENTS && Settings.UseRules) { // Generate event of all non-json topic/payloads
-                  String RuleEvent = strformat(F("%s#%s=%s"),
-                                               getTaskDeviceName(event->TaskIndex).c_str(),
-                                               event->String1.c_str(),
-                                               wrapWithQuotesIfContainsParameterSeparatorChar(unparsedPayload).c_str());
-                  P037_addEventToQueue(event, RuleEvent);
-                }
 
-                // Log the event
-                # if !defined(P037_LIMIT_BUILD_SIZE) || defined(P037_OVERRIDE)
-
-                if (loglevelActiveFor(LOG_LEVEL_INFO)) {
-                  addLog(LOG_LEVEL_INFO, strformat(F("IMPT : [%s#%s] : %s"),
-                                                   getTaskDeviceName(event->TaskIndex).c_str(),
-                                                   checkJson ? key.c_str() : getTaskValueName(event->TaskIndex, x).c_str(),
-                                                   toString(doublePayload, ExtraTaskSettings.TaskDeviceValueDecimals[x]).c_str()));
-                }
-                # endif // if !defined(P037_LIMIT_BUILD_SIZE) || defined(P037_OVERRIDE)
 
                 // Generate event for rules processing - proposed by TridentTD
 
@@ -678,6 +661,29 @@ boolean Plugin_037(uint8_t function, struct EventStruct *event, String& string)
                     }
                     P037_addEventToQueue(event, RuleEvent);
                   }
+                  else
+                  { // Generate event of all non-json topic/payloads
+                    String tmp = unparsedPayload;
+                    tmp.replace('}', '>'); // Replace curly braces by angle brackets to avoid problems with string processing in rules
+                    tmp.replace('{', '<');
+
+                    String RuleEvent = strformat(F("%s#%s=%s"),
+                                                getTaskDeviceName(event->TaskIndex).c_str(),
+                                                event->String1.c_str(),
+                                                wrapWithQuotesIfContainsParameterSeparatorChar(tmp).c_str());
+                    P037_addEventToQueue(event, RuleEvent);
+                  }
+
+                  // Log the event
+                  # if !defined(P037_LIMIT_BUILD_SIZE) || defined(P037_OVERRIDE)
+
+                  if (loglevelActiveFor(LOG_LEVEL_INFO)) {
+                    addLog(LOG_LEVEL_INFO, strformat(F("IMPT : [%s#%s] : %s"),
+                                                    getTaskDeviceName(event->TaskIndex).c_str(),
+                                                    checkJson ? key.c_str() : getTaskValueName(event->TaskIndex, x).c_str(),
+                                                    toString(doublePayload, ExtraTaskSettings.TaskDeviceValueDecimals[x]).c_str()));
+                  }
+                  # endif // if !defined(P037_LIMIT_BUILD_SIZE) || defined(P037_OVERRIDE)
 
                   // (Always) Generate <Taskname>#<Valuename>=<Payload> event
                   String RuleEvent;
@@ -690,7 +696,11 @@ boolean Plugin_037(uint8_t function, struct EventStruct *event, String& string)
                   if (numericPayload) {
                     RuleEvent += toString(doublePayload, ExtraTaskSettings.TaskDeviceValueDecimals[x]);
                   } else {
-                    RuleEvent += wrapWithQuotesIfContainsParameterSeparatorChar(Payload);
+                    String tmp = Payload;
+                    tmp.replace('}', '>');  // Replace curly braces by angle brackets to avoid problems with 
+                    tmp.replace('{', '<');  // string processing in rules if a JSON message is received
+
+                    RuleEvent += wrapWithQuotesIfContainsParameterSeparatorChar(tmp);
                   }
                   P037_addEventToQueue(event, RuleEvent);
                 }

--- a/src/src/Helpers/StringParser.cpp
+++ b/src/src/Helpers/StringParser.cpp
@@ -46,6 +46,17 @@ void stripEscapeCharacters(String& str)
   }
 }
 
+void addEscapeCharacters(String& str)
+{
+  const char braces[]     = { '%', '[', ']', '{', '}', '(', ')' };
+  constexpr uint8_t nrbraces = NR_ELEMENTS(braces);
+
+  for (uint8_t i = 0; i < nrbraces; ++i) {
+    const String s(concat(F("\\"), braces[i]));
+    str.replace(s.substring(1), s);
+  }
+}
+
 #if FEATURE_STRING_VARIABLES
 String parseTemplateAndCalculate(String& tmpString) {
   stripEscapeCharacters(tmpString);

--- a/src/src/Helpers/StringParser.h
+++ b/src/src/Helpers/StringParser.h
@@ -15,6 +15,8 @@ bool hasEscapedCharacter(String& str, const char EscapeChar);
 // So far \\% \\[ \\] \\{ \\} \\( and \\) are used (all with single backslash!)
 void   stripEscapeCharacters(String& str);
 
+void   addEscapeCharacters(String& str);
+
 #if FEATURE_STRING_VARIABLES
 String parseTemplateAndCalculate(String& tmpString);
 uint8_t getDerivedValueCountForTask(taskIndex_t taskIndex);


### PR DESCRIPTION
Currently the processing of JSON formated messages can only be done via the MQTTImport device.

As this device has certain limitations in processing of JSON messages, it is beneficial if it would also be possible to process JSON messages in rules. This is currently not possible, because the curly brackets used in JSON messages are handled as special characters by the rules engine.

I propose to substitute all curly brackets in **unprocessed** JSON messages with angle brackets before the data is put into the event queue by the MQTTImport device. So, JSON messages do not interfere with string manipulation commands in rules.

**example:**
Note the outcome at the last line at before and after...

rule:
```
On MQTTImport* Do
  LogEntry,'get: %eventname% - %eventpar% - %eventvalue1%'
  LogEntry,`get: {substring:11:17:'%eventvalue1%'}`
Endon
```

before:
```
Info   | EVENT: MQTTImport#devices/rpc/request='{"method":"setDo0","params":true}'
Info   | ACT  : LogEntry,'get: MQTTImport#devices/rpc/request - devices/rpc/request - {"method":"setDo0","params":true}'
>  LogEntry,'get: MQTTImport#devices/rpc/request - devices/rpc/request - {"method":"setDo0","params":true}'
Info   | get: MQTTImport#devices/rpc/request - devices/rpc/request - {"method":"setDo0","params":true}
>  get: MQTTImport#devices/rpc/request - devices/rpc/request - {"method":"setDo0","params":true}
Info   | ACT  : LogEntry,`get: {substring:11:17:'{"method":"setDo0","params":true}'}`
>  LogEntry,`get: {substring:11:17:'{"method":"setDo0","params":true}'}`
Info   | get: {substring:11:17:'{"method":"setDo0","params":true}'}
>  get: {substring:11:17:'{"method":"setDo0","params":true}'}
```

after:
```
Info   | EVENT: MQTTImport#devices/rpc/request='<"method":"setDo0","params":true>'
Info   | ACT  : LogEntry,'get: MQTTImport#devices/rpc/request - devices/rpc/request - <"method":"setDo0","params":true>'
>  LogEntry,'get: MQTTImport#devices/rpc/request - devices/rpc/request - <"method":"setDo0","params":true>'
Info   | get: MQTTImport#devices/rpc/request - devices/rpc/request - <"method":"setDo0","params":true>
>  get: MQTTImport#devices/rpc/request - devices/rpc/request - <"method":"setDo0","params":true>
Info   | ACT  : LogEntry,`get: setDo0`
>  LogEntry,`get: setDo0`
Info   | get: setDo0
>  get: setDo0
```