### PR TITLE
[Fix] Write _plugin_sets_overview.repl as utf-8 so it works again on Windows

### DIFF
--- a/docs/builds_overview.py
+++ b/docs/builds_overview.py
@@ -173,7 +173,7 @@ def generateBuildOverview(fileName):
   
   print('Writing build sets overview to:', filepath)
 
-  output = open(filepath, "w")
+  output = open(filepath, "w", encoding="utf-8")
   output.write('Plugins per build set\n')
   output.write('=====================\n')
   output.write('\n')


### PR DESCRIPTION
As reported [here](https://github.com/letscontrolit/ESPEasy/pull/5390#issuecomment-5122301703)

File was written with default encoding, that's CP1252 on Windows that doesn't support the (UTF-8) check-mark used,