### PR TITLE
[Build] Fix Minimal 1M builds without I2C included

### DIFF
--- a/platformio_esp82xx_base.ini
+++ b/platformio_esp82xx_base.ini
@@ -410,6 +410,7 @@ lib_ignore                = ESP32_ping
                             htcw_ip5306										
                             ld2410											
                             supertinycron
+                            AT24CX
 ;lib_ignore                = ${esp82xx_1M.lib_ignore}
 ; Adding the libs below to the lib_ignore will even increase build size
 ;                            Adafruit TCS34725


### PR DESCRIPTION
Fix builds, that don't have I2C included for size reasons, to exclude the AT24CX library