### PR TITLE
[Build] Fix Neopixel build-size by disabling Chart-JS feature

### DIFF
--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -2525,11 +2525,11 @@ To create/register a plugin, you have to :
   #ifdef ESP8266
     #define FEATURE_PLUGIN_STATS  0
   #endif
-  #if FEATURE_CHART_JS && defined(ESP8266)
+  #if FEATURE_CHART_JS // && defined(ESP8266)
     // Does not fit in build
     #undef FEATURE_CHART_JS
   #endif
-  #ifdef ESP8266
+  #ifndef FEATURE_CHART_JS
     #define FEATURE_CHART_JS  0
   #endif
   #if !defined(USES_P138) && defined(ESP32)


### PR DESCRIPTION
It failed for ESP32-C6, and may soon fail for other ESP32 builds too, so disabled a 'less needed' feature from the Neopixel builds