### PR TITLE
[Build] Fix serial defines and streamline EEPROM settings

### DIFF
--- a/src/src/CustomBuild/define_plugin_sets.h
+++ b/src/src/CustomBuild/define_plugin_sets.h
@@ -2190,6 +2190,18 @@ To create/register a plugin, you have to :
   #if !defined(USES_P180) && defined(ESP32)
     #define USES_P180   // Generic - I2C Generic
   #endif
+
+  #if FEATURE_CHART_JS // && defined(ESP8266)
+    // Does not fit in build
+    #undef FEATURE_CHART_JS
+  #endif
+  #ifndef FEATURE_CHART_JS
+    #if PLUGIN_BUILD_MAX_ESP32
+    #define FEATURE_CHART_JS  1
+    #else
+    #define FEATURE_CHART_JS  0
+    #endif
+  #endif
 #endif // ifdef PLUGIN_DISPLAY_B_COLLECTION
 
 // Collection of climate A plugins.

--- a/src/src/Helpers/_Plugin_Helper_serial.h
+++ b/src/src/Helpers/_Plugin_Helper_serial.h
@@ -4,10 +4,6 @@
 
 #include "../../ESPEasy_common.h"
 
-#ifdef PLUGIN_USES_SERIAL
-
-#include <ESPeasySerial.h>
-
 constexpr uint8_t INCLUDE_SW_SERIAL  = (1 << 0);
 constexpr uint8_t INCLUDE_HW_SERIAL  = (1 << 1); // Ignored for now, always enabled
 constexpr uint8_t INCLUDE_I2C_SERIAL = (1 << 2);
@@ -15,6 +11,10 @@ constexpr uint8_t INCLUDE_CDC_SERIAL = (1 << 3);
 constexpr uint8_t INCLUDE_ALL_SERIAL = (INCLUDE_SW_SERIAL | INCLUDE_HW_SERIAL | INCLUDE_I2C_SERIAL | INCLUDE_CDC_SERIAL);
 constexpr uint8_t INCLUDE_DEFAULT_SERIAL = INCLUDE_ALL_SERIAL;
 constexpr uint8_t INCLUDE_NOT_CDC_SERIAL = (INCLUDE_SW_SERIAL | INCLUDE_HW_SERIAL | INCLUDE_I2C_SERIAL);
+
+#ifdef PLUGIN_USES_SERIAL
+
+#include <ESPeasySerial.h>
 
 struct ESPeasySerialType;
 

--- a/src/src/WebServer/EepromVarPage.cpp
+++ b/src/src/WebServer/EepromVarPage.cpp
@@ -50,11 +50,15 @@ void handle_eepromvars() {
 
     const uint32_t maxSlots = ESPEasy::eeprom::getEEPROMMaxSlots();
     uint32_t count{};
+    uint32_t start = millis();
 
     for (uint32_t slot = 0; slot < maxSlots; ++slot) {
       const ESPEASY_RULES_FLOAT_TYPE value = ESPEasy::eeprom::readEEPROMSlot(slot);
 
-      if (slot % 50 == 0) { delay(0); }
+      if ((slot % 50 == 0) || (timePassedSince(start) > 50)) {
+        delay(0);
+        start = millis();
+      }
 
       if (!isnan(value) && !essentiallyZero(value)) {
         ++count;
@@ -119,11 +123,15 @@ void handle_eepromvars() {
 
     const uint32_t maxSlots = ESPEasy::eeprom::getRTCSRAMMaxSlots();
     uint32_t count{};
+    uint32_t start = millis();
 
     for (uint32_t slot = 0; slot < maxSlots; ++slot) {
       const ESPEASY_RULES_FLOAT_TYPE value = ESPEasy::eeprom::readRTCSRAMSlot(slot);
 
-      if (slot % 50 == 0) { delay(0); }
+      if ((slot % 50 == 0) || (timePassedSince(start) > 50)) {
+        delay(0);
+        start = millis();
+      }
 
       if (!isnan(value) && !essentiallyZero(value)) {
         ++count;

--- a/src/src/WebServer/HardwarePage.cpp
+++ b/src/src/WebServer/HardwarePage.cpp
@@ -47,21 +47,23 @@ void handle_hardware() {
       set3BitToUL(Settings.I2C_peripheral_bus, I2C_PERIPHERAL_BUS_PCFMCP, getFormItemInt(F("pi2cbuspcf")));
     }
     #endif // if FEATURE_I2C_MULTIPLE
+    
     // EEPROM settings
-
-    #if FEATURE_I2CMULTIPLEXER && !FEATURE_I2C_MULTIPLE && FEATURE_EEPROM_EXTERNAL
-    constexpr uint8_t i2cBus = 0;
-    #else // if FEATURE_I2CMULTIPLEXER && !FEATURE_I2C_MULTIPLE && FEATURE_EEPROM_EXTERNAL
-    const uint8_t i2cBus = getFormItemInt(F("pi2cbuseeprom"), 0);
-    set3BitToUL(Settings.I2C_peripheral_bus, I2C_PERIPHERAL_BUS_EEPROM, i2cBus);
-    #endif // if FEATURE_I2CMULTIPLEXER && !FEATURE_I2C_MULTIPLE && FEATURE_EEPROM_EXTERNAL
-
     #if FEATURE_EEPROM_EXTERNAL
+
     Settings.EEPROMExternalType(getFormItemInt(F("eepromtype"),
                                 static_cast<int>(ESPEasy::eeprom::EEPROMExternal_Type_e::AT24C256)));
     Settings.EEPROMExternalI2CAddress(getFormItemInt(F("i2c_eeprom"), 0));
+    
+    #  if FEATURE_I2C_MULTIPLE
+    const uint8_t i2cBus = getFormItemInt(F("pi2cbuseeprom"), 0);
+    set3BitToUL(Settings.I2C_peripheral_bus, I2C_PERIPHERAL_BUS_EEPROM, i2cBus);
+    #endif // if FEATURE_I2C_MULTIPLE
 
     # if FEATURE_I2CMULTIPLEXER
+    #  if !FEATURE_I2C_MULTIPLE
+    constexpr uint8_t i2cBus = 0;
+    #  endif // if FEATURE_I2C_MULTIPLE
 
     bool muxPortsOption{};
     int selectedPorts{};
@@ -198,12 +200,11 @@ void handle_hardware() {
 
     }
     #endif // if FEATURE_I2C_MULTIPLE
-
-    #if FEATURE_I2CMULTIPLEXER && !FEATURE_I2C_MULTIPLE && FEATURE_EEPROM_EXTERNAL
-    constexpr uint8_t i2cBus = 0;
-    #endif // if FEATURE_I2CMULTIPLEXER && !FEATURE_I2C_MULTIPLE && FEATURE_EEPROM_EXTERNAL
-
+    
     #if FEATURE_I2CMULTIPLEXER
+    # if !FEATURE_I2C_MULTIPLE
+    constexpr uint8_t i2cBus = 0;
+    # endif // if FEATURE_I2C_MULTIPLE
     const uint16_t eepromMux = Settings.EEPROMExternalI2CMultiplexerFlags();
     ShowI2CMultiplexerUI(i2cBus,
                          bitRead(eepromMux, EEPROM_MUX_FLAGS_MULTI),


### PR DESCRIPTION
Fixes:
- Serial defines visibility for minimal builds
- Conditional compilation for EEPROM settings on HardwarePage simplified