### PR TITLE
docs: fix the misspellings across docs/source

### DIFF
--- a/docs/source/Hardware/Hardware.rst
+++ b/docs/source/Hardware/Hardware.rst
@@ -11,7 +11,7 @@ ESPEasy has some centralized hardware configuration settings, shown in this page
 Wifi Status LED
 ---------------
 
-To display the Wifi acitivity, a pin can be configured to light up a LED when data is transfered via Wifi. Optionally, the LED signal can be 'inverted'.
+To display the Wifi acitivity, a pin can be configured to light up a LED when data is transferred via Wifi. Optionally, the LED signal can be 'inverted'.
 
 As many ESP boards have an onboard LED connected to GPIO-2 and inverted, it is shown as a note how to configure that.
 

--- a/docs/source/Plugin/P002.rst
+++ b/docs/source/Plugin/P002.rst
@@ -310,7 +310,7 @@ But also the wind direction is not increasing when the resistance increases.
 
 Therefore we need a look-up table. 
 
-What binning does is it tries to match each sample to a specific bin (similar to an entry in the Multipoint Processing table) and simply counts each occurence per bin.
+What binning does is it tries to match each sample to a specific bin (similar to an entry in the Multipoint Processing table) and simply counts each occurrence per bin.
 After a measurement period (the time between 2 calls to "run" the task, typically the "interval") the bin with the highest count is picked and the output value of this bin will be returned as output.
 
 When using "Binning", it can be useful to also have some formula to process the data first before mapping the data to the correct bin.

--- a/docs/source/Plugin/P039.rst
+++ b/docs/source/Plugin/P039.rst
@@ -163,7 +163,7 @@ After that, the configuration page of the device provides a three step configura
 
 #.  **Choose the type of sensor you want to use**
       
-    Inital configuration step is to decide on which sensor family you want to use. This device support two:
+    Initial configuration step is to decide on which sensor family you want to use. This device support two:
 
     * Thermocouple  -->   Thermocoupling Sensors
     * RTD           -->   Resistor Temperature Device Sensors

--- a/docs/source/Plugin/P062.rst
+++ b/docs/source/Plugin/P062.rst
@@ -99,7 +99,7 @@ Sensitivity
 
 * **Release treshold (1..255)** The amount of 'touch' until a touch is no longer registered (released). This is the global configuration value, see below for per-key configuration.
 
-* **Panel sensitivity** When having direct access to the keypad, the sensitivity should be set to Normal. When mounting the keypad behind a sheet of glass or another capacitive inert material, the sensitivity can be set to Extra sensitive, to accomodate for a glass sheet of 4-6 mm.
+* **Panel sensitivity** When having direct access to the keypad, the sensitivity should be set to Normal. When mounting the keypad behind a sheet of glass or another capacitive inert material, the sensitivity can be set to Extra sensitive, to accommodate for a glass sheet of 4-6 mm.
 
 .. image:: P062_PanelSensitivityOptions.png
   :alt: Panel sensitivity options.

--- a/docs/source/Plugin/P166.rst
+++ b/docs/source/Plugin/P166.rst
@@ -89,7 +89,7 @@ When leaving the *Name* field empty, that preset will not be saved, thus effecti
 Values
 ^^^^^^
 
-The plugin provides the ``Output0`` and ``Output1`` values, analogue to the availabe output connections. A formula can be set to recalculate the displayed, and sent, value. The number of decimals can be set as desired, and defaults to 2.
+The plugin provides the ``Output0`` and ``Output1`` values, analogue to the available output connections. A formula can be set to recalculate the displayed, and sent, value. The number of decimals can be set as desired, and defaults to 2.
 
 In selected builds, per Value is a **Stats** checkbox available, that when checked, gathers the data and presents recent data in a graph, as described here: :ref:`Task Value Statistics:  <Task Value Statistics>`
 

--- a/docs/source/Plugin/P169.rst
+++ b/docs/source/Plugin/P169.rst
@@ -274,7 +274,7 @@ Some tips:
 
 The sensor chip does have an internal voltage regulator.
 
-On some boards, this regulator can be enabled by pulling the ``EN-V`` or ``EN_VREG`` pin high (if made availabe on the board).
+On some boards, this regulator can be enabled by pulling the ``EN-V`` or ``EN_VREG`` pin high (if made available on the board).
 
 Onboard voltage regulator:
 

--- a/docs/source/Plugin/P176.rst
+++ b/docs/source/Plugin/P176.rst
@@ -106,7 +106,7 @@ Also, the number of checksum errors is shown, this counter is automatically rese
 Get Config values
 -----------------
 
-All data values received can be retrieved by using the ``[<taskname>#<data_name>]`` syntax. To get the success count and error count, varables ``[<taskname>#successcount]`` and ``[<taskname>#errorcount]`` are available, and also the ``[<taskname>#updated]`` value, to see if data was updated since the last call for this variable (returns 0/1). So this should only be called once for evaluation. The ``errorcount`` value is reset after 50 succesful received packets, so after receiving 50 successful packets it will return 0.
+All data values received can be retrieved by using the ``[<taskname>#<data_name>]`` syntax. To get the success count and error count, varables ``[<taskname>#successcount]`` and ``[<taskname>#errorcount]`` are available, and also the ``[<taskname>#updated]`` value, to see if data was updated since the last call for this variable (returns 0/1). So this should only be called once for evaluation. The ``errorcount`` value is reset after 50 successful received packets, so after receiving 50 successful packets it will return 0.
 
 Change log
 ----------

--- a/docs/source/Rules/Rules.rst
+++ b/docs/source/Rules/Rules.rst
@@ -2668,7 +2668,7 @@ The next script should be placed at the top of ``Rules Set 1`` as they are calle
         // So we have not found the key
         // No need to continue searching
       Else
-        // When refering to an index, make sure to use the [int#<n>] notation, not the floating point version.
+        // When referring to an index, make sure to use the [int#<n>] notation, not the floating point version.
         If %eventvalue1% > [int#%v997%]
           // Check upper half
           if [int#998] < %eventvalue3%

--- a/docs/source/Tools/Tools.rst
+++ b/docs/source/Tools/Tools.rst
@@ -755,7 +755,7 @@ Given enough time, their count value will be high, or even overflow since they a
 When this happens, the values for calls/sec or avg will be no longer useful.
 
 A really busy node (CPU load > 75%) may drop a few scheduled calls in order to keep up.
-This will be noticable in low values for calls/sec of the most frequently called functions like ``FIFTY_PER_SECOND`` or ``TEN_PER_SECOND``.
+This will be noticeable in low values for calls/sec of the most frequently called functions like ``FIFTY_PER_SECOND`` or ``TEN_PER_SECOND``.
 
 
 Tweaking Timeout using Timing Stats


### PR DESCRIPTION
Corrects a single misspelling of `noticable` in `docs/source/Tools/Tools.rst`.

Documentation only, no behaviour change.