### PR TITLE
[I2CScan] Avoid using PCONFIG() during I2CScan

### DIFF
--- a/src/_P022_PCA9685.ino
+++ b/src/_P022_PCA9685.ino
@@ -30,7 +30,7 @@ boolean Plugin_022(uint8_t function, struct EventStruct *event, String& string)
   uint16_t freq    = PCA9685_MAX_FREQUENCY;
   uint16_t range   = PCA9685_MAX_PWM;
 
-  if ((event != nullptr) && (event->TaskIndex >= 0))
+  if ((event != nullptr) && validTaskIndex(event->TaskIndex))
   {
     address = CONFIG_PORT;
     mode2   = PCONFIG(0);

--- a/src/_P023_OLED.ino
+++ b/src/_P023_OLED.ino
@@ -7,6 +7,7 @@
 // #######################################################################################################
 
 /** Changelog:
+ * 2026-09-01 tonhuisman: Function PLUGIN_I2C_HAS_ADDRESS doesn't have a valid TaskIndex when called, so don't pass PCONFIG() value
  * 2024-08-17 tonhuisman: Disable preview of on-display content for LIMIT_BUILD_SIZE builds.
  * 2023-10-16 tonhuisman: Bugfix: Template parsing stopped after initial display since previous updates :-(
  * 2023-03-18 tonhuisman: Show current on-display content on Devices page (75% size, omits trailing empty lines)
@@ -64,7 +65,7 @@ boolean Plugin_023(uint8_t function, struct EventStruct *event, String& string)
     case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      success = OLedI2CAddressCheck(function, event->Par1, F("i2c_addr"), PCONFIG(0));
+      success = OLedI2CAddressCheck(function, event->Par1, F("i2c_addr"), PLUGIN_I2C_HAS_ADDRESS == function ? -1 : PCONFIG(0));
 
       break;
     }
@@ -105,9 +106,9 @@ boolean Plugin_023(uint8_t function, struct EventStruct *event, String& string)
       {
         const __FlashStringHelper *options4[] = { F("Normal"), F("Optimized") };
         const int optionValues4[]             = { 1, 2 };
-        constexpr size_t optionCount = NR_ELEMENTS(optionValues4);
+        constexpr size_t optionCount          = NR_ELEMENTS(optionValues4);
         const FormSelectorOptions selector(optionCount, options4, optionValues4);
-        selector.addFormSelector(F("Font Width"), F("font_spacing"),  PCONFIG(4));
+        selector.addFormSelector(F("Font Width"), F("font_spacing"), PCONFIG(4));
       }
       {
         String strings[P23_Nlines];
@@ -162,7 +163,8 @@ boolean Plugin_023(uint8_t function, struct EventStruct *event, String& string)
       P023_data_struct::Spacing font_spacing = P023_data_struct::Spacing::normal;
 
 
-      switch (PCONFIG(3)) {
+      switch (PCONFIG(3))
+      {
         case 1:
           // 128x64
           type = P023_data_struct::OLED_128x64;
@@ -183,7 +185,8 @@ boolean Plugin_023(uint8_t function, struct EventStruct *event, String& string)
         font_spacing = static_cast<P023_data_struct::Spacing>(PCONFIG(4));
       }
 
-      void * ptr = special_calloc(1, sizeof(P023_data_struct));
+      void *ptr = special_calloc(1, sizeof(P023_data_struct));
+
       if (ptr) {
         initPluginTaskData(event->TaskIndex, new (ptr) P023_data_struct(PCONFIG(0), type, font_spacing, PCONFIG(2), PCONFIG(5)));
       }

--- a/src/_P024_MLX90614.ino
+++ b/src/_P024_MLX90614.ino
@@ -6,6 +6,7 @@
 // #######################################################################################################
 
 /** Changelog:
+ * 2026-09-02 tonhuisman: Disable function PLUGIN_I2C_HAS_ADDRESS as it uses the wrong value, and it can be configured for many addresses
  * 2025-01-12 tonhuisman: Add support for MQTT AutoDiscovery
  * 2024-08-17 tonhuisman: Show correct I2C address when non-default address is used (by setting a Port nr. 0..15)
  * 2023-11-23 tonhuisman: Add Device flag for I2CMax100kHz as this sensor won't work at 400 kHz
@@ -64,11 +65,11 @@ boolean Plugin_024(uint8_t function, struct EventStruct *event, String& string)
     }
     # endif // if FEATURE_MQTT_DISCOVER
 
-    case PLUGIN_I2C_HAS_ADDRESS:
-    {
-      success = event->Par1 == (0x5a + CONFIG_PORT);
-      break;
-    }
+    // case PLUGIN_I2C_HAS_ADDRESS:
+    // {
+    //   success = event->Par1 == (0x5a + CONFIG_PORT);
+    //   break;
+    // }
 
     # if FEATURE_I2C_GET_ADDRESS
     case PLUGIN_I2C_GET_ADDRESS:

--- a/src/_P036_FrameOLED.ino
+++ b/src/_P036_FrameOLED.ino
@@ -14,6 +14,8 @@
 // Added to the main repository with some optimizations and some limitations.
 // As long as the device is not enabled, no RAM is wasted.
 //
+// @tonhuisman: 2026-09-01
+// CHG: Function PLUGIN_I2C_HAS_ADDRESS doesn't have a valid TaskIndex when called, so don't pass PCONFIG() value
 // @andbad: 2026-07-09
 // ADD: 72x40 OLED size added to the the existing sizes (128x64, 128x32, 64x48)
 // @tonhuisman: 2025-03-03
@@ -269,7 +271,7 @@ boolean Plugin_036(uint8_t function, struct EventStruct *event, String& string)
     case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      success = OLedI2CAddressCheck(function, event->Par1, F("i2c_addr"), P036_ADR);
+      success = OLedI2CAddressCheck(function, event->Par1, F("i2c_addr"), PLUGIN_I2C_HAS_ADDRESS == function ? -1 : P036_ADR);
 
       break;
     }
@@ -753,11 +755,12 @@ boolean Plugin_036(uint8_t function, struct EventStruct *event, String& string)
       P036_CheckHeap(F("_INIT: Before P036_data->init()"));
 # endif // P036_CHECK_HEAP
 
-      #if FEATURE_I2C_MULTIPLE
+      # if FEATURE_I2C_MULTIPLE
       const uint8_t i2cBus = Settings.getI2CInterface(event->TaskIndex);
-      #else
+      # else
       const uint8_t i2cBus = 0;
-      #endif // if FEATURE_I2C_MULTIPLE
+      # endif // if FEATURE_I2C_MULTIPLE
+
       if (!(P036_data->init(event->TaskIndex,
                             get4BitFromUL(P036_FLAGS_0, P036_FLAG_SETTINGS_VERSION), // Bit23-20 Version CustomTaskSettings
                             P036_CONTROLLER,                                         // Type
@@ -1100,6 +1103,7 @@ boolean Plugin_036(uint8_t function, struct EventStruct *event, String& string)
 }
 
 # ifdef P036_CHECK_HEAP
+
 void P036_CheckHeap(String dbgtxt) {
   addLog(LOG_LEVEL_INFO,
          strformat(F("%s FreeHeap:%d FreeStack:%d"),

--- a/src/_P047_i2c-soil-moisture-sensor.ino
+++ b/src/_P047_i2c-soil-moisture-sensor.ino
@@ -12,6 +12,7 @@
 //
 
 /** Changelog:
+ * 2026-09-01 tonhuisman: Disable function PLUGIN_I2C_HAS_ADDRESS as it uses the wrong value, and it can be configured for any address
  * 2025-01-12 tonhuisman: Add support for MQTT AutoDiscovery
  * 2024-05-09 tonhuisman: Add support for BeFlE v3.x (low power) Moisture sensor
  *                        Code improvements
@@ -37,7 +38,6 @@
 # define PLUGIN_VALUENAME3_047  "Light"
 
 # include "src/PluginStructs/P047_data_struct.h"
-
 
 boolean Plugin_047(uint8_t function, struct EventStruct *event, String& string)
 {
@@ -127,11 +127,11 @@ boolean Plugin_047(uint8_t function, struct EventStruct *event, String& string)
       break;
     }
 
-    case PLUGIN_I2C_HAS_ADDRESS:
-    {
-      success = event->Par1 == P047_I2C_ADDR; // Show for currently configured address
-      break;
-    }
+      // case PLUGIN_I2C_HAS_ADDRESS:
+      // {
+      //   success = event->Par1 == P047_I2C_ADDR; // Show for currently configured address
+      //   break;
+      // }
 
     # if FEATURE_I2C_GET_ADDRESS
     case PLUGIN_I2C_GET_ADDRESS:
@@ -166,11 +166,10 @@ boolean Plugin_047(uint8_t function, struct EventStruct *event, String& string)
           # endif // if P047_FEATURE_ADAFRUIT
         };
         constexpr size_t P047_MODEL_OPTIONS = NR_ELEMENTS(SensorModelIds);
-        FormSelectorOptions selector( P047_MODEL_OPTIONS, SensorModels, SensorModelIds);
-        selector.default_index = static_cast<int>(P047_MODEL_CATNIP);
+        FormSelectorOptions selector(P047_MODEL_OPTIONS, SensorModels, SensorModelIds);
+        selector.default_index  = static_cast<int>(P047_MODEL_CATNIP);
         selector.reloadonchange = true;
         selector.addFormSelector(F("Sensor model"), F("model"), P047_MODEL);
-        // addFormNote(F("Changing the Sensor model will reload the page."));
       }
 
       if ((P047_MODEL_CATNIP == static_cast<P047_SensorModels>(P047_MODEL))

--- a/src/_P109_ThermOLED.ino
+++ b/src/_P109_ThermOLED.ino
@@ -43,6 +43,7 @@
    ------------------------------------------------------------------------------------------
    Copyleft Nagy Sándor 2018 - https://bitekmindenhol.blog.hu/
    ------------------------------------------------------------------------------------------
+   2026-09-01 tonhuisman: Function PLUGIN_I2C_HAS_ADDRESS doesn't have a valid TaskIndex when called, so don't pass PCONFIG() value
    2025-06-14 tonhuisman: Add support for Custom Value Type per task value
    2025-01-12 tonhuisman: Add support for MQTT AutoDiscovery (not supported ThermOLED)
    2022-12-08 tonhuisman: Add Relay invert state option, reorder config option Contrast
@@ -77,7 +78,6 @@
 # define PLUGIN_VALUENAME2_109  "heating"
 # define PLUGIN_VALUENAME3_109  "mode"
 # define PLUGIN_VALUENAME4_109  "timeout"
-
 
 boolean Plugin_109(uint8_t function, struct EventStruct *event, String& string)
 {
@@ -139,7 +139,7 @@ boolean Plugin_109(uint8_t function, struct EventStruct *event, String& string)
     case PLUGIN_I2C_HAS_ADDRESS:
     case PLUGIN_WEBFORM_SHOW_I2C_PARAMS:
     {
-      success = OLedI2CAddressCheck(function, event->Par1, F("pi2caddr"), P109_CONFIG_I2CADDRESS);
+      success = OLedI2CAddressCheck(function, event->Par1, F("pi2caddr"), PLUGIN_I2C_HAS_ADDRESS == function ? -1 : P109_CONFIG_I2CADDRESS);
 
       break;
     }

--- a/src/_P178_LU9685.ino
+++ b/src/_P178_LU9685.ino
@@ -25,7 +25,7 @@ boolean Plugin_178(uint8_t function, struct EventStruct *event, String& string)
   int      address = LU9685_ADDRESS;
   uint16_t freq    = LU9685_DEFAULT_FREQUENCY;
 
-  if (event != nullptr) {
+  if ((event != nullptr) && validTaskIndex(event->TaskIndex)) {
     address = P178_I2C_ADDR;
     freq    = P178_FREQ;
   }

--- a/src/src/Helpers/OLed_helper.cpp
+++ b/src/src/Helpers/OLed_helper.cpp
@@ -15,8 +15,9 @@ void OLedFormController(const __FlashStringHelper *id,
   const int controllerValues[] = { 1, 2 };
   const FormSelectorOptions selector(
     NR_ELEMENTS(controllerOptions),
-    controllerOptions, 
+    controllerOptions,
     values == nullptr ? controllerValues : values);
+
   selector.addFormSelector(F("Controller"), id, selectedIndex);
 }
 
@@ -34,6 +35,7 @@ void OLedFormRotation(const __FlashStringHelper *id,
   const FormSelectorOptions selector(
     NR_ELEMENTS(rotationOptions),
     rotationOptions, rotationValues);
+
   selector.addFormSelector(F("Rotation"), id, selectedIndex);
 }
 
@@ -55,8 +57,8 @@ void OLedFormContrast(const __FlashStringHelper *id,
     contrastOptions, contrastValues);
 
   selector.addFormSelector(
-    F("Contrast"), 
-    id, 
+    F("Contrast"),
+    id,
     selectedIndex == 0 ? OLED_CONTRAST_HIGH : selectedIndex);
 }
 
@@ -73,10 +75,11 @@ void OLedFormSizes(const __FlashStringHelper *id,
     F("128x32"),
     F("64x48"),
     F("72x40") };
-  FormSelectorOptions selector(optionsSize, options3, values);  
+  FormSelectorOptions selector(optionsSize, options3, values);
+
   selector.reloadonchange = reloadOnChange;
   selector.addFormSelector(
-    F("Display Size"), 
+    F("Display Size"),
     id,
     selectedIndex);
 }
@@ -93,15 +96,19 @@ void OLedSetContrast(OLEDDisplay   *_display,
   char precharge = 241;
   char comdetect = 64;
 
-  switch (OLED_contrast) {
+  switch (OLED_contrast)
+  {
     case OLED_CONTRAST_OFF:
       _display->displayOff();
       return; // Done
     case OLED_CONTRAST_LOW:
-      contrast = 10; precharge = 5; comdetect = 0;
+      contrast  = 10;
+      precharge = 5;
+      comdetect = 0;
       break;
     case OLED_CONTRAST_MED:
-      contrast = OLED_CONTRAST_MED; precharge = 0x1F;
+      contrast  = OLED_CONTRAST_MED;
+      precharge = 0x1F;
       break;
     case OLED_CONTRAST_HIGH:
     default:
@@ -119,7 +126,7 @@ void OLedSetContrast(OLEDDisplay   *_display,
 bool OLedI2CAddressCheck(uint8_t                    function,
                          int                        checkI2cAddress,
                          const __FlashStringHelper *id,
-                         int8_t                     deviceAddress) {
+                         int16_t                    deviceAddress) {
   bool success                     = false;
   const uint8_t i2cAddressValues[] = { 0x3c, 0x3d };
 
@@ -130,4 +137,5 @@ bool OLedI2CAddressCheck(uint8_t                    function,
   }
   return success;
 }
-#endif
+
+#endif // if defined(USES_P023) || defined(USES_P036) || defined(USES_P109)

--- a/src/src/Helpers/OLed_helper.h
+++ b/src/src/Helpers/OLed_helper.h
@@ -13,13 +13,13 @@
  */
 
 #if defined(USES_P023) || defined(USES_P036) || defined(USES_P109)
-#include "SSD1306.h"
-#include "SH1106Wire.h"
+# include "SSD1306.h"
+# include "SH1106Wire.h"
 
-#define OLED_CONTRAST_OFF  0x01
-#define OLED_CONTRAST_LOW  0x40
-#define OLED_CONTRAST_MED  0xCF
-#define OLED_CONTRAST_HIGH 0xFF
+# define OLED_CONTRAST_OFF  0x01
+# define OLED_CONTRAST_LOW  0x40
+# define OLED_CONTRAST_MED  0xCF
+# define OLED_CONTRAST_HIGH 0xFF
 
 void OLedFormController(const __FlashStringHelper *id,
                         const int                 *values,
@@ -31,14 +31,14 @@ void OLedFormContrast(const __FlashStringHelper *id,
 void OLedFormSizes(const __FlashStringHelper *id,
                    const int                 *values,
                    uint8_t                    selectedIndex,
-                   uint8_t                    optionsSize = 3,
+                   uint8_t                    optionsSize    = 3,
                    bool                       reloadOnChange = false);
 void OLedSetContrast(OLEDDisplay   *_display,
                      const uint8_t& OLED_contrast);
 bool OLedI2CAddressCheck(uint8_t                    function,
                          int                        checkI2cAddress,
                          const __FlashStringHelper *id,
-                         int8_t                     deviceAddress);
+                         int16_t                    deviceAddress);
 
-#endif
+#endif // if defined(USES_P023) || defined(USES_P036) || defined(USES_P109)
 #endif // ifndef HELPERS_OLED_HELPER_H

--- a/src/src/WebServer/I2C_Scanner.cpp
+++ b/src/src/WebServer/I2C_Scanner.cpp
@@ -172,7 +172,7 @@ String getKnownI2Cdevice(uint8_t address) {
   String result;
 
   #if FEATURE_I2C_DEVICE_SCAN
-  deviceIndex_t x;
+  deviceIndex_t x{};
   bool done = false;
   while (!done) {
     const deviceIndex_t deviceIndex = getDeviceIndex_sorted(x);


### PR DESCRIPTION
Features:
- [Bugfix] During I2CScan some plugins tried to return the configured I2C Address, but the TaskIndex is invalid during that call, so could cause index out of bounds errors
- Some source got uncrustify applied
